### PR TITLE
stop using relative paths in service

### DIFF
--- a/allennlp/commands/serve.py
+++ b/allennlp/commands/serve.py
@@ -23,13 +23,16 @@ their predictions.
 
 import argparse
 import json
+import os
 
 from allennlp.service import server_sanic
+
+_dir_path = os.path.dirname(os.path.realpath(__file__))  # pylint: disable=invalid-name
 
 DEFAULT_CONFIG = {
         'machine-comprehension': 'https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.08.31.tar.gz', # pylint: disable=line-too-long
         'semantic-role-labeling': 'https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2017.08.28.tar.gz', # pylint: disable=line-too-long
-        'textual-entailment': 'tests/fixtures/decomposable_attention/serialization/model.tar.gz' # pylint: disable=line-too-long
+        'textual-entailment': os.path.join(_dir_path, '../../tests/fixtures/decomposable_attention/serialization/model.tar.gz') # pylint: disable=line-too-long
 }
 
 def add_subparser(parser: argparse._SubParsersAction) -> argparse.ArgumentParser:  # pylint: disable=protected-access


### PR DESCRIPTION
currently `allennlp/run serve` only works if you run it from the top level directory. with this change it should work no matter where you run it from.

also, this opens the door to specifying a different "static" dir at runtime, although I didn't implement that in `serve`