### PR TITLE
Add default initialization to linear and bilinear similarity functions

### DIFF
--- a/allennlp/modules/similarity_functions/bilinear.py
+++ b/allennlp/modules/similarity_functions/bilinear.py
@@ -36,6 +36,11 @@ class BilinearSimilarity(SimilarityFunction):
         self._weight_matrix = Parameter(torch.Tensor(tensor_1_dim, tensor_2_dim))
         self._bias = Parameter(torch.Tensor(1))
         self._activation = activation
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        torch.nn.init.xavier_uniform(self._weight_matrix)
+        self._bias.data.fill_(0)
 
     @overrides
     def forward(self, tensor_1: torch.Tensor, tensor_2: torch.Tensor) -> torch.Tensor:

--- a/allennlp/modules/similarity_functions/linear.py
+++ b/allennlp/modules/similarity_functions/linear.py
@@ -1,3 +1,5 @@
+import math
+
 from overrides import overrides
 import torch
 from torch.nn.parameter import Parameter
@@ -53,6 +55,12 @@ class LinearSimilarity(SimilarityFunction):
         self._weight_vector = Parameter(torch.Tensor(combined_dim))
         self._bias = Parameter(torch.Tensor(1))
         self._activation = activation
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        std = 6.0 / math.sqrt(self._weight_vector.size(0))
+        self._weight_vector.data.uniform_(-std, std)
+        self._bias.data.fill_(0)
 
     @overrides
     def forward(self, tensor_1: torch.Tensor, tensor_2: torch.Tensor) -> torch.Tensor:

--- a/allennlp/modules/similarity_functions/linear.py
+++ b/allennlp/modules/similarity_functions/linear.py
@@ -58,7 +58,7 @@ class LinearSimilarity(SimilarityFunction):
         self.reset_parameters()
 
     def reset_parameters(self):
-        std = 6.0 / math.sqrt(self._weight_vector.size(0))
+        std = math.sqrt(6 / (self._weight_vector.size(0) + 1))
         self._weight_vector.data.uniform_(-std, std)
         self._bias.data.fill_(0)
 

--- a/experiment_config/bidaf.json
+++ b/experiment_config/bidaf.json
@@ -67,7 +67,7 @@
       "bidirectional": true,
       "input_size": 1400,
       "hidden_size": 100,
-      "num_layers": 2,
+      "num_layers": 1,
       "dropout": 0.2
     },
     "dropout": 0.2


### PR DESCRIPTION
And I fixed a small BiDAF parameter bug while I was at it.