### PR TITLE
fix python version compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,5 +104,5 @@ setup(name='allennlp',
       setup_requires=['pytest-runner'],
       tests_require=['pytest'],
       include_package_data=True,
-      python_requires='==3.6',
+      python_requires='>=3.6',
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ from setuptools import setup, find_packages
 #   X.YrcN  # Release Candidate
 #   X.Y     # Final release
 
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 
 setup(name='allennlp',


### PR DESCRIPTION
This fixes #285, I hadn't realised that if you specify 3.6 it isn't generic across sub-versions and actually means 3.6.0.

Also I don't know exactly how we want to manage releasing pip packages vs official releases. This seems important for people to be able to even install the package, so after this is approved i'll release a new minor version or something. 