### PR TITLE
add from_params method for DataIterator subclasses

### DIFF
--- a/allennlp/data/data_iterator.py
+++ b/allennlp/data/data_iterator.py
@@ -59,5 +59,4 @@ class DataIterator(Registrable):
         # to retrieve the scaling function etc.
 
         iterator_type = params.pop_choice("type", cls.list_available())
-        # TODO(joelgrus): implement `from_params` methods on subclasses + change
-        return cls.by_name(iterator_type)(**params.as_dict())  # type: ignore
+        return cls.by_name(iterator_type).from_params(params)

--- a/allennlp/data/iterators/adaptive_iterator.py
+++ b/allennlp/data/iterators/adaptive_iterator.py
@@ -135,45 +135,6 @@ class AdaptiveIterator(BucketIterator):
 
     @classmethod
     def from_params(cls, params: Params) -> 'AdaptiveIterator':
-        """
-        Parameters
-        ----------
-        adaptive_memory_usage_constant : int, required.
-            Only relevant if ``use_adaptive_grouping`` is ``True``.  This is a manually-tuned parameter,
-            specific to a particular model architecture and amount of GPU memory (e.g., if you change
-            the number of hidden layers in your model, this number will need to change). The recommended
-            way to tune this parameter is to (1) use a fixed batch size, with ``biggest_batch_first``
-            set to ``True``, and find out the maximum batch size you can handle on your biggest instances
-            without running out of memory.  Then (2) turn on ``use_adaptive_grouping``, and set this
-            parameter so that you get the right batch size for your biggest instances.  If you set the
-            log level to ``DEBUG`` in ``scripts/run_model.py``, you can see the batch sizes that are
-            computed.
-        padding_memory_scaling: Callable[[Dict[str, Dict[str, int]]], float], required.
-            This function is used for computing the adaptive batch sizes.  We assume that memory usage
-            is a function that looks like this: :math:`M = b * O(p) * c`, where :math:`M` is the memory
-            usage, :math:`b` is the batch size, :math:`c` is some constant that depends on how much GPU
-            memory you have and various model hyperparameters, and :math:`O(p)` is a function outlining
-            how memory usage asymptotically varies with the padding lengths.  Our approach will be to
-            let the user effectively set :math:`\\frac{M}{c}` using the ``adaptive_memory_usage_constant``
-            above. This function specifies :math:`O(p)`, so we can solve for the batch size :math:`b`.
-            The more specific you get in specifying :math:`O(p)` in this function, the better a job we
-            can do in optimizing memory usage.
-        maximum_batch_size : int, optional (default=10000)
-            If we're using adaptive batch sizes, you can use this to be sure you do not create batches
-            larger than this, even if you have enough memory to handle it on your GPU.  You might
-            choose to do this to keep smaller batches because you like the noisier gradient estimates
-            that come from smaller batches, for instance.
-        biggest_batch_first : bool, optional (default=False)
-            See :class:`BucketIterator`.  If this is ``True``, we bypass the adaptive grouping step, so
-            you can tune the ``adaptive_memory_usage_constant``.
-        batch_size : int, optional (default=None)
-            Only used when ``biggest_batch_first`` is ``True``, used for tuning
-            ``adaptive_memory_usage_constant``.
-        sorting_keys : List[Tuple[str, str]]
-            See :class:`BucketIterator`.
-        padding_noise : List[Tuple[str, str]]
-            See :class:`BucketIterator`.
-        """
         adaptive_memory_usage_constant = params.get('adaptive_memory_usage_constant')
         padding_memory_scaling = params.get('padding_memory_scaling')
         maximum_batch_size = params.get('maximum_batch_size', 10000)

--- a/allennlp/data/iterators/adaptive_iterator.py
+++ b/allennlp/data/iterators/adaptive_iterator.py
@@ -5,6 +5,7 @@ import logging
 
 from overrides import overrides
 
+from allennlp.common import Params
 from allennlp.data import Dataset, Instance
 from allennlp.data.data_iterator import DataIterator
 from allennlp.data.iterators.bucket_iterator import BucketIterator
@@ -131,3 +132,61 @@ class AdaptiveIterator(BucketIterator):
             logger.debug("Batch size: %d; padding: %s", len(current_batch), padding_lengths)
         batches.append(current_batch)
         return batches
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'AdaptiveIterator':
+        """
+        Parameters
+        ----------
+        adaptive_memory_usage_constant : int, required.
+            Only relevant if ``use_adaptive_grouping`` is ``True``.  This is a manually-tuned parameter,
+            specific to a particular model architecture and amount of GPU memory (e.g., if you change
+            the number of hidden layers in your model, this number will need to change). The recommended
+            way to tune this parameter is to (1) use a fixed batch size, with ``biggest_batch_first``
+            set to ``True``, and find out the maximum batch size you can handle on your biggest instances
+            without running out of memory.  Then (2) turn on ``use_adaptive_grouping``, and set this
+            parameter so that you get the right batch size for your biggest instances.  If you set the
+            log level to ``DEBUG`` in ``scripts/run_model.py``, you can see the batch sizes that are
+            computed.
+        padding_memory_scaling: Callable[[Dict[str, Dict[str, int]]], float], required.
+            This function is used for computing the adaptive batch sizes.  We assume that memory usage
+            is a function that looks like this: :math:`M = b * O(p) * c`, where :math:`M` is the memory
+            usage, :math:`b` is the batch size, :math:`c` is some constant that depends on how much GPU
+            memory you have and various model hyperparameters, and :math:`O(p)` is a function outlining
+            how memory usage asymptotically varies with the padding lengths.  Our approach will be to
+            let the user effectively set :math:`\\frac{M}{c}` using the ``adaptive_memory_usage_constant``
+            above. This function specifies :math:`O(p)`, so we can solve for the batch size :math:`b`.
+            The more specific you get in specifying :math:`O(p)` in this function, the better a job we
+            can do in optimizing memory usage.
+        maximum_batch_size : int, optional (default=10000)
+            If we're using adaptive batch sizes, you can use this to be sure you do not create batches
+            larger than this, even if you have enough memory to handle it on your GPU.  You might
+            choose to do this to keep smaller batches because you like the noisier gradient estimates
+            that come from smaller batches, for instance.
+        biggest_batch_first : bool, optional (default=False)
+            See :class:`BucketIterator`.  If this is ``True``, we bypass the adaptive grouping step, so
+            you can tune the ``adaptive_memory_usage_constant``.
+        batch_size : int, optional (default=None)
+            Only used when ``biggest_batch_first`` is ``True``, used for tuning
+            ``adaptive_memory_usage_constant``.
+        sorting_keys : List[Tuple[str, str]]
+            See :class:`BucketIterator`.
+        padding_noise : List[Tuple[str, str]]
+            See :class:`BucketIterator`.
+        """
+        adaptive_memory_usage_constant = params.get('adaptive_memory_usage_constant')
+        padding_memory_scaling = params.get('padding_memory_scaling')
+        maximum_batch_size = params.get('maximum_batch_size', 10000)
+        biggest_batch_first = params.get('biggest_batch_first', False)
+        batch_size = params.get('batch_size', None)
+        sorting_keys = params.get('sorting_keys', None)
+        padding_noise = params.get('sorting_noise', 0.2)
+        params.assert_empty(cls.__name__)
+
+        return cls(adaptive_memory_usage_constant=adaptive_memory_usage_constant,
+                   padding_memory_scaling=padding_memory_scaling,
+                   maximum_batch_size=maximum_batch_size,
+                   biggest_batch_first=biggest_batch_first,
+                   batch_size=batch_size,
+                   sorting_keys=sorting_keys,
+                   padding_noise=padding_noise)

--- a/allennlp/data/iterators/adaptive_iterator.py
+++ b/allennlp/data/iterators/adaptive_iterator.py
@@ -135,13 +135,13 @@ class AdaptiveIterator(BucketIterator):
 
     @classmethod
     def from_params(cls, params: Params) -> 'AdaptiveIterator':
-        adaptive_memory_usage_constant = params.get('adaptive_memory_usage_constant')
-        padding_memory_scaling = params.get('padding_memory_scaling')
-        maximum_batch_size = params.get('maximum_batch_size', 10000)
-        biggest_batch_first = params.get('biggest_batch_first', False)
-        batch_size = params.get('batch_size', None)
-        sorting_keys = params.get('sorting_keys', None)
-        padding_noise = params.get('sorting_noise', 0.2)
+        adaptive_memory_usage_constant = params.pop('adaptive_memory_usage_constant')
+        padding_memory_scaling = params.pop('padding_memory_scaling')
+        maximum_batch_size = params.pop('maximum_batch_size', 10000)
+        biggest_batch_first = params.pop('biggest_batch_first', False)
+        batch_size = params.pop('batch_size', None)
+        sorting_keys = params.pop('sorting_keys', None)
+        padding_noise = params.pop('sorting_noise', 0.2)
         params.assert_empty(cls.__name__)
 
         return cls(adaptive_memory_usage_constant=adaptive_memory_usage_constant,

--- a/allennlp/data/iterators/basic_iterator.py
+++ b/allennlp/data/iterators/basic_iterator.py
@@ -3,6 +3,7 @@ import random
 
 from overrides import overrides
 
+from allennlp.common import Params
 from allennlp.common.util import group_by_count
 from allennlp.data import DataIterator, Dataset, Instance
 
@@ -31,3 +32,15 @@ class BasicIterator(DataIterator):
         # are None, which is how group_by_count pads non-complete batches.
         grouped_instances[-1] = [instance for instance in grouped_instances[-1] if instance is not None]
         return grouped_instances
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'BasicIterator':
+        """
+        Parameters
+        ----------
+        batch_size : int, optional, (default = 32)
+            The size of each batch of instances yielded when calling the iterator.
+        """
+        batch_size = params.pop('batch_size', 32)
+        params.assert_empty(cls.__name__)
+        return cls(batch_size=batch_size)

--- a/allennlp/data/iterators/basic_iterator.py
+++ b/allennlp/data/iterators/basic_iterator.py
@@ -35,12 +35,6 @@ class BasicIterator(DataIterator):
 
     @classmethod
     def from_params(cls, params: Params) -> 'BasicIterator':
-        """
-        Parameters
-        ----------
-        batch_size : int, optional, (default = 32)
-            The size of each batch of instances yielded when calling the iterator.
-        """
         batch_size = params.pop('batch_size', 32)
         params.assert_empty(cls.__name__)
         return cls(batch_size=batch_size)

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -3,6 +3,7 @@ import random
 
 from overrides import overrides
 
+from allennlp.common import Params
 from allennlp.common.util import add_noise_to_dict_values
 from allennlp.data import Dataset, Instance
 from allennlp.data.data_iterator import DataIterator
@@ -104,3 +105,48 @@ class BucketIterator(BasicIterator):
             instances_with_lengths.append(instance_with_lengths)
         instances_with_lengths.sort(key=lambda x: x[0])
         return Dataset([instance_with_lengths[-1] for instance_with_lengths in instances_with_lengths])
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'BucketIterator':
+        """
+        Parameters
+        ----------
+        sorting_keys : List[Tuple[str, str]], optional (default = [])
+            To bucket inputs into batches, we want to group the instances by padding length, so that we
+            minimize the amount of padding necessary per batch. In order to do this, we need to know
+            which fields need what type of padding, and in what order.
+
+            For example:
+            ``[("sentence1", "num_tokens"),
+            ("sentence2", "num_tokens"),
+            ("sentence1", "num_token_characters")]``
+
+            would sort a dataset first by the "num_tokens" of the "sentence1" field, then by the
+            "num_tokens" of the "sentence2" field, and finally by the "num_token_characters" of the
+            "sentence1" field.  TODO(mattg): we should have some documentation somewhere that gives the
+            standard padding keys used by different fields.
+
+            By default, the list of sorting keys is empty, meaning the dataset won't be sorted and
+            batches will just be padded using the max lengths of all fields requiring padding
+            calculated per batch.
+        padding_noise : float, optional (default=.1)
+            When sorting by padding length, we add a bit of noise to the lengths, so that the sorting
+            isn't deterministic.  This parameter determines how much noise we add, as a percentage of
+            the actual padding value for each instance.
+        biggest_batch_first : bool, optional (default=False)
+            This is largely for testing, to see how large of a batch you can safely use with your GPU.
+            This will let you try out the largest batch that you have in the data `first`, so that if
+            you're going to run out of memory, you know it early, instead of waiting through the whole
+            epoch to find out at the end that you're going to crash.
+        batch_size : int, optional, (default = 32)
+            The size of each batch of instances yielded when calling the iterator.
+        """
+        sorting_keys = params.pop('sorting_keys', [])
+        padding_noise = params.pop('padding_noise', 0.1)
+        biggest_batch_first = params.pop('biggest_batch_first', False)
+        batch_size = params.pop('batch_size', 32)
+        params.assert_empty(cls.__name__)
+        return cls(sorting_keys=sorting_keys,
+                   padding_noise=padding_noise,
+                   biggest_batch_first=biggest_batch_first,
+                   batch_size=batch_size)

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -108,39 +108,6 @@ class BucketIterator(BasicIterator):
 
     @classmethod
     def from_params(cls, params: Params) -> 'BucketIterator':
-        """
-        Parameters
-        ----------
-        sorting_keys : List[Tuple[str, str]], optional (default = [])
-            To bucket inputs into batches, we want to group the instances by padding length, so that we
-            minimize the amount of padding necessary per batch. In order to do this, we need to know
-            which fields need what type of padding, and in what order.
-
-            For example:
-            ``[("sentence1", "num_tokens"),
-            ("sentence2", "num_tokens"),
-            ("sentence1", "num_token_characters")]``
-
-            would sort a dataset first by the "num_tokens" of the "sentence1" field, then by the
-            "num_tokens" of the "sentence2" field, and finally by the "num_token_characters" of the
-            "sentence1" field.  TODO(mattg): we should have some documentation somewhere that gives the
-            standard padding keys used by different fields.
-
-            By default, the list of sorting keys is empty, meaning the dataset won't be sorted and
-            batches will just be padded using the max lengths of all fields requiring padding
-            calculated per batch.
-        padding_noise : float, optional (default=.1)
-            When sorting by padding length, we add a bit of noise to the lengths, so that the sorting
-            isn't deterministic.  This parameter determines how much noise we add, as a percentage of
-            the actual padding value for each instance.
-        biggest_batch_first : bool, optional (default=False)
-            This is largely for testing, to see how large of a batch you can safely use with your GPU.
-            This will let you try out the largest batch that you have in the data `first`, so that if
-            you're going to run out of memory, you know it early, instead of waiting through the whole
-            epoch to find out at the end that you're going to crash.
-        batch_size : int, optional, (default = 32)
-            The size of each batch of instances yielded when calling the iterator.
-        """
         sorting_keys = params.pop('sorting_keys', [])
         padding_noise = params.pop('padding_noise', 0.1)
         biggest_batch_first = params.pop('biggest_batch_first', False)

--- a/tests/data/iterators/adaptive_iterator_test.py
+++ b/tests/data/iterators/adaptive_iterator_test.py
@@ -1,4 +1,8 @@
 # pylint: disable=no-self-use,invalid-name
+from pytest import raises
+
+from allennlp.common import Params
+from allennlp.common.checks import ConfigurationError
 from allennlp.data.iterators import AdaptiveIterator
 from tests.data.iterators.basic_iterator_test import IteratorTest
 
@@ -37,3 +41,20 @@ class TestAdaptiveIterator(IteratorTest):
         assert grouped_instances == [[self.instances[3]],
                                      [self.instances[0], self.instances[1]],
                                      [self.instances[4], self.instances[2]]]
+
+    def test_from_params(self):
+        # pylint: disable=protected-access
+        params = Params({})
+        # not all params have default values
+        with raises(ConfigurationError):
+            _ = AdaptiveIterator.from_params(params)
+
+        param_dict = {
+                "adaptive_memory_usage_constant": 10,
+                "padding_memory_scaling": lambda x: 2.4
+        }
+
+        iterator = AdaptiveIterator.from_params(Params(param_dict))
+        assert iterator._adaptive_memory_usage_constant == 10
+        assert iterator._padding_memory_scaling({}) == 2.4
+        assert iterator._maximum_batch_size == 10000

--- a/tests/data/iterators/basic_iterator_test.py
+++ b/tests/data/iterators/basic_iterator_test.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-self-use,invalid-name
 from typing import List
 
+from allennlp.common import Params
 from allennlp.data import Dataset, Instance, Vocabulary
 from allennlp.data.fields import TextField
 from allennlp.data.iterators import BasicIterator
@@ -68,3 +69,13 @@ class TestBasicIterator(IteratorTest):
         assert grouped_instances == [[self.instances[0], self.instances[1]],
                                      [self.instances[2], self.instances[3]],
                                      [self.instances[4]]]
+
+    def test_from_params(self):
+        # pylint: disable=protected-access
+        params = Params({})
+        iterator = BasicIterator.from_params(params)
+        assert iterator._batch_size == 32  # default value
+
+        params = Params({"batch_size": 10})
+        iterator = BasicIterator.from_params(params)
+        assert iterator._batch_size == 10

--- a/tests/data/iterators/bucket_iterator_test.py
+++ b/tests/data/iterators/bucket_iterator_test.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-self-use,invalid-name
+from allennlp.common import Params
 from allennlp.data.iterators import BucketIterator
 from tests.data.iterators.basic_iterator_test import IteratorTest
 
@@ -21,3 +22,26 @@ class TestBucketIterator(IteratorTest):
         assert grouped_instances == [[self.instances[3]],
                                      [self.instances[0], self.instances[1]],
                                      [self.instances[4], self.instances[2]]]
+
+    def test_from_params(self):
+        # pylint: disable=protected-access
+        params = Params({})
+        iterator = BucketIterator.from_params(params)
+        assert iterator._sorting_keys == []
+        assert iterator._padding_noise == 0.1
+        assert not iterator._biggest_batch_first
+        assert iterator._batch_size == 32
+
+        sorting_keys = [("s1", "nt"), ("s2", "nt2")]
+        params = Params({
+                "sorting_keys": sorting_keys,
+                "padding_noise": 0.5,
+                "biggest_batch_first": True,
+                "batch_size": 100
+        })
+
+        iterator = BucketIterator.from_params(params)
+        assert iterator._sorting_keys == sorting_keys
+        assert iterator._padding_noise == 0.5
+        assert iterator._biggest_batch_first
+        assert iterator._batch_size == 100


### PR DESCRIPTION
pretty straightforward. two things I don't like about this

(1) the documentation is copied twice
(2) the default values for the parameters are specified twice (in both `__init__` and `from_params`). 

I considered two approaches to the second issue.
(2a) pull those out into shared constants (but nowhere else in the code does that)
(2b) give `Params.as_dict` two extra named parameters `required_fields` and `optional_fields`. If you pass those in, then it must be the case that 

```
required_fields \subset params.keys() \subset required_fields.union(optional_fields)
```

and then every `from_params` method could just just call

```
cls(**params.to_dict(required_fields=[...], optional_fields=[...]))
```

of course there's also always

(2c) do nothing

thoughts?