### PR TITLE
Make service tests only construct the app when they are run

### DIFF
--- a/tests/service/server_sanic_test.py
+++ b/tests/service/server_sanic_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-self-use,invalid-name
 import json
+import os
 
 from allennlp.service.server_sanic import make_app
 from allennlp.service.predictors import load_predictors
@@ -8,10 +9,23 @@ from allennlp.common.testing import AllenNlpTestCase
 
 class TestApp(AllenNlpTestCase):
 
-    app = make_app()
-    app.predictors = load_predictors()
-    app.testing = True
-    client = app.test_client
+    client = None
+
+    def setUp(self):
+        super(TestApp, self).setUp()
+        if self.client is None:
+            app = make_app()
+            app.predictors = load_predictors()
+            app.testing = True
+            self.client = app.test_client
+
+    def tearDown(self):
+        super(TestApp, self).tearDown()
+        try:
+            os.remove('access.log')
+            os.remove('error.log')
+        except FileNotFoundError:
+            pass
 
     def test_list_models(self):
         _, response = self.client.get("/models")


### PR DESCRIPTION
Hiding the app construction inside of `setUp` makes it so that I can still run `py.test -k SomeOtherThing` and have those tests run, even if the app construction fails for whatever reason (as it was, I would get errors on test _collection_, which would make it so the tests I wanted to focus on wouldn't even get run).  It also makes it so that log files are only created when `setUp` is run, and so `tearDown` will be able to clean them up, so we can remove the logging redirection that we had.

I saved the relevant variables to the class, so that, even though app initialization is only run in `setUp`, it doesn't get run more than once.