### PR TITLE
Fix ordering of text field embedders

### DIFF
--- a/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
@@ -40,7 +40,9 @@ class BasicTextFieldEmbedder(TextFieldEmbedder):
                                                             str(text_field_input.keys()))
             raise ConfigurationError(message)
         embedded_representations = []
-        for key, tensor in text_field_input.items():
+        keys = sorted(text_field_input.keys())
+        for key in keys:
+            tensor = text_field_input[key]
             embedder = self._token_embedders[key]
             token_vectors = embedder(tensor)
             embedded_representations.append(token_vectors)


### PR DESCRIPTION
This fixes the order of `tokens` vs `token_characters` when concatenated. This used to rely on dictionary ordering which changed from Python 3.5 to 3.6. This will fix it to the order we had in 3.5 (`token_characters` before `tokens`) and should have the earlier models behaving well again.

FYI @schmmd @matt-gardner 