### PR TITLE
Use post3 url for PyTorch.

### DIFF
--- a/build_tools/readthedocs/requirements.txt
+++ b/build_tools/readthedocs/requirements.txt
@@ -7,7 +7,7 @@
 # your OS. We're including the linux version here so that our tests can run and docs can build
 # correctly using cloud platforms.  Remove this line and visit http://pytorch.org/ for installation
 # instructions if you are using an operating system other than linux.
-http://download.pytorch.org/whl/cu80/torch-0.2.0.post1-cp35-cp35m-manylinux1_x86_64.whl
+http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl
 
 # Neural net and related libraries.
 h5py

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -37,7 +37,7 @@ source activate testenv
 
 # Install requirements via pip and download data inside our conda environment.
 INSTALL_TEST_REQUIREMENTS="true" bash scripts/install_requirements.sh
-pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.2.0.post1-cp35-cp35m-manylinux1_x86_64.whl
+pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl
 
 # List the packages to get their versions for debugging
 pip list


### PR DESCRIPTION
This was breaking the ReadTheDocs build, and could break the Travis build.  I think the Travis build has only been working due to the cache.