### PR TITLE
Simple LSTM wrapper with better default initialization

### DIFF
--- a/allennlp/modules/default_lstm.py
+++ b/allennlp/modules/default_lstm.py
@@ -1,0 +1,36 @@
+import re
+from overrides import overrides
+import torch
+
+from allennlp.nn.initializers import block_orthogonal
+
+
+class DefaultLstm(torch.nn.LSTM):
+    """
+    A wrapper of the Pytorch LSTM which provides a good default initialization
+    of weights and biases, and disables training of the superfluous bias_hh parameters.
+
+    Input parameters are identical to Pytorch LSTM.
+    """
+    @overrides
+    def reset_parameters(self):
+        hidden_size = self.hidden_size
+        for param_name, param in self.named_parameters():
+            if re.search("bias_hh", param_name):
+                torch.nn.init.constant(param, 0)
+                # This parameter is superfluous, so we should not update it in training
+                param.requires_grad = False
+            elif re.search("bias_ih", param_name):
+                bias = param.data
+                bias_size = bias.size(0)
+                # The forget get bias is between fractions 1/4 and 1/2 of the vector
+                start, end = bias_size//4, bias_size//2
+                bias.fill_(0)
+                bias[start:end].fill_(1)
+            elif re.search("weight_ih", param_name):
+                # Initialize each block matrix separately
+                for i in range(0, 4):
+                    block = param.data[i*hidden_size:(i+1)*hidden_size]
+                    torch.nn.init.xavier_uniform(block)
+            elif re.search("weight_hh", param_name):
+                block_orthogonal(param, [hidden_size, hidden_size])

--- a/allennlp/modules/initialized_lstm.py
+++ b/allennlp/modules/initialized_lstm.py
@@ -24,6 +24,7 @@ class InitializedLstm(torch.nn.LSTM):
                 param.requires_grad = False
             elif param_name.startswith("bias_ih"):
                 bias = param.data
+                bias.fill_(0)
                 # The forget get bias is in the second hidden_size block
                 bias[hidden_size:2*hidden_size].fill_(1)
             elif param_name.startswith("weight_ih"):

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -7,7 +7,7 @@ from allennlp.common.checks import ConfigurationError
 from allennlp.modules.seq2seq_encoders.seq2seq_encoder import Seq2SeqEncoder
 from allennlp.modules.seq2seq_encoders.pytorch_seq2seq_wrapper import PytorchSeq2SeqWrapper
 from allennlp.modules.augmented_lstm import AugmentedLstm
-from allennlp.modules.default_lstm import DefaultLstm
+from allennlp.modules.initialized_lstm import InitializedLstm
 from allennlp.modules.stacked_alternating_lstm import StackedAlternatingLstm
 
 class _Seq2SeqWrapper:
@@ -36,7 +36,7 @@ class _Seq2SeqWrapper:
     ``PytorchSeq2SeqWrapper``.  This lets us use this class in the registry and have everything just
     work.
     """
-    PYTORCH_MODELS = [torch.nn.GRU, torch.nn.LSTM, torch.nn.RNN, DefaultLstm]
+    PYTORCH_MODELS = [torch.nn.GRU, torch.nn.LSTM, torch.nn.RNN, InitializedLstm]
 
     def __init__(self, module_class: Type[torch.nn.modules.RNNBase]) -> None:
         self._module_class = module_class
@@ -54,7 +54,7 @@ class _Seq2SeqWrapper:
 
 # pylint: disable=protected-access
 Seq2SeqEncoder.register("gru")(_Seq2SeqWrapper(torch.nn.GRU))
-Seq2SeqEncoder.register("lstm")(_Seq2SeqWrapper(DefaultLstm))
+Seq2SeqEncoder.register("lstm")(_Seq2SeqWrapper(InitializedLstm))
 Seq2SeqEncoder.register("rnn")(_Seq2SeqWrapper(torch.nn.RNN))
 Seq2SeqEncoder.register("augmented_lstm")(_Seq2SeqWrapper(AugmentedLstm))
 Seq2SeqEncoder.register("alternating_lstm")(_Seq2SeqWrapper(StackedAlternatingLstm))

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -7,6 +7,7 @@ from allennlp.common.checks import ConfigurationError
 from allennlp.modules.seq2seq_encoders.seq2seq_encoder import Seq2SeqEncoder
 from allennlp.modules.seq2seq_encoders.pytorch_seq2seq_wrapper import PytorchSeq2SeqWrapper
 from allennlp.modules.augmented_lstm import AugmentedLstm
+from allennlp.modules.default_lstm import DefaultLstm
 from allennlp.modules.stacked_alternating_lstm import StackedAlternatingLstm
 
 class _Seq2SeqWrapper:
@@ -35,7 +36,7 @@ class _Seq2SeqWrapper:
     ``PytorchSeq2SeqWrapper``.  This lets us use this class in the registry and have everything just
     work.
     """
-    PYTORCH_MODELS = [torch.nn.GRU, torch.nn.LSTM, torch.nn.RNN]
+    PYTORCH_MODELS = [torch.nn.GRU, torch.nn.LSTM, torch.nn.RNN, DefaultLstm]
 
     def __init__(self, module_class: Type[torch.nn.modules.RNNBase]) -> None:
         self._module_class = module_class
@@ -53,7 +54,7 @@ class _Seq2SeqWrapper:
 
 # pylint: disable=protected-access
 Seq2SeqEncoder.register("gru")(_Seq2SeqWrapper(torch.nn.GRU))
-Seq2SeqEncoder.register("lstm")(_Seq2SeqWrapper(torch.nn.LSTM))
+Seq2SeqEncoder.register("lstm")(_Seq2SeqWrapper(DefaultLstm))
 Seq2SeqEncoder.register("rnn")(_Seq2SeqWrapper(torch.nn.RNN))
 Seq2SeqEncoder.register("augmented_lstm")(_Seq2SeqWrapper(AugmentedLstm))
 Seq2SeqEncoder.register("alternating_lstm")(_Seq2SeqWrapper(StackedAlternatingLstm))

--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -8,6 +8,7 @@ from allennlp.modules.seq2vec_encoders.cnn_encoder import CnnEncoder
 from allennlp.modules.seq2vec_encoders.pytorch_seq2vec_wrapper import PytorchSeq2VecWrapper
 from allennlp.modules.seq2vec_encoders.seq2vec_encoder import Seq2VecEncoder
 from allennlp.modules.augmented_lstm import AugmentedLstm
+from allennlp.modules.default_lstm import DefaultLstm
 from allennlp.modules.stacked_alternating_lstm import StackedAlternatingLstm
 
 
@@ -37,7 +38,7 @@ class _Seq2VecWrapper:
     ``PytorchSeq2VecWrapper``.  This lets us use this class in the registry and have everything just
     work.
     """
-    PYTORCH_MODELS = [torch.nn.GRU, torch.nn.LSTM, torch.nn.RNN]
+    PYTORCH_MODELS = [torch.nn.GRU, torch.nn.LSTM, torch.nn.RNN, DefaultLstm]
     def __init__(self, module_class: Type[torch.nn.modules.RNNBase]) -> None:
         self._module_class = module_class
 
@@ -54,7 +55,7 @@ class _Seq2VecWrapper:
 
 # pylint: disable=protected-access
 Seq2VecEncoder.register("gru")(_Seq2VecWrapper(torch.nn.GRU))
-Seq2VecEncoder.register("lstm")(_Seq2VecWrapper(torch.nn.LSTM))
+Seq2VecEncoder.register("lstm")(_Seq2VecWrapper(DefaultLstm))
 Seq2VecEncoder.register("rnn")(_Seq2VecWrapper(torch.nn.RNN))
 Seq2VecEncoder.register("augmented_lstm")(_Seq2VecWrapper(AugmentedLstm))
 Seq2VecEncoder.register("alternating_lstm")(_Seq2VecWrapper(StackedAlternatingLstm))

--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -8,7 +8,7 @@ from allennlp.modules.seq2vec_encoders.cnn_encoder import CnnEncoder
 from allennlp.modules.seq2vec_encoders.pytorch_seq2vec_wrapper import PytorchSeq2VecWrapper
 from allennlp.modules.seq2vec_encoders.seq2vec_encoder import Seq2VecEncoder
 from allennlp.modules.augmented_lstm import AugmentedLstm
-from allennlp.modules.default_lstm import DefaultLstm
+from allennlp.modules.initialized_lstm import InitializedLstm
 from allennlp.modules.stacked_alternating_lstm import StackedAlternatingLstm
 
 
@@ -38,7 +38,7 @@ class _Seq2VecWrapper:
     ``PytorchSeq2VecWrapper``.  This lets us use this class in the registry and have everything just
     work.
     """
-    PYTORCH_MODELS = [torch.nn.GRU, torch.nn.LSTM, torch.nn.RNN, DefaultLstm]
+    PYTORCH_MODELS = [torch.nn.GRU, torch.nn.LSTM, torch.nn.RNN, InitializedLstm]
     def __init__(self, module_class: Type[torch.nn.modules.RNNBase]) -> None:
         self._module_class = module_class
 
@@ -55,7 +55,7 @@ class _Seq2VecWrapper:
 
 # pylint: disable=protected-access
 Seq2VecEncoder.register("gru")(_Seq2VecWrapper(torch.nn.GRU))
-Seq2VecEncoder.register("lstm")(_Seq2VecWrapper(DefaultLstm))
+Seq2VecEncoder.register("lstm")(_Seq2VecWrapper(InitializedLstm))
 Seq2VecEncoder.register("rnn")(_Seq2VecWrapper(torch.nn.RNN))
 Seq2VecEncoder.register("augmented_lstm")(_Seq2VecWrapper(AugmentedLstm))
 Seq2VecEncoder.register("alternating_lstm")(_Seq2VecWrapper(StackedAlternatingLstm))

--- a/tests/common/registrable_test.py
+++ b/tests/common/registrable_test.py
@@ -121,14 +121,14 @@ class TestRegistrable(AllenNlpTestCase):
     def test_registry_has_builtin_seq2seq_encoders(self):
         # pylint: disable=protected-access
         assert Seq2SeqEncoder.by_name('gru')._module_class.__name__ == 'GRU'
-        assert Seq2SeqEncoder.by_name('lstm')._module_class.__name__ == 'DefaultLstm'
+        assert Seq2SeqEncoder.by_name('lstm')._module_class.__name__ == 'InitializedLstm'
         assert Seq2SeqEncoder.by_name('rnn')._module_class.__name__ == 'RNN'
 
     def test_registry_has_builtin_seq2vec_encoders(self):
         assert Seq2VecEncoder.by_name('cnn').__name__ == 'CnnEncoder'
         # pylint: disable=protected-access
         assert Seq2VecEncoder.by_name('gru')._module_class.__name__ == 'GRU'
-        assert Seq2VecEncoder.by_name('lstm')._module_class.__name__ == 'DefaultLstm'
+        assert Seq2VecEncoder.by_name('lstm')._module_class.__name__ == 'InitializedLstm'
         assert Seq2VecEncoder.by_name('rnn')._module_class.__name__ == 'RNN'
 
     def test_registry_has_builtin_similarity_functions(self):

--- a/tests/common/registrable_test.py
+++ b/tests/common/registrable_test.py
@@ -121,14 +121,14 @@ class TestRegistrable(AllenNlpTestCase):
     def test_registry_has_builtin_seq2seq_encoders(self):
         # pylint: disable=protected-access
         assert Seq2SeqEncoder.by_name('gru')._module_class.__name__ == 'GRU'
-        assert Seq2SeqEncoder.by_name('lstm')._module_class.__name__ == 'LSTM'
+        assert Seq2SeqEncoder.by_name('lstm')._module_class.__name__ == 'DefaultLstm'
         assert Seq2SeqEncoder.by_name('rnn')._module_class.__name__ == 'RNN'
 
     def test_registry_has_builtin_seq2vec_encoders(self):
         assert Seq2VecEncoder.by_name('cnn').__name__ == 'CnnEncoder'
         # pylint: disable=protected-access
         assert Seq2VecEncoder.by_name('gru')._module_class.__name__ == 'GRU'
-        assert Seq2VecEncoder.by_name('lstm')._module_class.__name__ == 'LSTM'
+        assert Seq2VecEncoder.by_name('lstm')._module_class.__name__ == 'DefaultLstm'
         assert Seq2VecEncoder.by_name('rnn')._module_class.__name__ == 'RNN'
 
     def test_registry_has_builtin_similarity_functions(self):

--- a/tests/modules/seq2seq_encoder_test.py
+++ b/tests/modules/seq2seq_encoder_test.py
@@ -21,7 +21,7 @@ class TestSeq2SeqEncoder(AllenNlpTestCase):
         encoder = Seq2SeqEncoder.from_params(params)
         # pylint: disable=protected-access
         assert encoder.__class__.__name__ == 'PytorchSeq2SeqWrapper'
-        assert encoder._module.__class__.__name__ == 'DefaultLstm'
+        assert encoder._module.__class__.__name__ == 'InitializedLstm'
         assert encoder._module.num_layers == 3
         assert encoder._module.input_size == 5
         assert encoder._module.hidden_size == 7

--- a/tests/modules/seq2seq_encoder_test.py
+++ b/tests/modules/seq2seq_encoder_test.py
@@ -21,7 +21,7 @@ class TestSeq2SeqEncoder(AllenNlpTestCase):
         encoder = Seq2SeqEncoder.from_params(params)
         # pylint: disable=protected-access
         assert encoder.__class__.__name__ == 'PytorchSeq2SeqWrapper'
-        assert encoder._module.__class__.__name__ == 'LSTM'
+        assert encoder._module.__class__.__name__ == 'DefaultLstm'
         assert encoder._module.num_layers == 3
         assert encoder._module.input_size == 5
         assert encoder._module.hidden_size == 7

--- a/tests/modules/seq2vec_encoder_test.py
+++ b/tests/modules/seq2vec_encoder_test.py
@@ -21,7 +21,7 @@ class TestSeq2VecEncoder(AllenNlpTestCase):
         encoder = Seq2VecEncoder.from_params(params)
         # pylint: disable=protected-access
         assert encoder.__class__.__name__ == 'PytorchSeq2VecWrapper'
-        assert encoder._module.__class__.__name__ == 'DefaultLstm'
+        assert encoder._module.__class__.__name__ == 'InitializedLstm'
         assert encoder._module.num_layers == 3
         assert encoder._module.input_size == 5
         assert encoder._module.hidden_size == 7

--- a/tests/modules/seq2vec_encoder_test.py
+++ b/tests/modules/seq2vec_encoder_test.py
@@ -21,7 +21,7 @@ class TestSeq2VecEncoder(AllenNlpTestCase):
         encoder = Seq2VecEncoder.from_params(params)
         # pylint: disable=protected-access
         assert encoder.__class__.__name__ == 'PytorchSeq2VecWrapper'
-        assert encoder._module.__class__.__name__ == 'LSTM'
+        assert encoder._module.__class__.__name__ == 'DefaultLstm'
         assert encoder._module.num_layers == 3
         assert encoder._module.input_size == 5
         assert encoder._module.hidden_size == 7

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -35,7 +35,8 @@ class TestTrainer(AllenNlpTestCase):
                         }
                 })
         self.model = SimpleTagger.from_params(self.vocab, self.model_params)
-        self.optimizer = torch.optim.SGD(self.model.parameters(), 0.01)
+        parameters = [p for p in self.model.parameters() if p.requires_grad]
+        self.optimizer = torch.optim.SGD(parameters, 0.01)
         self.iterator = BasicIterator(batch_size=2)
 
     def test_trainer_can_run(self):


### PR DESCRIPTION
Not urgent, but this is an attempt at a mechanism for providing better default initialization for, say, LSTMs (and also suppress training of the superfluous `bias_hh` variables). I considered adding extra arguments to this new class so that it's easier to change the details, but that would be inconsistent with the other paradigm of parameter regexes global to the model. Maybe later though we'll also have module-specific initialization settings more generally, along the lines of Keras etc. 