### PR TITLE
make TokenIndexer generic over token type

### DIFF
--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -2,7 +2,7 @@
 A ``TextField`` represents a string of text, the kind that you might want to represent with
 standard word vectors, or pass through an LSTM.
 """
-from typing import Dict, List, Optional, Union  # pylint: disable=unused-import
+from typing import Dict, List, Optional  # pylint: disable=unused-import
 
 from overrides import overrides
 import numpy

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -2,14 +2,13 @@
 A ``TextField`` represents a string of text, the kind that you might want to represent with
 standard word vectors, or pass through an LSTM.
 """
-from typing import Dict, List, Optional  # pylint: disable=unused-import
+from typing import Dict, List, Optional, Union  # pylint: disable=unused-import
 
 from overrides import overrides
 import numpy
 
 from allennlp.data.fields.sequence_field import SequenceField
 from allennlp.data.vocabulary import Vocabulary
-from allennlp.data.token_indexers.token_indexer import TokenType  # pylint: disable=unused-import
 from allennlp.data.token_indexers import TokenIndexer
 from allennlp.common.checks import ConfigurationError
 
@@ -31,7 +30,7 @@ class TextField(SequenceField):
     def __init__(self, tokens: List[str], token_indexers: List[TokenIndexer]) -> None:
         self._tokens = tokens
         self._token_indexers = token_indexers
-        self._indexed_tokens = None  # type: Optional[List[List[TokenType]]]
+        self._indexed_tokens = None  # type: Optional[List[List[Union[int, List[int]]]]]
 
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -9,9 +9,10 @@ import numpy
 
 from allennlp.data.fields.sequence_field import SequenceField
 from allennlp.data.vocabulary import Vocabulary
-from allennlp.data.token_indexers import TokenIndexer
+from allennlp.data.token_indexers import TokenIndexer, TokenType
 from allennlp.common.checks import ConfigurationError
 
+TokenList = List[TokenType]  # pylint: disable=invalid-name
 
 class TextField(SequenceField):
     """
@@ -30,7 +31,7 @@ class TextField(SequenceField):
     def __init__(self, tokens: List[str], token_indexers: List[TokenIndexer]) -> None:
         self._tokens = tokens
         self._token_indexers = token_indexers
-        self._indexed_tokens = None  # type: Optional[List[List[Union[int, List[int]]]]]
+        self._indexed_tokens = None  # type: Optional[List[TokenList]]
 
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/data/token_indexers/__init__.py
+++ b/allennlp/data/token_indexers/__init__.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from typing import Dict, Type # mypy: disable=unused-import
-from allennlp.data.token_indexers.token_indexer import TokenIndexer
+from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
 from allennlp.data.token_indexers.token_characters_indexer import TokenCharactersIndexer
 from allennlp.data.token_indexers.single_id_token_indexer import SingleIdTokenIndexer
 

--- a/allennlp/data/token_indexers/single_id_token_indexer.py
+++ b/allennlp/data/token_indexers/single_id_token_indexer.py
@@ -5,6 +5,8 @@ from allennlp.common import Params
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
 
+# pylint: disable=no-self-use
+
 
 class SingleIdTokenIndexer(TokenIndexer[int]):
     """
@@ -36,19 +38,19 @@ class SingleIdTokenIndexer(TokenIndexer[int]):
         return vocabulary.get_token_index(token, self.token_namespace)
 
     # @overrides
-    def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):  # pylint: disable=unused-argument,no-self-use
+    def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):  # pylint: disable=unused-argument
         return (num_tokens,)
 
     # @overrides
-    def get_padding_token(self) -> int:  # pylint: disable=no-self-use
+    def get_padding_token(self) -> int:
         return 0
 
     # @overrides
-    def get_padding_lengths(self, token: int) -> Dict[str, int]:  # pylint: disable=unused-argument,no-self-use
+    def get_padding_lengths(self, token: int) -> Dict[str, int]:  # pylint: disable=unused-argument
         return {}
 
     # @overrides
-    def pad_token_sequence(self,                                           # pylint: disable=no-self-use
+    def pad_token_sequence(self,
                            tokens: List[int],
                            desired_num_tokens: int,
                            padding_lengths: Dict[str, int]) -> List[int]:  # pylint: disable=unused-argument

--- a/allennlp/data/token_indexers/single_id_token_indexer.py
+++ b/allennlp/data/token_indexers/single_id_token_indexer.py
@@ -1,14 +1,12 @@
-from typing import Dict, List, cast
-
-from overrides import overrides
+from typing import Dict, List
 
 from allennlp.common.util import pad_sequence_to_length
 from allennlp.common import Params
 from allennlp.data.vocabulary import Vocabulary
-from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
+from allennlp.data.token_indexers.token_indexer import TokenIndexer
 
 
-class SingleIdTokenIndexer(TokenIndexer):
+class SingleIdTokenIndexer(TokenIndexer[int]):
     """
     This :class:`TokenIndexer` represents tokens as single integers.
 
@@ -24,38 +22,37 @@ class SingleIdTokenIndexer(TokenIndexer):
         self.token_namespace = token_namespace
         self.lowercase_tokens = lowercase_tokens
 
-    @overrides
+    # TODO(joelgrus) uncomment these once fix is merged to overrides library
+    # @overrides
     def count_vocab_items(self, token: str, counter: Dict[str, Dict[str, int]]):
         if self.lowercase_tokens:
             token = token.lower()
         counter[self.token_namespace][token] += 1
 
-    @overrides
-    def token_to_indices(self, token: str, vocabulary: Vocabulary) -> TokenType:
+    # @overrides
+    def token_to_indices(self, token: str, vocabulary: Vocabulary) -> int:
         if self.lowercase_tokens:
             token = token.lower()
         return vocabulary.get_token_index(token, self.token_namespace)
 
-    @overrides
-    def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):
+    # @overrides
+    def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):  # pylint: disable=unused-argument,no-self-use
         return (num_tokens,)
 
-    @overrides
-    def get_padding_token(self) -> TokenType:
+    # @overrides
+    def get_padding_token(self) -> int:  # pylint: disable=no-self-use
         return 0
 
-    @overrides
-    def get_padding_lengths(self, token: TokenType) -> Dict[str, int]:
+    # @overrides
+    def get_padding_lengths(self, token: int) -> Dict[str, int]:  # pylint: disable=unused-argument,no-self-use
         return {}
 
-    @overrides
-    def pad_token_sequence(self,
-                           tokens: List[TokenType],
+    # @overrides
+    def pad_token_sequence(self,                                           # pylint: disable=no-self-use
+                           tokens: List[int],
                            desired_num_tokens: int,
-                           padding_lengths: Dict[str, int]) -> List[TokenType]:
-        # cast is runtime no-op that makes mypy happy
-        int_tokens = cast(List[int], tokens)
-        return pad_sequence_to_length(int_tokens, desired_num_tokens)
+                           padding_lengths: Dict[str, int]) -> List[int]:  # pylint: disable=unused-argument
+        return pad_sequence_to_length(tokens, desired_num_tokens)
 
     @classmethod
     def from_params(cls, params: Params):

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -7,6 +7,8 @@ from allennlp.data.vocabulary import Vocabulary
 from allennlp.data.tokenizers import CharacterTokenizer
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
 
+# pylint: disable=no-self-use
+
 
 class TokenCharactersIndexer(TokenIndexer[List[int]]):
     """
@@ -43,19 +45,19 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
         return indices
 
     # @overrides
-    def get_padding_lengths(self, token: List[int]) -> Dict[str, int]:  # pylint: disable=no-self-use
+    def get_padding_lengths(self, token: List[int]) -> Dict[str, int]:
         return {'num_token_characters': len(token)}
 
     # overrides
-    def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):  # pylint: disable=no-self-use
+    def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):
         return (num_tokens, padding_lengths['num_token_characters'])
 
     # @overrides
-    def get_padding_token(self) -> List[int]:  # pylint: disable=no-self-use
+    def get_padding_token(self) -> List[int]:
         return []
 
     # @overrides
-    def pad_token_sequence(self,  # pylint: disable=no-self-use
+    def pad_token_sequence(self,
                            tokens: List[List[int]],
                            desired_num_tokens: int,
                            padding_lengths: Dict[str, int]) -> List[List[int]]:

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -1,16 +1,14 @@
-from typing import Dict, List, cast
+from typing import Dict, List
 import itertools
-
-from overrides import overrides
 
 from allennlp.common.params import Params
 from allennlp.common.util import pad_sequence_to_length
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.data.tokenizers import CharacterTokenizer
-from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
+from allennlp.data.token_indexers.token_indexer import TokenIndexer
 
 
-class TokenCharactersIndexer(TokenIndexer):
+class TokenCharactersIndexer(TokenIndexer[List[int]]):
     """
     This :class:`TokenIndexer` represents tokens as lists of character indices.
 
@@ -31,41 +29,39 @@ class TokenCharactersIndexer(TokenIndexer):
         self.character_namespace = character_namespace
         self.character_tokenizer = character_tokenizer
 
-    @overrides
+    # TODO(joelgrus) uncomment these once fix is merged to overrides library
+    # @overrides
     def count_vocab_items(self, token: str, counter: Dict[str, Dict[str, int]]):
         for character in self.character_tokenizer.tokenize(token):
             counter[self.character_namespace][character] += 1
 
-    @overrides
-    def token_to_indices(self, token: str, vocabulary: Vocabulary) -> TokenType:
+    # @overrides
+    def token_to_indices(self, token: str, vocabulary: Vocabulary) -> List[int]:
         indices = []
         for character in self.character_tokenizer.tokenize(token):
             indices.append(vocabulary.get_token_index(character, self.character_namespace))
         return indices
 
-    @overrides
-    def get_padding_lengths(self, token: TokenType) -> Dict[str, int]:
-        list_token = cast(List[int], token)
-        return {'num_token_characters': len(list_token)}
+    # @overrides
+    def get_padding_lengths(self, token: List[int]) -> Dict[str, int]:  # pylint: disable=no-self-use
+        return {'num_token_characters': len(token)}
 
-    @overrides
-    def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):
+    # overrides
+    def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):  # pylint: disable=no-self-use
         return (num_tokens, padding_lengths['num_token_characters'])
 
-    @overrides
-    def get_padding_token(self) -> TokenType:
+    # @overrides
+    def get_padding_token(self) -> List[int]:  # pylint: disable=no-self-use
         return []
 
-    @overrides
-    def pad_token_sequence(self,
-                           tokens: List[TokenType],
+    # @overrides
+    def pad_token_sequence(self,  # pylint: disable=no-self-use
+                           tokens: List[List[int]],
                            desired_num_tokens: int,
-                           padding_lengths: Dict[str, int]) -> List[TokenType]:
-        # cast is runtime no-op that makes mypy happy
-        list_tokens = cast(List[List[int]], tokens)
-        padded_tokens = pad_sequence_to_length(list_tokens, desired_num_tokens, default_value=lambda: [])
+                           padding_lengths: Dict[str, int]) -> List[List[int]]:
+        padded_tokens = pad_sequence_to_length(tokens, desired_num_tokens, default_value=lambda: [])
         desired_token_length = padding_lengths['num_token_characters']
-        longest_token = max(list_tokens, key=len)
+        longest_token = max(tokens, key=len)
         if desired_token_length > len(longest_token):
             # Since we want to pad to greater than the longest token, we add a
             # "dummy token" to get the speed of itertools.zip_longest.

--- a/allennlp/data/token_indexers/token_indexer.py
+++ b/allennlp/data/token_indexers/token_indexer.py
@@ -1,13 +1,12 @@
-from typing import Dict, List, Union
+from typing import Dict, List, TypeVar, Generic
 
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.common import Params
 
 
-TokenType = Union[int, List[int]]  # pylint: disable=invalid-name
+TokenType = TypeVar("TokenType", int, List[int])  # pylint: disable=invalid-name
 
-
-class TokenIndexer:
+class TokenIndexer(Generic[TokenType]):
     """
     A ``TokenIndexer`` determines how string tokens get represented as arrays of indices in a model.
     This class both converts strings into numerical values, with the help of a :class:`Vocabulary`,
@@ -75,7 +74,7 @@ class TokenIndexer:
         raise NotImplementedError
 
     @classmethod
-    def from_params(cls, params: Params):
+    def from_params(cls, params: Params):  # type: ignore
         from allennlp.data.token_indexers import token_indexers
         choice = params.pop_choice('type', list(token_indexers.keys()), default_to_first_choice=True)
         return token_indexers[choice].from_params(params)


### PR DESCRIPTION
this gets rid of most of the `cast`s in the code and feels like a better design. a few things to note:

(1) as mentioned on slack, this doesn't play well with `overrides`, so I had to comment those out from these files. I left a TODO to re-enable them when we can. I've already submitted a PR to that library, but the maintainer doesn't seem that active on GitHub, so we'll see what happens.
(2) after this change, pylint complains about `no-self-use` all over the place. I can't really see why it wasn't complaining about those already, but I added overrides.
(3) I had to add a `type: ignore` to `TokenIndexer.from_params`. it appears to have something to do with the intersection of Generics, type erasure, and classmethods. I don't think digging into it is the best use of my time right now.
(4) I *think* the intermediate `TokenList` class in text_field does what I want, which is that I want each list to have only a single type, but then I want the collection of them to allow different types.