### PR TITLE
Respect initializer ordering

### DIFF
--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -114,7 +114,8 @@ Registrable._registry[Initializer] = {  # pylint: disable=protected-access
         "kaiming_uniform": _initializer_wrapper(torch.nn.init.kaiming_uniform),
         "sparse": _initializer_wrapper(torch.nn.init.sparse),
         "eye": _initializer_wrapper(torch.nn.init.eye),
-        "block_orthogonal": _initializer_wrapper(block_orthogonal)
+        "block_orthogonal": _initializer_wrapper(block_orthogonal),
+        "none": _initializer_wrapper(lambda x: x)
 }
 
 
@@ -147,17 +148,15 @@ class InitializerApplicator:
         """
         logger.info("Initializing parameters")
         unused_regexes = set([initializer[0] for initializer in self._initializers])
-        uninitialized_parameters = set()
+        uninitialized_parameters = set([name for name, _ in module.named_parameters()])
         # Store which initialisers were applied to which parameters.
-        for name, parameter in module.named_parameters():
-            for initializer_regex, initializer in self._initializers:
-                if re.search(initializer_regex, name):
+        for initializer_regex, initializer in self._initializers:
+            for name, parameter in module.named_parameters():
+                if name in uninitialized_parameters and re.search(initializer_regex, name):
                     logger.info("Initializing %s using %s intitializer", name, initializer_regex)
                     initializer(parameter)
                     unused_regexes.discard(initializer_regex)
-                    break
-            else:  # no break
-                uninitialized_parameters.add(name)
+                    uninitialized_parameters.discard(name)
         for regex in unused_regexes:
             logger.warning("Did not use initialization regex that was passed: %s", regex)
         logger.info("Done initializing parameters; the following parameters are using their "


### PR DESCRIPTION
This will respect the order of initializers given in the parameter file, also adds a `"none"` to skip initializing certain parameters. I used this in the messy init [here](https://github.com/allenai/allennlp/compare/master...OyvindTafjord:rnn_forget_init) which tries to do xavier_uniform for all the weights and zero for most biases, we'll probably want something more elegant than that though... 