### PR TITLE
Upgrade to python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh
 
-# Use python 3.5
-RUN conda install python=3.5
+# Use python 3.6
+RUN conda install python=3.6
 
 # Copy select files needed for installing requirements.
 # We only copy what we need here so small changes to the repository does not trigger re-installation of the requirements.
@@ -43,7 +43,7 @@ COPY requirements.txt .
 COPY requirements_test.txt .
 COPY scripts/install_requirements.sh scripts/install_requirements.sh
 RUN INSTALL_TEST_REQUIREMENTS="true" ./scripts/install_requirements.sh
-RUN pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl
+RUN pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl
 
 COPY allennlp/ allennlp/
 COPY tests/ tests/

--- a/allennlp/common/registrable.py
+++ b/allennlp/common/registrable.py
@@ -5,7 +5,7 @@ for registering them.
 """
 
 from collections import defaultdict
-from typing import TypeVar, Type, Dict, List  # pylint: disable=unused-import
+from typing import TypeVar, Type, Dict, List
 
 from allennlp.common.checks import ConfigurationError
 
@@ -34,8 +34,8 @@ class Registrable:
     a subclass to load all other subclasses and the abstract class).
     """
 
-    _registry = defaultdict(dict)  # type: Dict[Type, Dict[str, Type]]
-    default_implementation = None  # type: str
+    _registry: Dict[Type, Dict[str, Type]] = defaultdict(dict)
+    default_implementation: str = None
 
     @classmethod
     def register(cls: Type[T], name: str):

--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -31,8 +31,9 @@ class Dataset:
         types).  If you change the constructor, you also have to override all methods in this base
         class that call the constructor, such as `truncate()`.
         """
-        all_instance_fields_and_types = [{k: v.__class__.__name__ for k, v in x.fields.items()}
-                                         for x in instances]  # type: List[Dict[str, str]]
+        all_instance_fields_and_types: List[Dict[str, str]] = [{k: v.__class__.__name__
+                                                                for k, v in x.fields.items()}
+                                                               for x in instances]
         # Check all the field names and Field types are the same for every instance.
         if not all([all_instance_fields_and_types[0] == x for x in all_instance_fields_and_types]):
             raise ConfigurationError("You cannot construct a Dataset with non-homogeneous Instances.")
@@ -67,12 +68,12 @@ class Dataset:
         This can then be used to convert this dataset into arrays of consistent length, or to set
         model parameters, etc.
         """
-        padding_lengths = defaultdict(dict)  # type: Dict[str, Dict[str, int]]
-        all_instance_lengths = [instance.get_padding_lengths()
-                                for instance in self.instances]  # type: List[Dict[str, Dict[str, int]]]
+        padding_lengths: Dict[str, Dict[str, int]] = defaultdict(dict)
+        all_instance_lengths: List[Dict[str, Dict[str, int]]] = [instance.get_padding_lengths()
+                                                                 for instance in self.instances]
         if not all_instance_lengths:
             return {**padding_lengths}
-        all_field_lengths = defaultdict(list)  # type: Dict[str, List[Dict[str, int]]]
+        all_field_lengths: Dict[str, List[Dict[str, int]]] = defaultdict(list)
         for instance_lengths in all_instance_lengths:
             for field_name, instance_field_lengths in instance_lengths.items():
                 all_field_lengths[field_name].append(instance_field_lengths)
@@ -134,7 +135,7 @@ class Dataset:
         instance_padding_lengths = self.get_padding_lengths()
         if verbose:
             logger.info("Instance max lengths: %s", str(instance_padding_lengths))
-        lengths_to_use = defaultdict(dict)  # type: Dict[str, Dict[str, int]]
+        lengths_to_use: Dict[str, Dict[str, int]] = defaultdict(dict)
         for field_name, instance_field_lengths in instance_padding_lengths.items():
             for padding_key in instance_field_lengths.keys():
                 if padding_lengths[field_name].get(padding_key) is not None:
@@ -143,7 +144,7 @@ class Dataset:
                     lengths_to_use[field_name][padding_key] = instance_field_lengths[padding_key]
 
         # Now we actually pad the instances to numpy arrays.
-        field_arrays = defaultdict(list)  # type: Dict[str, list]
+        field_arrays: Dict[str, list] = defaultdict(list)
         if verbose:
             logger.info("Now actually padding instances to length: %s", str(lengths_to_use))
         for instance in self.instances:
@@ -158,7 +159,7 @@ class Dataset:
             if isinstance(field_array_list[0], dict):
                 # This is creating a dict of {token_indexer_key: batch_array} for each
                 # token indexer used to index this field. This is mostly utilised by TextFields.
-                token_indexer_key_to_batch_dict = defaultdict(list)  # type: Dict[str, List[numpy.ndarray]]
+                token_indexer_key_to_batch_dict: Dict[str, List[numpy.ndarray]] = defaultdict(list)
                 for namespace_dict in field_array_list:
                     for indexer_name, array in namespace_dict.items():
                         token_indexer_key_to_batch_dict[indexer_name].append(array)

--- a/allennlp/data/dataset_readers/language_modeling.py
+++ b/allennlp/data/dataset_readers/language_modeling.py
@@ -74,7 +74,7 @@ class LanguageModelingReader(DatasetReader):
         # single token id.  This code lets you learn a language model that concatenates word
         # embeddings with character-level encoders, in order to predict the word token that comes
         # next.
-        output_indexer = None  # type: Dict[str, TokenIndexer]
+        output_indexer: Dict[str, TokenIndexer] = None
         for name, indexer in self._token_indexers.items():
             if isinstance(indexer, SingleIdTokenIndexer):
                 output_indexer = {name: indexer}

--- a/allennlp/data/dataset_readers/semantic_role_labeling.py
+++ b/allennlp/data/dataset_readers/semantic_role_labeling.py
@@ -1,7 +1,7 @@
 import codecs
 import os
 import logging
-from typing import Dict, List, Optional  # pylint: disable=unused-import
+from typing import Dict, List, Optional
 
 from overrides import overrides
 import tqdm
@@ -177,10 +177,10 @@ class SrlReader(DatasetReader):
 
         instances = []
 
-        sentence = []  # type: List[str]
-        verbal_predicates = []  # type: List[int]
-        predicate_argument_labels = []  # type: List[List[str]]
-        current_span_label = []  # type: List[Optional[str]]
+        sentence: List[str] = []
+        verbal_predicates: List[int] = []
+        predicate_argument_labels: List[List[str]] = []
+        current_span_label: List[Optional[str]] = []
 
         logger.info("Reading SRL instances from dataset files at: %s", file_path)
         for root, _, files in tqdm.tqdm(list(os.walk(file_path))):

--- a/allennlp/data/dataset_readers/squad.py
+++ b/allennlp/data/dataset_readers/squad.py
@@ -3,7 +3,7 @@ import logging
 import random
 from collections import Counter
 from copy import deepcopy
-from typing import List, Tuple, Dict, Set  # pylint: disable=unused-import
+from typing import List, Tuple, Dict, Set
 
 import numpy
 from tqdm import tqdm
@@ -16,8 +16,7 @@ from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.instance import Instance
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
 from allennlp.data.tokenizers.tokenizer import Tokenizer
-from allennlp.data.fields import TextField, ListField, IndexField
-from allennlp.data.fields.field import Field  # pylint: disable=unused-import
+from allennlp.data.fields import Field, TextField, ListField, IndexField
 from allennlp.data.tokenizers import WordTokenizer
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -137,7 +136,7 @@ class SquadReader(DatasetReader):
 
                     # There may be multiple answer annotations, so pick the one that occurs the
                     # most.
-                    candidate_answers = Counter() # type: Counter
+                    candidate_answers: Counter = Counter()
                     for answer in question_answer["answers"]:
                         candidate_answers[(answer["answer_start"], answer["text"])] += 1
                     char_span_start, answer_text = candidate_answers.most_common(1)[0][0]
@@ -245,24 +244,24 @@ class SquadSentenceSelectionReader(DatasetReader):
 
         # Initializing some data structures here that will be useful when reading a file.
         # Maps sentence strings to sentence indices
-        self._sentence_to_id = {}  # type: Dict[str, int]
+        self._sentence_to_id: Dict[str, int] = {}
         # Maps sentence indices to sentence strings
-        self._id_to_sentence = {}  # type: Dict[int, str]
+        self._id_to_sentence: Dict[int, str] = {}
         # Maps paragraph ids to lists of contained sentence ids
-        self._paragraph_sentences = {}  # type: Dict[int, List[int]]
+        self._paragraph_sentences: Dict[int, List[int]] = {}
         # Maps sentence ids to the containing paragraph id.
-        self._sentence_paragraph_map = {}  # type: Dict[int, int]
+        self._sentence_paragraph_map: Dict[int, int] = {}
         # Maps question strings to question indices
-        self._question_to_id = {}  # type: Dict[str, int]
+        self._question_to_id: Dict[str, int] = {}
         # Maps question indices to question strings
-        self._id_to_question = {}  # type: Dict[int, str]
+        self._id_to_question: Dict[int, str] = {}
 
     def _get_sentence_choices(self,
                               question_id: int,
                               answer_id: int) -> Tuple[List[str], int]:  # pylint: disable=invalid-sequence-index
         # Because sentences and questions have different indices, we need this to hold tuples of
         # ("sentence", id) or ("question", id), instead of just single ids.
-        negative_sentences = set()  # type: Set[Tuple[str, int]]
+        negative_sentences: Set[Tuple[str, int]] = set()
         for selection_method in self._negative_sentence_selection_methods:
             if selection_method == 'paragraph':
                 paragraph_id = self._sentence_paragraph_map[answer_id]
@@ -360,7 +359,7 @@ class SquadSentenceSelectionReader(DatasetReader):
 
                     # There may be multiple answer annotations, so pick the one
                     # that occurs the most.
-                    candidate_answer_start_indices = Counter() # type: Counter
+                    candidate_answer_start_indices: Counter = Counter()
                     for answer in question_answer["answers"]:
                         candidate_answer_start_indices[answer["answer_start"]] += 1
                     answer_start_index, _ = candidate_answer_start_indices.most_common(1)[0]
@@ -389,7 +388,7 @@ class SquadSentenceSelectionReader(DatasetReader):
         for question_id, answer_id in tqdm(questions):
             sentence_choices, correct_choice = self._get_sentence_choices(question_id, answer_id)
             question_text = self._id_to_question[question_id]
-            sentence_fields = []  # type: List[Field]
+            sentence_fields: List[Field] = []
             for sentence in sentence_choices:
                 tokenized_sentence, _ = self._tokenizer.tokenize(sentence)
                 sentence_field = TextField(tokenized_sentence, self._token_indexers)

--- a/allennlp/data/fields/list_field.py
+++ b/allennlp/data/fields/list_field.py
@@ -29,7 +29,8 @@ class ListField(SequenceField[DataArray]):
         field_class_set = set([field.__class__ for field in field_list])
         assert len(field_class_set) == 1, "ListFields must contain a single field type, found " +\
                                           str(field_class_set)
-        self.field_list = field_list  # type: List[Field]
+        # Not sure why mypy has a hard time with this type...
+        self.field_list: List[Field] = field_list
 
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/data/fields/sequence_label_field.py
+++ b/allennlp/data/fields/sequence_label_field.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union  # pylint: disable=unused-import
+from typing import Dict, List, Union
 import logging
 
 from overrides import overrides

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -2,7 +2,7 @@
 A ``TextField`` represents a string of text, the kind that you might want to represent with
 standard word vectors, or pass through an LSTM.
 """
-from typing import Dict, List, Optional  # pylint: disable=unused-import
+from typing import Dict, List, Optional
 
 from overrides import overrides
 import numpy
@@ -33,7 +33,7 @@ class TextField(SequenceField[Dict[str, numpy.ndarray]]):
     def __init__(self, tokens: List[str], token_indexers: Dict[str, TokenIndexer]) -> None:
         self.tokens = tokens
         self._token_indexers = token_indexers
-        self._indexed_tokens = None  # type: Optional[Dict[str, TokenList]]
+        self._indexed_tokens: Optional[Dict[str, TokenList]] = None
 
         if not all([isinstance(x, str) for x in tokens]):
             raise ConfigurationError("TextFields must be passed strings. "

--- a/allennlp/data/iterators/adaptive_iterator.py
+++ b/allennlp/data/iterators/adaptive_iterator.py
@@ -118,7 +118,7 @@ class AdaptiveIterator(BucketIterator):
     def _adaptive_grouping(self, dataset: Dataset):
         batches = []
         current_batch = []
-        current_lengths = defaultdict(dict)  # type: Dict[str, Dict[str, int]]
+        current_lengths: Dict[str, Dict[str, int]] = defaultdict(dict)
         logger.debug("Creating adaptive groups")
         for instance in dataset.instances:
             current_batch.append(instance)

--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -70,8 +70,8 @@ class SimpleWordSplitter(WordSplitter):
         """
         fields = sentence.split()
         tokens = []
-        for field in fields:  # type: str
-            add_at_end = []  # type: List[str]
+        for field in fields:
+            add_at_end: List[str] = []
             while self._can_split(field) and field[0] in self.beginning_punctuation:
                 tokens.append(field[0])
                 field = field[1:]
@@ -144,7 +144,7 @@ class SpacyWordSplitter(WordSplitter):
         if SpacyWordSplitter.en_nlp is None:
             # Load is here because it's slow, and can be unnecessary.
             SpacyWordSplitter.en_nlp = spacy.load('en', parser=False, tagger=False, entity=False)
-        tokens = self.en_nlp.tokenizer(sentence)  # type: ignore
+        tokens = self.en_nlp.tokenizer(sentence)
         words = [str(token) for token in tokens]
         offsets = [(token.idx, token.idx + len(token)) for token in tokens]
         return words, offsets

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -278,7 +278,7 @@ class Vocabulary:
         :func:`__init__`.  See that method for a description of what the other parameters do.
         """
         logger.info("Fitting token dictionary from dataset.")
-        namespace_token_counts = defaultdict(lambda: defaultdict(int))  # type: Dict[str, Dict[str, int]]
+        namespace_token_counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
         for instance in tqdm.tqdm(dataset.instances):
             instance.count_vocab_items(namespace_token_counts)
 

--- a/allennlp/modules/token_embedders/token_characters_encoder.py
+++ b/allennlp/modules/token_embedders/token_characters_encoder.py
@@ -37,12 +37,12 @@ class TokenCharactersEncoder(TokenEmbedder):
 
     @classmethod
     def from_params(cls, vocab: Vocabulary, params: Params) -> 'TokenCharactersEncoder':
-        embedding_params = params.pop("embedding")  # type: Params
+        embedding_params: Params = params.pop("embedding")
         # Embedding.from_params() uses "tokens" as the default namespace, but we need to change
         # that to be "token_characters" by default.
         embedding_params.setdefault("vocab_namespace", "token_characters")
         embedding = Embedding.from_params(vocab, embedding_params)
-        encoder_params = params.pop("encoder")  # type: Params
+        encoder_params: Params = params.pop("encoder")
         encoder = Seq2VecEncoder.from_params(encoder_params)
         dropout = params.pop("dropout", 0.0)
         params.assert_empty(cls.__name__)

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -60,7 +60,7 @@ class SemanticRoleLabelerPredictor(Predictor):
 
         spacy_doc = self.nlp(sentence)
         words = [token.text for token in spacy_doc]
-        results = {"words": words, "verbs": []}  # type: JsonDict
+        results: JsonDict = {"words": words, "verbs": []}
         text = TextField(words, token_indexers=self.token_indexers)
         for i, word in enumerate(spacy_doc):
             if word.pos_ == "VERB":

--- a/allennlp/training/metrics/span_based_f1_measure.py
+++ b/allennlp/training/metrics/span_based_f1_measure.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Set, Tuple  # pylint: disable=unused-import
+from typing import Dict, List, Optional, Set, Tuple
 from collections import defaultdict
 
 import torch
@@ -52,9 +52,9 @@ class SpanBasedF1Measure(Metric):
         self._ignore_classes = ignore_classes or []
 
         # These will hold per label span counts.
-        self._true_positives = defaultdict(int)  # type: Dict[str, int]
-        self._false_positives = defaultdict(int)  # type: Dict[str, int]
-        self._false_negatives = defaultdict(int)  # type: Dict[str, int]
+        self._true_positives: Dict[str, int] = defaultdict(int)
+        self._false_positives: Dict[str, int] = defaultdict(int)
+        self._false_negatives: Dict[str, int] = defaultdict(int)
 
     def __call__(self,
                  predictions: torch.Tensor,
@@ -187,7 +187,7 @@ class SpanBasedF1Measure(Metric):
         Additionally, an ``overall`` key is included, which provides the precision,
         recall and f1-measure for all spans.
         """
-        all_tags = set()  # type: Set[str]
+        all_tags: Set[str] = set()
         all_tags.update(self._true_positives.keys())
         all_tags.update(self._false_positives.keys())
         all_tags.update(self._false_negatives.keys())

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -16,8 +16,7 @@ from typing import List
 
 import torch
 
-from allennlp.common.params import Params  # pylint: disable=unused-import
-from allennlp.common.registrable import Registrable
+from allennlp.common import Params, Registrable
 
 
 class Optimizer(Registrable):

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import time
 from inspect import signature
-from typing import Dict, Optional, List  # pylint: disable=unused-import
+from typing import Dict, Optional, List
 
 import torch
 import torch.optim.lr_scheduler
@@ -150,7 +150,7 @@ class Trainer:
         num_training_batches = self._iterator.get_num_batches(self._train_dataset)
         if self._validation_dataset is not None:
             num_validation_batches = self._iterator.get_num_batches(self._validation_dataset)
-        validation_metric_per_epoch = []  # type: List[float]
+        validation_metric_per_epoch: List[float] = []
         for epoch in range(epoch_counter, self._num_epochs):
             logger.info("Epoch %d/%d", epoch + 1, self._num_epochs)
             train_loss = 0.0

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -27,7 +27,7 @@ if [[ ! -f /home/travis/miniconda3/bin/activate ]]
     fi
     chmod +x miniconda.sh && ./miniconda.sh -b -f
     conda update --yes conda
-    conda create -n testenv --yes python=3.5
+    conda create -n testenv --yes python=3.6
 fi
 cd ..
 popd
@@ -37,7 +37,7 @@ source activate testenv
 
 # Install requirements via pip and download data inside our conda environment.
 INSTALL_TEST_REQUIREMENTS="true" bash scripts/install_requirements.sh
-pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl
+pip install --no-cache-dir -q http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl
 
 # List the packages to get their versions for debugging
 pip list

--- a/tutorials/getting_started/getting_started.md
+++ b/tutorials/getting_started/getting_started.md
@@ -32,7 +32,7 @@ A third alternative is to clone from our git repository:
 git clone https://github.com/allenai/allennlp.git
 ```
 
-Create a Python 3.5 (or 3.6) virtual environment, and run
+Create a Python 3.6 virtual environment, and run
 
 ```bash
 INSTALL_TEST_REQUIREMENTS=true scripts/install_requirements.sh


### PR DESCRIPTION
This lets us put type annotations on variables directly, instead of in comments, so we can get rid of all of the places we had to disable pylint's `unused-imports` check.

Fixes #254.