### PR TITLE
pin pyhocon to 0.3.35 (until they fix ConfigTree.pop())

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ h5py
 scikit-learn
 
 # Parameter parsing.
-pyhocon
+pyhocon==0.3.35
 
 # Type checking for python
 typing


### PR DESCRIPTION
this fixes the issue that we see on Docker and in new installs.

I'm sending a PR to pyhocon to fix their bug as well.