### PR TITLE
Add best span string as output to `predict_span`

### DIFF
--- a/allennlp/models/bidaf.py
+++ b/allennlp/models/bidaf.py
@@ -254,6 +254,7 @@ class BidirectionalAttentionFlow(Model):
         span_start_probs : numpy.ndarray
         span_end_probs : numpy.ndarray
         best_span : (int, int)
+        best_span_str : str
         """
         instance = Instance({'question': question, 'passage': passage})
         instance.index_fields(self.vocab)
@@ -266,11 +267,14 @@ class BidirectionalAttentionFlow(Model):
         span_start_logits = output_dict["span_start_logits"]
         span_end_logits = output_dict["span_end_logits"]
         best_span = self._get_best_span(span_start_logits, span_end_logits)
+        best_span = tuple(best_span.data.squeeze(0).numpy())
+        best_span_str = ' '.join(passage.tokens[best_span[0]:best_span[1]])
 
         return {
                 "span_start_probs": output_dict["span_start_probs"].data.squeeze(0).numpy(),
                 "span_end_probs": output_dict["span_end_probs"].data.squeeze(0).numpy(),
-                "best_span": tuple(best_span.data.squeeze(0).numpy()),
+                "best_span": best_span,
+                "best_span_str": best_span_str,
                 }
 
     @staticmethod

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -56,7 +56,8 @@ class TestPredict(TestCase):
 
         assert len(results) == 2
         for result in results:
-            assert set(result.keys()) == {"span_start_probs", "span_end_probs", "best_span"}
+            assert set(result.keys()) == {"span_start_probs", "span_end_probs", "best_span",
+                                          "best_span_str"}
 
     def test_fails_without_required_args(self):
         args = ["predict",           # command

--- a/tests/models/bidaf_test.py
+++ b/tests/models/bidaf_test.py
@@ -39,6 +39,8 @@ class BidirectionalAttentionFlowTest(ModelTestCase):
         assert span_start < span_end
         assert span_end < passage.sequence_length()
 
+        assert isinstance(output_dict['best_span_str'], str)
+
     def test_get_best_span(self):
         # pylint: disable=protected-access
 


### PR DESCRIPTION
@schmmd, if you really want the tokenized question and/or passage for whatever reason, you could modify the BiDAF predictor to return the tokens in the resulting json: https://github.com/allenai/allennlp/blob/311db7f69ac809ceb4c1a47d1fe8da1203b4947b/allennlp/service/predictors/bidaf.py#L17

This PR should get you a decent pass at an answer string, though.