### PR TITLE
fix int64 serialization + add tests

### DIFF
--- a/allennlp/service/servable/models/bidaf.py
+++ b/allennlp/service/servable/models/bidaf.py
@@ -29,6 +29,11 @@ class BidafServable(Servable):
                             token_indexers=self.token_indexers)
 
         output_dict = self.model.predict_span(question, passage)
+
+        # best_span is np.int64, we need to get pure python types so we can serialize them
+        output_dict["best_span"] = [x.item() for x in output_dict["best_span"]]
+
+        # similarly, the probability tensors must be converted to lists
         output_dict["span_start_probs"] = output_dict["span_start_probs"].tolist()
         output_dict["span_end_probs"] = output_dict["span_end_probs"].tolist()
 

--- a/tests/service/servables/servable_test.py
+++ b/tests/service/servables/servable_test.py
@@ -11,8 +11,7 @@ class TestServable(Servable):
 
 class TestApp(TestCase):
 
-    def setUp(self):
-        self.default_models = ServableCollection.default()
+    default_models = ServableCollection.default()
 
     def test_list_available(self):
         available = self.default_models.list_available()

--- a/tests/service/server_flask_test.py
+++ b/tests/service/server_flask_test.py
@@ -7,12 +7,10 @@ from allennlp.common.testing import AllenNlpTestCase
 
 class TestApp(AllenNlpTestCase):
 
-    def setUp(self):
-        super().setUp()
-        app = make_app()
-        app.testing = True
-        app.servables = ServableCollection.default()
-        self.client = app.test_client()
+    app = make_app()
+    app.testing = True
+    app.servables = ServableCollection.default()
+    client = app.test_client()
 
     # TODO(joelgrus): this is a fragile test
     def test_list_models(self):

--- a/tests/service/server_sanic_test.py
+++ b/tests/service/server_sanic_test.py
@@ -8,12 +8,10 @@ from allennlp.common.testing import AllenNlpTestCase
 
 class TestApp(AllenNlpTestCase):
 
-    def setUp(self):
-        super().setUp()
-        app = make_app()
-        app.servables = ServableCollection.default()
-        app.testing = True
-        self.client = app.test_client
+    app = make_app()
+    app.servables = ServableCollection.default()
+    app.testing = True
+    client = app.test_client
 
     def test_list_models(self):
         _, response = self.client.get("/models")

--- a/tests/service/server_sanic_test.py
+++ b/tests/service/server_sanic_test.py
@@ -25,3 +25,26 @@ class TestApp(AllenNlpTestCase):
                                        json={"input": "broken"})
         assert response.status == 400
         assert "unknown model" in response.text and "bogus_model" in response.text
+
+    def test_bidaf(self):
+        _, response = self.client.post("/predict/bidaf",
+                                       json={"passage": "the super bowl was played in seattle",
+                                             "question": "where was the super bowl played?"})
+        assert response.status == 200
+        results = json.loads(response.text)
+        assert "best_span" in results
+
+    def test_snli(self):
+        _, response = self.client.post("/predict/snli",
+                                       json={"premise": "the super bowl was played in seattle",
+                                             "hypothesis": "the super bowl was played in ohio"})
+        assert response.status == 200
+        results = json.loads(response.text)
+        assert "label_probs" in results
+
+    def test_srl(self):
+        _, response = self.client.post("/predict/srl",
+                                       json={"sentence": "the super bowl was played in seattle"})
+        assert response.status == 200
+        results = json.loads(response.text)
+        assert "verbs" in results


### PR DESCRIPTION
at some point the `best_span` from bidaf became a tuple of `np.int64`, which the json serializer chokes on. so now I convert it to python types.

I also added tests to catch this sort of error.