### PR TITLE
add caching utils

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -118,7 +118,7 @@ ignored-modules=
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
+ignored-classes=optparse.Values,thread._local,_thread._local,responses
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -1,0 +1,62 @@
+import os
+import base64
+import logging
+from urllib.parse import urlparse
+
+import requests
+import tqdm
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+CACHE_ROOT = os.path.expanduser(os.path.join('~', '.allennlp'))
+DATASET_CACHE = os.path.join(CACHE_ROOT, "datasets")
+
+def url_to_filename(url: str) -> str:
+    url_bytes = url.encode('utf-8')
+    b64_bytes = base64.b64encode(url_bytes)
+    return b64_bytes.decode('utf-8')
+
+def filename_to_url(filename: str) -> str:
+    filename_bytes = filename.encode('utf-8')
+    url_bytes = base64.b64decode(filename_bytes)
+    return url_bytes.decode('utf-8')
+
+def cached_path(maybe_uri: str, cache_dir: str = DATASET_CACHE) -> str:
+    """
+    Given something that might be a URI (or might be a local path),
+    determine which. If it's a URI, download the file and cache it, and
+    return the path to the cached file. If it's already a local path,
+    make sure it exists and then return it.
+    """
+    parsed = urlparse(maybe_uri)
+
+    if parsed.scheme in ('http', 'https'):
+        return get_from_cache(maybe_uri, cache_dir)
+    elif parsed.scheme == '' and os.path.exists(maybe_uri):
+        return maybe_uri
+    elif parsed.scheme == '':
+        raise FileNotFoundError("file {} not found".format(maybe_uri))
+    else:
+        raise ValueError("unable to parse {} as a URL or as a local path".format(maybe_uri))
+
+
+# TODO(joelgrus): do we want to do checksums or anything like that?
+def get_from_cache(url: str, cache_dir: str = DATASET_CACHE) -> str:
+    """
+    Given a URL, look for the corresponding dataset in the local cache.
+    If it's not there, download it. Then return the path to the cached file.
+    """
+    os.makedirs(cache_dir, exist_ok=True)
+    path = os.path.join(cache_dir, url_to_filename(url))
+
+    if not os.path.exists(path):
+        logger.info("%s not found in cache, downloading to %s", url, path)
+        req = requests.get(url, stream=True)
+        progress = tqdm.tqdm(unit="B", total=int(req.headers['Content-Length']))
+        with open(path, 'wb') as output_file:
+            for chunk in req.iter_content(chunk_size=1024):
+                if chunk: # filter out keep-alive new chunks
+                    progress.update(len(chunk))
+                    output_file.write(chunk)
+
+    return path

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -12,32 +12,42 @@ CACHE_ROOT = os.path.expanduser(os.path.join('~', '.allennlp'))
 DATASET_CACHE = os.path.join(CACHE_ROOT, "datasets")
 
 def url_to_filename(url: str) -> str:
+    """
+    Converts a url into a filename in a reversible way.
+    """
     url_bytes = url.encode('utf-8')
     b64_bytes = base64.b64encode(url_bytes)
     return b64_bytes.decode('utf-8')
 
 def filename_to_url(filename: str) -> str:
+    """
+    Recovers the the url from the encoded filename.
+    """
     filename_bytes = filename.encode('utf-8')
     url_bytes = base64.b64decode(filename_bytes)
     return url_bytes.decode('utf-8')
 
-def cached_path(maybe_uri: str, cache_dir: str = DATASET_CACHE) -> str:
+def cached_path(url_or_filename: str, cache_dir: str = DATASET_CACHE) -> str:
     """
-    Given something that might be a URI (or might be a local path),
-    determine which. If it's a URI, download the file and cache it, and
+    Given something that might be a URL (or might be a local path),
+    determine which. If it's a URL, download the file and cache it, and
     return the path to the cached file. If it's already a local path,
-    make sure it exists and then return it.
+    make sure the file exists and then return the path.
     """
-    parsed = urlparse(maybe_uri)
+    parsed = urlparse(url_or_filename)
 
     if parsed.scheme in ('http', 'https'):
-        return get_from_cache(maybe_uri, cache_dir)
-    elif parsed.scheme == '' and os.path.exists(maybe_uri):
-        return maybe_uri
+        # URL, so get it from the cache (downloading if necessary)
+        return get_from_cache(url_or_filename, cache_dir)
+    elif parsed.scheme == '' and os.path.exists(url_or_filename):
+        # File, and it exists.
+        return url_or_filename
     elif parsed.scheme == '':
-        raise FileNotFoundError("file {} not found".format(maybe_uri))
+        # File, but it doesn't exist.
+        raise FileNotFoundError("file {} not found".format(url_or_filename))
     else:
-        raise ValueError("unable to parse {} as a URL or as a local path".format(maybe_uri))
+        # Something unknown
+        raise ValueError("unable to parse {} as a URL or as a local path".format(url_or_filename))
 
 
 # TODO(joelgrus): do we want to do checksums or anything like that?

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,9 @@ argparse
 # Used to read the NewsQA CSV and output a clean one.
 pandas==0.19.2
 
+# Used for downloading datasets over HTTP
+requests>=2.18
+
 # progress bars in data cleaning scripts
 tqdm
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -28,6 +28,9 @@ codecov
 # Required to run sanic tests
 aiohttp
 
+# Required to mock out `requests` calls
+responses>=0.7
+
 #### DOC-RELATED PACKAGES ####
 
 # Builds our documentation.

--- a/tests/common/file_utils_test.py
+++ b/tests/common/file_utils_test.py
@@ -1,0 +1,96 @@
+# pylint: disable=no-self-use,invalid-name
+import os
+import pytest
+
+import responses
+
+from allennlp.common.file_utils import url_to_filename, filename_to_url, get_from_cache, cached_path
+from allennlp.common.testing import AllenNlpTestCase
+
+
+class TestFileUtils(AllenNlpTestCase):
+
+    def test_url_to_filename(self):
+        for url in ['http://allenai.org', 'http://allennlp.org',
+                    'https://www.google.com', 'http://pytorch.org']:
+            filename = url_to_filename(url)
+            assert "http" not in filename
+            back_to_url = filename_to_url(filename)
+            assert back_to_url == url
+
+    @responses.activate
+    def test_get_from_cache(self):
+        url = 'http://fake.datastore.com/glove.txt.gz'
+
+        with open('tests/fixtures/glove.6B.100d.sample.txt.gz', 'rb') as glove:
+            glove_bytes = glove.read()
+
+        # Mock response for the datastore url that returns glove vectors
+        responses.add(
+                responses.GET,
+                url,
+                body=glove_bytes,
+                status=200,
+                content_type='application/gzip',
+                stream=True,
+                headers={'Content-Length': str(len(glove_bytes))}
+        )
+
+        filename = get_from_cache(url, cache_dir=self.TEST_DIR)
+
+        # We should have made a HTTP call and cached the result
+        assert filename == os.path.join(self.TEST_DIR, url_to_filename(url))
+        assert len(responses.calls) == 1
+
+        # And the cached file should have the correct contents
+        with open(filename, 'rb') as cached_file:
+            assert cached_file.read() == glove_bytes
+
+        # A second call to `get_from_cache` should not make a HTTP call
+        # but should just return the cached filename.
+        filename2 = get_from_cache(url, cache_dir=self.TEST_DIR)
+        assert filename2 == filename
+        assert len(responses.calls) == 1
+
+        with open(filename2, 'rb') as cached_file:
+            assert cached_file.read() == glove_bytes
+
+
+    @responses.activate
+    def test_cached_path(self):
+        url = 'http://fake.datastore.com/glove.txt.gz'
+        glove_file = 'tests/fixtures/glove.6B.100d.sample.txt.gz'
+
+        with open(glove_file, 'rb') as glove:
+            glove_bytes = glove.read()
+
+        # Mock response for the datastore url that returns glove vectors
+        responses.add(
+                responses.GET,
+                url,
+                body=glove_bytes,
+                status=200,
+                content_type='application/gzip',
+                stream=True,
+                headers={'Content-Length': str(len(glove_bytes))}
+        )
+
+        # non-existent file
+        with pytest.raises(FileNotFoundError):
+            filename = cached_path("tests/fixtures/does_not_exist/fake_file.tar.gz")
+
+        # unparsable URI
+        with pytest.raises(ValueError):
+            filename = cached_path("fakescheme://path/to/fake/file.tar.gz")
+
+        # existing file as path
+        assert cached_path(glove_file) == glove_file
+
+        # caches urls
+        filename = cached_path(url, cache_dir=self.TEST_DIR)
+
+        assert len(responses.calls) == 1
+        assert filename == os.path.join(self.TEST_DIR, url_to_filename(url))
+
+        with open(filename, 'rb') as cached_file:
+            assert cached_file.read() == glove_bytes

--- a/tests/common/file_utils_test.py
+++ b/tests/common/file_utils_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-self-use,invalid-name
 import os
+import pathlib
 import pytest
 
 import responses
@@ -15,6 +16,7 @@ class TestFileUtils(AllenNlpTestCase):
                     'https://www.google.com', 'http://pytorch.org']:
             filename = url_to_filename(url)
             assert "http" not in filename
+            pathlib.Path(os.path.join(self.TEST_DIR, filename)).touch()
             back_to_url = filename_to_url(filename)
             assert back_to_url == url
 


### PR DESCRIPTION
these fileutils will (once they're integrated elsewhere) allow us to specify URLs instead of files, resolving them to a local cache and downloading only if necessary.

this will allow us to point default configs to datasets / glove vectors on s3 instead of fixed paths.

we can also use this with `run evaluate` and so on