### PR TITLE
api docs for the modules class

### DIFF
--- a/allennlp/modules/__init__.py
+++ b/allennlp/modules/__init__.py
@@ -1,6 +1,6 @@
 """
 Custom PyTorch
-`Modules <http://pytorch.org/docs/master/nn.html#torch.nn.Module>`_
+`Module <http://pytorch.org/docs/master/nn.html#torch.nn.Module>`_ s
 that are used as components in AllenNLP
 :class:`~allennlp.models.model.Model` s.
 """

--- a/allennlp/modules/__init__.py
+++ b/allennlp/modules/__init__.py
@@ -1,3 +1,10 @@
+"""
+Custom PyTorch
+`Modules <http://pytorch.org/docs/master/nn.html#torch.nn.Module>`_
+that are used as components in AllenNLP
+:class:`~allennlp.models.model.Model` s.
+"""
+
 from allennlp.modules.attention import Attention
 from allennlp.modules.feedforward import FeedForward
 from allennlp.modules.highway import Highway

--- a/allennlp/modules/attention.py
+++ b/allennlp/modules/attention.py
@@ -1,3 +1,8 @@
+"""
+An *attention* module that computes the similarity between
+an input vector and the rows of a matrix.
+"""
+
 import torch
 from overrides import overrides
 

--- a/allennlp/modules/augmented_lstm.py
+++ b/allennlp/modules/augmented_lstm.py
@@ -1,3 +1,8 @@
+"""
+An LSTM with Recurrent Dropout and the option to use highway
+connections between layers.
+"""
+
 from typing import Optional, Tuple
 
 import torch

--- a/allennlp/modules/feedforward.py
+++ b/allennlp/modules/feedforward.py
@@ -1,3 +1,6 @@
+"""
+A feed-forward neural network.
+"""
 from typing import Sequence, Union
 
 import torch

--- a/allennlp/modules/highway.py
+++ b/allennlp/modules/highway.py
@@ -1,3 +1,8 @@
+"""
+A `Highway layer <https://arxiv.org/abs/1505.00387>`_ that does a gated combination of a linear
+transformation and a non-linear transformation of its input.
+"""
+
 from typing import Callable
 
 import torch

--- a/allennlp/modules/matrix_attention.py
+++ b/allennlp/modules/matrix_attention.py
@@ -1,3 +1,7 @@
+"""
+A ``Module`` that takes two matrices as input and returns a matrix of attentions.
+"""
+
 import torch
 from overrides import overrides
 

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -1,15 +1,16 @@
 """
-Modules that transform an input sequence into an output sequence.
+Modules that transform a sequence of input vectors
+into a sequence of output vectors.
 Some are just basic wrappers around existing PyTorch modules,
-others are wrappers around AllenNLP.
+others are AllenNLP modules.
 
 The available Seq2Seq encoders are
 
 * `"gru" <http://pytorch.org/docs/master/nn.html#torch.nn.GRU>`_
 * `"lstm" <http://pytorch.org/docs/master/nn.html#torch.nn.LSTM>`_
 * `"rnn" <http://pytorch.org/docs/master/nn.html#torch.nn.RNN>`_
-* :class:`"augmented_lstm" <~allennlp.modules.augmented_lstm.AugmentedLstm>`
-* :class:`"alternating_lstm" <~allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`
+* :class:`"augmented_lstm" <allennlp.modules.augmented_lstm.AugmentedLstm>`
+* :class:`"alternating_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`
 """
 
 from typing import Type

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -1,3 +1,17 @@
+"""
+Modules that transform an input sequence into an output sequence.
+Some are just basic wrappers around existing PyTorch modules,
+others are wrappers around AllenNLP.
+
+The available Seq2Seq encoders are
+
+* `"gru" <http://pytorch.org/docs/master/nn.html#torch.nn.GRU>`_
+* `"lstm" <http://pytorch.org/docs/master/nn.html#torch.nn.LSTM>`_
+* `"rnn" <http://pytorch.org/docs/master/nn.html#torch.nn.RNN>`_
+* :class:`"augmented_lstm" <~allennlp.modules.augmented_lstm.AugmentedLstm>`
+* :class:`"alternating_lstm" <~allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`
+"""
+
 from typing import Type
 
 import torch

--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -1,3 +1,19 @@
+"""
+Modules that transform a sequence of input vectors
+into a single output vector.
+Some are just basic wrappers around existing PyTorch modules,
+others are AllenNLP modules.
+
+The available Seq2Vec encoders are
+
+* `"gru" <http://pytorch.org/docs/master/nn.html#torch.nn.GRU>`_
+* `"lstm" <http://pytorch.org/docs/master/nn.html#torch.nn.LSTM>`_
+* `"rnn" <http://pytorch.org/docs/master/nn.html#torch.nn.RNN>`_
+* :class:`"cnn" <allennlp.modules.seq2vec_encoders.cnn_encoder.CnnEncoder>`
+* :class:`"augmented_lstm" <allennlp.modules.augmented_lstm.AugmentedLstm>`
+* :class:`"alternating_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`
+"""
+
 from typing import Type
 
 import torch

--- a/allennlp/modules/similarity_function.py
+++ b/allennlp/modules/similarity_function.py
@@ -1,7 +1,11 @@
+"""
+A ``SimilarityFunction`` takes a pair of tensors with the same shape, and computes a similarity
+function on the vectors in the last dimension.
+"""
+
 import torch
 
 from allennlp.common import Params, Registrable
-
 
 class SimilarityFunction(torch.nn.Module, Registrable):
     """

--- a/allennlp/modules/similarity_function.py
+++ b/allennlp/modules/similarity_function.py
@@ -1,8 +1,3 @@
-"""
-A ``SimilarityFunction`` takes a pair of tensors with the same shape, and computes a similarity
-function on the vectors in the last dimension.
-"""
-
 import torch
 
 from allennlp.common import Params, Registrable

--- a/allennlp/modules/similarity_functions/__init__.py
+++ b/allennlp/modules/similarity_functions/__init__.py
@@ -1,3 +1,8 @@
+"""
+A ``SimilarityFunction`` takes a pair of tensors with the same shape, and computes a similarity
+function on the vectors in the last dimension.
+"""
+
 from allennlp.modules.similarity_functions.bilinear import BilinearSimilarity
 from allennlp.modules.similarity_functions.dot_product import DotProductSimilarity
 from allennlp.modules.similarity_functions.linear import LinearSimilarity

--- a/allennlp/modules/stacked_alternating_lstm.py
+++ b/allennlp/modules/stacked_alternating_lstm.py
@@ -1,3 +1,8 @@
+"""
+A stacked LSTM with LSTM layers which alternate between going forwards over
+the sequence and going backwards.
+"""
+
 from typing import Optional, Tuple
 import torch
 from torch.nn.utils.rnn import PackedSequence

--- a/allennlp/modules/text_field_embedders/__init__.py
+++ b/allennlp/modules/text_field_embedders/__init__.py
@@ -1,7 +1,6 @@
 """
 A :class:`~allennlp.modules.text_field_embedders.text_field_embedder.TextFieldEmbedder`
-is a ``Module`` that takes as input the
-``dict`` of NumPy arrays
+is a ``Module`` that takes as input the ``dict`` of NumPy arrays
 produced by a :class:`~allennlp.data.fields.text_field.TextField` and
 returns as output an embedded representation of the tokens in that field.
 """

--- a/allennlp/modules/text_field_embedders/__init__.py
+++ b/allennlp/modules/text_field_embedders/__init__.py
@@ -1,2 +1,10 @@
+"""
+A :class:`~allennlp.modules.text_field_embedders.text_field_embedder.TextFieldEmbedder`
+is a ``Module`` that takes as input the
+``dict`` of NumPy arrays
+produced by a :class:`~allennlp.data.fields.text_field.TextField` and
+returns as output an embedded representation of the tokens in that field.
+"""
+
 from allennlp.modules.text_field_embedders.text_field_embedder import TextFieldEmbedder
 from allennlp.modules.text_field_embedders.basic_text_field_embedder import BasicTextFieldEmbedder

--- a/allennlp/modules/time_distributed.py
+++ b/allennlp/modules/time_distributed.py
@@ -1,3 +1,9 @@
+"""
+A wrapper that unrolls the second (time) dimension of a tensor
+into the first (batch) dimension, applies some other ``Module``,
+and then rolls the time dimension back up.
+"""
+
 import torch
 
 

--- a/allennlp/modules/token_embedders/__init__.py
+++ b/allennlp/modules/token_embedders/__init__.py
@@ -1,3 +1,8 @@
+"""
+A :class:`~allennlp.modules.token_embedders.token_embedder.TokenEmbedder` is a ``Module`` that
+embeds one-hot-encoded tokens as vectors.
+"""
+
 from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 from allennlp.modules.token_embedders.embedding import Embedding
 from allennlp.modules.token_embedders.token_characters_encoder import TokenCharactersEncoder

--- a/doc/api/allennlp.models.model.rst
+++ b/doc/api/allennlp.models.model.rst
@@ -2,7 +2,6 @@ allennlp.models.model
 =========================================
 
 .. automodule:: allennlp.models.model
-   :noindex:
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/allennlp.modules.rst
+++ b/doc/api/allennlp.modules.rst
@@ -1,6 +1,11 @@
 allennlp.modules
 ========================
 
+.. automodule:: allennlp.modules
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. toctree::
 
    allennlp.modules.attention
@@ -17,7 +22,3 @@ allennlp.modules
    allennlp.modules.token_embedders
 
 
-.. automodule:: allennlp.modules
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/doc/api/allennlp.modules.rst
+++ b/doc/api/allennlp.modules.rst
@@ -1,9 +1,6 @@
 allennlp.modules
 ========================
 
-This submodule contains custom PyTorch ``Module`` s
-that are used as components in AllenNLP ``Model`` s.
-
 .. toctree::
 
    allennlp.modules.attention

--- a/doc/api/allennlp.modules.similarity_functions.rst
+++ b/doc/api/allennlp.modules.similarity_functions.rst
@@ -1,31 +1,43 @@
 allennlp.modules.similarity_functions
 =============================================
 
-.. automodule:: allennlp.modules.similarity_function
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 .. automodule:: allennlp.modules.similarity_functions
    :members:
    :undoc-members:
    :show-inheritance:
 
+
+* :ref:`SimilarityFunction<similarity-function>`
+* :ref:`BilinearSimilarity<bilinear>`
+* :ref:`CosineSimilarity<cosine>`
+* :ref:`DotProductSimilarity<dot-product>`
+* :ref:`LinearSimilarity<linear>`
+
+.. _similarity-function:
+.. automodule:: allennlp.modules.similarity_function
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _bilinear:
 .. automodule:: allennlp.modules.similarity_functions.bilinear
    :members:
    :undoc-members:
    :show-inheritance:
 
+.. _cosine:
 .. automodule:: allennlp.modules.similarity_functions.cosine
    :members:
    :undoc-members:
    :show-inheritance:
 
+.. _dot-product:
 .. automodule:: allennlp.modules.similarity_functions.dot_product
    :members:
    :undoc-members:
    :show-inheritance:
 
+.. _linear:
 .. automodule:: allennlp.modules.similarity_functions.linear
    :members:
    :undoc-members:

--- a/doc/api/allennlp.modules.text_field_embedders.rst
+++ b/doc/api/allennlp.modules.text_field_embedders.rst
@@ -6,12 +6,18 @@ allennlp.modules.text_field_embedders
    :undoc-members:
    :show-inheritance:
 
+* :ref:`TextFieldEmbedder<text-field-embedder>`
+* :ref:`BasicTextFieldEmbedder<basic-text-field-embedder>`
+
+.. _text-field-embedder:
+.. automodule:: allennlp.modules.text_field_embedders.text_field_embedder
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _basic-text-field-embedder:
 .. automodule:: allennlp.modules.text_field_embedders.basic_text_field_embedder
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: allennlp.modules.text_field_embedders.text_field_embedder
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/doc/api/allennlp.modules.token_embedders.rst
+++ b/doc/api/allennlp.modules.token_embedders.rst
@@ -6,17 +6,25 @@ allennlp.modules.token_embedders
    :undoc-members:
    :show-inheritance:
 
+
+* :ref:`TokenEmbedder<token-embedder>`
+* :ref:`Embedding<embedding>`
+* :ref:`TokenCharactersEncoder<token-characters-encoder>`
+
+.. _token-embedder:
+.. automodule:: allennlp.modules.token_embedders.token_embedder
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _embedding:
 .. automodule:: allennlp.modules.token_embedders.embedding
    :members:
    :undoc-members:
    :show-inheritance:
 
+.. _token-characters-encoder:
 .. automodule:: allennlp.modules.token_embedders.token_characters_encoder
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-.. automodule:: allennlp.modules.token_embedders.token_embedder
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
there's a small amount of duplication, the docstring for the `text_field_embedders` module is basically a snippet from the docstring of `TextFieldEmbedder`, couldn't think of anything better to do. other than that should be pretty straightforward.