### PR TITLE
Remove debugging output from TE.

### DIFF
--- a/allennlp/service/static/index.html
+++ b/allennlp/service/static/index.html
@@ -339,7 +339,6 @@ class TeOutput extends React.Component {
             </table>
           </div>
         </div>
-        <code>{JSON.stringify(rawOutput)}</code>
       </div>
     );
   }


### PR DESCRIPTION
This removes the raw json response from the TE output.

I'm interested in having a raw json response on all the pages, but this output presently looks terrible.