### PR TITLE
Require mask in encoders, update models, fix bug in BiDAF

### DIFF
--- a/allennlp/models/bidaf.py
+++ b/allennlp/models/bidaf.py
@@ -146,10 +146,8 @@ class BidirectionalAttentionFlow(Model):
         question_mask = util.get_text_field_mask(question).float()
         passage_mask = util.get_text_field_mask(passage).float()
 
-        question_sequence_lengths = util.get_lengths_from_binary_sequence_mask(question_mask)
-        passage_sentence_lengths = util.get_lengths_from_binary_sequence_mask(passage_mask)
-        encoded_question = self._dropout(self._phrase_layer(embedded_question, question_sequence_lengths))
-        encoded_passage = self._dropout(self._phrase_layer(embedded_passage, passage_sentence_lengths))
+        encoded_question = self._dropout(self._phrase_layer(embedded_question, question_mask))
+        encoded_passage = self._dropout(self._phrase_layer(embedded_passage, passage_mask))
         encoding_dim = encoded_question.size(-1)
 
         # Shape: (batch_size, passage_length, question_length)
@@ -182,7 +180,7 @@ class BidirectionalAttentionFlow(Model):
                                           encoded_passage * tiled_question_passage_vector],
                                          dim=-1)
 
-        modeled_passage = self._dropout(self._modeling_layer(final_merged_passage))
+        modeled_passage = self._dropout(self._modeling_layer(final_merged_passage, passage_mask))
         modeling_dim = modeled_passage.size(-1)
 
         # Shape: (batch_size, passage_length, encoding_dim * 4 + modeling_dim))
@@ -206,7 +204,7 @@ class BidirectionalAttentionFlow(Model):
                                              modeled_passage * tiled_start_representation],
                                             dim=-1)
         # Shape: (batch_size, passage_length, encoding_dim)
-        encoded_span_end = self._dropout(self._span_end_encoder(span_end_representation))
+        encoded_span_end = self._dropout(self._span_end_encoder(span_end_representation, passage_mask))
         # Shape: (batch_size, passage_length, encoding_dim * 4 + span_end_encoding_dim)
         span_end_input = self._dropout(torch.cat([final_merged_passage, encoded_span_end], dim=-1))
         span_end_logits = self._span_end_predictor(span_end_input).squeeze(-1)

--- a/allennlp/models/decomposable_attention.py
+++ b/allennlp/models/decomposable_attention.py
@@ -10,7 +10,7 @@ from allennlp.models.model import Model
 from allennlp.modules import FeedForward, MatrixAttention
 from allennlp.modules import Seq2SeqEncoder, SimilarityFunction, TimeDistributed, TextFieldEmbedder
 from allennlp.nn.util import get_text_field_mask, last_dim_softmax, weighted_sum
-from allennlp.nn.util import arrays_to_variables, get_lengths_from_binary_sequence_mask
+from allennlp.nn.util import arrays_to_variables
 from allennlp.training.metrics import CategoricalAccuracy
 
 
@@ -117,13 +117,11 @@ class DecomposableAttention(Model):
         embedded_hypothesis = self._text_field_embedder(hypothesis)
         premise_mask = get_text_field_mask(premise).float()
         hypothesis_mask = get_text_field_mask(hypothesis).float()
-        premise_sequence_lengths = get_lengths_from_binary_sequence_mask(premise_mask)
-        hypothesis_sequence_lengths = get_lengths_from_binary_sequence_mask(hypothesis_mask)
 
         if self._premise_encoder:
-            embedded_premise = self._premise_encoder(embedded_premise, premise_sequence_lengths)
+            embedded_premise = self._premise_encoder(embedded_premise, premise_mask)
         if self._hypothesis_encoder:
-            embedded_hypothesis = self._hypothesis_encoder(embedded_hypothesis, hypothesis_sequence_lengths)
+            embedded_hypothesis = self._hypothesis_encoder(embedded_hypothesis, hypothesis_mask)
 
         projected_premise = self._attend_feedforward(embedded_premise)
         projected_hypothesis = self._attend_feedforward(embedded_hypothesis)

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -12,7 +12,7 @@ from allennlp.data.fields import SequenceLabelField, TextField
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder
 from allennlp.modules.token_embedders import Embedding
 from allennlp.models.model import Model
-from allennlp.nn.util import arrays_to_variables, viterbi_decode, get_lengths_from_binary_sequence_mask
+from allennlp.nn.util import arrays_to_variables, viterbi_decode
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 from allennlp.training.metrics import SpanBasedF1Measure
 
@@ -124,8 +124,7 @@ class SemanticRoleLabeler(Model):
                                      "specified. Therefore, the 'input_dim' of the stacked_encoder "
                                      "must be equal to total_embedding_dim + 1.")
 
-        batch_sequence_lengths = get_lengths_from_binary_sequence_mask(mask)
-        encoded_text = self.stacked_encoder(embedded_text_with_verb_indicator, batch_sequence_lengths)
+        encoded_text = self.stacked_encoder(embedded_text_with_verb_indicator, mask)
 
         logits = self.tag_projection_layer(encoded_text)
         reshaped_log_probs = logits.view(-1, self.num_classes)

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -10,7 +10,7 @@ from allennlp.data.fields.text_field import TextField
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder
 from allennlp.models.model import Model
 from allennlp.nn.util import arrays_to_variables, sequence_cross_entropy_with_logits
-from allennlp.nn.util import get_text_field_mask, get_lengths_from_binary_sequence_mask
+from allennlp.nn.util import get_text_field_mask
 from allennlp.training.metrics import CategoricalAccuracy
 
 
@@ -82,8 +82,7 @@ class SimpleTagger(Model):
         embedded_text_input = self.text_field_embedder(tokens)
         batch_size, sequence_length, _ = embedded_text_input.size()
         mask = get_text_field_mask(tokens)
-        batch_sequence_lengths = get_lengths_from_binary_sequence_mask(mask)
-        encoded_text = self.stacked_encoder(embedded_text_input, batch_sequence_lengths)
+        encoded_text = self.stacked_encoder(embedded_text_input, mask)
 
         logits = self.tag_projection_layer(encoded_text)
         reshaped_log_probs = logits.view(-1, self.num_classes)

--- a/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
+++ b/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
@@ -3,7 +3,7 @@ from torch.nn.utils.rnn import pack_padded_sequence
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.modules.seq2vec_encoders.seq2vec_encoder import Seq2VecEncoder
-from allennlp.nn.util import sort_batch_by_length
+from allennlp.nn.util import sort_batch_by_length, get_lengths_from_binary_sequence_mask
 
 
 class PytorchSeq2VecWrapper(Seq2VecEncoder):
@@ -32,6 +32,10 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
 
     This is what pytorch's RNN's look like - just make sure your class looks like those, and it
     should work.
+
+    Note that we *require* you to pass sequence lengths when you call this module, to avoid subtle
+    bugs around masking.  If you already have a ``PackedSequence`` you can pass ``None`` as the
+    second parameter.
     """
     def __init__(self, module: torch.nn.modules.RNNBase) -> None:
         super(PytorchSeq2VecWrapper, self).__init__()
@@ -54,16 +58,16 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
 
     def forward(self,  # pylint: disable=arguments-differ
                 inputs: torch.Tensor,
-                sequence_lengths: torch.LongTensor = None,
+                mask: torch.Tensor,
                 hidden_state: torch.Tensor = None) -> torch.Tensor:
 
-        if sequence_lengths is None:
-            # If sequence_lengths aren't passed, there is no padding in the batch of
-            # instances, so we can just return the last sequence output as the state.
-            # This doesn't work in the case of variable length sequences, as the last
-            # state for each element of the batch won't be at the end of the max sequence
-            # length, so we have to use the state of the RNN below.
+        if mask is None:
+            # If a mask isn't passed, there is no padding in the batch of instances, so we can just
+            # return the last sequence output as the state.  This doesn't work in the case of
+            # variable length sequences, as the last state for each element of the batch won't be
+            # at the end of the max sequence length, so we have to use the state of the RNN below.
             return self._module(inputs, hidden_state)[0][:, -1, :]
+        sequence_lengths = get_lengths_from_binary_sequence_mask(mask)
         sorted_inputs, sorted_sequence_lengths, restoration_indices = sort_batch_by_length(inputs,
                                                                                            sequence_lengths)
         packed_sequence_input = pack_padded_sequence(sorted_inputs,


### PR DESCRIPTION
Thanks to @OyvindTafjord's exploration, I discovered I wasn't passing the mask into the modeling layer or the span end encoder in BiDAF.  I fixed that bug, and made the mask a required argument to the encoders, to head off any similar bugs later.

While I was at it, I also moved the conversion from binary mask to tensor of sequence lengths into the encoder wrappers themselves, so the model just has to worry about the mask.