### PR TITLE
remove evalution_json_file key from config during load_archive

### DIFF
--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -56,8 +56,11 @@ def _sanitize_config(config: Params) -> None:
     that are unlikely to exist on the un-archiving machine. To be extra-safe
     we just remove them from the config.
     """
-    # TODO(joelgrus): come up with a better solution for this
-    config.get("model", {}).pop('evaluation_json_file', None)
+    evaluation_json_file = config.get("model", {}).get('evaluation_json_file', None)
+
+    if evaluation_json_file and not os.path.exists(evaluation_json_file):
+        logger.warning("specified evaluation_json_file %s does not exist, removing key", evaluation_json_file)
+        config.get("model", {}).pop('evaluation_json_file')
 
 def load_archive(archive_file: str, cuda_device: int = -1) -> Archive:
     """

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -55,6 +55,9 @@ def _sanitize_config(config: Params) -> None:
     when we load from archive, as they refer to paths on the training machine
     that are unlikely to exist on the un-archiving machine. To be extra-safe
     we just remove them from the config.
+
+    This is a temporary fix; once we implement https://github.com/allenai/allennlp/issues/244
+    it should become unnecessary.
     """
     evaluation_json_file = config.get("model", {}).get('evaluation_json_file', None)
 

--- a/tests/models/archival_test.py
+++ b/tests/models/archival_test.py
@@ -123,7 +123,3 @@ class ArchivalTest(AllenNlpTestCase):
         # shouldn't have removed anything else
         config["model"]["evaluation_json_file"] = filename
         assert config.as_dict() == original
-
-
-
-

--- a/tests/models/archival_test.py
+++ b/tests/models/archival_test.py
@@ -79,74 +79,6 @@ class ArchivalTest(AllenNlpTestCase):
         config = Params({
                 "model": {
                         "type": "bidaf",
-                        "evaluation_json_file": "path/that/does/not/exist",
-                        "text_field_embedder": {
-                                "tokens": {
-                                        "type": "embedding",
-                                        "embedding_dim": 5
-                                }
-                        },
-                        "stacked_encoder": {
-                                "type": "lstm",
-                                "input_size": 5,
-                                "hidden_size": 7,
-                                "num_layers": 2
-                        }
-                },
-                "dataset_reader": {"type": "sequence_tagging"},
-                "train_data_path": 'tests/fixtures/data/sequence_tagging.tsv',
-                "validation_data_path": 'tests/fixtures/data/sequence_tagging.tsv',
-                "iterator": {"type": "basic", "batch_size": 2},
-                "trainer": {
-                        "num_epochs": 2,
-                        "optimizer": "adam",
-                }
-        })
-
-        # same, but without the evaluation json file
-        config2 = Params({
-                "model": {
-                        "type": "bidaf",
-                        "text_field_embedder": {
-                                "tokens": {
-                                        "type": "embedding",
-                                        "embedding_dim": 5
-                                }
-                        },
-                        "stacked_encoder": {
-                                "type": "lstm",
-                                "input_size": 5,
-                                "hidden_size": 7,
-                                "num_layers": 2
-                        }
-                },
-                "dataset_reader": {"type": "sequence_tagging"},
-                "train_data_path": 'tests/fixtures/data/sequence_tagging.tsv',
-                "validation_data_path": 'tests/fixtures/data/sequence_tagging.tsv',
-                "iterator": {"type": "basic", "batch_size": 2},
-                "trainer": {
-                        "num_epochs": 2,
-                        "optimizer": "adam",
-                }
-        })
-
-        # Should be different before sanitization
-        assert config.as_dict() != config2.as_dict()
-
-        # Should be the same after we sanitize config
-        _sanitize_config(config)
-        assert config.as_dict() == config2.as_dict()
-
-        # Santizing config2 shouldn't do anything
-        _sanitize_config(config2)
-        assert config.as_dict() == config2.as_dict()
-
-    def test_sanitize_skips_existing_file(self):
-        super(ArchivalTest, self).setUp()
-
-        config = Params({
-                "model": {
-                        "type": "bidaf",
                         "text_field_embedder": {
                                 "tokens": {
                                         "type": "embedding",
@@ -187,6 +119,10 @@ class ArchivalTest(AllenNlpTestCase):
         _sanitize_config(config)
         assert config.as_dict() != original
         assert "evaluation_json_file" not in config["model"]
+
+        # shouldn't have removed anything else
+        config["model"]["evaluation_json_file"] = filename
+        assert config.as_dict() == original
 
 
 


### PR DESCRIPTION
this may be too aggressive (I can imagine wanting to use the evaluation_json_file in `run evaluate`, if that's the case I could check if it exists or pass through a flag not to delete it, but this was simplest)

(also, I know the config file in the test is sort of nonsensical)