### PR TITLE
Fix byte encoding, bypassing the vocabulary

### DIFF
--- a/allennlp/data/dataset_readers/squad.py
+++ b/allennlp/data/dataset_readers/squad.py
@@ -121,14 +121,12 @@ class SquadReader(DatasetReader):
         for article in tqdm(dataset):
             for paragraph_json in article['paragraphs']:
                 paragraph = paragraph_json["context"]
-                # replace newlines in the paragraph
-                cleaned_paragraph = paragraph.replace("\n", " ")
 
                 # We add a special token to the end of the passage.  This is because our span
                 # labels are end-exclusive, and we do a softmax over the passage to determine span
                 # end.  So if we want to be able to include the last token of the passage, we need
                 # to have a special symbol at the end.
-                paragraph_tokens, paragraph_offsets = self._tokenizer.tokenize(cleaned_paragraph)
+                paragraph_tokens, paragraph_offsets = self._tokenizer.tokenize(paragraph)
                 paragraph_tokens.append(self.STOP_TOKEN)
                 paragraph_offsets.append((-1, -1))
 
@@ -326,11 +324,9 @@ class SquadSentenceSelectionReader(DatasetReader):
                 self._paragraph_sentences[paragraph_id] = []
 
                 context_article = paragraph["context"]
-                # replace newlines in the context article
-                cleaned_context_article = context_article.replace("\n", "")
 
-                # Split the cleaned_context_article into a list of sentences.
-                sentences = nltk.sent_tokenize(cleaned_context_article)
+                # Split the context_article into a list of sentences.
+                sentences = nltk.sent_tokenize(context_article)
 
                 # Make a dict from span indices to sentence. The end span is
                 # exclusive, and the start span is inclusive.

--- a/allennlp/data/token_indexers/single_id_token_indexer.py
+++ b/allennlp/data/token_indexers/single_id_token_indexer.py
@@ -29,14 +29,19 @@ class SingleIdTokenIndexer(TokenIndexer[int]):
 
     @overrides
     def count_vocab_items(self, token: str, counter: Dict[str, Dict[str, int]]):
-        if self.lowercase_tokens:
-            token = token.lower()
-        counter[self.namespace][token] += 1
+        if not isinstance(token, int):
+            if self.lowercase_tokens:
+                token = token.lower()
+            counter[self.namespace][token] += 1
 
     @overrides
     def token_to_indices(self, token: str, vocabulary: Vocabulary) -> int:
-        if self.lowercase_tokens:
-            token = token.lower()
+        if isinstance(token, int):
+            index = token
+        else:
+            if self.lowercase_tokens:
+                token = token.lower()
+            index = vocabulary.get_token_index(token, self.namespace)
         return vocabulary.get_token_index(token, self.namespace)
 
     @overrides

--- a/allennlp/data/token_indexers/single_id_token_indexer.py
+++ b/allennlp/data/token_indexers/single_id_token_indexer.py
@@ -29,6 +29,8 @@ class SingleIdTokenIndexer(TokenIndexer[int]):
 
     @overrides
     def count_vocab_items(self, token: str, counter: Dict[str, Dict[str, int]]):
+        # If this is used with a CharacterTokenizer that's doing byte encoding, the token might
+        # already be an int.  In that case, we'll just bypass the vocabulary entirely.
         if not isinstance(token, int):
             if self.lowercase_tokens:
                 token = token.lower()
@@ -36,13 +38,15 @@ class SingleIdTokenIndexer(TokenIndexer[int]):
 
     @overrides
     def token_to_indices(self, token: str, vocabulary: Vocabulary) -> int:
+        # If this is used with a CharacterTokenizer that's doing byte encoding, the token might
+        # already be an int.  In that case, we'll just bypass the vocabulary entirely.
         if isinstance(token, int):
             index = token
         else:
             if self.lowercase_tokens:
                 token = token.lower()
             index = vocabulary.get_token_index(token, self.namespace)
-        return vocabulary.get_token_index(token, self.namespace)
+        return index
 
     @overrides
     def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):  # pylint: disable=unused-argument

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -36,6 +36,8 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
     @overrides
     def count_vocab_items(self, token: str, counter: Dict[str, Dict[str, int]]):
         for character in self.character_tokenizer.tokenize(token)[0]:
+            # If our character tokenizer is using byte encoding, the character might already be an
+            # int.  In that case, we'll bypass the vocabulary entirely.
             if not isinstance(character, int):
                 counter[self.namespace][character] += 1
 
@@ -43,6 +45,8 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
     def token_to_indices(self, token: str, vocabulary: Vocabulary) -> List[int]:
         indices = []
         for character in self.character_tokenizer.tokenize(token)[0]:
+            # If our character tokenizer is using byte encoding, the character might already be an
+            # int.  In that case, we'll bypass the vocabulary entirely.
             if isinstance(character, int):
                 index = character
             else:

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -36,13 +36,18 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
     @overrides
     def count_vocab_items(self, token: str, counter: Dict[str, Dict[str, int]]):
         for character in self.character_tokenizer.tokenize(token)[0]:
-            counter[self.namespace][character] += 1
+            if not isinstance(character, int):
+                counter[self.namespace][character] += 1
 
     @overrides
     def token_to_indices(self, token: str, vocabulary: Vocabulary) -> List[int]:
         indices = []
         for character in self.character_tokenizer.tokenize(token)[0]:
-            indices.append(vocabulary.get_token_index(character, self.namespace))
+            if isinstance(character, int):
+                index = character
+            else:
+                index = vocabulary.get_token_index(character, self.namespace)
+            indices.append(index)
         return indices
 
     @overrides

--- a/allennlp/data/tokenizers/character_tokenizer.py
+++ b/allennlp/data/tokenizers/character_tokenizer.py
@@ -39,7 +39,7 @@ class CharacterTokenizer(Tokenizer):
         if self.lowercase_characters:
             text = text.lower()
         if self.byte_encoding is not None:
-            return list(text.encode(self.byte_encoding)), None
+            return list(text.encode(self.byte_encoding)), None  # type: ignore
         return list(text), None
 
     @classmethod

--- a/allennlp/data/tokenizers/character_tokenizer.py
+++ b/allennlp/data/tokenizers/character_tokenizer.py
@@ -22,6 +22,9 @@ class CharacterTokenizer(Tokenizer):
         accented 'a' will be different than the token for an unaccented 'a' - hopefully your
         embedding will decide that they are at least similar - while the token for the accent is
         indeed shared across different accented vowels.
+
+        If this is not ``None``, ``tokenize`` will return a ``List[int]`` instead of a
+        ``List[str]``, and we will bypass the vocabulary in the ``TokenIndexer``.
     lowercase_characters : ``bool``, optional (default=``False``)
         If ``True``, we will lowercase all of the characters in the text before doing any other
         operation.  You probably do not want to do this, as character vocabularies are generally
@@ -36,7 +39,7 @@ class CharacterTokenizer(Tokenizer):
         if self.lowercase_characters:
             text = text.lower()
         if self.byte_encoding is not None:
-            return [chr(x) for x in text.encode(self.byte_encoding)], None
+            return list(text.encode(self.byte_encoding)), None
         return list(text), None
 
     @classmethod

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -126,12 +126,21 @@ class Embedding(TokenEmbedder):
 
     @classmethod
     def from_params(cls, vocab: Vocabulary, params: Params) -> 'Embedding':
-        embedding_dim = params.pop('embedding_dim')
+        """
+        We need the vocabulary here to know how many items we need to embed, and we look for a
+        ``vocab_namespace`` key in the parameter dictionary to know which vocabulary to use.  If
+        you know beforehand exactly how many embeddings you need, or aren't using a vocabulary
+        mapping for the things getting embedded here, then you can pass in the ``num_embeddings``
+        key directly, and the vocabulary will be ignored.
+        """
+        num_embeddings = params.pop('num_embeddings', None)
         vocab_namespace = params.pop("vocab_namespace", "tokens")
+        if num_embeddings is None:
+            num_embeddings = vocab.get_vocab_size(vocab_namespace)
+        embedding_dim = params.pop('embedding_dim')
         pretrained_file = params.pop("pretrained_file", None)
         projection_dim = params.pop("projection_dim", None)
         trainable = params.pop("trainable", True)
-        num_embeddings = vocab.get_vocab_size(vocab_namespace)
         padding_index = params.pop('padding_index', None)
         max_norm = params.pop('max_norm', None)
         norm_type = params.pop('norm_type', 2.)

--- a/experiment_config/bidaf.json
+++ b/experiment_config/bidaf.json
@@ -29,6 +29,7 @@
       "token_characters": {
         "type": "character_encoding",
         "embedding": {
+          "num_embeddings": 260,
           "embedding_dim": 16
         },
         "encoder": {

--- a/tests/fixtures/bidaf/experiment.json
+++ b/tests/fixtures/bidaf/experiment.json
@@ -28,6 +28,7 @@
       "token_characters": {
         "type": "character_encoding",
         "embedding": {
+          "num_embeddings": 260,
           "embedding_dim": 8
         },
         "encoder": {


### PR DESCRIPTION
Byte encoding converts tokens to ints directly, and using the vocabulary to then map those ints to other ints is both unnecessary and problematic (because how do you save the resultant int mapping, when the loading code expects that it's reading strings?).  This makes it so that `TokenIndexers` can bypass the vocabulary if what they're given is already an `int`.

I also fixed a small bug in the `SquadReader`, where we were removing newlines.  This was necessary for our old data code where we output one instance per line, but is no longer necessary.