### PR TITLE
Predictor fix

### DIFF
--- a/allennlp/data/fields/index_field.py
+++ b/allennlp/data/fields/index_field.py
@@ -6,6 +6,7 @@ import numpy
 
 from allennlp.data.fields.field import Field
 from allennlp.data.fields.sequence_field import SequenceField
+from allennlp.common.checks import ConfigurationError
 
 
 class IndexField(Field[numpy.ndarray]):
@@ -28,6 +29,9 @@ class IndexField(Field[numpy.ndarray]):
         self.sequence_index = index
         self.sequence_field = sequence_field
 
+        if not isinstance(index, int):
+            raise ConfigurationError("IndexFields must be passed integer indices. "
+                                     "Found index: {} with type: {}.".format(index, type(index)))
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:
         return {'num_options': self.sequence_field.sequence_length()}

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -14,8 +14,9 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class LabelField(Field[numpy.ndarray]):
     """
     A ``LabelField`` is a categorical label of some kind, where the labels are either strings of
-    text or 0-indexed integers.  If the labels need indexing, we will use a :class:`Vocabulary` to
-    convert the string labels into integers.
+    text or 0-indexed integers (if you wish to skip indexing by passing skip_indexing=True).
+    If the labels need indexing, we will use a :class:`Vocabulary` to convert the string labels
+    into integers.
 
     This field will get converted into an integer index representing the class label.
 
@@ -32,8 +33,7 @@ class LabelField(Field[numpy.ndarray]):
         "passage_labels" and "question_labels").
     skip_indexing : ``bool``, optional (default=False)
         If your labels are 0-indexed integers, you can pass in this flag, and we'll skip the indexing
-        step.  If this is ``False``, no matter the type of ``label``, we'll use a vocabulary to give
-        the labels new IDs.
+        step.  If this is ``False`` and your labels are not strings, this throws a ``ConfigurationError``.
     """
     def __init__(self,
                  label: Union[str, int],
@@ -53,6 +53,10 @@ class LabelField(Field[numpy.ndarray]):
                                          "Found label = {}".format(label))
             else:
                 self._label_id = label
+        else:
+            if not (isinstance(label, str)):
+                raise ConfigurationError("LabelFields must be passed a string label if skip_indexing=False. "
+                                         "Found label: {} with type: {}.".format(label, type(label)))
 
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -54,7 +54,7 @@ class LabelField(Field[numpy.ndarray]):
             else:
                 self._label_id = label
         else:
-            if not (isinstance(label, str)):
+            if not isinstance(label, str):
                 raise ConfigurationError("LabelFields must be passed a string label if skip_indexing=False. "
                                          "Found label: {} with type: {}.".format(label, type(label)))
 

--- a/allennlp/data/fields/sequence_label_field.py
+++ b/allennlp/data/fields/sequence_label_field.py
@@ -58,6 +58,11 @@ class SequenceLabelField(Field[numpy.ndarray]):
         if all([isinstance(x, int) for x in labels]):
             self._indexed_labels = labels
 
+        elif not all([isinstance(x, str) for x in labels]):
+            raise ConfigurationError("SequenceLabelFields must be passed either all "
+                                     "strings or all ints. Found labels {} with "
+                                     "types: {}.".format(labels, [type(x) for x in labels]))
+
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
         if self._indexed_labels is None:

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -34,6 +34,10 @@ class TextField(SequenceField[Dict[str, numpy.ndarray]]):
         self._token_indexers = token_indexers
         self._indexed_tokens = None  # type: Optional[Dict[str, TokenList]]
 
+        if not all([isinstance(x, str) for x in tokens]):
+            raise ConfigurationError("TextFields must be passed strings. "
+                                     "Found: {}".format([type(x) for x in tokens]))
+
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
         for indexer in self._token_indexers.values():

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -36,7 +36,7 @@ class TextField(SequenceField[Dict[str, numpy.ndarray]]):
 
         if not all([isinstance(x, str) for x in tokens]):
             raise ConfigurationError("TextFields must be passed strings. "
-                                     "Found: {}".format([type(x) for x in tokens]))
+                                     "Found: {} with types {}.".format(tokens, [type(x) for x in tokens]))
 
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -42,11 +42,11 @@ class SemanticRoleLabelerPredictor(Predictor):
     def predict_json(self, inputs: JsonDict) -> JsonDict:
         sentence = inputs["sentence"]
         tokens = self.nlp.tokenizer(sentence)
-        text = TextField(tokens, token_indexers=self.token_indexers)
 
         results = {"verbs": []}  # type: JsonDict
         spacy_doc = self.nlp(sentence)
         words = [token.text for token in spacy_doc]
+        text = TextField(words, token_indexers=self.token_indexers)
         for i, word in enumerate(spacy_doc):
             if word.pos_ == "VERB":
                 verb_labels = [0 for _ in tokens]

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -30,7 +30,7 @@ class SemanticRoleLabelerPredictor(Predictor):
                     chunk = []
 
                 if tag.startswith("B-"):
-                    chunk.append(tag + " " + token)
+                    chunk.append(tag[2:] + ": " + token)
                 elif tag == "O":
                     frame.append(token)
 

--- a/tests/data/dataset_test.py
+++ b/tests/data/dataset_test.py
@@ -23,7 +23,7 @@ class TestDataset(AllenNlpTestCase):
         super(TestDataset, self).setUp()
 
     def test_instances_must_have_homogeneous_fields(self):
-        instance1 = Instance({"tag": (LabelField(1))})
+        instance1 = Instance({"tag": (LabelField(1, skip_indexing=True))})
         instance2 = Instance({"words": TextField(["hello"], {})})
         with pytest.raises(ConfigurationError):
             _ = Dataset([instance1, instance2])

--- a/tests/data/fields/index_field_test.py
+++ b/tests/data/fields/index_field_test.py
@@ -1,10 +1,10 @@
 # pylint: disable=no-self-use,invalid-name
 import numpy
-
+import pytest
 from allennlp.data.fields import TextField, IndexField
 from allennlp.data.token_indexers import SingleIdTokenIndexer
 from allennlp.common.testing import AllenNlpTestCase
-
+from allennlp.common.checks import ConfigurationError
 
 class TestIndexField(AllenNlpTestCase):
 
@@ -22,3 +22,7 @@ class TestIndexField(AllenNlpTestCase):
         index_field = IndexField(4, self.text)
         array = index_field.as_array(index_field.get_padding_lengths())
         numpy.testing.assert_array_equal(array, numpy.array([4]))
+
+    def test_index_field_raises_on_incorrect_label_type(self):
+        with pytest.raises(ConfigurationError):
+            _ = IndexField("hello", self.text)

--- a/tests/data/fields/label_field_test.py
+++ b/tests/data/fields/label_field_test.py
@@ -29,3 +29,7 @@ class TestLabelField(AllenNlpTestCase):
     def test_label_field_raises_with_non_integer_labels_and_no_indexing(self):
         with pytest.raises(ConfigurationError):
             _ = LabelField("non integer field", skip_indexing=True)
+
+    def test_label_field_raises_with_incorrect_label_type(self):
+        with pytest.raises(ConfigurationError):
+            _ = LabelField([], skip_indexing=False)

--- a/tests/data/fields/sequence_label_field_test.py
+++ b/tests/data/fields/sequence_label_field_test.py
@@ -61,3 +61,8 @@ class TestSequenceLabelField(AllenNlpTestCase):
         padding_lengths = sequence_label_field.get_padding_lengths()
         array = sequence_label_field.as_array(padding_lengths)
         numpy.testing.assert_array_almost_equal(array, numpy.array([0, 1, 2, 2, 2]))
+
+    def test_sequence_label_field_raises_on_incorrect_type(self):
+
+        with pytest.raises(ConfigurationError):
+            _ = SequenceLabelField([[], [], [], [], []], self.text)

--- a/tests/data/fields/text_field_test.py
+++ b/tests/data/fields/text_field_test.py
@@ -182,3 +182,7 @@ class TestTextField(AllenNlpTestCase):
                                                              [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                                              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                                              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]))
+
+    def test_text_field_raises_on_non_string_input(self):
+        with pytest.raises(ConfigurationError):
+            _ = TextField([1, 2, 3, 4], {"tokens": SingleIdTokenIndexer()})


### PR DESCRIPTION
- Adds type checks to all the fields.
- Change logic in `LabelField` to require labels to be strings if `skip_indexing=True`.
- Fixes a bug in the SRL predictor that meant we were trying to get the indexes of Spacy objects rather than strings, so they were returning OOV ids rather than the correct ids for the string.