### PR TITLE
Adding a `text_to_instance` method on DatasetReader

### DIFF
--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -1,8 +1,5 @@
-from typing import Dict
-
 from allennlp.data.dataset import Dataset
-from allennlp.data.tokenizers import Tokenizer
-from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
+from allennlp.data.instance import Instance
 from allennlp.common import Params
 from allennlp.common.registrable import Registrable
 
@@ -13,15 +10,28 @@ class DatasetReader(Registrable):
     parameters necessary to read the data apart from the filepath should be passed to the
     constructor of the ``DatasetReader``.
     """
-    def __init__(self,
-                 token_indexers: Dict[str, TokenIndexer] = None,
-                 tokenizer: Tokenizer = None) -> None:
-        self._tokenizer = tokenizer
-        self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
-
     def read(self, file_path: str) -> Dataset:
         """
         Actually reads some data from the `file_path` and returns a :class:`Dataset`.
+        """
+        raise NotImplementedError
+
+    def text_to_instance(self, *inputs) -> Instance:
+        """
+        Does whatever tokenization or processing is necessary to go from textual input to an
+        ``Instance``.  The primary intended use for this is with a
+        :class:`~allennlp.service.predictors.predictor.Predictor`, which gets text input as a JSON
+        object and needs to process it to be input to a model.
+
+        The intent here is to share code between :func:`read` and what happens at
+        model serving time, or any other time you want to make a prediction from new data.  We need
+        to process the data in the same way it was done at training time.  Allowing the
+        ``DatasetReader`` to process new text lets us accomplish this, as we can just call
+        ``DatasetReader.text_to_instance`` when serving predictions.
+
+        The input type here is rather vaguely specified, unfortunately.  The ``Predictor`` will
+        have to make some assumptions about the kind of ``DatasetReader`` that it's using, in order
+        to pass it the right information.
         """
         raise NotImplementedError
 

--- a/allennlp/data/dataset_readers/squad.py
+++ b/allennlp/data/dataset_readers/squad.py
@@ -2,10 +2,10 @@ import json
 import logging
 import random
 from collections import Counter
-from copy import deepcopy
 from typing import List, Tuple, Dict, Set
 
 import numpy
+from overrides import overrides
 from tqdm import tqdm
 
 from allennlp.common import Params
@@ -14,7 +14,7 @@ from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.instance import Instance
-from allennlp.data.token_indexers.token_indexer import TokenIndexer
+from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
 from allennlp.data.tokenizers.tokenizer import Tokenizer
 from allennlp.data.fields import Field, TextField, ListField, IndexField
 from allennlp.data.tokenizers import WordTokenizer
@@ -105,10 +105,12 @@ class SquadReader(DatasetReader):
         Default is ``{"tokens": SingleIdTokenIndexer()}``.
     """
     def __init__(self,
-                 tokenizer: Tokenizer = WordTokenizer(),
+                 tokenizer: Tokenizer = None,
                  token_indexers: Dict[str, TokenIndexer] = None) -> None:
-        super().__init__(tokenizer=tokenizer, token_indexers=token_indexers)
+        self._tokenizer = tokenizer or WordTokenizer()
+        self._token_indexers = token_indexers or {'tokens': SingleIdTokenIndexer()}
 
+    @overrides
     def read(self, file_path: str):
         # if `file_path` is a URL, redirect to the cache
         file_path = cached_path(file_path)
@@ -122,66 +124,80 @@ class SquadReader(DatasetReader):
         for article in tqdm(dataset):
             for paragraph_json in article['paragraphs']:
                 paragraph = paragraph_json["context"]
-
-                # We add a special token to the end of the passage.  This is because our span
-                # labels are end-exclusive, and we do a softmax over the passage to determine span
-                # end.  So if we want to be able to include the last token of the passage, we need
-                # to have a special symbol at the end.
-                paragraph_tokens, paragraph_offsets = self._tokenizer.tokenize(paragraph)
+                tokenized_paragraph = self._tokenizer.tokenize(paragraph)
 
                 for question_answer in paragraph_json['qas']:
                     question_text = question_answer["question"].strip().replace("\n", "")
                     question_id = question_answer['id'].strip()
-                    question_tokens, _ = self._tokenizer.tokenize(question_text)
 
-                    # There may be multiple answer annotations, so pick the one that occurs the
-                    # most.
+                    # There may be multiple answer annotations, so we pick the one that occurs the
+                    # most.  This only matters on the SQuAD dev set, and it means our computed
+                    # metrics ("start_acc", "end_acc", and "span_acc") aren't quite the same as the
+                    # official metrics, which look at all of the annotations.  This is why we have
+                    # a separate official SQuAD metric calculation (the "em" and "f1" metrics use
+                    # the official script).
                     candidate_answers: Counter = Counter()
                     for answer in question_answer["answers"]:
                         candidate_answers[(answer["answer_start"], answer["text"])] += 1
                     char_span_start, answer_text = candidate_answers.most_common(1)[0][0]
 
-                    # SQuAD gives answer annotations as a character index into the paragraph, but
-                    # we need a token index for our models.  We convert them here.
-                    char_span_end = char_span_start + len(answer_text)
-                    (span_start, span_end), error = _char_span_to_token_span(paragraph_offsets,
-                                                                             (char_span_start,
-                                                                              char_span_end))
-                    if error:
-                        logger.debug("Passage: %s", paragraph)
-                        logger.debug("Passage tokens: %s", paragraph_tokens)
-                        logger.debug("Question: %s", question_text)
-                        logger.debug("Answer span: (%d, %d)", char_span_start, char_span_end)
-                        logger.debug("Token span: (%d, %d)", span_start, span_end)
-                        logger.debug("Tokens in answer: %s", paragraph_tokens[span_start:span_end + 1])
-                        logger.debug("Answer: %s", answer_text)
-
-                    # Because the paragraph is shared across multiple questions, we do a deepcopy
-                    # here to avoid any weird issues with shared state between instances (e.g.,
-                    # when indexing is done, and when padding is done).  I _think_ all of those
-                    # operations would be safe with shared objects, but I'd rather just be safe by
-                    # doing a copy here.  Extra memory usage should be minimal.
-                    paragraph_field = TextField(deepcopy(paragraph_tokens), self._token_indexers)
-                    question_field = TextField(question_tokens, self._token_indexers)
-                    span_start_field = IndexField(span_start, paragraph_field)
-                    span_end_field = IndexField(span_end, paragraph_field)
-                    fields = {
-                            'question': question_field,
-                            'passage': paragraph_field,
-                            'span_start': span_start_field,
-                            'span_end': span_end_field
-                            }
-                    metadata = {
-                            'id': question_id,
-                            'original_passage': paragraph,
-                            'token_offsets': paragraph_offsets
-                            }
-                    instance = Instance(fields, metadata)
+                    instance = self.text_to_instance(question_text,
+                                                     paragraph,
+                                                     question_id,
+                                                     answer_text,
+                                                     char_span_start,
+                                                     tokenized_paragraph)
                     instances.append(instance)
         if not instances:
             raise ConfigurationError("No instances were read from the given filepath {}. "
                                      "Is the path correct?".format(file_path))
         return Dataset(instances)
+
+    @overrides
+    def text_to_instance(self,  # type: ignore
+                         question_text: str,
+                         passage_text: str,
+                         question_id: str = None,
+                         answer_text: str = None,
+                         char_span_start: int = None,
+                         tokenized_passage: Tuple[List[str], List[Tuple[int, int]]] = None) -> Instance:
+        # pylint: disable=arguments-differ
+        fields = {}  # type: Dict[str, Field]
+        if tokenized_passage:
+            passage_tokens, passage_offsets = tokenized_passage
+        else:
+            passage_tokens, passage_offsets = self._tokenizer.tokenize(passage_text)
+        question_tokens, _ = self._tokenizer.tokenize(question_text)
+        # Separate so we can reference it later with a known type.
+        passage_field = TextField(passage_tokens, self._token_indexers)
+        fields['passage'] = passage_field
+        fields['question'] = TextField(question_tokens, self._token_indexers)
+
+        if answer_text:
+            # SQuAD gives answer annotations as a character index into the paragraph, but we need a
+            # token index for our models.  We convert them here.
+            char_span_end = char_span_start + len(answer_text)
+            (span_start, span_end), error = _char_span_to_token_span(passage_offsets,
+                                                                     (char_span_start,
+                                                                      char_span_end))
+            if error:
+                logger.debug("Passage: %s", passage_text)
+                logger.debug("Passage tokens: %s", passage_tokens)
+                logger.debug("Question: %s", question_text)
+                logger.debug("Answer span: (%d, %d)", char_span_start, char_span_end)
+                logger.debug("Token span: (%d, %d)", span_start, span_end)
+                logger.debug("Tokens in answer: %s", passage_tokens[span_start:span_end + 1])
+                logger.debug("Answer: %s", answer_text)
+
+            fields['span_start'] = IndexField(span_start, passage_field)
+            fields['span_end'] = IndexField(span_end, passage_field)
+        metadata = {
+                'original_passage': passage_text,
+                'token_offsets': passage_offsets
+                }
+        if question_id:
+            metadata['question_id'] = question_id
+        return Instance(fields, metadata)
 
     @classmethod
     def from_params(cls, params: Params) -> 'SquadReader':
@@ -224,9 +240,10 @@ class SquadSentenceSelectionReader(DatasetReader):
     """
     def __init__(self,
                  negative_sentence_selection: str = "paragraph",
-                 tokenizer: Tokenizer = WordTokenizer(),
+                 tokenizer: Tokenizer = None,
                  token_indexers: Dict[str, TokenIndexer] = None) -> None:
-        super().__init__(tokenizer=tokenizer, token_indexers=token_indexers)
+        self._tokenizer = tokenizer or WordTokenizer()
+        self._token_indexers = token_indexers or {'tokens': SingleIdTokenIndexer()}
         self._negative_sentence_selection_methods = negative_sentence_selection.split(",")
 
         # Initializing some data structures here that will be useful when reading a file.
@@ -300,6 +317,7 @@ class SquadSentenceSelectionReader(DatasetReader):
                 sentence_choices.append(self._id_to_question[index])
         return sentence_choices, correct_choice
 
+    @overrides
     def read(self, file_path: str):
         # Import is here, since it isn't necessary by default.
         import nltk
@@ -375,23 +393,34 @@ class SquadSentenceSelectionReader(DatasetReader):
         for question_id, answer_id in tqdm(questions):
             sentence_choices, correct_choice = self._get_sentence_choices(question_id, answer_id)
             question_text = self._id_to_question[question_id]
-            sentence_fields: List[Field] = []
-            for sentence in sentence_choices:
-                tokenized_sentence, _ = self._tokenizer.tokenize(sentence)
-                sentence_field = TextField(tokenized_sentence, self._token_indexers)
-                sentence_fields.append(sentence_field)
-            sentences_field = ListField(sentence_fields)
-            question_tokens, _ = self._tokenizer.tokenize(question_text)
-            question_field = TextField(question_tokens, self._token_indexers)
-            correct_sentence_field = IndexField(correct_choice, sentences_field)
-            instances.append(Instance({'question': question_field,
-                                       'sentences': sentences_field,
-                                       'correct_sentence': correct_sentence_field}))
+            instance = self.text_to_instance(question_text, sentence_choices, correct_choice)
+            instances.append(instance)
 
         if not instances:
             raise ConfigurationError("No instances were read from the given filepath {}. "
                                      "Is the path correct?".format(file_path))
         return Dataset(instances)
+
+    @overrides
+    def text_to_instance(self,  # type: ignore
+                         question: str,
+                         sentences: List[str],
+                         correct_choice: int = None) -> Instance:
+        # pylint: disable=arguments-differ
+        fields: Dict[str, Field] = {}
+        sentence_fields: List[Field] = []
+        for sentence in sentences:
+            tokenized_sentence, _ = self._tokenizer.tokenize(sentence)
+            sentence_field = TextField(tokenized_sentence, self._token_indexers)
+            sentence_fields.append(sentence_field)
+        # Separate so we can reference it later with a known type.
+        sentences_field = ListField(sentence_fields)
+        fields['sentences'] = sentences_field
+        question_tokens, _ = self._tokenizer.tokenize(question)
+        fields['question'] = TextField(question_tokens, self._token_indexers)
+        if correct_choice is not None:
+            fields['correct_sentence'] = IndexField(correct_choice, sentences_field)
+        return Instance(fields)
 
     @classmethod
     def from_params(cls, params: Params) -> 'SquadSentenceSelectionReader':

--- a/allennlp/models/decomposable_attention.py
+++ b/allennlp/models/decomposable_attention.py
@@ -4,13 +4,11 @@ import torch
 
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
-from allennlp.data import Instance, Vocabulary
-from allennlp.data.fields import TextField
+from allennlp.data import Vocabulary
 from allennlp.models.model import Model
 from allennlp.modules import FeedForward, MatrixAttention
 from allennlp.modules import Seq2SeqEncoder, SimilarityFunction, TimeDistributed, TextFieldEmbedder
 from allennlp.nn.util import get_text_field_mask, last_dim_softmax, weighted_sum
-from allennlp.nn.util import arrays_to_variables
 from allennlp.training.metrics import CategoricalAccuracy
 from allennlp.nn.initializers import InitializerApplicator
 
@@ -171,36 +169,6 @@ class DecomposableAttention(Model):
         return {
                 'accuracy': self._accuracy.get_metric(reset),
                 }
-
-    def predict_entailment(self, premise: TextField, hypothesis: TextField) -> Dict[str, torch.Tensor]:
-        """
-        Given a premise and a hypothesis sentence, predict the entailment relationship between
-        them.  Note that in the paper, a null token was appended to each sentence, to allow for
-        words to align to nothing in the other sentence.  If you've trained your model with a null
-        token, you probably want to include it here, too.
-
-        Parameters
-        ----------
-        premise : ``TextField``
-        hypothesis : ``TextField``
-
-        Returns
-        -------
-        A Dict containing:
-
-        label_probs : torch.FloatTensor
-            A tensor of shape ``(num_labels,)`` representing probabilities of the entailment label.
-        """
-        instance = Instance({"premise": premise, "hypothesis": hypothesis})
-        instance.index_fields(self.vocab)
-        model_input = arrays_to_variables(instance.as_array_dict(),
-                                          add_batch_dimension=True,
-                                          for_training=False)
-        output_dict = self.forward(**model_input)
-
-        # Remove batch dimension, as we only had one input.
-        label_probs = output_dict["label_probs"].data.squeeze(0)
-        return {'label_probs': label_probs.numpy()}
 
     @classmethod
     def from_params(cls, vocab: Vocabulary, params: Params) -> 'DecomposableAttention':

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -112,6 +112,22 @@ class Model(torch.nn.Module, Registrable):
             outputs[name] = output
         return outputs
 
+    def decode(self, output_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        """
+        Takes the result of :func:`forward` and runs inference / decoding / whatever
+        post-processing you need to do your model.  The intent is that ``model.forward()`` should
+        produce potentials or probabilities, and then ``model.decode()`` can take those results and
+        run some kind of beam search or constrained inference or whatever is necessary.  This does
+        not handle all possible decoding use cases, but it at least handles simple kinds of
+        decoding.
+
+        This method `modifies` the input dictionary, and also `returns` the same dictionary.
+
+        By default in the base class we do nothing.  If your model has some special decoding step,
+        override this method.
+        """
+        return output_dict
+
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         """
         Returns a dictionary of metrics. This method will be called by

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -126,6 +126,7 @@ class Model(torch.nn.Module, Registrable):
         By default in the base class we do nothing.  If your model has some special decoding step,
         override this method.
         """
+        # pylint: disable=no-self-use
         return output_dict
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -159,7 +159,7 @@ class SemanticRoleLabeler(Model):
                     for x in max_likelihood_sequence]
             all_tags.append(tags)
         if len(all_tags) == 1:
-            all_tags = all_tags[0]
+            all_tags = all_tags[0]  # type: ignore
         output_dict['tags'] = all_tags
         return output_dict
 

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+import numpy
 from overrides import overrides
 import torch
 from torch.nn.modules.linear import Linear
@@ -118,7 +119,7 @@ class SimpleTagger(Model):
                     for x in argmax_indices]
             all_tags.append(tags)
         if len(all_tags) == 1:
-            all_tags = all_tags[0]
+            all_tags = all_tags[0]  # type: ignore
         output_dict['tags'] = all_tags
         return output_dict
 

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -130,8 +130,10 @@ def arrays_to_variables(data_structure: Dict[str, Union[dict, numpy.ndarray]],
     if isinstance(data_structure, dict):
         for key, value in data_structure.items():
             if key == 'metadata':
-                continue
-            data_structure[key] = arrays_to_variables(value, cuda_device, add_batch_dimension)
+                if add_batch_dimension:
+                    data_structure[key] = [value]
+            else:
+                data_structure[key] = arrays_to_variables(value, cuda_device, add_batch_dimension)
         return data_structure
     else:
         tensor = torch.from_numpy(data_structure)

--- a/allennlp/service/predictors/bidaf.py
+++ b/allennlp/service/predictors/bidaf.py
@@ -1,5 +1,7 @@
-from allennlp.common.util import JsonDict, sanitize
-from allennlp.data.fields import TextField
+from overrides import overrides
+
+from allennlp.common.util import JsonDict
+from allennlp.data import Instance
 from allennlp.service.predictors.predictor import Predictor
 
 
@@ -8,29 +10,11 @@ class BidafPredictor(Predictor):
     """
     Wrapper for the :class:`~allennlp.models.bidaf.BidirectionalAttentionFlow` model.
     """
-    def predict_json(self, inputs: JsonDict) -> JsonDict:
+    @overrides
+    def _json_to_instance(self, json: JsonDict) -> Instance:
         """
-        Expects JSON that looks like ``{"question": "...", "passage": "..."}``
-        and returns JSON that looks like
-        ``{"best_span": "...", "best_span_str": "...", "span_start_probs": "...", "span_end_probs": "..."}``
+        Expects JSON that looks like ``{"question": "...", "passage": "..."}``.
         """
-        question_text = inputs["question"]
-        passage_text = inputs["passage"]
-
-        question_tokens, _ = self.tokenizer.tokenize(question_text)
-        passage_tokens, passage_tokens_offsets = self.tokenizer.tokenize(passage_text)
-
-        question = TextField(question_tokens, token_indexers=self.token_indexers)
-        passage = TextField(passage_tokens, token_indexers=self.token_indexers)
-
-        prediction = self.model.predict_span(question, passage)
-
-        best_span = prediction["best_span"]
-        best_span_char_start = passage_tokens_offsets[best_span[0]][0]
-        best_span_char_end = passage_tokens_offsets[best_span[1]][1]
-        prediction["best_span_str"] = passage_text[best_span_char_start:best_span_char_end]
-
-        # Add the question tokens, so the token intervals are useful
-        prediction["tokens"] = passage_tokens
-
-        return sanitize(prediction)
+        question_text = json["question"]
+        passage_text = json["passage"]
+        return self._dataset_reader.text_to_instance(question_text, passage_text)

--- a/allennlp/service/predictors/decomposable_attention.py
+++ b/allennlp/service/predictors/decomposable_attention.py
@@ -1,24 +1,20 @@
-from allennlp.common.util import JsonDict, sanitize
-from allennlp.data.fields import TextField
+from overrides import overrides
+
+from allennlp.common.util import JsonDict
+from allennlp.data import Instance
 from allennlp.service.predictors.predictor import Predictor
+
 
 @Predictor.register('textual-entailment')
 class DecomposableAttentionPredictor(Predictor):
     """
     Wrapper for the :class:`~allennlp.models.bidaf.DecomposableAttention` model.
     """
-    def predict_json(self, inputs: JsonDict) -> JsonDict:
+    @overrides
+    def _json_to_instance(self, json: JsonDict) -> Instance:
         """
-        Expects JSON that looks like ``{"premise": "...", "hypothesis": "..."}``
-        and returns JSON that looks like
-        ``{"label_probs": [entailment_prob, contradiction_prob, neutral_prob]}``
+        Expects JSON that looks like ``{"premise": "...", "hypothesis": "..."}``.
         """
-        premise_text = inputs["premise"]
-        hypothesis_text = inputs["hypothesis"]
-
-        premise = TextField(self.tokenizer.tokenize(premise_text)[0],
-                            token_indexers=self.token_indexers)
-        hypothesis = TextField(self.tokenizer.tokenize(hypothesis_text)[0],
-                               token_indexers=self.token_indexers)
-
-        return sanitize(self.model.predict_entailment(premise, hypothesis))
+        premise_text = json["premise"]
+        hypothesis_text = json["hypothesis"]
+        return self._dataset_reader.text_to_instance(premise_text, hypothesis_text)

--- a/allennlp/service/predictors/predictor.py
+++ b/allennlp/service/predictors/predictor.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 from allennlp.common import Registrable
 from allennlp.common.util import JsonDict, sanitize
 from allennlp.data import DatasetReader, Instance
@@ -25,8 +23,7 @@ class Predictor(Registrable):
 
     def predict_json(self, inputs: JsonDict) -> JsonDict:
         instance = self._json_to_instance(inputs)
-        outputs = self._model.forward_on_instance(instance)
-        outputs = self._model.decode(outputs)
+        outputs = self._model.decode(self._model.forward_on_instance(instance))
         return sanitize(outputs)
 
     def _json_to_instance(self, json: JsonDict) -> Instance:

--- a/allennlp/service/predictors/predictor.py
+++ b/allennlp/service/predictors/predictor.py
@@ -26,21 +26,14 @@ class Predictor(Registrable):
     def predict_json(self, inputs: JsonDict) -> JsonDict:
         instance = self._json_to_instance(inputs)
         outputs = self._model.forward_on_instance(instance)
-        return self._predictions_to_json(outputs)
+        outputs = self._model.decode(outputs)
+        return sanitize(outputs)
 
     def _json_to_instance(self, json: JsonDict) -> Instance:
         """
         Converts a JSON object into an :class:`~allennlp.data.instance.Instance`.
         """
         raise NotImplementedError
-
-    def _predictions_to_json(self, model_outputs: Dict[str, Any]) -> JsonDict:
-        """
-        Takes the output of :func:`~allennlp.models.model.Model.instance_forward()` and converts it
-        into a JSON object, for a single instance.
-        """
-        # pylint: disable=no-self-use
-        return sanitize(model_outputs)
 
     @classmethod
     def from_archive(cls, archive: Archive, predictor_name: str = None) -> 'Predictor':

--- a/allennlp/service/predictors/predictor.py
+++ b/allennlp/service/predictors/predictor.py
@@ -1,10 +1,8 @@
-from typing import Dict
+from typing import Any, Dict
 
 from allennlp.common import Registrable
-from allennlp.common.util import JsonDict
-from allennlp.data.tokenizers import Tokenizer, WordTokenizer
-from allennlp.data.token_indexers import TokenIndexer
-from allennlp.data.dataset_readers import DatasetReader
+from allennlp.common.util import JsonDict, sanitize
+from allennlp.data import DatasetReader, Instance
 from allennlp.models import Model
 from allennlp.models.archival import Archive
 
@@ -21,16 +19,28 @@ class Predictor(Registrable):
     a ``Predictor`` is a thin wrapper around an AllenNLP model that handles JSON -> JSON predictions
     that can be used for serving models through the web API or making predictions in bulk.
     """
-    def __init__(self,
-                 model: Model,
-                 tokenizer: Tokenizer,
-                 token_indexers: Dict[str, TokenIndexer]) -> None:
-        self.model = model
-        self.tokenizer = tokenizer
-        self.token_indexers = token_indexers
+    def __init__(self, model: Model, dataset_reader: DatasetReader) -> None:
+        self._model = model
+        self._dataset_reader = dataset_reader
 
     def predict_json(self, inputs: JsonDict) -> JsonDict:
-        raise NotImplementedError()
+        instance = self._json_to_instance(inputs)
+        outputs = self._model.forward_on_instance(instance)
+        return self._predictions_to_json(outputs)
+
+    def _json_to_instance(self, json: JsonDict) -> Instance:
+        """
+        Converts a JSON object into an :class:`~allennlp.data.instance.Instance`.
+        """
+        raise NotImplementedError
+
+    def _predictions_to_json(self, model_outputs: Dict[str, Any]) -> JsonDict:
+        """
+        Takes the output of :func:`~allennlp.models.model.Model.instance_forward()` and converts it
+        into a JSON object, for a single instance.
+        """
+        # pylint: disable=no-self-use
+        return sanitize(model_outputs)
 
     @classmethod
     def from_archive(cls, archive: Archive, predictor_name: str = None) -> 'Predictor':
@@ -44,12 +54,9 @@ class Predictor(Registrable):
         dataset_reader_params = config["dataset_reader"]
         dataset_reader = DatasetReader.from_params(dataset_reader_params)
 
-        tokenizer = dataset_reader._tokenizer or WordTokenizer()  # pylint: disable=protected-access
-        token_indexers = dataset_reader._token_indexers           # pylint: disable=protected-access
-
         model = archive.model
         model.eval()
 
         model_name = config.get("model").get("type")
         predictor_name = predictor_name or DEFAULT_PREDICTORS[model_name]
-        return Predictor.by_name(predictor_name)(model, tokenizer, token_indexers)
+        return Predictor.by_name(predictor_name)(model, dataset_reader)

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -2,7 +2,6 @@ from typing import List
 
 from overrides import overrides
 import spacy
-import torch
 
 from allennlp.common.util import JsonDict, sanitize
 from allennlp.data import DatasetReader, Instance

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -7,7 +7,6 @@ import torch
 from allennlp.common.util import JsonDict, sanitize
 from allennlp.data import DatasetReader, Instance
 from allennlp.models import Model
-from allennlp.nn.util import viterbi_decode
 from allennlp.service.predictors.predictor import Predictor
 
 
@@ -75,13 +74,8 @@ class SemanticRoleLabelerPredictor(Predictor):
                 verb_labels = [0 for _ in words]
                 verb_labels[i] = 1
                 instance = self._dataset_reader.text_to_instance(words, verb_labels)
-                output = self._model.forward_on_instance(instance)
-                transition_matrix = self._model.get_viterbi_pairwise_potentials()
-
-                predictions = torch.from_numpy(output['class_probabilities'])
-                max_likelihood_sequence, _ = viterbi_decode(predictions, transition_matrix)
-                tags = [self._model.vocab.get_token_from_index(x, namespace="labels")
-                        for x in max_likelihood_sequence]
+                output = self._model.decode(self._model.forward_on_instance(instance))
+                tags = output['tags']
 
                 description = SemanticRoleLabelerPredictor.make_srl_string(words, tags)
 

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -1,22 +1,23 @@
-from typing import Dict, List
+from typing import List
+
+from overrides import overrides
+import spacy
+import torch
 
 from allennlp.common.util import JsonDict, sanitize
-from allennlp.data import Tokenizer, TokenIndexer
-from allennlp.data.fields import TextField, SequenceLabelField
+from allennlp.data import DatasetReader, Instance
 from allennlp.models import Model
+from allennlp.nn.util import viterbi_decode
 from allennlp.service.predictors.predictor import Predictor
 
-import spacy
 
 @Predictor.register("semantic-role-labeling")
 class SemanticRoleLabelerPredictor(Predictor):
     """
     Wrapper for the :class:`~allennlp.models.bidaf.SemanticRoleLabeler` model.
     """
-    def __init__(self, model: Model,
-                 tokenizer: Tokenizer, token_indexers: Dict[str, TokenIndexer]) -> None:
-        super().__init__(model, tokenizer, token_indexers)
-
+    def __init__(self, model: Model, dataset_reader: DatasetReader) -> None:
+        super().__init__(model, dataset_reader)
         self.nlp = spacy.load('en', parser=False, vectors=False, entity=False)
 
     @staticmethod
@@ -42,6 +43,13 @@ class SemanticRoleLabelerPredictor(Predictor):
 
         return " ".join(frame)
 
+    def _json_to_instance(self, json: JsonDict) -> Instance:
+        # We're overriding `predict_json` directly, so we don't need this.  But I'd rather have a
+        # useless stub here then make the base class throw a RuntimeError instead of a
+        # NotImplementedError - the checking on the base class is worth it.
+        raise RuntimeError("this should never be called")
+
+    @overrides
     def predict_json(self, inputs: JsonDict) -> JsonDict:
         """
         Expects JSON that looks like ``{"sentence": "..."}``
@@ -61,16 +69,20 @@ class SemanticRoleLabelerPredictor(Predictor):
         spacy_doc = self.nlp(sentence)
         words = [token.text for token in spacy_doc]
         results: JsonDict = {"words": words, "verbs": []}
-        text = TextField(words, token_indexers=self.token_indexers)
         for i, word in enumerate(spacy_doc):
             if word.pos_ == "VERB":
+                verb = word.text
                 verb_labels = [0 for _ in words]
                 verb_labels[i] = 1
-                verb_indicator = SequenceLabelField(verb_labels, text)
-                output = self.model.tag(text, verb_indicator)
+                instance = self._dataset_reader.text_to_instance(words, verb_labels)
+                output = self._model.forward_on_instance(instance)
+                transition_matrix = self._model.get_viterbi_pairwise_potentials()
 
-                verb = word.text
-                tags = output["tags"]
+                predictions = torch.from_numpy(output['class_probabilities'])
+                max_likelihood_sequence, _ = viterbi_decode(predictions, transition_matrix)
+                tags = [self._model.vocab.get_token_from_index(x, namespace="labels")
+                        for x in max_likelihood_sequence]
+
                 description = SemanticRoleLabelerPredictor.make_srl_string(words, tags)
 
                 results["verbs"].append({

--- a/allennlp/service/predictors/simple_tagger.py
+++ b/allennlp/service/predictors/simple_tagger.py
@@ -1,7 +1,4 @@
-from typing import Any, Dict
-
 from overrides import overrides
-import numpy
 
 from allennlp.common.util import JsonDict
 from allennlp.data import DatasetReader, Instance

--- a/allennlp/service/predictors/simple_tagger.py
+++ b/allennlp/service/predictors/simple_tagger.py
@@ -29,12 +29,3 @@ class SimpleTaggerPredictor(Predictor):
         sentence = json["sentence"]
         tokens, _ = self._tokenizer.tokenize(sentence)
         return self._dataset_reader.text_to_instance(tokens)
-
-    @overrides
-    def _predictions_to_json(self, model_outputs: Dict[str, Any]) -> JsonDict:
-        predictions = model_outputs['class_probabilities']
-        argmax_indices = numpy.argmax(predictions, axis=-1)
-        tags = [self._model.vocab.get_token_from_index(x, namespace="labels")
-                for x in argmax_indices]
-        model_outputs['tags'] = tags
-        return super(SimpleTaggerPredictor, self)._predictions_to_json(model_outputs)

--- a/allennlp/service/predictors/simple_tagger.py
+++ b/allennlp/service/predictors/simple_tagger.py
@@ -1,5 +1,12 @@
-from allennlp.common.util import JsonDict, sanitize
-from allennlp.data.fields import TextField
+from typing import Any, Dict
+
+from overrides import overrides
+import numpy
+
+from allennlp.common.util import JsonDict
+from allennlp.data import DatasetReader, Instance
+from allennlp.data.tokenizers import WordTokenizer
+from allennlp.models import Model
 from allennlp.service.predictors.predictor import Predictor
 
 
@@ -8,15 +15,26 @@ class SimpleTaggerPredictor(Predictor):
     """
     Wrapper for the :class:`~allennlp.models.bidaf.SimpleTagger` model.
     """
-    def predict_json(self, inputs: JsonDict) -> JsonDict:
+    def __init__(self, model: Model, dataset_reader: DatasetReader) -> None:
+        super(SimpleTaggerPredictor, self).__init__(model, dataset_reader)
+        self._tokenizer = WordTokenizer()
+
+    @overrides
+    def _json_to_instance(self, json: JsonDict) -> Instance:
         """
         Expects JSON that looks like ``{"sentence": "..."}``
         and returns JSON that looks like
         ``{"tags": [...], "class_probabilities": [[...], ..., [...]]}``
         """
-        sentence = inputs["sentence"]
+        sentence = json["sentence"]
+        tokens, _ = self._tokenizer.tokenize(sentence)
+        return self._dataset_reader.text_to_instance(tokens)
 
-        tokens = TextField(self.tokenizer.tokenize(sentence)[0],
-                           token_indexers=self.token_indexers)
-
-        return sanitize(self.model.tag(tokens))
+    @overrides
+    def _predictions_to_json(self, model_outputs: Dict[str, Any]) -> JsonDict:
+        predictions = model_outputs['class_probabilities']
+        argmax_indices = numpy.argmax(predictions, axis=-1)
+        tags = [self._model.vocab.get_token_from_index(x, namespace="labels")
+                for x in argmax_indices]
+        model_outputs['tags'] = tags
+        return super(SimpleTaggerPredictor, self)._predictions_to_json(model_outputs)

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -56,8 +56,9 @@ class TestPredict(TestCase):
 
         assert len(results) == 2
         for result in results:
-            assert set(result.keys()) == {"span_start_probs", "span_end_probs", "best_span",
-                                          "best_span_str", "tokens"}
+            assert set(result.keys()) == {"span_start_logits", "span_end_logits",
+                                          "span_start_probs", "span_end_probs", "best_span",
+                                          "best_span_str"}
 
     def test_fails_without_required_args(self):
         sys.argv = ["run.py",            # executable

--- a/tests/models/bidaf_test.py
+++ b/tests/models/bidaf_test.py
@@ -8,7 +8,6 @@ from torch.autograd import Variable
 from allennlp.common import Params
 from allennlp.common.testing import ModelTestCase
 from allennlp.data import DatasetReader, Vocabulary
-from allennlp.data.fields import TextField
 from allennlp.models import BidirectionalAttentionFlow, Model
 from allennlp.nn.util import arrays_to_variables
 
@@ -20,7 +19,8 @@ class BidirectionalAttentionFlowTest(ModelTestCase):
 
     def test_forward_pass_runs_correctly(self):
         training_arrays = arrays_to_variables(self.dataset.as_array_dict())
-        _ = self.model.forward(**training_arrays)
+        output_dict = self.model.forward(**training_arrays)
+
         metrics = self.model.get_metrics(reset=True)
         # We've set up the data such that there's a fake answer that consists of the whole
         # paragraph.  _Any_ valid prediction for that question should produce an F1 of greater than
@@ -29,6 +29,16 @@ class BidirectionalAttentionFlowTest(ModelTestCase):
         # loaded the evaluation data correctly and have hooked things up to the official evaluation
         # script.
         assert metrics['f1'] > 0
+
+        span_start_probs = output_dict['span_start_probs'][0].data.numpy()
+        span_end_probs = output_dict['span_start_probs'][0].data.numpy()
+        assert_almost_equal(numpy.sum(span_start_probs, -1), 1, decimal=6)
+        assert_almost_equal(numpy.sum(span_end_probs, -1), 1, decimal=6)
+        span_start, span_end = tuple(output_dict['best_span'][0].data.numpy())
+        assert span_start >= 0
+        assert span_start <= span_end
+        assert span_end < self.dataset.instances[0].fields['passage'].sequence_length()
+        assert isinstance(output_dict['best_span_str'][0], str)
 
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)
@@ -64,22 +74,6 @@ class BidirectionalAttentionFlowTest(ModelTestCase):
         # Restore the state.
         self.model = saved_model
         self.dataset = saved_dataset
-
-    def test_predict_span_gives_reasonable_outputs(self):
-        # TODO(mattg): "What", "is", "?" crashed, because the CNN encoder expected at least 5
-        # characters.  We need to fix that somehow.
-        question = TextField(["Whatever", "is", "?"], token_indexers=self.token_indexers)
-        passage = TextField(["This", "is", "a", "passage"],
-                            token_indexers=self.token_indexers)
-        output_dict = self.model.predict_span(question, passage)
-
-        assert_almost_equal(numpy.sum(output_dict["span_start_probs"], -1), 1, decimal=6)
-        assert_almost_equal(numpy.sum(output_dict["span_end_probs"], -1), 1, decimal=6)
-
-        span_start, span_end = output_dict['best_span']
-        assert span_start >= 0
-        assert span_start <= span_end
-        assert span_end < passage.sequence_length()
 
     def test_get_best_span(self):
         # pylint: disable=protected-access

--- a/tests/models/decomposable_attention_test.py
+++ b/tests/models/decomposable_attention_test.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_almost_equal
 
 from allennlp.common import Params
 from allennlp.common.testing import ModelTestCase
-from allennlp.data.fields import TextField
 from allennlp.models import DecomposableAttention, Model
 from allennlp.nn.util import arrays_to_variables
 
@@ -18,7 +17,8 @@ class TestDecomposableAttention(ModelTestCase):
 
     def test_forward_pass_runs_correctly(self):
         training_arrays = arrays_to_variables(self.dataset.as_array_dict())
-        _ = self.model.forward(**training_arrays)
+        output_dict = self.model.forward(**training_arrays)
+        assert_almost_equal(numpy.sum(output_dict["label_probs"][0].data.numpy(), -1), 1, decimal=6)
 
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)
@@ -26,12 +26,6 @@ class TestDecomposableAttention(ModelTestCase):
     @flaky
     def test_batch_predictions_are_consistent(self):
         self.ensure_batch_predictions_are_consistent()
-
-    def test_predict_entailment_gives_reasonable_outputs(self):
-        premise = TextField(["A", "dog", "is", "a", "mammal"], token_indexers=self.token_indexers)
-        hypothesis = TextField(["A", "dog", "is", "an", "animal"], token_indexers=self.token_indexers)
-        output_dict = self.model.predict_entailment(premise, hypothesis)
-        assert_almost_equal(numpy.sum(output_dict["label_probs"], -1), 1, decimal=6)
 
     def test_model_load(self):
         params = Params.from_file('tests/fixtures/decomposable_attention/experiment.json')

--- a/tests/models/simple_tagger_test.py
+++ b/tests/models/simple_tagger_test.py
@@ -3,8 +3,6 @@ from flaky import flaky
 import numpy
 
 from allennlp.common.testing import ModelTestCase
-from allennlp.data.fields import TextField
-from allennlp.data.token_indexers import SingleIdTokenIndexer
 from allennlp.nn.util import arrays_to_variables
 
 
@@ -23,14 +21,6 @@ class SimpleTaggerTest(ModelTestCase):
 
     def test_forward_pass_runs_correctly(self):
         training_arrays = self.dataset.as_array_dict()
-        _ = self.model.forward(**arrays_to_variables(training_arrays))
-
-    def test_tag_returns_distributions_per_token(self):
-        text = TextField(["This", "is", "a", "sentence"], token_indexers={"tokens": SingleIdTokenIndexer()})
-        output = self.model.tag(text)
-        possible_tags = self.vocab.get_index_to_token_vocabulary("labels").values()
-        for tag in output["tags"]:
-            assert tag in possible_tags
-        # Predictions are a distribution.
-        numpy.testing.assert_almost_equal(numpy.sum(output["class_probabilities"], -1),
-                                          numpy.array([1, 1, 1, 1]))
+        output_dict = self.model.forward(**arrays_to_variables(training_arrays))
+        class_probs = output_dict['class_probabilities'][0].data.numpy()
+        numpy.testing.assert_almost_equal(numpy.sum(class_probs, -1), numpy.array([1, 1, 1, 1]))

--- a/tests/service/server_sanic_test.py
+++ b/tests/service/server_sanic_test.py
@@ -20,6 +20,7 @@ class CountingPredictor(Predictor):
     bogus predictor that just returns its input as is
     and also counts how many times it was called with a given input
     """
+    # pylint: disable=abstract-method
     def __init__(self):                 # pylint: disable=super-init-not-called
         self.calls = defaultdict(int)
 


### PR DESCRIPTION
This is so that the `Predictors`, or anything else that wants to make
predictions given a trained model, has an easier time of processing the
data in the same way the trained model did - all you need is the
instantiated `DatasetReader`, and not any private members pulled out
from that class.

Changing this on the `DatasetReaders`, though, meant changing the
`Predictors` themselves.  And that meant unifying the API around making
model predictions from single instance inputs.  I was able to remove
all of the `tag` and `predict_` methods on individual models, replacing
them with a single `Model.forward_on_instance` method.  I _think_ the
result is a lot cleaner, but I could have missed something important
when making this change - it was a whole bunch of pulling things apart
and putting them back together.

Fixes #190.