### PR TITLE
don't manually add the config file to the params for archiving

### DIFF
--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -58,7 +58,7 @@ class AllenNlpTestCase(TestCase):  # pylint: disable=too-many-public-methods
     def get_trainer_params(self, additional_arguments=None):
         params = Params({})
         params['save_models'] = False
-        params['serialization_prefix'] = self.MODEL_FILE
+        params['serialization_dir'] = self.MODEL_FILE
         params['num_epochs'] = 1
 
         if additional_arguments:

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -19,7 +19,7 @@ Archive = NamedTuple("Archive", [("model", Model), ("config", Params)])
 _CONFIG_NAME = "config.json"
 _WEIGHTS_NAME = "weights.th"
 
-def archive_model(serialization_prefix: str,
+def archive_model(serialization_dir: str,
                   weights: str = _DEFAULT_WEIGHTS) -> None:
     """
     Archives the model weights, its training configuration, and its
@@ -27,26 +27,26 @@ def archive_model(serialization_prefix: str,
 
     Parameters
     ----------
-    serialization_prefix: ``str``
+    serialization_dir: ``str``
         The directory where the weights and vocabulary are written out.
     weights: ``str``, optional (default=_DEFAULT_WEIGHTS)
         Which weights file to include in the archive. The default is ``best.th``.
     """
-    weights_file = os.path.join(serialization_prefix, weights)
+    weights_file = os.path.join(serialization_dir, weights)
     if not os.path.exists(weights_file):
         logger.error("weights file %s does not exist, unable to archive model", weights_file)
         return
 
-    config_file = os.path.join(serialization_prefix, "_model_params.json")
+    config_file = os.path.join(serialization_dir, "model_params.json")
     if not os.path.exists(config_file):
         logger.error("config file %s does not exist, unable to archive model", config_file)
 
-    archive_file = os.path.join(serialization_prefix, "model.tar.gz")
+    archive_file = os.path.join(serialization_dir, "model.tar.gz")
     logger.info("archiving weights and vocabulary to %s", archive_file)
     with tarfile.open(archive_file, 'w:gz') as archive:
         archive.add(config_file, arcname=_CONFIG_NAME)
         archive.add(weights_file, arcname=_WEIGHTS_NAME)
-        archive.add(os.path.join(serialization_prefix, "vocabulary"),
+        archive.add(os.path.join(serialization_dir, "vocabulary"),
                     arcname="vocabulary")
 
 def load_archive(archive_file: str, cuda_device: int = -1) -> Archive:
@@ -76,7 +76,7 @@ def load_archive(archive_file: str, cuda_device: int = -1) -> Archive:
     # Instantiate model. Use a duplicate of the config, as it will get consumed.
     model = Model.load(config.duplicate(),
                        weights_file=os.path.join(tempdir, _WEIGHTS_NAME),
-                       serialization_prefix=tempdir,
+                       serialization_dir=tempdir,
                        cuda_device=cuda_device)
 
     # Clean up temp dir

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -20,7 +20,6 @@ _CONFIG_NAME = "config.json"
 _WEIGHTS_NAME = "weights.th"
 
 def archive_model(serialization_prefix: str,
-                  config_file: str,
                   weights: str = _DEFAULT_WEIGHTS) -> None:
     """
     Archives the model weights, its training configuration, and its
@@ -30,8 +29,6 @@ def archive_model(serialization_prefix: str,
     ----------
     serialization_prefix: ``str``
         The directory where the weights and vocabulary are written out.
-    config_file: ``str``
-        The path to the experiment configuration file used to train the model.
     weights: ``str``, optional (default=_DEFAULT_WEIGHTS)
         Which weights file to include in the archive. The default is ``best.th``.
     """
@@ -39,6 +36,10 @@ def archive_model(serialization_prefix: str,
     if not os.path.exists(weights_file):
         logger.error("weights file %s does not exist, unable to archive model", weights_file)
         return
+
+    config_file = os.path.join(serialization_prefix, "_model_params.json")
+    if not os.path.exists(config_file):
+        logger.error("config file %s does not exist, unable to archive model", config_file)
 
     archive_file = os.path.join(serialization_prefix, "model.tar.gz")
     logger.info("archiving weights and vocabulary to %s", archive_file)

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -104,7 +104,7 @@ class Model(torch.nn.Module, Registrable):
     @classmethod
     def load(cls,
              config: Params,
-             serialization_prefix: str = None,
+             serialization_dir: str = None,
              weights_file: str = None,
              cuda_device: int = -1) -> 'Model':
         """
@@ -117,8 +117,8 @@ class Model(torch.nn.Module, Registrable):
             The configuration that was used to train the model. It should definitely
             have a `model` section, and should probably have a `trainer` section
             as well.
-        serialization_prefix: str = None
-            By default we look at `config['trainer']['serialization_prefix']` to
+        serialization_dir: str = None
+            By default we look at `config['trainer']['serialization_dir']` to
             get the path to the serialized model, but you can override that
             value here.
         weights_file: str = None
@@ -136,15 +136,15 @@ class Model(torch.nn.Module, Registrable):
             vocabulary and the trained weights.
         """
         trainer_config = config.get("trainer", {})
-        serialization_prefix = (serialization_prefix or
-                                trainer_config.get('serialization_prefix'))
-        if serialization_prefix is None:
-            raise ConfigurationError('serialization_prefix must be specified')
+        serialization_dir = (serialization_dir or
+                             trainer_config.get('serialization_dir'))
+        if serialization_dir is None:
+            raise ConfigurationError('serialization_dir must be specified')
 
-        weights_file = weights_file or os.path.join(serialization_prefix, _DEFAULT_WEIGHTS)
+        weights_file = weights_file or os.path.join(serialization_dir, _DEFAULT_WEIGHTS)
 
         # Load vocabulary from file
-        vocab_dir = os.path.join(serialization_prefix, 'vocabulary')
+        vocab_dir = os.path.join(serialization_dir, 'vocabulary')
         vocab = Vocabulary.from_files(vocab_dir)
 
         model_params = config.get('model')

--- a/allennlp/service/predictors/predictor.py
+++ b/allennlp/service/predictors/predictor.py
@@ -12,7 +12,8 @@ from allennlp.models.archival import Archive
 DEFAULT_PREDICTORS = {
         'srl': 'semantic-role-labeling',
         'decomposable_attention': 'textual-entailment',
-        'bidaf': 'machine-comprehension'
+        'bidaf': 'machine-comprehension',
+        'simple_tagger': 'simple-tagger'
 }
 
 class Predictor(Registrable):

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -28,7 +28,7 @@ class Trainer:
                  patience: int = 2,
                  validation_metric: str = "-loss",
                  num_epochs: int = 20,
-                 serialization_prefix: Optional[str] = None,
+                 serialization_dir: Optional[str] = None,
                  cuda_device: int = -1,
                  grad_norm: Optional[float] = None,
                  grad_clipping: Optional[float] = None,
@@ -58,7 +58,7 @@ class Trainer:
             is an increasing or decreasing function.
         num_epochs : int, optional (default = 20)
             Number of training epochs.
-        serialization_prefix : str, optional (default=None)
+        serialization_dir : str, optional (default=None)
             Path to directory for saving and loading model files. Models will not be saved if
             this parameter is not passed.
         cuda_device : int, optional (default = -1)
@@ -86,7 +86,7 @@ class Trainer:
 
         self._patience = patience
         self._num_epochs = num_epochs
-        self._serialization_prefix = serialization_prefix
+        self._serialization_dir = serialization_dir
         self._cuda_device = cuda_device
         self._grad_norm = grad_norm
         self._grad_clipping = grad_clipping
@@ -105,12 +105,12 @@ class Trainer:
     def train(self) -> None:
         epoch_counter = 0
         # Resume from serialization path if it contains a saved model.
-        if self._serialization_prefix is not None:
+        if self._serialization_dir is not None:
             # Set up tensorboard logging.
-            train_log = SummaryWriter(os.path.join(self._serialization_prefix, "log", "train"))
-            validation_log = SummaryWriter(os.path.join(self._serialization_prefix, "log", "validation"))
+            train_log = SummaryWriter(os.path.join(self._serialization_dir, "log", "train"))
+            validation_log = SummaryWriter(os.path.join(self._serialization_dir, "log", "validation"))
             if any(["model_state_epoch_" in x
-                    for x in os.listdir(self._serialization_prefix)]):
+                    for x in os.listdir(self._serialization_dir)]):
                 logger.info("Loading model from checkpoint.")
                 epoch_counter = self._restore_checkpoint()
 
@@ -193,7 +193,7 @@ class Trainer:
                 message_template = "Training %s : %3f    Validation %s : %3f "
                 for name, value in metrics.items():
                     logger.info(message_template, name, value, name, val_metrics[name])
-                    if self._serialization_prefix:
+                    if self._serialization_dir:
                         train_log.add_scalar(name, value, epoch)
                         validation_log.add_scalar(name, val_metrics[name], epoch)
 
@@ -214,15 +214,15 @@ class Trainer:
                     is_best_so_far = this_epoch == min(validation_metric_per_epoch)
                 else:
                     is_best_so_far = this_epoch == max(validation_metric_per_epoch)
-                if self._serialization_prefix:
+                if self._serialization_dir:
                     self._save_checkpoint(epoch, is_best=is_best_so_far)
             else:
                 message_template = "Training %s : %3f "
                 for name, value in metrics.items():
                     logger.info(message_template, name, value)
-                    if self._serialization_prefix:
+                    if self._serialization_dir:
                         train_log.add_scalar(name, value, epoch)
-                if self._serialization_prefix:
+                if self._serialization_dir:
                     self._save_checkpoint(epoch)
 
     def _description_from_metrics(self, metrics: Dict[str, float]) -> str:
@@ -242,21 +242,21 @@ class Trainer:
             be copied to a "best.th" file. The value of this flag should
             be based on some validation metric computed by your model.
         """
-        model_path = os.path.join(self._serialization_prefix, "model_state_epoch_{}.th".format(epoch))
+        model_path = os.path.join(self._serialization_dir, "model_state_epoch_{}.th".format(epoch))
         model_state = self._model.state_dict()
         torch.save(model_state, model_path)
 
         training_state = {'epoch': epoch, 'optimizer': self._optimizer.state_dict()}
-        torch.save(training_state, os.path.join(self._serialization_prefix,
+        torch.save(training_state, os.path.join(self._serialization_dir,
                                                 "training_state_epoch_{}.th".format(epoch)))
         if is_best:
             logger.info("Best validation performance so far. "
-                        "Copying weights to %s/best.th'.", self._serialization_prefix)
-            shutil.copyfile(model_path, os.path.join(self._serialization_prefix, "best.th"))
+                        "Copying weights to %s/best.th'.", self._serialization_dir)
+            shutil.copyfile(model_path, os.path.join(self._serialization_dir, "best.th"))
 
     def _restore_checkpoint(self) -> int:
         """
-        Restores a model from a serialization_prefix to the last saved checkpoint.
+        Restores a model from a serialization_dir to the last saved checkpoint.
         This includes an epoch count and optimizer state, which is serialized separately
         from  model parameters. This function should only be used to continue training -
         if you wish to load a model for inference/load parts of a model into a new
@@ -268,17 +268,17 @@ class Trainer:
         epoch: int
             The epoch at which to resume training.
         """
-        if not self._serialization_prefix:
-            raise ConfigurationError("serialization_prefix not specified - cannot "
+        if not self._serialization_dir:
+            raise ConfigurationError("serialization_dir not specified - cannot "
                                      "restore a model without a directory path.")
 
-        serialization_files = os.listdir(self._serialization_prefix)
+        serialization_files = os.listdir(self._serialization_dir)
         model_checkpoints = [x for x in serialization_files if "model_state_epoch" in x]
         epoch_to_load = max([int(x.split("model_state_epoch_")[-1].strip(".th")) for x in model_checkpoints])
 
-        model_path = os.path.join(self._serialization_prefix,
+        model_path = os.path.join(self._serialization_dir,
                                   "model_state_epoch_{}.th".format(epoch_to_load))
-        training_state_path = os.path.join(self._serialization_prefix,
+        training_state_path = os.path.join(self._serialization_dir,
                                            "training_state_epoch_{}.th".format(epoch_to_load))
 
         model_state = torch.load(model_path, map_location=device_mapping(self._cuda_device))
@@ -300,7 +300,7 @@ class Trainer:
         patience = params.pop("patience", 2)
         validation_metric = params.pop("validation_metric", "-loss")
         num_epochs = params.pop("num_epochs", 20)
-        serialization_prefix = params.pop("serialization_prefix", None)
+        serialization_dir = params.pop("serialization_dir", None)
         cuda_device = params.pop("cuda_device", -1)
         grad_norm = params.pop("grad_norm", None)
         grad_clipping = params.pop("grad_clipping", None)
@@ -311,7 +311,7 @@ class Trainer:
                        patience=patience,
                        validation_metric=validation_metric,
                        num_epochs=num_epochs,
-                       serialization_prefix=serialization_prefix,
+                       serialization_dir=serialization_dir,
                        cuda_device=cuda_device,
                        grad_norm=grad_norm,
                        grad_clipping=grad_clipping,

--- a/experiment_config/bidaf.json
+++ b/experiment_config/bidaf.json
@@ -103,7 +103,7 @@
     "grad_norm": 1.0,
     "patience": 20,
     "validation_metric": "+full_span_acc",
-    "serialization_prefix": "bidaf_with_spacy",
+    "serialization_dir": "bidaf_with_spacy",
     "cuda_device": 0,
     "no_tqdm": true
   }

--- a/experiment_config/decomposable_attention.json
+++ b/experiment_config/decomposable_attention.json
@@ -54,6 +54,6 @@
     "num_epochs": 20,
     "patience": 5,
     "cuda_device": 0,
-    "serialization_prefix" : "tmp_output"
+    "serialization_dir" : "tmp_output"
   }
 }

--- a/experiment_config/semantic_role_labeler.json
+++ b/experiment_config/semantic_role_labeler.json
@@ -52,7 +52,7 @@
     "grad_clipping": 1.0,
     "patience": 20,
     "validation_metric": "+f1-measure-overall",
-    "serialization_prefix": "/net/efs/aristo/allennlp/srl/luheng-xavier",
+    "serialization_dir": "/net/efs/aristo/allennlp/srl/luheng-xavier",
     "cuda_device": 0
   }
 }

--- a/scripts/regenerate_archived_models.py
+++ b/scripts/regenerate_archived_models.py
@@ -10,11 +10,11 @@ from allennlp.models.archival import _CONFIG_NAME, _WEIGHTS_NAME
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 def generate_archive(config_file: str,
-                     serialization_prefix: str,
+                     serialization_dir: str,
                      weights_file: str = 'best.th',
                      archive_name: str = 'model.tar.gz',
                      exist_ok: bool = False) -> None:
-    archive_file = os.path.join(serialization_prefix, archive_name)
+    archive_file = os.path.join(serialization_dir, archive_name)
 
     if os.path.exists(archive_file):
         if exist_ok:
@@ -27,8 +27,8 @@ def generate_archive(config_file: str,
 
     with tarfile.open(archive_file, 'w:gz') as archive:
         archive.add(config_file, arcname=_CONFIG_NAME)
-        archive.add(os.path.join(serialization_prefix, weights_file), arcname=_WEIGHTS_NAME)
-        archive.add(os.path.join(serialization_prefix, "vocabulary"), arcname="vocabulary")
+        archive.add(os.path.join(serialization_dir, weights_file), arcname=_WEIGHTS_NAME)
+        archive.add(os.path.join(serialization_dir, "vocabulary"), arcname="vocabulary")
 
 if __name__ == "__main__":
     generate_archive("tests/fixtures/bidaf/experiment.json",

--- a/scripts/train_fixtures.py
+++ b/scripts/train_fixtures.py
@@ -12,15 +12,15 @@ from allennlp.common import Params
 
 def train_fixture(config_file: str) -> None:
     params = Params.from_file(config_file)
-    serialization_prefix = params.get("trainer").get("serialization_prefix")
+    serialization_dir = params.get("trainer").get("serialization_dir")
 
     # train the model
     train_model_from_file(config_file)
 
     # remove unnecessary files
-    shutil.rmtree(os.path.join(serialization_prefix, "log"))
+    shutil.rmtree(os.path.join(serialization_dir, "log"))
 
-    for filename in glob.glob(os.path.join(serialization_prefix, "*")):
+    for filename in glob.glob(os.path.join(serialization_dir, "*")):
         if filename.endswith(".log") or filename.endswith(".json") or re.search(r"epoch_[0-9]+\.th$", filename):
             os.remove(filename)
 
@@ -30,15 +30,15 @@ def train_fixture_gpu(config_file: str) -> None:
     params["trainer"]["cuda_device"] = 0
 
     # train this one to a tempdir
-    serialization_prefix = params["trainer"]["serialization_prefix"]
+    serialization_dir = params["trainer"]["serialization_dir"]
     tempdir = tempfile.gettempdir()
-    params["trainer"]["serialization_prefix"] = tempdir
+    params["trainer"]["serialization_dir"] = tempdir
 
     train_model(params)
 
     # now copy back the weights and and archived model
-    shutil.copy(os.path.join(tempdir, "best.th"), os.path.join(serialization_prefix, "best_gpu.th"))
-    shutil.copy(os.path.join(tempdir, "model.tar.gz"), os.path.join(serialization_prefix, "model_gpu.tar.gz"))
+    shutil.copy(os.path.join(tempdir, "best.th"), os.path.join(serialization_dir, "best_gpu.th"))
+    shutil.copy(os.path.join(tempdir, "model.tar.gz"), os.path.join(serialization_dir, "model_gpu.tar.gz"))
 
 
 if __name__ == "__main__":

--- a/tests/commands/train_test.py
+++ b/tests/commands/train_test.py
@@ -1,11 +1,9 @@
 # pylint: disable=invalid-name,no-self-use
 import argparse
-import os
-import json
 
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.commands.train import train_model, add_subparser, _train_model_from_args, _CONFIG_FILE_KEY
+from allennlp.commands.train import train_model, add_subparser, _train_model_from_args
 
 
 class TestTrain(AllenNlpTestCase):
@@ -37,11 +35,6 @@ class TestTrain(AllenNlpTestCase):
                 }
         })
 
-        # Write params to file for archiving purposes
-        config_file = os.path.join(self.TEST_DIR, "config.json")
-        with open(config_file, 'w') as outfile:
-            json.dump(params.as_dict(), outfile)
-        params[_CONFIG_FILE_KEY] = config_file
         train_model(params)
 
     def test_train_args(self):

--- a/tests/commands/train_test.py
+++ b/tests/commands/train_test.py
@@ -31,7 +31,7 @@ class TestTrain(AllenNlpTestCase):
                 "optimizer": "adam",
                 "trainer": {
                         "num_epochs": 2,
-                        "serialization_prefix": self.TEST_DIR
+                        "serialization_dir": self.TEST_DIR
                 }
         })
 

--- a/tests/fixtures/bidaf/experiment.json
+++ b/tests/fixtures/bidaf/experiment.json
@@ -83,7 +83,7 @@
     "grad_norm": 100.0,
     "grad_clipping": 100,
     "patience" : 12,
-    "serialization_prefix" : "tests/fixtures/bidaf/serialization",
+    "serialization_dir" : "tests/fixtures/bidaf/serialization",
     "cuda_device" : -1
   }
 }

--- a/tests/fixtures/decomposable_attention/experiment.json
+++ b/tests/fixtures/decomposable_attention/experiment.json
@@ -62,6 +62,6 @@
     "num_epochs": 20,
     "patience": 5,
     "cuda_device": -1,
-    "serialization_prefix" : "tests/fixtures/decomposable_attention/serialization"
+    "serialization_dir" : "tests/fixtures/decomposable_attention/serialization"
   }
 }

--- a/tests/fixtures/srl/experiment.json
+++ b/tests/fixtures/srl/experiment.json
@@ -42,7 +42,7 @@
     "num_epochs": 1,
     "grad_norm": 1.0,
     "patience": 500,
-    "serialization_prefix": "tests/fixtures/srl/serialization",
+    "serialization_dir": "tests/fixtures/srl/serialization",
     "cuda_device": -1
   }
 }

--- a/tests/models/archival_test.py
+++ b/tests/models/archival_test.py
@@ -1,12 +1,11 @@
 # pylint: disable=invalid-name
 import os
-import json
 
 import torch
 
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.commands.train import train_model, _CONFIG_FILE_KEY
+from allennlp.commands.train import train_model
 from allennlp.models.archival import load_archive
 
 
@@ -40,13 +39,6 @@ class ArchivalTest(AllenNlpTestCase):
                         "serialization_prefix": self.TEST_DIR
                 }
         })
-
-        # write out config file
-        config_file = os.path.join(self.TEST_DIR, "config.json")
-        with open(config_file, 'w') as outfile:
-            json.dump(params.as_dict(), outfile)
-
-        params[_CONFIG_FILE_KEY] = config_file
 
         # `train_model` should create an archive
         model = train_model(params)

--- a/tests/models/archival_test.py
+++ b/tests/models/archival_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=invalid-name
 import os
+import copy
 
 import torch
 
@@ -40,6 +41,9 @@ class ArchivalTest(AllenNlpTestCase):
                 }
         })
 
+        # copy params, since they'll get consumed during training
+        params_copy = copy.deepcopy(params.as_dict())
+
         # `train_model` should create an archive
         model = train_model(params)
 
@@ -64,3 +68,7 @@ class ArchivalTest(AllenNlpTestCase):
 
         assert vocab._token_to_index == vocab2._token_to_index  # pylint: disable=protected-access
         assert vocab._index_to_token == vocab2._index_to_token  # pylint: disable=protected-access
+
+        # check that params are the same
+        params2 = archive.config
+        assert params2.as_dict() == params_copy

--- a/tests/models/archival_test.py
+++ b/tests/models/archival_test.py
@@ -37,7 +37,7 @@ class ArchivalTest(AllenNlpTestCase):
                 "optimizer": "adam",
                 "trainer": {
                         "num_epochs": 2,
-                        "serialization_prefix": self.TEST_DIR
+                        "serialization_dir": self.TEST_DIR
                 }
         })
 

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -46,11 +46,11 @@ class TestTrainer(AllenNlpTestCase):
     def test_train_driver_can_resume_training(self):
         trainer = Trainer(self.model, self.optimizer,
                           self.iterator, self.dataset,
-                          num_epochs=1, serialization_prefix=self.TEST_DIR)
+                          num_epochs=1, serialization_dir=self.TEST_DIR)
         trainer.train()
         new_trainer = Trainer(self.model, self.optimizer,
                               self.iterator, self.dataset,
-                              num_epochs=3, serialization_prefix=self.TEST_DIR)
+                              num_epochs=3, serialization_dir=self.TEST_DIR)
 
         epoch = new_trainer._restore_checkpoint()  # pylint: disable=protected-access
         assert epoch == 0
@@ -64,5 +64,5 @@ class TestTrainer(AllenNlpTestCase):
         with pytest.raises(ConfigurationError):
             trainer = Trainer(FakeModel(), self.optimizer,
                               self.iterator, self.dataset,
-                              num_epochs=2, serialization_prefix=self.TEST_DIR)
+                              num_epochs=2, serialization_dir=self.TEST_DIR)
             trainer.train()

--- a/tutorials/getting_started/getting_started.md
+++ b/tutorials/getting_started/getting_started.md
@@ -101,7 +101,7 @@ you might care about the `trainer` section, which specifies how we want to train
   "trainer": {
     "num_epochs": 40,
     "patience": 10,
-    "serialization_prefix": "/tmp/tutorials/getting_started",
+    "serialization_dir": "/tmp/tutorials/getting_started",
     "cuda_device": -1
   }
 ```
@@ -112,7 +112,7 @@ so this training should take about 40, unless it stops early. `patience`
 controls the early stopping -- if our validation metric doesn't improve for
 this many epochs, training halts.
 
-The `serialization_prefix` is the path where the model's vocabulary and checkpointed weights will be saved. And if you have a GPU you can change `cuda_device` to 0 to use it.
+The `serialization_dir` is the directory where the model's vocabulary and checkpointed weights will be saved. And if you have a GPU you can change `cuda_device` to 0 to use it.
 
 Change any of those if you want to, and then run
 

--- a/tutorials/getting_started/simple_tagger.json
+++ b/tutorials/getting_started/simple_tagger.json
@@ -50,7 +50,7 @@
   "trainer": {
     "num_epochs": 40,
     "patience": 10,
-    "serialization_prefix": "/tmp/tutorials/getting_started",
+    "serialization_dir": "/tmp/tutorials/getting_started",
     "cuda_device": -1
   }
 }


### PR DESCRIPTION
this was clunky and it turns out unnecessary.

we're already serializing it as `_model_params.json`, so we can just use that. also fixes a bug where we were popping off the trainer params before serializing.

(there is a stray change in here to add a default `Predictor` for the simple tagger, I need that for the Tutorial, and it was so minor that it didn't seem worth the work to split it out into its own PR)