### PR TITLE
Add the root of the project to PYTHONPATH in run.py.

### DIFF
--- a/allennlp/run
+++ b/allennlp/run
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir))))
+
 from allennlp.commands.main import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
This obviates the need to `export PYTHONPATH=.`.