### PR TITLE
Fix masked max in BiDAF

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -57,8 +57,8 @@ def pad_sequence_to_length(sequence: List,
             padded_sequence.insert(0, default_value())
     return padded_sequence
 
-A = TypeVar('A')
 
+A = TypeVar('A')
 def add_noise_to_dict_values(dictionary: Dict[A, float], noise_param: float) -> Dict[A, float]:
     """
     Returns a new dictionary with noise added to every key in ``dictionary``.  The noise is
@@ -71,40 +71,6 @@ def add_noise_to_dict_values(dictionary: Dict[A, float], noise_param: float) -> 
         noise = random.uniform(-noise_value, noise_value)
         new_dict[key] = value + noise
     return new_dict
-
-
-def clean_layer_name(input_name: str,
-                     strip_right_of_last_backslash: bool = True,
-                     strip_numerics_after_underscores: bool = True):
-    """
-    There exist cases when layer names need to be concatenated in order to create new, unique
-    layer names. However, the indices added to layer names designating the ith output of calling
-    the layer cannot occur within a layer name apart from at the end, so this utility function
-    removes these.
-
-    Parameters
-    ----------
-
-    input_name: str, required
-        A Keras layer name.
-    strip_right_of_last_backslash: bool, optional, (default = True)
-        Should we strip anything past the last backslash in the name?
-        This can be useful for controlling scopes.
-    strip_numerics_after_underscores: bool, optional, (default = True)
-        If there are numerical values after an underscore at the end of the layer name,
-        this flag specifies whether or not to remove them.
-    """
-    # Always strip anything after :, as these will be numerical
-    # counts of the number of times the layer has been called,
-    # which cannot be included in a layer name.
-    if ':' in input_name:
-        input_name = input_name.split(':')[0]
-    if '/' in input_name and strip_right_of_last_backslash:
-        input_name = input_name.rsplit('/', 1)[0]
-    if input_name.split('_')[-1].isdigit() and strip_numerics_after_underscores:
-        input_name = '_'.join(input_name.split('_')[:-1])
-
-    return input_name
 
 
 def namespace_match(pattern: str, namespace: str):

--- a/allennlp/models/bidaf.py
+++ b/allennlp/models/bidaf.py
@@ -142,10 +142,11 @@ class BidirectionalAttentionFlow(Model):
         passage_question_vectors = util.weighted_sum(encoded_question, passage_question_attention)
 
         print("passage question similarity:", passage_question_similarity)
-        # We replace masked values with -inf here, so they don't affect the max below.
+        # We replace masked values with something really negative here, so they don't affect the
+        # max below.
         masked_similarity = util.replace_masked_values(passage_question_similarity,
                                                        question_mask.unsqueeze(1),
-                                                       float('-inf'))
+                                                       -1e7)
         # Shape: (batch_size, passage_length)
         question_passage_similarity = masked_similarity.max(dim=-1)[0].squeeze(-1)
         print("quesiton passage similarity:", question_passage_similarity)

--- a/allennlp/models/bidaf.py
+++ b/allennlp/models/bidaf.py
@@ -141,7 +141,6 @@ class BidirectionalAttentionFlow(Model):
         # Shape: (batch_size, passage_length, encoding_dim)
         passage_question_vectors = util.weighted_sum(encoded_question, passage_question_attention)
 
-        print("passage question similarity:", passage_question_similarity)
         # We replace masked values with something really negative here, so they don't affect the
         # max below.
         masked_similarity = util.replace_masked_values(passage_question_similarity,
@@ -149,7 +148,6 @@ class BidirectionalAttentionFlow(Model):
                                                        -1e7)
         # Shape: (batch_size, passage_length)
         question_passage_similarity = masked_similarity.max(dim=-1)[0].squeeze(-1)
-        print("quesiton passage similarity:", question_passage_similarity)
         # Shape: (batch_size, passage_length)
         question_passage_attention = util.masked_softmax(question_passage_similarity, passage_mask)
         # Shape: (batch_size, encoding_dim)

--- a/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
+++ b/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
@@ -49,7 +49,6 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
             is_bidirectional = self._module.bidirectional
         except AttributeError:
             is_bidirectional = False
-        print("is bidirectional: ", is_bidirectional)
         return self._module.hidden_size * (2 if is_bidirectional else 1)
 
     def forward(self,  # pylint: disable=arguments-differ

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -1,7 +1,8 @@
 from typing import Dict, List, Optional, Union
+
+import numpy
 import torch
 from torch.autograd import Variable
-import numpy
 
 from allennlp.common.checks import ConfigurationError
 
@@ -344,3 +345,19 @@ def sequence_cross_entropy_with_logits(logits: torch.FloatTensor,
         num_non_empty_sequences = ((weights.sum(1) > 0).float().sum() + 1e-13)
         return per_batch_loss.sum() / num_non_empty_sequences
     return per_batch_loss.squeeze(1)
+
+
+def replace_masked_values(tensor: Variable, mask: Variable, replace_with: float) -> Variable:
+    """
+    Replaces all masked values in ``tensor`` with ``replace_with``.  ``mask`` must be broadcastable
+    to the same shape as ``tensor``.
+    """
+    # We'll build a tensor of the same shape as `tensor`, subtract away masked values, then add
+    # back in the `replace_with` value.
+    # TODO(mattg): use broadcasting here when it's available in pytorch 0.2.
+    while mask.dim() < tensor.dim():
+        mask = mask.unsqueeze(-1)
+    one_minus_mask = 1.0 - mask.expand_as(tensor)
+    values_to_subtract = tensor * one_minus_mask
+    values_to_add = replace_with * one_minus_mask
+    return tensor - values_to_subtract + values_to_add

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -351,12 +351,15 @@ def replace_masked_values(tensor: Variable, mask: Variable, replace_with: float)
     """
     Replaces all masked values in ``tensor`` with ``replace_with``.  ``mask`` must be broadcastable
     to the same shape as ``tensor``.
+
+    Until pytorch 0.2 is released, we require that ``tensor.dim() == mask.dim()``.  Otherwise we
+    won't know which dimensions of the mask to unsqueeze.
     """
     # We'll build a tensor of the same shape as `tensor`, subtract away masked values, then add
     # back in the `replace_with` value.
     # TODO(mattg): use broadcasting here when it's available in pytorch 0.2.
-    while mask.dim() < tensor.dim():
-        mask = mask.unsqueeze(-1)
+    if tensor.dim() != mask.dim():
+        raise ConfigurationError("tensor.dim() (%d) != mask.dim() (%d)" % (tensor.dim(), mask.dim()))
     one_minus_mask = 1.0 - mask.expand_as(tensor)
     values_to_subtract = tensor * one_minus_mask
     values_to_add = replace_with * one_minus_mask

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -460,13 +460,6 @@ class TestNnUtil(AllenNlpTestCase):
         # Batch has one completely padded row, so divide by 4.
         assert loss.data.numpy() == vector_loss.data.sum() / 4
 
-    def test_replace_masked_values_replaces_masked_values_with_minus_inf(self):
-        tensor = Variable(torch.FloatTensor([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]]))
-        mask = Variable(torch.FloatTensor([[1, 1, 0]]))
-        inf = float('-inf')
-        replaced = replace_masked_values(tensor, mask.unsqueeze(-1), inf).data.numpy()
-        assert_almost_equal(replaced, [[[1, 2, 3, 4], [5, 6, 7, 8], [inf, inf, inf, inf]]])
-
     def test_replace_masked_values_replaces_masked_values_with_finite_value(self):
         tensor = Variable(torch.FloatTensor([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]]))
         mask = Variable(torch.FloatTensor([[1, 1, 0]]))

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -461,14 +461,14 @@ class TestNnUtil(AllenNlpTestCase):
         assert loss.data.numpy() == vector_loss.data.sum() / 4
 
     def test_replace_masked_values_replaces_masked_values_with_minus_inf(self):
-        tensor = torch.FloatTensor([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]])
-        mask = torch.FloatTensor([[1, 1, 0]])
+        tensor = Variable(torch.FloatTensor([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]]))
+        mask = Variable(torch.FloatTensor([[1, 1, 0]]))
         inf = float('-inf')
-        replaced = replace_masked_values(tensor, mask, inf).data.numpy()
+        replaced = replace_masked_values(tensor, mask.unsqueeze(-1), inf).data.numpy()
         assert_almost_equal(replaced, [[[1, 2, 3, 4], [5, 6, 7, 8], [inf, inf, inf, inf]]])
 
     def test_replace_masked_values_replaces_masked_values_with_finite_value(self):
-        tensor = torch.FloatTensor([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]])
-        mask = torch.FloatTensor([[1, 1, 0]])
-        replaced = replace_masked_values(tensor, mask, 2).data.numpy()
+        tensor = Variable(torch.FloatTensor([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]]))
+        mask = Variable(torch.FloatTensor([[1, 1, 0]]))
+        replaced = replace_masked_values(tensor, mask.unsqueeze(-1), 2).data.numpy()
         assert_almost_equal(replaced, [[[1, 2, 3, 4], [5, 6, 7, 8], [2, 2, 2, 2]]])

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -11,16 +11,16 @@ from allennlp.nn.util import arrays_to_variables
 from allennlp.nn.util import get_lengths_from_binary_sequence_mask
 from allennlp.nn.util import get_text_field_mask
 from allennlp.nn.util import last_dim_softmax
-from allennlp.nn.util import masked_softmax
 from allennlp.nn.util import masked_log_softmax
+from allennlp.nn.util import masked_softmax
+from allennlp.nn.util import replace_masked_values
+from allennlp.nn.util import sequence_cross_entropy_with_logits
 from allennlp.nn.util import sort_batch_by_length
 from allennlp.nn.util import viterbi_decode
 from allennlp.nn.util import weighted_sum
-from allennlp.nn.util import sequence_cross_entropy_with_logits
 
 
-class TestTensor(AllenNlpTestCase):
-
+class TestNnUtil(AllenNlpTestCase):
     def test_arrays_to_variables_handles_recursion(self):
 
         array_dict = {
@@ -459,3 +459,16 @@ class TestTensor(AllenNlpTestCase):
                                                          batch_average=False)
         # Batch has one completely padded row, so divide by 4.
         assert loss.data.numpy() == vector_loss.data.sum() / 4
+
+    def test_replace_masked_values_replaces_masked_values_with_minus_inf(self):
+        tensor = torch.FloatTensor([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]])
+        mask = torch.FloatTensor([[1, 1, 0]])
+        inf = float('-inf')
+        replaced = replace_masked_values(tensor, mask, inf).data.numpy()
+        assert_almost_equal(replaced, [[[1, 2, 3, 4], [5, 6, 7, 8], [inf, inf, inf, inf]]])
+
+    def test_replace_masked_values_replaces_masked_values_with_finite_value(self):
+        tensor = torch.FloatTensor([[[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]])
+        mask = torch.FloatTensor([[1, 1, 0]])
+        replaced = replace_masked_values(tensor, mask, 2).data.numpy()
+        assert_almost_equal(replaced, [[[1, 2, 3, 4], [5, 6, 7, 8], [2, 2, 2, 2]]])


### PR DESCRIPTION
There was a TODO in BiDAF to replace masked values before doing a max.  This fixes that issue.