### PR TITLE
remove conda / pytorch from install_requirements.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ENV PYTHONHASHSEED 2157
 
 COPY . .
 
-RUN /bin/bash -c "source activate runenv && scripts/install_requirements.sh"
+RUN /bin/bash -c 'source activate runenv && scripts/install_requirements.sh &&\
+ pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.1.11.post5-cp35-cp35m-linux_x86_64.whl &&\
+ conda install pytorch torchvision -c soumith -y -q'
 
 CMD ["/bin/sh", "-c]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ ENV PYTHONHASHSEED 2157
 COPY . .
 
 RUN /bin/bash -c 'source activate runenv && scripts/install_requirements.sh &&\
- pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.1.11.post5-cp35-cp35m-linux_x86_64.whl &&\
- conda install pytorch torchvision -c soumith -y -q'
+ pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.1.11.post5-cp35-cp35m-linux_x86_64.whl'
 
 CMD ["/bin/sh", "-c]

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -38,7 +38,6 @@ source activate testenv
 # Install requirements via pip and download data inside our conda environment.
 bash scripts/install_requirements.sh
 pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.1.11.post5-cp35-cp35m-linux_x86_64.whl
-conda install pytorch torchvision -c soumith -y -q
 
 # List the packages to get their versions for debugging
 pip list

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -37,6 +37,8 @@ source activate testenv
 
 # Install requirements via pip and download data inside our conda environment.
 bash scripts/install_requirements.sh
+pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.1.11.post5-cp35-cp35m-linux_x86_64.whl
+conda install pytorch torchvision -c soumith -y -q
 
 # List the packages to get their versions for debugging
 pip list

--- a/scripts/install_requirements.sh
+++ b/scripts/install_requirements.sh
@@ -3,5 +3,3 @@
 pip install -r requirements.txt
 python -m nltk.downloader punkt
 python -m spacy.en.download all
-pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.1.11.post5-cp35-cp35m-linux_x86_64.whl
-conda install pytorch torchvision -c soumith -y -q


### PR DESCRIPTION
This eliminates `conda install` from the installation script by eliminating the automated pytorch installation. 

(the setup instructions tell you to install it separately anyway: https://github.com/allenai/allennlp#setting-up-a-development-environment ) 

Since the instructions say conda is "the easiest way" (rather than "the only way") to get things setup, I'm hesitant to have the installation scripts assume it. (Also, there are people who can't/don't use conda for various reasons, I think we should accommodate them if it's not costly to do so.)

I then added those steps back to the Dockerfile and travis setup. let me know if there's anywhere else where pytorch needs to be installed programatically.

(I assume at some point we'll probably just want a base docker image that already has pytorch on it?)