### PR TITLE
get code to pass mypy type checking

### DIFF
--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -22,7 +22,7 @@ def __param(self, message, *args, **kws):
     # Logger takes its '*args' as 'args'.
     if self.isEnabledFor(PARAMETER):
         self._log(PARAMETER, message, args, **kws) # pylint: disable=protected-access
-logging.Logger.param = __param
+logging.Logger.param = __param  # type: ignore
 
 
 class Params(MutableMapping):
@@ -52,7 +52,7 @@ class Params(MutableMapping):
     # and passing no value to the default parameter of "pop".
     DEFAULT = object()
 
-    def __init__(self, params: Dict[str, Any], history: str = ""):
+    def __init__(self, params: Dict[str, Any], history: str = "") -> None:
         self.params = params
         self.history = history
 
@@ -72,7 +72,7 @@ class Params(MutableMapping):
                 raise ConfigurationError("key \"{}\" is required at location \"{}\"".format(key, self.history))
         else:
             value = self.params.pop(key, default)
-        logger.param(self.history + key + " = " + str(value))
+        logger.param(self.history + key + " = " + str(value))  # type: ignore
         return self.__check_is_dict(key, value)
 
     @overrides

--- a/allennlp/common/tee_logger.py
+++ b/allennlp/common/tee_logger.py
@@ -10,7 +10,7 @@ class TeeLogger:
         sys.stdout = TeeLogger("stdout.log", sys.stdout)
         sys.stderr = TeeLogger("stdout.log", sys.stderr)
     """
-    def __init__(self, filename: str, terminal: io.TextIOWrapper):
+    def __init__(self, filename: str, terminal: io.TextIOWrapper) -> None:
         self.terminal = terminal
         parent_directory = os.path.dirname(filename)
         os.makedirs(parent_directory, exist_ok=True)

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -1,5 +1,5 @@
 from itertools import zip_longest
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, TypeVar
 import random
 
 
@@ -57,8 +57,9 @@ def pad_sequence_to_length(sequence: List,
             padded_sequence.insert(0, default_value())
     return padded_sequence
 
+A = TypeVar('A')
 
-def add_noise_to_dict_values(dictionary: Dict[Any, float], noise_param: float) -> Dict[Any, float]:
+def add_noise_to_dict_values(dictionary: Dict[A, float], noise_param: float) -> Dict[A, float]:
     """
     Returns a new dictionary with noise added to every key in ``dictionary``.  The noise is
     uniformly distributed within ``noise_param`` percent of the value for every value in the

--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -18,7 +18,7 @@ class Dataset:
     could be in an indexed or unindexed state - the ``Dataset`` has methods around indexing the
     data and converting the data into arrays.
     """
-    def __init__(self, instances: List[Instance]):
+    def __init__(self, instances: List[Instance]) -> None:
         """
         A Dataset just takes a list of instances in its constructor.  It's important that all
         subclasses have an identical constructor to this (though possibly with different Instance
@@ -26,7 +26,7 @@ class Dataset:
         class that call the constructor, such as `truncate()`.
         """
         all_instance_fields_and_types = [{k: v.__class__.__name__ for k, v in x.fields().items()}
-                                         for x in instances]
+                                         for x in instances]  # type: List[Dict[str, str]]
         # Check all the field names and Field types are the same for every instance.
         if not all([all_instance_fields_and_types[0] == x for x in all_instance_fields_and_types]):
             raise ConfigurationError("You cannot construct a Dataset with non-homogeneous Instances.")
@@ -60,11 +60,12 @@ class Dataset:
         This can then be used to convert this dataset into arrays of consistent length, or to set
         model parameters, etc.
         """
-        padding_lengths = defaultdict(dict)
-        all_instance_lengths = [instance.get_padding_lengths() for instance in self.instances]
+        padding_lengths = defaultdict(dict)  # type: Dict[str, Dict[str, int]]
+        all_instance_lengths = [instance.get_padding_lengths()
+                                for instance in self.instances]  # type: List[Dict[str, Dict[str, int]]]
         if not all_instance_lengths:
             return {**padding_lengths}
-        all_field_lengths = defaultdict(list)
+        all_field_lengths = defaultdict(list)  # type: Dict[str, List[Dict[str, int]]]
         for instance_lengths in all_instance_lengths:
             for field_name, instance_field_lengths in instance_lengths.items():
                 all_field_lengths[field_name].append(instance_field_lengths)
@@ -120,7 +121,7 @@ class Dataset:
         instance_padding_lengths = self.get_padding_lengths()
         if verbose:
             logger.info("Instance max lengths: %s", str(instance_padding_lengths))
-        lengths_to_use = defaultdict(dict)
+        lengths_to_use = defaultdict(dict)  # type: Dict[str, Dict[str, int]]
         for field_name, instance_field_lengths in instance_padding_lengths.items():
             for padding_key in instance_field_lengths.keys():
                 if padding_lengths[field_name].get(padding_key) is not None:
@@ -129,7 +130,7 @@ class Dataset:
                     lengths_to_use[field_name][padding_key] = instance_field_lengths[padding_key]
 
         # Now we actually pad the instances to numpy arrays.
-        field_arrays = defaultdict(list)
+        field_arrays = defaultdict(list)  # type: Dict[str, list]
         if verbose:
             logger.info("Now actually padding instances to length: %s", str(lengths_to_use))
             for instance in tqdm.tqdm(self.instances):

--- a/allennlp/data/dataset_readers/__init__.py
+++ b/allennlp/data/dataset_readers/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict  # pylint: disable=unused-import
+from typing import Dict, Type  # pylint: disable=unused-import
 
 from .dataset_reader import DatasetReader
 from .language_modeling import LanguageModelingReader
@@ -7,7 +7,7 @@ from .squad import SquadSentenceSelectionReader
 from .sequence_tagging import SequenceTaggingDatasetReader
 
 # pylint: disable=invalid-name
-dataset_readers = {}  # type: Dict[str, type]
+dataset_readers = {}  # type: Dict[str, Type[DatasetReader]]
 # pylint: enable=invalid-name
 dataset_readers['language modeling'] = LanguageModelingReader
 dataset_readers['snli'] = SnliReader

--- a/allennlp/data/dataset_readers/__init__.py
+++ b/allennlp/data/dataset_readers/__init__.py
@@ -1,11 +1,15 @@
+from typing import Dict, cast  # pylint: disable=unused-import
+
 from .dataset_reader import DatasetReader
 from .language_modeling import LanguageModelingReader
 from .snli import SnliReader
 from .squad import SquadSentenceSelectionReader
 from .sequence_tagging import SequenceTaggingDatasetReader
 
-dataset_readers = {}  # pylint: disable=invalid-name
-dataset_readers['language modeling'] = LanguageModelingReader
-dataset_readers['snli'] = SnliReader
-dataset_readers['squad sentence selection'] = SquadSentenceSelectionReader
-dataset_readers['sequence tagging'] = SequenceTaggingDatasetReader
+# pylint: disable=invalid-name
+dataset_readers = {}  # type: Dict[str, 'DatasetReader']
+# pylint: enable=invalid-name
+dataset_readers['language modeling'] = cast(DatasetReader, LanguageModelingReader)
+dataset_readers['snli'] = cast(DatasetReader, SnliReader)
+dataset_readers['squad sentence selection'] = cast(DatasetReader, SquadSentenceSelectionReader)
+dataset_readers['sequence tagging'] = cast(DatasetReader, SequenceTaggingDatasetReader)

--- a/allennlp/data/dataset_readers/__init__.py
+++ b/allennlp/data/dataset_readers/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, cast  # pylint: disable=unused-import
+from typing import Dict  # pylint: disable=unused-import
 
 from .dataset_reader import DatasetReader
 from .language_modeling import LanguageModelingReader
@@ -7,9 +7,9 @@ from .squad import SquadSentenceSelectionReader
 from .sequence_tagging import SequenceTaggingDatasetReader
 
 # pylint: disable=invalid-name
-dataset_readers = {}  # type: Dict[str, 'DatasetReader']
+dataset_readers = {}  # type: Dict[str, type]
 # pylint: enable=invalid-name
-dataset_readers['language modeling'] = cast(DatasetReader, LanguageModelingReader)
-dataset_readers['snli'] = cast(DatasetReader, SnliReader)
-dataset_readers['squad sentence selection'] = cast(DatasetReader, SquadSentenceSelectionReader)
-dataset_readers['sequence tagging'] = cast(DatasetReader, SequenceTaggingDatasetReader)
+dataset_readers['language modeling'] = LanguageModelingReader
+dataset_readers['snli'] = SnliReader
+dataset_readers['squad sentence selection'] = SquadSentenceSelectionReader
+dataset_readers['sequence tagging'] = SequenceTaggingDatasetReader

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -18,4 +18,4 @@ class DatasetReader:
     def from_params(cls, params: Params):
         from . import dataset_readers
         choice = params.pop_choice('type', list(dataset_readers.keys()))
-        return dataset_readers[choice].from_params(params)  # type: ignore
+        return dataset_readers[choice].from_params(params)

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -18,4 +18,4 @@ class DatasetReader:
     def from_params(cls, params: Params):
         from . import dataset_readers
         choice = params.pop_choice('type', list(dataset_readers.keys()))
-        return dataset_readers[choice].from_params(params)
+        return dataset_readers[choice].from_params(params)  # type: ignore

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -14,8 +14,8 @@ class DatasetReader:
         """
         raise NotImplementedError
 
-    @staticmethod
-    def from_params(params: Params):
+    @classmethod
+    def from_params(cls, params: Params):
         from . import dataset_readers
         choice = params.pop_choice('type', list(dataset_readers.keys()))
         return dataset_readers[choice].from_params(params)

--- a/allennlp/data/dataset_readers/language_modeling.py
+++ b/allennlp/data/dataset_readers/language_modeling.py
@@ -2,7 +2,7 @@ from typing import List
 
 from overrides import overrides
 
-from . import DatasetReader
+from .dataset_reader import DatasetReader
 from .. import Dataset
 from .. import Instance
 from ...common import Params
@@ -39,7 +39,7 @@ class LanguageModelingReader(DatasetReader):
                  filename: str,
                  tokens_per_instance: int = None,
                  tokenizer: Tokenizer = WordTokenizer(),
-                 token_indexers: List[TokenIndexer] = None):
+                 token_indexers: List[TokenIndexer] = None) -> None:
         self._filename = filename
         self._tokens_per_instance = tokens_per_instance
         self._tokenizer = tokenizer

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -2,7 +2,7 @@ from typing import List
 
 from overrides import overrides
 
-from allennlp.data.dataset_readers import DatasetReader
+from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data import Dataset, Instance
 from allennlp.common import Params
 from allennlp.data.fields import TextField, TagField
@@ -27,7 +27,7 @@ class SequenceTaggingDatasetReader(DatasetReader):
     """
     def __init__(self,
                  filename: str,
-                 token_indexers: List[TokenIndexer] = None):
+                 token_indexers: List[TokenIndexer] = None) -> None:
         self._filename = filename
         self._token_indexers = token_indexers or [SingleIdTokenIndexer()]
 

--- a/allennlp/data/dataset_readers/snli.py
+++ b/allennlp/data/dataset_readers/snli.py
@@ -3,7 +3,7 @@ import json
 
 from overrides import overrides
 
-from . import DatasetReader
+from .dataset_reader import DatasetReader
 from .. import Dataset
 from .. import Instance
 from ...common import Params
@@ -30,7 +30,7 @@ class SnliReader(DatasetReader):
     def __init__(self,
                  snli_filename: str,
                  tokenizer: Tokenizer = WordTokenizer(),
-                 token_indexers: List[TokenIndexer] = None):
+                 token_indexers: List[TokenIndexer] = None) -> None:
         self._snli_filename = snli_filename
         self._tokenizer = tokenizer
         if token_indexers is None:

--- a/allennlp/data/dataset_readers/squad.py
+++ b/allennlp/data/dataset_readers/squad.py
@@ -2,12 +2,12 @@ from collections import Counter
 import json
 import logging
 import random
-from typing import List, Tuple
+from typing import List, Tuple, Dict, Set  # pylint: disable=unused-import
 
 import numpy
 from tqdm import tqdm
 
-from . import DatasetReader
+from .dataset_reader import DatasetReader
 from .. import Dataset
 from .. import Instance
 from ...common import Params
@@ -51,7 +51,7 @@ class SquadSentenceSelectionReader(DatasetReader):
                  squad_filename: str,
                  negative_sentence_selection: str = "paragraph",
                  tokenizer: Tokenizer = WordTokenizer(),
-                 token_indexers: List[TokenIndexer] = None):
+                 token_indexers: List[TokenIndexer] = None) -> None:
         self._squad_filename = squad_filename
         self._negative_sentence_selection_methods = negative_sentence_selection.split(",")
         self._tokenizer = tokenizer
@@ -61,24 +61,24 @@ class SquadSentenceSelectionReader(DatasetReader):
 
         # Initializing some data structures here that will be useful when reading a file.
         # Maps sentence strings to sentence indices
-        self._sentence_to_id = {}
+        self._sentence_to_id = {}  # type: Dict[str, int]
         # Maps sentence indices to sentence strings
-        self._id_to_sentence = {}
+        self._id_to_sentence = {}  # type: Dict[int, str]
         # Maps paragraph ids to lists of contained sentence ids
-        self._paragraph_sentences = {}
+        self._paragraph_sentences = {}  # type: Dict[int, List[int]]
         # Maps sentence ids to the containing paragraph id.
-        self._sentence_paragraph_map = {}
+        self._sentence_paragraph_map = {}  # type: Dict[int, int]
         # Maps question strings to question indices
-        self._question_to_id = {}
+        self._question_to_id = {}  # type: Dict[str, int]
         # Maps question indices to question strings
-        self._id_to_question = {}
+        self._id_to_question = {}  # type: Dict[int, str]
 
     def _get_sentence_choices(self,
                               question_id: int,
                               answer_id: int) -> Tuple[List[str], int]:  # pylint: disable=invalid-sequence-index
         # Because sentences and questions have different indices, we need this to hold tuples of
         # ("sentence", id) or ("question", id), instead of just single ids.
-        negative_sentences = set()
+        negative_sentences = set()  # type: Set[Tuple[str, int]]
         for selection_method in self._negative_sentence_selection_methods:
             if selection_method == 'paragraph':
                 paragraph_id = self._sentence_paragraph_map[answer_id]

--- a/allennlp/data/fields/index_field.py
+++ b/allennlp/data/fields/index_field.py
@@ -27,7 +27,7 @@ class IndexField(Field):
     sequence_field : ``SequenceField``
         A field containing the sequence that this ``IndexField`` is a pointer into.
     """
-    def __init__(self, index: int, sequence_field: SequenceField):
+    def __init__(self, index: int, sequence_field: SequenceField) -> None:
         self._index = index
         self._sequence_field = sequence_field
 

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -38,7 +38,7 @@ class LabelField(Field):
     def __init__(self,
                  label: Union[str, int],
                  label_namespace: str = 'labels',
-                 num_labels: int = None):
+                 num_labels: int = None) -> None:
         self._label = label
         self._label_namespace = label_namespace
         if num_labels is None:
@@ -57,12 +57,12 @@ class LabelField(Field):
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
         if self._label_id is None:
-            counter[self._label_namespace][self._label] += 1
+            counter[self._label_namespace][self._label] += 1  # type: ignore
 
     @overrides
     def index(self, vocab: Vocabulary):
         if self._label_id is None:
-            self._label_id = vocab.get_token_index(self._label, self._label_namespace)
+            self._label_id = vocab.get_token_index(self._label, self._label_namespace)  # type: ignore
             self._num_labels = vocab.get_vocab_size(self._label_namespace)
 
     @overrides

--- a/allennlp/data/fields/list_field.py
+++ b/allennlp/data/fields/list_field.py
@@ -24,7 +24,7 @@ class ListField(SequenceField):
         A list of ``Field`` objects to be concatenated into a single input tensor.  All of the
         contained ``Field`` objects must be of the same type.
     """
-    def __init__(self, field_list: List[Field]):
+    def __init__(self, field_list: List[Field]) -> None:
         field_class_set = set([field.__class__ for field in field_list])
         assert len(field_class_set) == 1, "ListFields must contain a single field type, found " +\
                                           str(field_class_set)

--- a/allennlp/data/fields/tag_field.py
+++ b/allennlp/data/fields/tag_field.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional  # pylint: disable=unused-import
 import logging
 
 from overrides import overrides
@@ -35,12 +35,12 @@ class TagField(Field):
         integers for you, and this parameter tells the ``Vocabulary`` object which mapping from
         strings to integers to use (so that "O" as a tag doesn't get the same id as "O" as a word).
     """
-    def __init__(self, tags: List[str], sequence_field: SequenceField, tag_namespace: str = 'tags'):
+    def __init__(self, tags: List[str], sequence_field: SequenceField, tag_namespace: str = 'tags') -> None:
         self._tags = tags
         self._sequence_field = sequence_field
         self._tag_namespace = tag_namespace
-        self._indexed_tags = None
-        self._num_tags = None
+        self._indexed_tags = None  # type: Optional[List[int]]
+        self._num_tags = None      # type: Optional[int]
 
         if not self._tag_namespace.endswith("tags"):
             logger.warning("Your tag namespace was '%s'. We recommend you use a namespace "

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -2,13 +2,14 @@
 A ``TextField`` represents a string of text, the kind that you might want to represent with
 standard word vectors, or pass through an LSTM.
 """
-from typing import Dict, List
+from typing import Dict, List, Optional  # pylint: disable=unused-import
 
 from overrides import overrides
 import numpy
 
 from .sequence_field import SequenceField
 from ..vocabulary import Vocabulary
+from ..token_indexers.token_indexer import TokenType  # pylint: disable=unused-import
 from ..token_indexers import TokenIndexer
 from ...common.checks import ConfigurationError
 
@@ -27,10 +28,10 @@ class TextField(SequenceField):
     ``SingleIdTokenIndexer`` produces an array of shape (num_tokens,), while a
     ``TokenCharactersIndexer`` produces an array of shape (num_tokens, num_characters).
     """
-    def __init__(self, tokens: List[str], token_indexers: List[TokenIndexer]):
+    def __init__(self, tokens: List[str], token_indexers: List[TokenIndexer]) -> None:
         self._tokens = tokens
         self._token_indexers = token_indexers
-        self._indexed_tokens = None
+        self._indexed_tokens = None  # type: Optional[List[List[TokenType]]]
 
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
@@ -67,7 +68,8 @@ class TextField(SequenceField):
             lengths.append(indexer_lengths)
         padding_lengths = {'num_tokens': len(self._indexed_tokens[0])}
         # Get all the keys which have been used for padding.
-        padding_keys = set().union(*[d.keys() for d in lengths])
+        # TODO: figure out the right type hint for this next line
+        padding_keys = set().union(*[d.keys() for d in lengths])  # type: ignore
         for padding_key in padding_keys:
             padding_lengths[padding_key] = max(x[padding_key] if padding_key in x else 0 for x in lengths)
         return padding_lengths

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -68,8 +68,7 @@ class TextField(SequenceField):
             lengths.append(indexer_lengths)
         padding_lengths = {'num_tokens': len(self._indexed_tokens[0])}
         # Get all the keys which have been used for padding.
-        # TODO: figure out the right type hint for this next line
-        padding_keys = set().union(*[d.keys() for d in lengths])  # type: ignore
+        padding_keys = {key for d in lengths for key in d.keys()}
         for padding_key in padding_keys:
             padding_lengths[padding_key] = max(x[padding_key] if padding_key in x else 0 for x in lengths)
         return padding_lengths

--- a/allennlp/data/instance.py
+++ b/allennlp/data/instance.py
@@ -18,7 +18,7 @@ class Instance:
     processing pipeline, all fields will end up as ``IndexedFields``, and will then be converted
     into padded arrays by a ``DataGenerator``.
     """
-    def __init__(self, fields: Dict[str, Field]):
+    def __init__(self, fields: Dict[str, Field]) -> None:
         self._fields = fields
 
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/data/iterators/__init__.py
+++ b/allennlp/data/iterators/__init__.py
@@ -1,12 +1,15 @@
 from collections import OrderedDict
+from typing import Dict, cast
 
 from .data_iterator import DataIterator
 from .basic_iterator import BasicIterator
 from .bucket_iterator import BucketIterator
 from .adaptive_iterator import AdaptiveIterator
 
+# pylint: disable=invalid-name
+iterators = OrderedDict()  # type: Dict[str, 'DataIterator']
+# pylint: enable=invalid-name
 
-iterators = OrderedDict()  # pylint: disable=invalid-name
-iterators["bucket"] = BucketIterator
-iterators["basic"] = BasicIterator
-iterators["adaptive"] = AdaptiveIterator
+iterators["bucket"] = cast(DataIterator, BucketIterator)
+iterators["basic"] = cast(DataIterator, BasicIterator)
+iterators["adaptive"] = cast(DataIterator, AdaptiveIterator)

--- a/allennlp/data/iterators/__init__.py
+++ b/allennlp/data/iterators/__init__.py
@@ -11,5 +11,5 @@ iterators = OrderedDict()  # type: Dict[str, type]
 # pylint: enable=invalid-name
 
 iterators["bucket"] = BucketIterator
-iterators["basic"] = DataIterator
+iterators["basic"] = BasicIterator
 iterators["adaptive"] = AdaptiveIterator

--- a/allennlp/data/iterators/__init__.py
+++ b/allennlp/data/iterators/__init__.py
@@ -7,9 +7,9 @@ from .bucket_iterator import BucketIterator
 from .adaptive_iterator import AdaptiveIterator
 
 # pylint: disable=invalid-name
-iterators = OrderedDict()  # type: Dict[str, 'DataIterator']
+iterators = OrderedDict()  # type: Dict[str, type]
 # pylint: enable=invalid-name
 
-iterators["bucket"] = cast(DataIterator, BucketIterator)
-iterators["basic"] = cast(DataIterator, BasicIterator)
-iterators["adaptive"] = cast(DataIterator, AdaptiveIterator)
+iterators["bucket"] = BucketIterator
+iterators["basic"] = DataIterator
+iterators["adaptive"] = AdaptiveIterator

--- a/allennlp/data/iterators/__init__.py
+++ b/allennlp/data/iterators/__init__.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, cast
+from typing import Dict, cast, Type
 
 from .data_iterator import DataIterator
 from .basic_iterator import BasicIterator
@@ -7,7 +7,7 @@ from .bucket_iterator import BucketIterator
 from .adaptive_iterator import AdaptiveIterator
 
 # pylint: disable=invalid-name
-iterators = OrderedDict()  # type: Dict[str, type]
+iterators = OrderedDict()  # type: Dict[str, Type[DataIterator]]
 # pylint: enable=invalid-name
 
 iterators["bucket"] = BucketIterator

--- a/allennlp/data/iterators/__init__.py
+++ b/allennlp/data/iterators/__init__.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, cast, Type
+from typing import Dict, Type
 
 from .data_iterator import DataIterator
 from .basic_iterator import BasicIterator

--- a/allennlp/data/iterators/adaptive_iterator.py
+++ b/allennlp/data/iterators/adaptive_iterator.py
@@ -79,7 +79,7 @@ class AdaptiveIterator(BucketIterator):
                  biggest_batch_first: bool = False,
                  batch_size: int = None,
                  sorting_keys: List[Tuple[str, str]] = None,
-                 padding_noise: float = 0.2):
+                 padding_noise: float = 0.2) -> None:
         self._padding_memory_scaling = padding_memory_scaling
         self._maximum_batch_size = maximum_batch_size
         self._adaptive_memory_usage_constant = adaptive_memory_usage_constant
@@ -93,13 +93,11 @@ class AdaptiveIterator(BucketIterator):
         if self._biggest_batch_first:
             return super(AdaptiveIterator, self)._create_batches(dataset, shuffle)
         if self._sorting_keys:
-            instances = self._sort_dataset_by_padding(dataset,
-                                                      self._sorting_keys,
-                                                      self._padding_noise)
-        else:
-            instances = dataset.instances
+            dataset = self._sort_dataset_by_padding(dataset,
+                                                    self._sorting_keys,
+                                                    self._padding_noise)
         # Group the instances into different sized batches, depending on how padded they are.
-        grouped_instances = self._adaptive_grouping(instances)
+        grouped_instances = self._adaptive_grouping(dataset)
         if shuffle:
             random.shuffle(grouped_instances)
         return grouped_instances
@@ -107,7 +105,7 @@ class AdaptiveIterator(BucketIterator):
     def _adaptive_grouping(self, dataset: Dataset):
         batches = []
         current_batch = []
-        current_lengths = defaultdict(dict)
+        current_lengths = defaultdict(dict)  # type: Dict[str, Dict[str, int]]
         logger.debug("Creating adaptive groups")
         for instance in dataset.instances:
             current_batch.append(instance)

--- a/allennlp/data/iterators/basic_iterator.py
+++ b/allennlp/data/iterators/basic_iterator.py
@@ -5,7 +5,7 @@ from overrides import overrides
 
 from allennlp.common.util import group_by_count
 from allennlp.data import Dataset, Instance
-from allennlp.data.iterators import DataIterator
+from allennlp.data.iterators.data_iterator import DataIterator
 
 
 class BasicIterator(DataIterator):
@@ -18,7 +18,7 @@ class BasicIterator(DataIterator):
     batch_size : int, optional, (default = 32)
         The size of each batch of instances yielded when calling the iterator.
     """
-    def __init__(self, batch_size: int = 32):
+    def __init__(self, batch_size: int = 32) -> None:
         self._batch_size = batch_size
 
     @overrides

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, Dict, cast
 import random
 
 from overrides import overrides
@@ -53,7 +53,7 @@ class BucketIterator(BasicIterator):
                  sorting_keys: List[Tuple[str, str]] = None,
                  padding_noise: float = 0.1,
                  biggest_batch_first: bool = False,
-                 batch_size: int = 32):
+                 batch_size: int = 32) -> None:
         self._sorting_keys = sorting_keys or []
         self._padding_noise = padding_noise
         self._biggest_batch_first = biggest_batch_first
@@ -88,7 +88,7 @@ class BucketIterator(BasicIterator):
         """
         instances_with_lengths = []
         for instance in dataset.instances:
-            padding_lengths = instance.get_padding_lengths()
+            padding_lengths = cast(Dict[str, Dict[str, float]], instance.get_padding_lengths())
             print("Instance:", instance)
             print("padding lengths:", padding_lengths)
             if padding_noise > 0.0:
@@ -96,8 +96,9 @@ class BucketIterator(BasicIterator):
                 for field_name, field_lengths in padding_lengths.items():
                     noisy_lengths[field_name] = add_noise_to_dict_values(field_lengths, padding_noise)
                 padding_lengths = noisy_lengths
-            instance_with_lengths = [padding_lengths[field_name][padding_key]
-                                     for (field_name, padding_key) in sorting_keys] + [instance]
+            instance_with_lengths = ([padding_lengths[field_name][padding_key]
+                                      for (field_name, padding_key) in sorting_keys],
+                                     instance)
             instances_with_lengths.append(instance_with_lengths)
-        instances_with_lengths.sort(key=lambda x: x[:-1])
+        instances_with_lengths.sort(key=lambda x: x[0])
         return Dataset([instance_with_lengths[-1] for instance_with_lengths in instances_with_lengths])

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -53,5 +53,5 @@ class DataIterator:
         from . import iterators
         # TODO(Mark): The adaptive iterator will need a bit of work here,
         # to retrieve the scaling function etc.
-        iterator_type = params.pop_choice("type", iterators.keys())
+        iterator_type = params.pop_choice("type", iterators.keys())  # type: ignore
         return iterators[iterator_type](**params.as_dict())

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -53,5 +53,5 @@ class DataIterator:
         from . import iterators
         # TODO(Mark): The adaptive iterator will need a bit of work here,
         # to retrieve the scaling function etc.
-        iterator_type = params.pop_choice("type", iterators.keys())  # type: ignore
-        return iterators[iterator_type](**params.as_dict())
+        iterator_type = params.pop_choice("type", list(iterators.keys()))
+        return iterators[iterator_type](**params.as_dict())  # type: ignore

--- a/allennlp/data/token_indexers/__init__.py
+++ b/allennlp/data/token_indexers/__init__.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
-from typing import Dict # mypy: disable=unused-import
+from typing import Dict, Type # mypy: disable=unused-import
 from .token_indexer import TokenIndexer
 from .token_characters_indexer import TokenCharactersIndexer
 from .single_id_token_indexer import SingleIdTokenIndexer
 
 # The first item added here will be used as the default in some cases.
 # pylint: disable=invalid-name
-token_indexers = OrderedDict()  # type: Dict[str, type]
+token_indexers = OrderedDict()  # type: Dict[str, Type[TokenIndexer]]
 # pylint: enable=invalid-name
 
 token_indexers['single id'] = SingleIdTokenIndexer

--- a/allennlp/data/token_indexers/__init__.py
+++ b/allennlp/data/token_indexers/__init__.py
@@ -1,13 +1,13 @@
 from collections import OrderedDict
-from typing import Dict, cast  # mypy: disable=unused-import
+from typing import Dict # mypy: disable=unused-import
 from .token_indexer import TokenIndexer
 from .token_characters_indexer import TokenCharactersIndexer
 from .single_id_token_indexer import SingleIdTokenIndexer
 
 # The first item added here will be used as the default in some cases.
 # pylint: disable=invalid-name
-token_indexers = OrderedDict()  # type: Dict[str, 'TokenIndexer']
+token_indexers = OrderedDict()  # type: Dict[str, type]
 # pylint: enable=invalid-name
 
-token_indexers['single id'] = cast(TokenIndexer, SingleIdTokenIndexer)
-token_indexers['characters'] = cast(TokenIndexer, TokenCharactersIndexer)
+token_indexers['single id'] = SingleIdTokenIndexer
+token_indexers['characters'] = TokenCharactersIndexer

--- a/allennlp/data/token_indexers/__init__.py
+++ b/allennlp/data/token_indexers/__init__.py
@@ -1,9 +1,13 @@
 from collections import OrderedDict
+from typing import Dict, cast  # mypy: disable=unused-import
 from .token_indexer import TokenIndexer
 from .token_characters_indexer import TokenCharactersIndexer
 from .single_id_token_indexer import SingleIdTokenIndexer
 
 # The first item added here will be used as the default in some cases.
-token_indexers = OrderedDict()  # pylint: disable=invalid-name
-token_indexers['single id'] = SingleIdTokenIndexer
-token_indexers['characters'] = TokenCharactersIndexer
+# pylint: disable=invalid-name
+token_indexers = OrderedDict()  # type: Dict[str, 'TokenIndexer']
+# pylint: enable=invalid-name
+
+token_indexers['single id'] = cast(TokenIndexer, SingleIdTokenIndexer)
+token_indexers['characters'] = cast(TokenIndexer, TokenCharactersIndexer)

--- a/allennlp/data/token_indexers/single_id_token_indexer.py
+++ b/allennlp/data/token_indexers/single_id_token_indexer.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, cast
 
 from overrides import overrides
 
@@ -20,7 +20,7 @@ class SingleIdTokenIndexer(TokenIndexer):
         If ``True``, we will call ``token.lower()`` before getting an index for the token from the
         vocabulary.
     """
-    def __init__(self, token_namespace: str = 'tokens', lowercase_tokens: bool = False):
+    def __init__(self, token_namespace: str = 'tokens', lowercase_tokens: bool = False) -> None:
         self.token_namespace = token_namespace
         self.lowercase_tokens = lowercase_tokens
 
@@ -50,10 +50,12 @@ class SingleIdTokenIndexer(TokenIndexer):
 
     @overrides
     def pad_token_sequence(self,
-                           tokens: List[int],
+                           tokens: List[TokenType],
                            desired_num_tokens: int,
                            padding_lengths: Dict[str, int]) -> List[TokenType]:
-        return pad_sequence_to_length(tokens, desired_num_tokens)
+        # cast is runtime no-op that makes mypy happy
+        int_tokens = cast(List[int], tokens)
+        return pad_sequence_to_length(int_tokens, desired_num_tokens)
 
     @classmethod
     def from_params(cls, params: Params):

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -45,10 +45,8 @@ class TokenCharactersIndexer(TokenIndexer):
 
     @overrides
     def get_padding_lengths(self, token: TokenType) -> Dict[str, int]:
-        if isinstance(token, list):
-            return {'num_token_characters': len(token)}
-        else:
-            raise ValueError("token should be a list")
+        list_token = cast(List[int], token)
+        return {'num_token_characters': len(list_token)}
 
     @overrides
     def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, cast
 import itertools
 
 from overrides import overrides
@@ -27,7 +27,7 @@ class TokenCharactersIndexer(TokenIndexer):
     """
     def __init__(self,
                  character_namespace: str = 'token_characters',
-                 character_tokenizer: CharacterTokenizer = CharacterTokenizer()):
+                 character_tokenizer: CharacterTokenizer = CharacterTokenizer()) -> None:
         self.character_namespace = character_namespace
         self.character_tokenizer = character_tokenizer
 
@@ -45,7 +45,10 @@ class TokenCharactersIndexer(TokenIndexer):
 
     @overrides
     def get_padding_lengths(self, token: TokenType) -> Dict[str, int]:
-        return {'num_token_characters': len(token)}
+        if isinstance(token, list):
+            return {'num_token_characters': len(token)}
+        else:
+            raise ValueError("token should be a list")
 
     @overrides
     def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):
@@ -57,12 +60,14 @@ class TokenCharactersIndexer(TokenIndexer):
 
     @overrides
     def pad_token_sequence(self,
-                           tokens: List[List[int]],
+                           tokens: List[TokenType],
                            desired_num_tokens: int,
                            padding_lengths: Dict[str, int]) -> List[TokenType]:
-        padded_tokens = pad_sequence_to_length(tokens, desired_num_tokens, default_value=lambda: [])
+        # cast is runtime no-op that makes mypy happy
+        list_tokens = cast(List[List[int]], tokens)
+        padded_tokens = pad_sequence_to_length(list_tokens, desired_num_tokens, default_value=lambda: [])
         desired_token_length = padding_lengths['num_token_characters']
-        longest_token = max(tokens, key=len)
+        longest_token = max(list_tokens, key=len)
         if desired_token_length > len(longest_token):
             # Since we want to pad to greater than the longest token, we add a
             # "dummy token" to get the speed of itertools.zip_longest.

--- a/allennlp/data/token_indexers/token_indexer.py
+++ b/allennlp/data/token_indexers/token_indexer.py
@@ -74,8 +74,8 @@ class TokenIndexer:
         """
         raise NotImplementedError
 
-    @staticmethod
-    def from_params(params: Params):
+    @classmethod
+    def from_params(cls, params: Params):
         from . import token_indexers
         choice = params.pop_choice('type', list(token_indexers.keys()), default_to_first_choice=True)
         return token_indexers[choice].from_params(params)

--- a/allennlp/data/token_indexers/token_indexer.py
+++ b/allennlp/data/token_indexers/token_indexer.py
@@ -78,4 +78,4 @@ class TokenIndexer:
     def from_params(cls, params: Params):
         from . import token_indexers
         choice = params.pop_choice('type', list(token_indexers.keys()), default_to_first_choice=True)
-        return token_indexers[choice].from_params(params)
+        return token_indexers[choice].from_params(params)  # type: ignore

--- a/allennlp/data/token_indexers/token_indexer.py
+++ b/allennlp/data/token_indexers/token_indexer.py
@@ -78,4 +78,4 @@ class TokenIndexer:
     def from_params(cls, params: Params):
         from . import token_indexers
         choice = params.pop_choice('type', list(token_indexers.keys()), default_to_first_choice=True)
-        return token_indexers[choice].from_params(params)  # type: ignore
+        return token_indexers[choice].from_params(params)

--- a/allennlp/data/tokenizers/__init__.py
+++ b/allennlp/data/tokenizers/__init__.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, cast  # pylint: disable=unused-import
+from typing import Dict  # pylint: disable=unused-import
 
 from .tokenizer import Tokenizer
 from .word_tokenizer import WordTokenizer
@@ -7,9 +7,8 @@ from .character_tokenizer import CharacterTokenizer
 
 # The first item added here will be used as the default in some cases.
 # pylint: disable=invalid-name
-tokenizers = OrderedDict()  # type: Dict[str, 'Tokenizer']
+tokenizers = OrderedDict()  # type: Dict[str, type]
 # pylint: enable=invalid-name
 
-# these `cast`s are runtime no-ops that make `mypy` happy
-tokenizers['words'] = cast(Tokenizer, WordTokenizer)
-tokenizers['characters'] = cast(Tokenizer, CharacterTokenizer)
+tokenizers['words'] = WordTokenizer
+tokenizers['characters'] = CharacterTokenizer

--- a/allennlp/data/tokenizers/__init__.py
+++ b/allennlp/data/tokenizers/__init__.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict  # pylint: disable=unused-import
+from typing import Dict, Type  # pylint: disable=unused-import
 
 from .tokenizer import Tokenizer
 from .word_tokenizer import WordTokenizer
@@ -7,7 +7,7 @@ from .character_tokenizer import CharacterTokenizer
 
 # The first item added here will be used as the default in some cases.
 # pylint: disable=invalid-name
-tokenizers = OrderedDict()  # type: Dict[str, type]
+tokenizers = OrderedDict()  # type: Dict[str, Type[Tokenizer]]
 # pylint: enable=invalid-name
 
 tokenizers['words'] = WordTokenizer

--- a/allennlp/data/tokenizers/__init__.py
+++ b/allennlp/data/tokenizers/__init__.py
@@ -1,10 +1,15 @@
 from collections import OrderedDict
+from typing import Dict, cast  # pylint: disable=unused-import
 
 from .tokenizer import Tokenizer
 from .word_tokenizer import WordTokenizer
 from .character_tokenizer import CharacterTokenizer
 
 # The first item added here will be used as the default in some cases.
-tokenizers = OrderedDict()  # pylint: disable=invalid-name
-tokenizers['words'] = WordTokenizer
-tokenizers['characters'] = CharacterTokenizer
+# pylint: disable=invalid-name
+tokenizers = OrderedDict()  # type: Dict[str, 'Tokenizer']
+# pylint: enable=invalid-name
+
+# these `cast`s are runtime no-ops that make `mypy` happy
+tokenizers['words'] = cast(Tokenizer, WordTokenizer)
+tokenizers['characters'] = cast(Tokenizer, CharacterTokenizer)

--- a/allennlp/data/tokenizers/character_tokenizer.py
+++ b/allennlp/data/tokenizers/character_tokenizer.py
@@ -25,7 +25,7 @@ class CharacterTokenizer(Tokenizer):
         operation.  You probably do not want to do this, as character vocabularies are generally
         not very large to begin with, but it's an option if you really want it.
     """
-    def __init__(self, byte_encoding: str = None, lowercase_characters: bool = False):
+    def __init__(self, byte_encoding: str = None, lowercase_characters: bool = False) -> None:
         self.byte_encoding = byte_encoding
         self.lowercase_characters = lowercase_characters
 
@@ -34,7 +34,7 @@ class CharacterTokenizer(Tokenizer):
         if self.lowercase_characters:
             text = text.lower()
         if self.byte_encoding is not None:
-            text = text.encode(self.byte_encoding)
+            text = text.encode(self.byte_encoding)  # type: ignore
         return list(text)
 
     @classmethod

--- a/allennlp/data/tokenizers/word_filter.py
+++ b/allennlp/data/tokenizers/word_filter.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
-from typing import List, Dict  # pylint: disable=unused-import
+from typing import List, Dict, Type  # pylint: disable=unused-import
 
 from overrides import overrides
 
 from ...common import Params
 
 # pylint: disable=invalid-name
-word_filters = OrderedDict()  # type: Dict[str, type]
+word_filters = OrderedDict()  # type: Dict[str, Type[WordFilter]]
 # pylint: enable=invalid-name
 
 
@@ -26,7 +26,7 @@ class WordFilter:
     def from_params(params: Params) -> 'WordFilter':
         choice = params.pop_choice('type', list(word_filters.keys()), default_to_first_choice=True)
         params.assert_empty('WordFilter')
-        return word_filters[choice]()  # type: ignore
+        return word_filters[choice]()
 
 
 class PassThroughWordFilter(WordFilter):

--- a/allennlp/data/tokenizers/word_filter.py
+++ b/allennlp/data/tokenizers/word_filter.py
@@ -1,9 +1,13 @@
 from collections import OrderedDict
-from typing import List
+from typing import List, cast, Dict  # pylint: disable=unused-import
 
 from overrides import overrides
 
 from ...common import Params
+
+# pylint: disable=invalid-name
+word_filters = OrderedDict()  # type: Dict[str, 'WordFilter']
+# pylint: enable=invalid-name
 
 
 class WordFilter:
@@ -22,7 +26,7 @@ class WordFilter:
     def from_params(params: Params) -> 'WordFilter':
         choice = params.pop_choice('type', list(word_filters.keys()), default_to_first_choice=True)
         params.assert_empty('WordFilter')
-        return word_filters[choice]()
+        return word_filters[choice]()  # type: ignore
 
 
 class PassThroughWordFilter(WordFilter):
@@ -70,6 +74,6 @@ class StopwordFilter(WordFilter):
         return [word for word in words if word not in self.stopwords]
 
 
-word_filters = OrderedDict()  # pylint: disable=invalid-name
-word_filters['pass_through'] = PassThroughWordFilter
-word_filters['stopwords'] = StopwordFilter
+# these `cast`s are runtime no-ops that make `mypy` happy
+word_filters['pass_through'] = cast(WordFilter, PassThroughWordFilter)
+word_filters['stopwords'] = cast(WordFilter, StopwordFilter)

--- a/allennlp/data/tokenizers/word_filter.py
+++ b/allennlp/data/tokenizers/word_filter.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
-from typing import List, cast, Dict  # pylint: disable=unused-import
+from typing import List, Dict  # pylint: disable=unused-import
 
 from overrides import overrides
 
 from ...common import Params
 
 # pylint: disable=invalid-name
-word_filters = OrderedDict()  # type: Dict[str, 'WordFilter']
+word_filters = OrderedDict()  # type: Dict[str, type]
 # pylint: enable=invalid-name
 
 
@@ -74,6 +74,5 @@ class StopwordFilter(WordFilter):
         return [word for word in words if word not in self.stopwords]
 
 
-# these `cast`s are runtime no-ops that make `mypy` happy
-word_filters['pass_through'] = cast(WordFilter, PassThroughWordFilter)
-word_filters['stopwords'] = cast(WordFilter, StopwordFilter)
+word_filters['pass_through'] = PassThroughWordFilter
+word_filters['stopwords'] = StopwordFilter

--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
-from typing import List, Dict, cast  # pylint: disable=unused-import
+from typing import List, Dict  # pylint: disable=unused-import
 
 from overrides import overrides
 
 from ...common import Params
 
 # pylint: disable=invalid-name
-word_splitters = OrderedDict()  # type: Dict[str, 'WordSplitter']
+word_splitters = OrderedDict()  # type: Dict[str, type]
 # pylint: enable=invalid-name
 
 class WordSplitter:
@@ -130,8 +130,7 @@ class SpacyWordSplitter(WordSplitter):
         return [str(token.lower_) for token in self.en_nlp.tokenizer(sentence)]
 
 
-# these `cast`s are runtime no-ops that make `mypy` happy
-word_splitters['simple'] = cast(WordSplitter, SimpleWordSplitter)
-word_splitters['spaces'] = cast(WordSplitter, SpaceWordSplitter)
-word_splitters['nltk'] = cast(WordSplitter, NltkWordSplitter)
-word_splitters['spacy'] = cast(WordSplitter, SpacyWordSplitter)
+word_splitters['simple'] = SimpleWordSplitter
+word_splitters['spaces'] = SpaceWordSplitter
+word_splitters['nltk'] = NltkWordSplitter
+word_splitters['spacy'] = SpacyWordSplitter

--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
-from typing import List, Dict  # pylint: disable=unused-import
+from typing import List, Dict, Type  # pylint: disable=unused-import
 
 from overrides import overrides
 
 from ...common import Params
 
 # pylint: disable=invalid-name
-word_splitters = OrderedDict()  # type: Dict[str, type]
+word_splitters = OrderedDict()  # type: Dict[str, Type[WordSplitter]]
 # pylint: enable=invalid-name
 
 class WordSplitter:
@@ -23,7 +23,7 @@ class WordSplitter:
     def from_params(params: Params) -> 'WordSplitter':
         choice = params.pop_choice('type', list(word_splitters.keys()), default_to_first_choice=True)
         params.assert_empty('WordSplitter')
-        return word_splitters[choice]()  # type: ignore
+        return word_splitters[choice]()
 
 
 class SimpleWordSplitter(WordSplitter):

--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -1,9 +1,13 @@
 from collections import OrderedDict
-from typing import List
+from typing import List, Dict, cast  # pylint: disable=unused-import
 
 from overrides import overrides
 
 from ...common import Params
+
+# pylint: disable=invalid-name
+word_splitters = OrderedDict()  # type: Dict[str, 'WordSplitter']
+# pylint: enable=invalid-name
 
 class WordSplitter:
     """
@@ -19,7 +23,7 @@ class WordSplitter:
     def from_params(params: Params) -> 'WordSplitter':
         choice = params.pop_choice('type', list(word_splitters.keys()), default_to_first_choice=True)
         params.assert_empty('WordSplitter')
-        return word_splitters[choice]()
+        return word_splitters[choice]()  # type: ignore
 
 
 class SimpleWordSplitter(WordSplitter):
@@ -55,7 +59,7 @@ class SimpleWordSplitter(WordSplitter):
         fields = sentence.lower().split()
         tokens = []
         for field in fields:  # type: str
-            add_at_end = []
+            add_at_end = []  # type: List[str]
             while self._can_split(field) and field[0] in self.beginning_punctuation:
                 tokens.append(field[0])
                 field = field[1:]
@@ -126,8 +130,8 @@ class SpacyWordSplitter(WordSplitter):
         return [str(token.lower_) for token in self.en_nlp.tokenizer(sentence)]
 
 
-word_splitters = OrderedDict()  # pylint: disable=invalid-name
-word_splitters['simple'] = SimpleWordSplitter
-word_splitters['spaces'] = SpaceWordSplitter
-word_splitters['nltk'] = NltkWordSplitter
-word_splitters['spacy'] = SpacyWordSplitter
+# these `cast`s are runtime no-ops that make `mypy` happy
+word_splitters['simple'] = cast(WordSplitter, SimpleWordSplitter)
+word_splitters['spaces'] = cast(WordSplitter, SpaceWordSplitter)
+word_splitters['nltk'] = cast(WordSplitter, NltkWordSplitter)
+word_splitters['spacy'] = cast(WordSplitter, SpacyWordSplitter)

--- a/allennlp/data/tokenizers/word_stemmer.py
+++ b/allennlp/data/tokenizers/word_stemmer.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, cast  # pylint: disable=unused-import
+from typing import Dict  # pylint: disable=unused-import
 
 from nltk.stem import PorterStemmer as NltkPorterStemmer
 from overrides import overrides
@@ -7,7 +7,7 @@ from overrides import overrides
 from ...common import Params
 
 # pylint: disable=invalid-name
-word_stemmers = OrderedDict()  # type: Dict[str, 'WordStemmer']
+word_stemmers = OrderedDict()  # type: Dict[str, type]
 # pylint: enable=invalid-name
 
 class WordStemmer:
@@ -50,6 +50,5 @@ class PorterStemmer(WordStemmer):
     def stem_word(self, word: str) -> str:
         return self.stemmer.stem(word)
 
-# these `cast`s are runtime no-ops that make `mypy` happy
-word_stemmers['pass_through'] = cast(WordStemmer, PassThroughWordStemmer)
-word_stemmers['porter'] = cast(WordStemmer, PorterStemmer)
+word_stemmers['pass_through'] = PassThroughWordStemmer
+word_stemmers['porter'] = PorterStemmer

--- a/allennlp/data/tokenizers/word_stemmer.py
+++ b/allennlp/data/tokenizers/word_stemmer.py
@@ -30,6 +30,7 @@ class WordStemmer:
         params.assert_empty('WordStemmer')
         return word_stemmers[choice]()
 
+
 class PassThroughWordStemmer(WordStemmer):
     """
     Does not stem words; it's a no-op.  This is the default word stemmer.
@@ -49,6 +50,7 @@ class PorterStemmer(WordStemmer):
     @overrides
     def stem_word(self, word: str) -> str:
         return self.stemmer.stem(word)
+
 
 word_stemmers['pass_through'] = PassThroughWordStemmer
 word_stemmers['porter'] = PorterStemmer

--- a/allennlp/data/tokenizers/word_stemmer.py
+++ b/allennlp/data/tokenizers/word_stemmer.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict  # pylint: disable=unused-import
+from typing import Dict, Type  # pylint: disable=unused-import
 
 from nltk.stem import PorterStemmer as NltkPorterStemmer
 from overrides import overrides
@@ -7,7 +7,7 @@ from overrides import overrides
 from ...common import Params
 
 # pylint: disable=invalid-name
-word_stemmers = OrderedDict()  # type: Dict[str, type]
+word_stemmers = OrderedDict()  # type: Dict[str, Type[WordStemmer]]
 # pylint: enable=invalid-name
 
 class WordStemmer:
@@ -28,7 +28,7 @@ class WordStemmer:
     def from_params(params: Params) -> 'WordStemmer':
         choice = params.pop_choice('type', list(word_stemmers.keys()), default_to_first_choice=True)
         params.assert_empty('WordStemmer')
-        return word_stemmers[choice]()  # type: ignore
+        return word_stemmers[choice]()
 
 class PassThroughWordStemmer(WordStemmer):
     """

--- a/allennlp/data/tokenizers/word_stemmer.py
+++ b/allennlp/data/tokenizers/word_stemmer.py
@@ -1,10 +1,14 @@
 from collections import OrderedDict
+from typing import Dict, cast  # pylint: disable=unused-import
 
 from nltk.stem import PorterStemmer as NltkPorterStemmer
 from overrides import overrides
 
 from ...common import Params
 
+# pylint: disable=invalid-name
+word_stemmers = OrderedDict()  # type: Dict[str, 'WordStemmer']
+# pylint: enable=invalid-name
 
 class WordStemmer:
     """
@@ -24,8 +28,7 @@ class WordStemmer:
     def from_params(params: Params) -> 'WordStemmer':
         choice = params.pop_choice('type', list(word_stemmers.keys()), default_to_first_choice=True)
         params.assert_empty('WordStemmer')
-        return word_stemmers[choice]()
-
+        return word_stemmers[choice]()  # type: ignore
 
 class PassThroughWordStemmer(WordStemmer):
     """
@@ -47,7 +50,6 @@ class PorterStemmer(WordStemmer):
     def stem_word(self, word: str) -> str:
         return self.stemmer.stem(word)
 
-
-word_stemmers = OrderedDict()  # pylint: disable=invalid-name
-word_stemmers['pass_through'] = PassThroughWordStemmer
-word_stemmers['porter'] = PorterStemmer
+# these `cast`s are runtime no-ops that make `mypy` happy
+word_stemmers['pass_through'] = cast(WordStemmer, PassThroughWordStemmer)
+word_stemmers['porter'] = cast(WordStemmer, PorterStemmer)

--- a/allennlp/data/tokenizers/word_tokenizer.py
+++ b/allennlp/data/tokenizers/word_tokenizer.py
@@ -32,7 +32,7 @@ class WordTokenizer(Tokenizer):
     def __init__(self,
                  word_splitter: WordSplitter = SimpleWordSplitter(),
                  word_filter: WordFilter = PassThroughWordFilter(),
-                 word_stemmer: WordStemmer = PassThroughWordStemmer()):
+                 word_stemmer: WordStemmer = PassThroughWordStemmer()) -> None:
         self.word_splitter = word_splitter
         self.word_filter = word_filter
         self.word_stemmer = word_stemmer

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -48,7 +48,7 @@ class _NamespaceDependentDefaultDict(defaultdict):
     def __init__(self,
                  non_padded_namespaces: List[str],
                  padded_function: Callable[[], Any],
-                 non_padded_function: Callable[[], Any]):
+                 non_padded_function: Callable[[], Any]) -> None:
         self._non_padded_namespaces = non_padded_namespaces
         self._padded_function = padded_function
         self._non_padded_function = non_padded_function
@@ -64,14 +64,14 @@ class _NamespaceDependentDefaultDict(defaultdict):
 
 
 class _TokenToIndexDefaultDict(_NamespaceDependentDefaultDict):
-    def __init__(self, non_padded_namespaces: List[str], padding_token: str, oov_token: str):
+    def __init__(self, non_padded_namespaces: List[str], padding_token: str, oov_token: str) -> None:
         super(_TokenToIndexDefaultDict, self).__init__(non_padded_namespaces,
                                                        lambda: {padding_token: 0, oov_token: 1},
                                                        lambda: {})
 
 
 class _IndexToTokenDefaultDict(_NamespaceDependentDefaultDict):
-    def __init__(self, non_padded_namespaces: List[str], padding_token: str, oov_token: str):
+    def __init__(self, non_padded_namespaces: List[str], padding_token: str, oov_token: str) -> None:
         super(_IndexToTokenDefaultDict, self).__init__(non_padded_namespaces,
                                                        lambda: {0: padding_token, 1: oov_token},
                                                        lambda: {})
@@ -126,13 +126,13 @@ class Vocabulary:
                  counter: Dict[str, Dict[str, int]] = None,
                  min_count: int = 1,
                  max_vocab_size: Union[int, Dict[str, int]] = None,
-                 non_padded_namespaces: List[str] = None):
+                 non_padded_namespaces: List[str] = None) -> None:
         self._padding_token = "@@PADDING@@"
         self._oov_token = "@@UNKOWN@@"
         if non_padded_namespaces is None:
             non_padded_namespaces = ["*tags", "*labels"]
         if not isinstance(max_vocab_size, dict):
-            max_vocab_size = defaultdict(lambda: max_vocab_size)
+            max_vocab_size = defaultdict(lambda: max_vocab_size)  # type: ignore
         self._token_to_index = _TokenToIndexDefaultDict(non_padded_namespaces,
                                                         self._padding_token,
                                                         self._oov_token)
@@ -191,7 +191,7 @@ class Vocabulary:
         :func:`__init__`.  See that method for a description of what the other parameters do.
         """
         logger.info("Fitting token dictionary")
-        namespace_token_counts = defaultdict(lambda: defaultdict(int))
+        namespace_token_counts = defaultdict(lambda: defaultdict(int))  # type: Dict[str, Dict[str, int]]
         for instance in tqdm.tqdm(dataset.instances):
             instance.count_vocab_items(namespace_token_counts)
 

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -33,7 +33,7 @@ class SimpleTagger(Model):
                  vocabulary: Vocabulary,
                  embedding_dim: int = 100,
                  hidden_size: int = 200,
-                 num_layers: int = 2):
+                 num_layers: int = 2) -> None:
         super(SimpleTagger, self).__init__()
 
         self.vocabulary = vocabulary
@@ -53,9 +53,10 @@ class SimpleTagger(Model):
                                                            self.num_classes))
         self.sequence_loss = torch.nn.CrossEntropyLoss()
 
-    def forward(self,  # pylint: disable=arguments-differ
+    # pylint: disable=arguments-differ
+    def forward(self,  # type: ignore
                 tokens: torch.LongTensor,
-                tags: torch.LongTensor = None):
+                tags: torch.LongTensor = None) -> Dict[str, torch.Tensor]:
         """
         Parameters
         ----------
@@ -96,6 +97,9 @@ class SimpleTagger(Model):
             output_dict["loss"] = loss
 
         return output_dict
+
+    # pylint: enable=arguments-differ
+
 
     def tag(self, text_field: TextField) -> Dict[str, Any]:
         """

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -100,7 +100,6 @@ class SimpleTagger(Model):
 
     # pylint: enable=arguments-differ
 
-
     def tag(self, text_field: TextField) -> Dict[str, Any]:
         """
         Perform inference on a TextField to produce predicted tags and class probabilities

--- a/allennlp/modules/embeddings.py
+++ b/allennlp/modules/embeddings.py
@@ -52,7 +52,7 @@ class Embedding(torch.nn.Module):
                  max_norm: float = None,
                  norm_type: float = 2.,
                  scale_grad_by_freq: bool = False,
-                 sparse: bool = False):
+                 sparse: bool = False) -> None:
         super(Embedding, self).__init__()
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim

--- a/allennlp/nlp_api.py
+++ b/allennlp/nlp_api.py
@@ -196,7 +196,7 @@ class NlpApi:
                  seq2seq_encoders: Dict[str, Module] = None,
                  seq2seq_encoder_fn: Callable[[], Module] = None,
                  seq2vec_encoders: Dict[str, Module] = None,
-                 seq2vec_encoder_fn: Callable[[], Module] = None):
+                 seq2vec_encoder_fn: Callable[[], Module] = None) -> None:
         self._token_embedders = token_embedders or {}
         self._token_embedder_fn = token_embedder_fn
         self._seq2seq_encoders = seq2seq_encoders or {}

--- a/allennlp/service/server.py
+++ b/allennlp/service/server.py
@@ -1,5 +1,6 @@
-from typing import Dict, Any, Callable
-from flask import Flask, jsonify, Response, request, send_from_directory
+from typing import Any, Callable, Dict
+
+from flask import Flask, Response, jsonify, request, send_from_directory
 
 app = Flask(__name__, static_url_path='')  # pylint: disable=invalid-name
 
@@ -51,6 +52,8 @@ def list_models() -> Response:
     """list the available models"""
     return jsonify({"models": list(models.keys())})
 
+# placeholder models
+# TODO: replace with actual models
 
 def string2string(model_name: str, transform: Callable[[str], str]) -> Model:
     """helper function to wrap string to string transformations"""
@@ -60,9 +63,6 @@ def string2string(model_name: str, transform: Callable[[str], str]) -> Model:
         return {'model_name': model_name, 'input': input_text, 'output': output_text}
     return wrapped
 
-
-# placeholder models
-# TODO: replace with actual models
 models['uppercase'] = string2string('uppercase', lambda s: s.upper())
 models['lowercase'] = string2string('lowercase', lambda s: s.lower())
 models['reverse'] = string2string('reverse', lambda s: ''.join(reversed(s)))

--- a/allennlp/training/model.py
+++ b/allennlp/training/model.py
@@ -19,7 +19,7 @@ class Model(torch.nn.Module):
     optimised during the training process.
     """
 
-    def forward(self, **kwargs) -> Dict[str, torch.Tensor]:  # pylint: disable=arguments-differ
+    def forward(self, *inputs) -> Dict[str, torch.Tensor]:  # pylint: disable=arguments-differ
         """
         Defines the forward pass of the model. In addition, to facilitate easy training,
         this method is designed to compute a loss function defined by a user.

--- a/allennlp/training/model.py
+++ b/allennlp/training/model.py
@@ -19,7 +19,7 @@ class Model(torch.nn.Module):
     optimised during the training process.
     """
 
-    def forward(self, *inputs) -> Dict[str, torch.Tensor]:  # pylint: disable=arguments-differ
+    def forward(self, **kwargs) -> Dict[str, torch.Tensor]:  # pylint: disable=arguments-differ
         """
         Defines the forward pass of the model. In addition, to facilitate easy training,
         this method is designed to compute a loss function defined by a user.


### PR DESCRIPTION
there are 7 or so `# type: ignore` annotations, which are a mix of "maybe this could type check with more work" and "this will never type check". find-in-page for those if you want to see where.

most of the changes are just adding `None` return types to `__init__` methods. the "interesting" parts are:

(1) because of circular references (I think), mypy can't cope with imports from a module's `__init__.py` by its submodules. so when you see me replace things like

```
from . import DatasetReader
```

with 

```
from .dataset_reader import DatasetReader
```

that's why

(2) I don't think there's a way to put a mypy hint and a pylint override on the same line, so I had to change some of the pylint overrides to [turn off] -> code -> [turn on], which is sort of ugly. I apologize.

(3) I found and fixed an actual bug in `adaptive_reader.py` so check that one out (especially if you're not yet sold on mypy)

(4) I made a tiny change to `bucket_reader::_sort_dataset_by_padding` to replace a heterogenous list with a tuple

(5) I changed the two `TokenIndexer::pad_token_sequence` implementations to accept the `TokenType` union and then I used `typing.cast` to force them as `int` or `List[int]`. I'm not thrilled about this, but it was the only way to make the types work.