### PR TITLE
Pass instance metadata through to `forward`, use it to compute official BiDAF metrics

### DIFF
--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -1,3 +1,4 @@
+from inspect import signature
 from typing import Dict, Any
 import argparse
 import logging
@@ -44,6 +45,8 @@ def evaluate(model: Model,
     logger.info("Iterating over dataset")
     for batch in tqdm.tqdm(generator, total=iterator.get_num_batches(dataset)):
         tensor_batch = arrays_to_variables(batch, cuda_device, for_training=False)
+        if 'metadata' in tensor_batch and 'metadata' not in signature(model.forward).parameters:
+            del tensor_batch['metadata']
         model.forward(**tensor_batch)
 
     return model.get_metrics()

--- a/allennlp/common/squad_eval.py
+++ b/allennlp/common/squad_eval.py
@@ -1,15 +1,11 @@
 """ Official evaluation script for v1.1 of the SQuAD dataset. """
 from __future__ import print_function
 from collections import Counter
-import editdistance
 import string
 import re
 import argparse
 import json
 import sys
-
-
-verbosity = 0
 
 
 def normalize_answer(s):
@@ -44,24 +40,7 @@ def f1_score(prediction, ground_truth):
 
 
 def exact_match_score(prediction, ground_truth):
-    normalized_prediction = normalize_answer(prediction)
-    normalized_ground_truth = normalize_answer(ground_truth)
-    correct = normalized_prediction == normalized_ground_truth
-    if verbosity > 0 and not correct:
-        pred_no_whitespace = normalized_prediction.replace(' ', '')
-        truth_no_whitespace = normalized_ground_truth.replace(' ', '')
-        if pred_no_whitespace == truth_no_whitespace:
-            print("Prediction and truth differ only in whitespace!")
-            print("Normalized ground truth:", normalized_ground_truth)
-            print("Normalized prediction:", normalized_prediction)
-            print()
-        if verbosity > 1:
-            if editdistance.eval(normalized_prediction, normalized_ground_truth) < 5:
-                print("Small edit distance between truth and prediction; could be a tokenization error")
-                print("Normalized ground truth:", normalized_ground_truth)
-                print("Normalized prediction:", normalized_prediction)
-                print()
-    return correct
+    return (normalize_answer(prediction) == normalize_answer(ground_truth))
 
 
 def metric_max_over_ground_truths(metric_fn, prediction, ground_truths):
@@ -81,7 +60,7 @@ def evaluate(dataset, predictions):
                 if qa['id'] not in predictions:
                     message = 'Unanswered question ' + qa['id'] + \
                               ' will receive score 0.'
-                    #print(message, file=sys.stderr)
+                    print(message, file=sys.stderr)
                     continue
                 ground_truths = list(map(lambda x: x['text'], qa['answers']))
                 prediction = predictions[qa['id']]

--- a/allennlp/common/squad_eval.py
+++ b/allennlp/common/squad_eval.py
@@ -1,4 +1,5 @@
 """ Official evaluation script for v1.1 of the SQuAD dataset. """
+# pylint: skip-file
 from __future__ import print_function
 from collections import Counter
 import string

--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -140,17 +140,15 @@ class Dataset:
         field_arrays = defaultdict(list)  # type: Dict[str, list]
         if verbose:
             logger.info("Now actually padding instances to length: %s", str(lengths_to_use))
-            for instance in tqdm.tqdm(self.instances):
-                for field, arrays in instance.as_array_dict(lengths_to_use).items():
-                    field_arrays[field].append(arrays)
-        else:
-            for instance in self.instances:
-                for field, arrays in instance.as_array_dict(lengths_to_use).items():
-                    field_arrays[field].append(arrays)
+        for instance in self.instances:
+            for field, arrays in instance.as_array_dict(lengths_to_use).items():
+                field_arrays[field].append(arrays)
 
         # Finally, we combine the arrays that we got for each instance into one big array (or set
         # of arrays) per field.
         for field_name, field_array_list in field_arrays.items():
+            if field_name == 'metadata':
+                continue
             if isinstance(field_array_list[0], dict):
                 # This is creating a dict of {token_indexer_key: batch_array} for each
                 # token indexer used to index this field. This is mostly utilised by TextFields.

--- a/allennlp/data/dataset_readers/language_modeling.py
+++ b/allennlp/data/dataset_readers/language_modeling.py
@@ -62,14 +62,14 @@ class LanguageModelingReader(DatasetReader):
             instance_strings = text_file.readlines()
         if self._tokens_per_instance is not None:
             all_text = " ".join([x.replace("\n", " ").strip() for x in instance_strings])
-            tokenized_text = self._tokenizer.tokenize(all_text)
+            tokenized_text, _ = self._tokenizer.tokenize(all_text)
             num_tokens = self._tokens_per_instance
             tokenized_strings = []
             logger.info("Creating dataset from all text in file: %s", file_path)
             for index in tqdm.tqdm(range(0, len(tokenized_text) - num_tokens, num_tokens)):
                 tokenized_strings.append(tokenized_text[index:index + num_tokens])
         else:
-            tokenized_strings = [self._tokenizer.tokenize(s) for s in instance_strings]
+            tokenized_strings = [self._tokenizer.tokenize(s)[0] for s in instance_strings]
 
         # TODO(matt): this isn't quite right, because you really want to split on sentences,
         # tokenize the sentences, add the start and end tokens per sentence, then change the tokens

--- a/allennlp/data/dataset_readers/snli.py
+++ b/allennlp/data/dataset_readers/snli.py
@@ -68,9 +68,9 @@ class SnliReader(DatasetReader):
                 label_field = LabelField(label)
 
                 premise = example["sentence1"]
-                premise_tokens = self._tokenizer.tokenize(premise)
+                premise_tokens, _ = self._tokenizer.tokenize(premise)
                 hypothesis = example["sentence2"]
-                hypothesis_tokens = self._tokenizer.tokenize(hypothesis)
+                hypothesis_tokens, _ = self._tokenizer.tokenize(hypothesis)
                 if self._append_null:
                     premise_tokens.append(self.null_token)
                     hypothesis_tokens.append(self.null_token)

--- a/allennlp/data/dataset_readers/squad.py
+++ b/allennlp/data/dataset_readers/squad.py
@@ -46,7 +46,7 @@ def _char_span_to_token_span(sentence: str,
     # First we'll tokenize the span and the sentence, so we can count tokens and check for
     # matches.
     span_chars = sentence[span[0]:span[1]]
-    tokenized_span = tokenizer.tokenize(span_chars)
+    tokenized_span, _ = tokenizer.tokenize(span_chars)
     # Then we'll find what we think is the first token in the span
     chars_seen = 0
     index = 0
@@ -85,9 +85,10 @@ class SquadReader(DatasetReader):
     fields: ``question``, a ``TextField``, ``passage``, another ``TextField``, and ``span_start``
     and ``span_end``, both ``IndexFields`` into the ``passage`` ``TextField``.
 
-    The ``Instances`` also store their ID and the original passage text in the instance metadata,
-    accessible as ``instance.metadata['id']`` and ``instance.metadata['original_passage']``.  You
-    will want this if you want to use the official SQuAD evaluation script.
+    The ``Instances`` also store their ID, the original passage text, and token offsets into the
+    original passage in the instance metadata, accessible as ``instance.metadata['id']``,
+    ``instance.metadata['original_passage']``, and ``instance.metadata['token_offsets']``.  This is
+    so that we can more easily use the official SQuAD evaluation script to get metrics.
 
     Parameters
     ----------
@@ -127,12 +128,14 @@ class SquadReader(DatasetReader):
                 # labels are end-exclusive, and we do a softmax over the passage to determine span
                 # end.  So if we want to be able to include the last token of the passage, we need
                 # to have a special symbol at the end.
-                tokenized_paragraph = self._tokenizer.tokenize(cleaned_paragraph) + [self.STOP_TOKEN]
+                paragraph_tokens, paragraph_offsets = self._tokenizer.tokenize(cleaned_paragraph)
+                paragraph_tokens.append(self.STOP_TOKEN)
+                paragraph_offsets.append((-1, -1))
 
                 for question_answer in paragraph_json['qas']:
                     question_text = question_answer["question"].strip().replace("\n", "")
                     question_id = question_answer['id'].strip()
-                    tokenized_question = self._tokenizer.tokenize(question_text)
+                    question_tokens, _ = self._tokenizer.tokenize(question_text)
 
                     # There may be multiple answer annotations, so pick the one that occurs the
                     # most.
@@ -145,7 +148,7 @@ class SquadReader(DatasetReader):
                     # we need a token index for our models.  We convert them here.
                     char_span_end = char_span_start + len(answer_text)
                     span_start, span_end = _char_span_to_token_span(paragraph,
-                                                                    tokenized_paragraph,
+                                                                    paragraph_tokens,
                                                                     (char_span_start, char_span_end),
                                                                     self._tokenizer)
 
@@ -154,8 +157,8 @@ class SquadReader(DatasetReader):
                     # when indexing is done, and when padding is done).  I _think_ all of those
                     # operations would be safe with shared objects, but I'd rather just be safe by
                     # doing a copy here.  Extra memory usage should be minimal.
-                    paragraph_field = TextField(deepcopy(tokenized_paragraph), self._token_indexers)
-                    question_field = TextField(tokenized_question, self._token_indexers)
+                    paragraph_field = TextField(deepcopy(paragraph_tokens), self._token_indexers)
+                    question_field = TextField(question_tokens, self._token_indexers)
                     span_start_field = IndexField(span_start, paragraph_field)
                     span_end_field = IndexField(span_end, paragraph_field)
                     fields = {
@@ -164,7 +167,11 @@ class SquadReader(DatasetReader):
                             'span_start': span_start_field,
                             'span_end': span_end_field
                             }
-                    metadata = {'id': question_id, 'original_passage': paragraph}
+                    metadata = {
+                            'id': question_id,
+                            'original_passage': paragraph,
+                            'token_offsets': paragraph_offsets
+                            }
                     instance = Instance(fields, metadata)
                     instances.append(instance)
         if not instances:
@@ -381,12 +388,12 @@ class SquadSentenceSelectionReader(DatasetReader):
             question_text = self._id_to_question[question_id]
             sentence_fields = []  # type: List[Field]
             for sentence in sentence_choices:
-                tokenized_sentence = self._tokenizer.tokenize(sentence)
+                tokenized_sentence, _ = self._tokenizer.tokenize(sentence)
                 sentence_field = TextField(tokenized_sentence, self._token_indexers)
                 sentence_fields.append(sentence_field)
             sentences_field = ListField(sentence_fields)
-            tokenized_question = self._tokenizer.tokenize(question_text)
-            question_field = TextField(tokenized_question, self._token_indexers)
+            question_tokens, _ = self._tokenizer.tokenize(question_text)
+            question_field = TextField(question_tokens, self._token_indexers)
             correct_sentence_field = IndexField(correct_choice, sentences_field)
             instances.append(Instance({'question': question_field,
                                        'sentences': sentences_field,

--- a/allennlp/data/instance.py
+++ b/allennlp/data/instance.py
@@ -66,9 +66,14 @@ class Instance:
 
         If ``padding_lengths`` is omitted, we will call ``self.get_padding_lengths()`` to get the
         sizes of the arrays to create.
+
+        In the array dictionary, we also pass along the instance metadata, if any is given.  This
+        is contained in the ``'metadata'`` key.
         """
         padding_lengths = padding_lengths or self.get_padding_lengths()
         arrays = {}
         for field_name, field in self.fields.items():
             arrays[field_name] = field.as_array(padding_lengths[field_name])
+        if self.metadata:
+            arrays['metadata'] = self.metadata
         return arrays

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -35,13 +35,13 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
 
     @overrides
     def count_vocab_items(self, token: str, counter: Dict[str, Dict[str, int]]):
-        for character in self.character_tokenizer.tokenize(token):
+        for character in self.character_tokenizer.tokenize(token)[0]:
             counter[self.namespace][character] += 1
 
     @overrides
     def token_to_indices(self, token: str, vocabulary: Vocabulary) -> List[int]:
         indices = []
-        for character in self.character_tokenizer.tokenize(token):
+        for character in self.character_tokenizer.tokenize(token)[0]:
             indices.append(vocabulary.get_token_index(character, self.namespace))
         return indices
 

--- a/allennlp/data/tokenizers/character_tokenizer.py
+++ b/allennlp/data/tokenizers/character_tokenizer.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from overrides import overrides
 
@@ -32,12 +32,12 @@ class CharacterTokenizer(Tokenizer):
         self.lowercase_characters = lowercase_characters
 
     @overrides
-    def tokenize(self, text: str) -> List[str]:
+    def tokenize(self, text: str) -> Tuple[List[str], List[Tuple[int, int]]]:
         if self.lowercase_characters:
             text = text.lower()
         if self.byte_encoding is not None:
-            return [chr(x) for x in text.encode(self.byte_encoding)]
-        return list(text)
+            return [chr(x) for x in text.encode(self.byte_encoding)], None
+        return list(text), None
 
     @classmethod
     def from_params(cls, params: Params) -> 'CharacterTokenizer':

--- a/allennlp/data/tokenizers/tokenizer.py
+++ b/allennlp/data/tokenizers/tokenizer.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from allennlp.common import Params, Registrable
 
@@ -22,9 +22,17 @@ class Tokenizer(Registrable):
     """
     default_implementation = 'word'
 
-    def tokenize(self, text: str) -> List[str]:
+    def tokenize(self, text: str) -> Tuple[List[str], List[Tuple[int, int]]]:
         """
         The only public method for this class.  Actually implements splitting words into tokens.
+
+        Returns
+        -------
+        tokens : ``List[str]``
+        offsets : ``List[Tuple[int, int]]``
+            A list of the same lengths as ``tokens``, giving character offsets into the original
+            string for each token.  Not all tokenizers implement this, so this value could be
+            ``None``.
         """
         raise NotImplementedError
 

--- a/allennlp/data/tokenizers/word_filter.py
+++ b/allennlp/data/tokenizers/word_filter.py
@@ -19,7 +19,7 @@ class WordFilter(Registrable):
         """
         Decides whether to remove words from the given list.  To make it easier to deal with data
         associated with the word list (like character offsets), we return a list of boolean
-        decisions for each word, which the caller can process to actually filter the list.  
+        decisions for each word, which the caller can process to actually filter the list.
         """
         raise NotImplementedError
 

--- a/allennlp/data/tokenizers/word_filter.py
+++ b/allennlp/data/tokenizers/word_filter.py
@@ -15,8 +15,12 @@ class WordFilter(Registrable):
     """
     default_implementation = 'pass_through'
 
-    def filter_words(self, words: List[str]) -> List[str]:
-        """Filters words from the given word list"""
+    def should_keep_words(self, words: List[str]) -> List[bool]:
+        """
+        Decides whether to remove words from the given list.  To make it easier to deal with data
+        associated with the word list (like character offsets), we return a list of boolean
+        decisions for each word, which the caller can process to actually filter the list.  
+        """
         raise NotImplementedError
 
     @classmethod
@@ -32,8 +36,8 @@ class PassThroughWordFilter(WordFilter):
     Does not filter words; it's a no-op.  This is the default word filter.
     """
     @overrides
-    def filter_words(self, words: List[str]) -> List[str]:
-        return words
+    def should_keep_words(self, words: List[str]) -> List[bool]:
+        return [True] * len(words)
 
 
 @WordFilter.register('stopwords')
@@ -69,5 +73,5 @@ class StopwordFilter(WordFilter):
                               "'", '"', '&', '$', '#', '@', '(', ')', '?'])
 
     @overrides
-    def filter_words(self, words: List[str]) -> List[str]:
-        return [word for word in words if word not in self.stopwords]
+    def should_keep_words(self, words: List[str]) -> List[bool]:
+        return [word not in self.stopwords for word in words]

--- a/allennlp/models/bidaf.py
+++ b/allennlp/models/bidaf.py
@@ -1,17 +1,21 @@
-from typing import Any, Dict
+import json
+import logging
+from typing import Any, Dict, List, Tuple
 
 import torch
 from torch.autograd import Variable
 from torch.nn.functional import nll_loss
 
-from allennlp.common import Params
+from allennlp.common import Params, squad_eval
 from allennlp.data import Instance, Vocabulary
 from allennlp.data.fields import TextField
 from allennlp.models.model import Model
 from allennlp.modules import Highway, MatrixAttention
 from allennlp.modules import Seq2SeqEncoder, SimilarityFunction, TimeDistributed, TextFieldEmbedder
 from allennlp.nn import InitializerApplicator, util
-from allennlp.training.metrics import BooleanAccuracy, CategoricalAccuracy
+from allennlp.training.metrics import Average, BooleanAccuracy, CategoricalAccuracy
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 @Model.register("bidaf")
@@ -56,6 +60,10 @@ class BidirectionalAttentionFlow(Model):
     dropout : ``float``, optional (default=``0.2``)
         If greater than 0, we will apply dropout with this probability after all encoders (pytorch
         LSTMs do not apply dropout to their last layer).
+    evaluation_json_file : ``str``, optional
+        If given, we will load this JSON into memory and use it to compute official metrics
+        against.  We need this separately from the validation dataset, because the official metrics
+        use all of the annotations, while our dataset reader picks the most frequent one.
     """
     def __init__(self, vocab: Vocabulary,
                  text_field_embedder: TextFieldEmbedder,
@@ -65,7 +73,8 @@ class BidirectionalAttentionFlow(Model):
                  modeling_layer: Seq2SeqEncoder,
                  span_end_encoder: Seq2SeqEncoder,
                  initializer: InitializerApplicator,
-                 dropout: float = 0.2) -> None:
+                 dropout: float = 0.2,
+                 evaluation_json_file: str = None) -> None:
         super(BidirectionalAttentionFlow, self).__init__(vocab)
 
         self._text_field_embedder = text_field_embedder
@@ -88,16 +97,35 @@ class BidirectionalAttentionFlow(Model):
         self._span_start_accuracy = CategoricalAccuracy()
         self._span_end_accuracy = CategoricalAccuracy()
         self._span_accuracy = BooleanAccuracy()
+        self._official_em = Average()
+        self._official_f1 = Average()
         if dropout > 0:
             self._dropout = torch.nn.Dropout(p=dropout)
         else:
             self._dropout = lambda x: x
 
+        if evaluation_json_file:
+            logger.info("Prepping official evaluation dataset from %s", evaluation_json_file)
+            with open(evaluation_json_file) as dataset_file:
+                dataset_json = json.load(dataset_file)
+            question_to_answers = {}
+            for article in dataset_json['data']:
+                for paragraph in article['paragraphs']:
+                    for question in paragraph['qas']:
+                        question_id = question['id']
+                        answers = [answer['text'] for answer in question['answers']]
+                        question_to_answers[question_id] = answers
+
+            self._official_eval_dataset = question_to_answers
+        else:
+            self._official_eval_dataset = None
+
     def forward(self,  # type: ignore
                 question: Dict[str, torch.LongTensor],
                 passage: Dict[str, torch.LongTensor],
                 span_start: torch.IntTensor = None,
-                span_end: torch.IntTensor = None) -> Dict[str, torch.Tensor]:
+                span_end: torch.IntTensor = None,
+                metadata: List[Dict[str, Any]] = None) -> Dict[str, torch.Tensor]:
         # pylint: disable=arguments-differ
         """
         Parameters
@@ -110,14 +138,21 @@ class BidirectionalAttentionFlow(Model):
             passage.  The ending position is `exclusive`, so our
             :class:`~allennlp.data.dataset_readers.SquadReader` adds a special ending token to the
             end of the passage, to allow for the last token to be included in the answer span.
-        span_start : torch.IntTensor, optional (default = None)
+        span_start : ``torch.IntTensor``, optional
             From an ``IndexField``.  This is one of the things we are trying to predict - the
             beginning position of the answer with the passage.  This is an `inclusive` index.  If
             this is given, we will compute a loss that gets included in the output dictionary.
-        span_end : torch.IntTensor, optional (default = None)
+        span_end : ``torch.IntTensor``, optional
             From an ``IndexField``.  This is one of the things we are trying to predict - the
             ending position of the answer with the passage.  This is an `exclusive` index.  If
             this is given, we will compute a loss that gets included in the output dictionary.
+        metadata : ``List[Dict[str, Any]]``, optional
+            If present, this should contain the question ID, original passage text, and token
+            offsets into the passage for each instance in the batch.  We use this for computing
+            official metrics using the official SQuAD evaluation script.  The length of this list
+            should be the batch size, and each dictionary should have the keys ``id``,
+            ``original_passage``, and ``token_offsets``.  If you only want the best span string and
+            don't care about official metrics, you can omit the ``id`` key.
 
         Returns
         -------
@@ -137,7 +172,10 @@ class BidirectionalAttentionFlow(Model):
             ``span_end_logits`` to find the most probable span.  Shape is ``(batch_size, 2)``.
         loss : torch.FloatTensor, optional
             A scalar loss to be optimised.
-
+        best_span_str : List[str]
+            If sufficient metadata was provided for the instances in the batch, we also return the
+            string from the original passage that the model thinks is the best answer to the
+            question.
         """
         embedded_question = self._highway_layer(self._text_field_embedder(question))
         embedded_passage = self._highway_layer(self._text_field_embedder(passage))
@@ -209,6 +247,8 @@ class BidirectionalAttentionFlow(Model):
         span_end_input = self._dropout(torch.cat([final_merged_passage, encoded_span_end], dim=-1))
         span_end_logits = self._span_end_predictor(span_end_input).squeeze(-1)
         span_end_probs = util.masked_softmax(span_end_logits, passage_mask)
+        span_start_logits = util.replace_masked_values(span_start_logits, passage_mask, -1e7)
+        span_end_logits = util.replace_masked_values(span_end_logits, passage_mask, -1e7)
         best_span = self._get_best_span(span_start_logits, span_end_logits)
 
         output_dict = {"span_start_logits": span_start_logits,
@@ -223,14 +263,44 @@ class BidirectionalAttentionFlow(Model):
             self._span_end_accuracy(span_end_logits, span_end.squeeze(-1))
             self._span_accuracy(best_span, torch.stack([span_start, span_end], -1))
             output_dict["loss"] = loss
-
+        if metadata is not None and self._official_eval_dataset:
+            output_dict['best_span_str'] = []
+            for i in range(batch_size):
+                predicted_span = tuple(best_span[i].data.cpu().numpy())
+                best_span_string = self._compute_official_metrics(metadata[i], predicted_span)  # type: ignore
+                output_dict['best_span_str'].append(best_span_string)
         return output_dict
+
+    def _compute_official_metrics(self,
+                                  metadata: Dict[str, Any],
+                                  predicted_span: Tuple[int, int]) -> str:
+        passage = metadata['original_passage']
+        offsets = metadata['token_offsets']
+        question_id = metadata.get('id', None)
+        start_offset = offsets[predicted_span[0]][0]
+        end_offset = offsets[predicted_span[1] - 1][1]  # span end is exclusive
+        span_string = passage[start_offset:end_offset]
+        if question_id in self._official_eval_dataset:
+            ground_truth = self._official_eval_dataset[question_id]
+            exact_match = squad_eval.metric_max_over_ground_truths(
+                    squad_eval.exact_match_score,
+                    span_string,
+                    ground_truth)
+            f1_score = squad_eval.metric_max_over_ground_truths(
+                    squad_eval.f1_score,
+                    span_string,
+                    ground_truth)
+            self._official_em(100 * exact_match)
+            self._official_f1(100 * f1_score)
+        return span_string
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         return {
-                'span_start_acc': self._span_start_accuracy.get_metric(reset),
-                'span_end_acc': self._span_end_accuracy.get_metric(reset),
-                'full_span_acc': self._span_accuracy.get_metric(reset),
+                'start_acc': self._span_start_accuracy.get_metric(reset),
+                'end_acc': self._span_end_accuracy.get_metric(reset),
+                'span_acc': self._span_accuracy.get_metric(reset),
+                'em': self._official_em.get_metric(reset),
+                'f1': self._official_f1.get_metric(reset),
                 }
 
     def predict_span(self, question: TextField, passage: TextField) -> Dict[str, Any]:
@@ -321,6 +391,7 @@ class BidirectionalAttentionFlow(Model):
         span_end_encoder = Seq2SeqEncoder.from_params(params.pop("span_end_encoder"))
         initializer = InitializerApplicator.from_params(params.pop("initializer", []))
         dropout = params.pop('dropout', 0.2)
+        evaluation_json_file = params.pop('evaluation_json_file', None)
         params.assert_empty(cls.__name__)
         return cls(vocab=vocab,
                    text_field_embedder=text_field_embedder,
@@ -330,4 +401,5 @@ class BidirectionalAttentionFlow(Model):
                    modeling_layer=modeling_layer,
                    span_end_encoder=span_end_encoder,
                    initializer=initializer,
-                   dropout=dropout)
+                   dropout=dropout,
+                   evaluation_json_file=evaluation_json_file)

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -125,6 +125,8 @@ def arrays_to_variables(data_structure: Dict[str, Union[dict, numpy.ndarray]],
     """
     if isinstance(data_structure, dict):
         for key, value in data_structure.items():
+            if key == 'metadata':
+                continue
             data_structure[key] = arrays_to_variables(value, cuda_device, add_batch_dimension)
         return data_structure
     else:

--- a/allennlp/service/predictors/bidaf.py
+++ b/allennlp/service/predictors/bidaf.py
@@ -10,8 +10,11 @@ class BidafPredictor(Predictor):
         question_text = inputs["question"]
         passage_text = inputs["passage"]
 
-        question = TextField(self.tokenizer.tokenize(question_text), token_indexers=self.token_indexers)
-        passage = TextField(self.tokenizer.tokenize(passage_text) + [SquadReader.STOP_TOKEN],
-                            token_indexers=self.token_indexers)
+        question_tokens, _ = self.tokenizer.tokenize(question_text)
+        passage_tokens, _ = self.tokenizer.tokenize(passage_text)
+        passage_tokens.append(SquadReader.STOP_TOKEN)
+
+        question = TextField(question_tokens, token_indexers=self.token_indexers)
+        passage = TextField(passage_tokens, token_indexers=self.token_indexers)
 
         return sanitize(self.model.predict_span(question, passage))

--- a/allennlp/service/predictors/decomposable_attention.py
+++ b/allennlp/service/predictors/decomposable_attention.py
@@ -8,9 +8,9 @@ class DecomposableAttentionPredictor(Predictor):
         premise_text = inputs["premise"]
         hypothesis_text = inputs["hypothesis"]
 
-        premise = TextField(self.tokenizer.tokenize(premise_text),
+        premise = TextField(self.tokenizer.tokenize(premise_text)[0],
                             token_indexers=self.token_indexers)
-        hypothesis = TextField(self.tokenizer.tokenize(hypothesis_text),
+        hypothesis = TextField(self.tokenizer.tokenize(hypothesis_text)[0],
                                token_indexers=self.token_indexers)
 
         return sanitize(self.model.predict_entailment(premise, hypothesis))

--- a/allennlp/service/predictors/simple_tagger.py
+++ b/allennlp/service/predictors/simple_tagger.py
@@ -8,7 +8,7 @@ class SimpleTaggerPredictor(Predictor):
     def predict_json(self, inputs: JsonDict) -> JsonDict:
         sentence = inputs["sentence"]
 
-        tokens = TextField(self.tokenizer.tokenize(sentence),
+        tokens = TextField(self.tokenizer.tokenize(sentence)[0],
                            token_indexers=self.token_indexers)
 
         return sanitize(self.model.tag(tokens))

--- a/allennlp/training/metrics/__init__.py
+++ b/allennlp/training/metrics/__init__.py
@@ -1,4 +1,5 @@
 from allennlp.training.metrics.metric import Metric
+from allennlp.training.metrics.average import Average
 from allennlp.training.metrics.boolean_accuracy import BooleanAccuracy
 from allennlp.training.metrics.categorical_accuracy import CategoricalAccuracy
 from allennlp.training.metrics.f1_measure import F1Measure

--- a/allennlp/training/metrics/average.py
+++ b/allennlp/training/metrics/average.py
@@ -1,0 +1,44 @@
+from overrides import overrides
+
+from allennlp.training.metrics.metric import Metric
+
+
+@Metric.register("average")
+class Average(Metric):
+    """
+    This :class:`Metric` breaks with the typical ``Metric`` API and just stores values that were
+    computed in some fashion outside of a ``Metric``.  If you have some external code that computes
+    the metric for you, for instance, you can use this to report the average result using our
+    ``Metric`` API.
+    """
+    def __init__(self) -> None:
+        self._total_value = 0.0
+        self._count = 0
+
+    @overrides
+    def __call__(self, value):
+        """
+        Parameters
+        ----------
+        value : ``float``
+            The value to average.
+        """
+        self._total_value += value
+        self._count += 1
+
+    @overrides
+    def get_metric(self, reset: bool = False):
+        """
+        Returns
+        -------
+        The average of all values that were passed to ``__call__``.
+        """
+        average_value = self._total_value / self._count if self._count > 0 else 0
+        if reset:
+            self.reset()
+        return average_value
+
+    @overrides
+    def reset(self):
+        self._total_value = 0.0
+        self._count = 0

--- a/experiment_config/bidaf.json
+++ b/experiment_config/bidaf.json
@@ -14,14 +14,15 @@
       }
     }
   },
-  "train_data_path": "/squad/train-v1.1.json",
-  "validation_data_path": "/squad/dev-v1.1.json",
+  "train_data_path": "/net/efs/aristo/dlfa/squad/train-v1.1.json",
+  "validation_data_path": "/net/efs/aristo/dlfa/squad/dev-v1.1.json",
   "model": {
     "type": "bidaf",
+    "evaluation_json_file": "/net/efs/aristo/dlfa/squad/dev-v1.1.json",
     "text_field_embedder": {
       "tokens": {
         "type": "embedding",
-        "pretrained_file": "/glove/glove.6B.100d.txt.gz",
+        "pretrained_file": "/net/efs/aristo/dlfa/glove/glove.6B.100d.txt.gz",
         "embedding_dim": 100,
         "trainable": false
       },
@@ -85,7 +86,7 @@
     "num_epochs": 20,
     "grad_norm": 5.0,
     "patience": 10,
-    "validation_metric": "+full_span_acc",
+    "validation_metric": "+em",
     "cuda_device": 0,
     "learning_rate_scheduler":  {
       "type": "reduce_on_plateau",

--- a/tests/commands/evaluate_test.py
+++ b/tests/commands/evaluate_test.py
@@ -20,4 +20,4 @@ class TestEvaluate(AllenNlpTestCase):
 
         metrics = evaluate_from_args(args)
 
-        assert metrics == {'full_span_acc': 0.0, 'span_end_acc': 0.0, 'span_start_acc': 0.0}
+        assert metrics == {'span_acc': 0.0, 'end_acc': 0.0, 'start_acc': 0.0, 'em': 0.0, 'f1': 0.0}

--- a/tests/data/dataset_readers/squad_reader_test.py
+++ b/tests/data/dataset_readers/squad_reader_test.py
@@ -13,7 +13,7 @@ class TestSquadReader(AllenNlpTestCase):
             "Carter, at Lenox Hill Hospital in New York. Five months later, she performed for four " +\
             "nights at Revel Atlantic City's Ovation Hall to celebrate the resort's opening, her " +\
             "first performances since giving birth to Blue Ivy."
-        tokenized_passage = tokenizer.tokenize(passage)
+        tokenized_passage, _ = tokenizer.tokenize(passage)
         # "January 7, 2012"
         token_span = _char_span_to_token_span(passage, tokenized_passage, (3, 18), tokenizer)
         assert token_span == (1, 5)

--- a/tests/data/dataset_readers/squad_sentence_selection_reader_test.py
+++ b/tests/data/dataset_readers/squad_sentence_selection_reader_test.py
@@ -89,7 +89,7 @@ class TestSquadSentenceSelectionReader(AllenNlpTestCase):
     def assert_list_field_contains_correct_sentences(self, list_field: ListField, sentences: List[str]):
         expected_tokens = set()
         for sentence in sentences:
-            sentence_tokens = tuple(self.tokenizer.tokenize(sentence.replace("\\\"", "\"")))
+            sentence_tokens = tuple(self.tokenizer.tokenize(sentence.replace("\\\"", "\""))[0])
             expected_tokens.add(sentence_tokens)
         actual_tokens = set()
         for field in list_field.field_list:
@@ -97,19 +97,19 @@ class TestSquadSentenceSelectionReader(AllenNlpTestCase):
         assert expected_tokens == actual_tokens
 
     def assert_index_field_points_to_correct_sentence(self, index_field: IndexField, sentence: str):
-        sentence_tokens = tuple(self.tokenizer.tokenize(sentence.replace("\\\"", "\"")))
+        sentence_tokens = tuple(self.tokenizer.tokenize(sentence.replace("\\\"", "\""))[0])
         tokens_list = [tuple(field.tokens) for field in index_field.sequence_field.field_list]
         assert index_field.sequence_index == tokens_list.index(sentence_tokens)
 
     def test_default_squad_sentence_selection_reader(self):
         reader = SquadSentenceSelectionReader()
         instances = reader.read(self.squad_file).instances
-        assert instances[0].fields["question"].tokens == self.tokenizer.tokenize(self.question0)
+        assert instances[0].fields["question"].tokens == self.tokenizer.tokenize(self.question0)[0]
         self.assert_list_field_contains_correct_sentences(instances[0].fields["sentences"],
                                                           self.sentences[:7])
         self.assert_index_field_points_to_correct_sentence(instances[0].fields['correct_sentence'],
                                                            self.sentences[5])
-        assert instances[1].fields["question"].tokens == self.tokenizer.tokenize(self.question1)
+        assert instances[1].fields["question"].tokens == self.tokenizer.tokenize(self.question1)[0]
         self.assert_list_field_contains_correct_sentences(instances[1].fields["sentences"],
                                                           self.sentences[:7])
         self.assert_index_field_points_to_correct_sentence(instances[1].fields['correct_sentence'],

--- a/tests/data/tokenizers/word_splitter_test.py
+++ b/tests/data/tokenizers/word_splitter_test.py
@@ -14,33 +14,33 @@ class TestSimpleWordSplitter(AllenNlpTestCase):
         sentence = "this (sentence) has 'crazy' \"punctuation\"."
         expected_tokens = ["this", "(", "sentence", ")", "has", "'", "crazy", "'", '"',
                            "punctuation", '"', "."]
-        tokens = self.word_splitter.split_words(sentence)
+        tokens, _ = self.word_splitter.split_words(sentence)
         assert tokens == expected_tokens
 
     def test_tokenize_handles_contraction(self):
         sentence = "it ain't joe's problem; would've been yesterday"
         expected_tokens = ["it", "ai", "n't", "joe", "'s", "problem", ";", "would", "'ve", "been",
                            "yesterday"]
-        tokens = self.word_splitter.split_words(sentence)
+        tokens, _ = self.word_splitter.split_words(sentence)
         assert tokens == expected_tokens
 
     def test_tokenize_handles_multiple_contraction(self):
         sentence = "wouldn't've"
         expected_tokens = ["would", "n't", "'ve"]
-        tokens = self.word_splitter.split_words(sentence)
+        tokens, _ = self.word_splitter.split_words(sentence)
         assert tokens == expected_tokens
 
     def test_tokenize_handles_final_apostrophe(self):
         sentence = "the jones' house"
         expected_tokens = ["the", "jones", "'", "house"]
-        tokens = self.word_splitter.split_words(sentence)
+        tokens, _ = self.word_splitter.split_words(sentence)
         assert tokens == expected_tokens
 
     def test_tokenize_handles_special_cases(self):
         sentence = "mr. and mrs. jones, etc., went to, e.g., the store"
         expected_tokens = ["mr.", "and", "mrs.", "jones", ",", "etc.", ",", "went", "to", ",",
                            "e.g.", ",", "the", "store"]
-        tokens = self.word_splitter.split_words(sentence)
+        tokens, _ = self.word_splitter.split_words(sentence)
         assert tokens == expected_tokens
 
 
@@ -53,33 +53,43 @@ class TestSpacyWordSplitter(AllenNlpTestCase):
         sentence = "this (sentence) has 'crazy' \"punctuation\"."
         expected_tokens = ["this", "(", "sentence", ")", "has", "'", "crazy", "'", '"',
                            "punctuation", '"', "."]
-        tokens = self.word_splitter.split_words(sentence)
+        tokens, offsets = self.word_splitter.split_words(sentence)
         assert tokens == expected_tokens
+        for token, (start, end) in zip(tokens, offsets):
+            assert sentence[start:end] == token
 
     def test_tokenize_handles_contraction(self):
         # note that "would've" is kept together, while "ain't" is not.
         sentence = "it ain't joe's problem; would've been yesterday"
         expected_tokens = ["it", "ai", "n't", "joe", "'s", "problem", ";", "would've", "been",
                            "yesterday"]
-        tokens = self.word_splitter.split_words(sentence)
+        tokens, offsets = self.word_splitter.split_words(sentence)
         assert tokens == expected_tokens
+        for token, (start, end) in zip(tokens, offsets):
+            assert sentence[start:end] == token
 
     def test_tokenize_handles_multiple_contraction(self):
         sentence = "wouldn't've"
         expected_tokens = ["would", "n't", "'ve"]
-        tokens = self.word_splitter.split_words(sentence)
+        tokens, offsets = self.word_splitter.split_words(sentence)
         assert tokens == expected_tokens
+        for token, (start, end) in zip(tokens, offsets):
+            assert sentence[start:end] == token
 
     def test_tokenize_handles_final_apostrophe(self):
         sentence = "the jones' house"
         expected_tokens = ["the", "jones", "'", "house"]
-        tokens = self.word_splitter.split_words(sentence)
+        tokens, offsets = self.word_splitter.split_words(sentence)
         assert tokens == expected_tokens
+        for token, (start, end) in zip(tokens, offsets):
+            assert sentence[start:end] == token
 
     def test_tokenize_handles_special_cases(self):
         # note that the etc. doesn't quite work --- we can special case this if we want.
         sentence = "Mr. and Mrs. Jones, etc., went to, e.g., the store"
         expected_tokens = ["Mr.", "and", "Mrs.", "Jones", ",", "etc", ".", ",", "went", "to", ",",
                            "e.g.", ",", "the", "store"]
-        tokens = self.word_splitter.split_words(sentence)
+        tokens, offsets = self.word_splitter.split_words(sentence)
         assert tokens == expected_tokens
+        for token, (start, end) in zip(tokens, offsets):
+            assert sentence[start:end] == token

--- a/tests/data/tokenizers/word_tokenizer_test.py
+++ b/tests/data/tokenizers/word_tokenizer_test.py
@@ -3,19 +3,19 @@
 from allennlp.data.tokenizers.word_tokenizer import WordTokenizer
 from allennlp.common.params import Params
 
-class TestWordProcessor:
+class TestWordTokenizer:
     def test_passes_through_correctly(self):
-        word_processor = WordTokenizer()
+        tokenizer = WordTokenizer()
         sentence = "this (sentence) has 'crazy' \"punctuation\"."
-        tokens = word_processor.tokenize(sentence)
+        tokens, _ = tokenizer.tokenize(sentence)
         expected_tokens = ["this", "(", "sentence", ")", "has", "'", "crazy", "'", "\"",
                            "punctuation", "\"", "."]
         assert tokens == expected_tokens
 
     def test_stems_and_filters_correctly(self):
-        word_processor = WordTokenizer.from_params(Params({'word_stemmer': {'type': 'porter'},
-                                                           'word_filter': {'type': 'stopwords'}}))
+        tokenizer = WordTokenizer.from_params(Params({'word_stemmer': {'type': 'porter'},
+                                                      'word_filter': {'type': 'stopwords'}}))
         sentence = "this (sentence) has 'crazy' \"punctuation\"."
         expected_tokens = ["sentenc", "ha", "crazi", "punctuat"]
-        tokens = word_processor.tokenize(sentence)
+        tokens, _ = tokenizer.tokenize(sentence)
         assert tokens == expected_tokens

--- a/tests/fixtures/bidaf/experiment.json
+++ b/tests/fixtures/bidaf/experiment.json
@@ -18,6 +18,7 @@
   "validation_data_path": "tests/fixtures/data/squad.json",
   "model": {
     "type": "bidaf",
+    "evaluation_json_file": "tests/fixtures/data/squad.json",
     "text_field_embedder": {
       "tokens": {
         "type": "embedding",

--- a/tests/fixtures/data/squad.json
+++ b/tests/fixtures/data/squad.json
@@ -21,6 +21,14 @@
                                 {
                                     "answer_start": 92,
                                     "text": "a golden statue of the Virgin Mary"
+                                },
+                                {
+                                    "answer_start": 92,
+                                    "text": "a golden statue of the Virgin Mary"
+                                },
+                                {
+                                    "answer_start": 0,
+                                    "text": "Architecturally, the school has a Catholic character. Atop the Main Building's gold dome is a golden statue of the Virgin Mary. Immediately in front of the Main Building and facing it, is a copper statue of Christ with arms upraised with the legend \"Venite Ad Me Omnes\". Next to the Main Building is the Basilica of the Sacred Heart. Immediately behind the basilica is the Grotto, a Marian place of prayer and reflection. It is a replica of the grotto at Lourdes, France where the Virgin Mary reputedly appeared to Saint Bernadette Soubirous in 1858. At the end of the main drive (and in a direct line that connects through 3 statues and the Gold Dome), is a simple, modern stone statue of Mary."
                                 }
                             ],
                             "question": "What sits on top of the Main Building at Notre Dame?",

--- a/tests/models/bidaf_test.py
+++ b/tests/models/bidaf_test.py
@@ -19,6 +19,14 @@ class BidirectionalAttentionFlowTest(ModelTestCase):
     def test_forward_pass_runs_correctly(self):
         training_arrays = arrays_to_variables(self.dataset.as_array_dict())
         _ = self.model.forward(**training_arrays)
+        metrics = self.model.get_metrics(reset=True)
+        # We've set up the data such that there's a fake answer that consists of the whole
+        # paragraph.  _Any_ valid prediction for that question should produce an F1 of greater than
+        # zero, while if we somehow haven't been able to load the evaluation data, or there was an
+        # error with using the evaluation script, this will fail.  This makes sure that we've
+        # loaded the evaluation data correctly and have hooked things up to the official evaluation
+        # script.
+        assert metrics['f1'] > 0
 
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)


### PR DESCRIPTION
There are two main things here:

1. I made the `metadata` that gets associated with each instance available in `Model.forward()`, if it's requested.  I used some reflection in order to make this work without _requiring_ `Model.forward()` to accept a `metadata` argument.  This is a bit magical, but I didn't really want to require every model to have to accept this argument.

2. I used this metadata inside of BiDAF to compute the official metrics.