### PR TITLE
Remove "namespace" from tutorial, play up a nice feature

### DIFF
--- a/tutorials/getting_started/configuration.md
+++ b/tutorials/getting_started/configuration.md
@@ -167,8 +167,8 @@ The second, `"token_characters"`, is a
 that represents each token as a list of int-encoded characters.
 
 Notice that this gives us two different encodings for each token.
-Each encoding has a "namespace", in this case `"tokens"` and `"token_characters"`.
-The `SequenceLabelField` also has a namespace, `"labels"`.
+Each encoding has a name, in this case `"tokens"` and `"token_characters"`,
+and these names will be referenced later by the model.
 
 ## Training and Validation Data
 
@@ -231,19 +231,19 @@ Let's first look at the text field embedder configuration:
     },
 ```
 
-You can see that it has an entry for each of the namespaces in our `TextField`.
+You can see that it has an entry for each of the named encodings in our `TextField`.
 Each entry specifies a
 [`TokenEmbedder`](http://docs.allennlp.org/en/latest/api/allennlp.modules.token_embedders.html?highlight=embedding#allennlp.modules.token_embedders.token_embedder.TokenEmbedder)
 that indicates how to embed
-the tokens in that particular namespace. The `TextFieldEmbedder`'s output is the concatenation
+the tokens encoded with that name. The `TextFieldEmbedder`'s output is the concatenation
 of these embeddings.
 
-The `"tokens"` namespace (which consists of integer encodings of the lowercased words in the input)
+The `"tokens"` input (which consists of integer encodings of the lowercased words in the input)
 gets fed into an
 [`Embedding`](http://docs.allennlp.org/en/latest/api/allennlp.modules.token_embedders.html?highlight=embedding#allennlp.modules.token_embedders.embedding.Embedding)
 module that embeds the vocabulary words in a 50-dimensional space, as specified by the `embedding_dim` parameter.
 
-The `"token_characters"` namespace (which consists of integer-sequence encodings of the characters in each word)
+The `"token_characters"` input (which consists of integer-sequence encodings of the characters in each word)
 gets fed into a
 [`TokenCharactersEncoder`](http://docs.allennlp.org/en/latest/api/allennlp.modules.token_embedders.html?highlight=embedding#allennlp.modules.token_embedders.token_characters_encoder.TokenCharactersEncoder),
 which embeds the characters in an 8-dimensional space
@@ -255,9 +255,15 @@ The output of this `TextFieldEmbedder` is a 50-dimensional vector for `"tokens"`
 concatenated with a 50-dimensional vector for `"token_characters`";
 that is, a 100-dimensional vector.
 
+Because both the encoding of `TextFields` and the `TextFieldEmbedder` are configurable in this way,
+it is trivial to experiment with different word representations as input to your model, switching
+between simple word embeddings, word embeddings concatenated with a character-level CNN, or even
+using a pre-trained model to get word-in-context embeddings, without changing a single line of
+code.
+
 ### The Seq2SeqEncoder
 
-The output of that embedding is processed by the "stacked encoder",
+The output of the `TextFieldEmbedder` is processed by the "stacked encoder",
 which needs to be a
 [`Seq2SeqEncoder`](http://docs.allennlp.org/en/latest/api/allennlp.modules.seq2seq_encoders.html#allennlp.modules.seq2seq_encoders.seq2seq_encoder.Seq2SeqEncoder):
 


### PR DESCRIPTION
I just looked over the tutorial - it looks great!  There was one minor tweak, though - I'd avoid using "namespace" in the way that you did, because those names are not actually related in any way to the vocabulary namespaces, and that could be confusing (and the vocab namespaces are an advanced topic, anyway, that most users shouldn't have to think about).