### PR TITLE
Add back Dockerfile.cpu.

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-ARG from=nvidia/cuda:8.0-cudnn5-devel
+ARG from=ubuntu:16.04
 FROM $from
 
 ENV LC_ALL=C.UTF-8

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ docker pull allennlp/allennlp-gpu:latest
 ## Building a Docker image
 
 Following are instructions on creating a Docker environment that use the CPU.  To use the GPU, use the same instructions
-but substitute `gpu` for `cpu`.  The following command will take some time, as it completely builds the environment
-needed to run AllenNLP.
+but substitute `Dockerfile` for `Dockerfile.cpu`.  The following command will take some time, as it completely builds the
+environment needed to run AllenNLP.
 
 ```bash
 docker build --file Dockerfile.cpu --tag allennlp/allennlp-cpu .


### PR DESCRIPTION
This is needed in the short term for our continuous docker build by Docker Swarm.  I will figure out how to remove this before long, but I need it in the short term.