### PR TITLE
deep_qa -> allennlp

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -94,9 +94,9 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/deep_qa.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/allennlp.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/deep_qa.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/allennlp.qhc"
 
 .PHONY: applehelp
 applehelp:
@@ -113,8 +113,8 @@ devhelp:
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/deep_qa"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/deep_qa"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/allennlp"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/allennlp"
 	@echo "# devhelp"
 
 .PHONY: epub

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -229,4 +229,4 @@ def linkcode_resolve(domain, info):
         linespec = ""
 
     filename = info['module'].replace('.', '/')
-    return "http://github.com/allenai/deep_qa/blob/master/%s.py%s" % (filename, linespec)
+    return "http://github.com/allenai/allennlp/blob/master/%s.py%s" % (filename, linespec)


### PR DESCRIPTION
the important change is the one to `conf.py`, right now all of the "source" links in the docs point to `allennlp/deep_qa/whatever`