### PR TITLE
Make Tokenizers return List[Token]

### DIFF
--- a/allennlp/data/__init__.py
+++ b/allennlp/data/__init__.py
@@ -4,5 +4,6 @@ from allennlp.data.fields.field import DataArray, Field
 from allennlp.data.instance import Instance
 from allennlp.data.iterators.data_iterator import DataIterator
 from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
+from allennlp.data.tokenizers.token import Token
 from allennlp.data.tokenizers.tokenizer import Tokenizer
 from allennlp.data.vocabulary import Vocabulary

--- a/allennlp/data/dataset_readers/language_modeling.py
+++ b/allennlp/data/dataset_readers/language_modeling.py
@@ -74,14 +74,14 @@ class LanguageModelingReader(DatasetReader):
 
         if self._tokens_per_instance is not None:
             all_text = " ".join([x.replace("\n", " ").strip() for x in instance_strings])
-            tokenized_text, _ = self._tokenizer.tokenize(all_text)
+            tokenized_text = self._tokenizer.tokenize(all_text)
             num_tokens = self._tokens_per_instance + 1
             tokenized_strings = []
             logger.info("Creating dataset from all text in file: %s", file_path)
             for index in tqdm.tqdm(range(0, len(tokenized_text) - num_tokens, num_tokens - 1)):
                 tokenized_strings.append(tokenized_text[index:(index + num_tokens)])
         else:
-            tokenized_strings = [self._tokenizer.tokenize(s)[0] for s in instance_strings]
+            tokenized_strings = [self._tokenizer.tokenize(s) for s in instance_strings]
 
         instances = []
         for tokenized_string in tokenized_strings:
@@ -98,7 +98,7 @@ class LanguageModelingReader(DatasetReader):
     @overrides
     def text_to_instance(self, sentence: str) -> Instance:  # type: ignore
         # pylint: disable=arguments-differ
-        tokenized_string, _ = self._tokenizer.tokenize(sentence)
+        tokenized_string = self._tokenizer.tokenize(sentence)
         input_field = TextField(tokenized_string[:-1], self._token_indexers)
         output_field = TextField(tokenized_string[1:], self._output_indexer)
         return Instance({'input_tokens': input_field, 'output_tokens': output_field})

--- a/allennlp/data/dataset_readers/semantic_role_labeling.py
+++ b/allennlp/data/dataset_readers/semantic_role_labeling.py
@@ -150,7 +150,7 @@ class SrlReader(DatasetReader):
         A list of Instances.
 
         """
-        tokens = list(map(Token, sentence_tokens))
+        tokens = [Token(t) for t in sentence_tokens]
         if not verbal_predicates:
             # Sentence contains no predicates.
             tags = ["O" for _ in sentence_tokens]

--- a/allennlp/data/dataset_readers/semantic_role_labeling.py
+++ b/allennlp/data/dataset_readers/semantic_role_labeling.py
@@ -7,14 +7,14 @@ from overrides import overrides
 import tqdm
 
 from allennlp.common import Params
+from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
-from allennlp.data.instance import Instance
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
-from allennlp.data.fields import TextField, SequenceLabelField
-from allennlp.data.fields.field import Field  # pylint: disable=unused-import
+from allennlp.data.fields import Field, TextField, SequenceLabelField
+from allennlp.data.instance import Instance
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenIndexer
-from allennlp.common.checks import ConfigurationError
+from allennlp.data.tokenizers import Token
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -150,18 +150,19 @@ class SrlReader(DatasetReader):
         A list of Instances.
 
         """
+        tokens = list(map(Token, sentence_tokens))
         if not verbal_predicates:
             # Sentence contains no predicates.
             tags = ["O" for _ in sentence_tokens]
             verb_label = [0 for _ in sentence_tokens]
-            return [self.text_to_instance(sentence_tokens, verb_label, tags)]
+            return [self.text_to_instance(tokens, verb_label, tags)]
         else:
             instances = []
             for verb_index, annotation in zip(verbal_predicates, predicate_argument_labels):
                 tags = annotation
                 verb_label = [0 for _ in sentence_tokens]
                 verb_label[verb_index] = 1
-                instances.append(self.text_to_instance(sentence_tokens, verb_label, tags))
+                instances.append(self.text_to_instance(tokens, verb_label, tags))
             return instances
 
     @overrides
@@ -261,7 +262,7 @@ class SrlReader(DatasetReader):
         return Dataset(instances)
 
     def text_to_instance(self,  # type: ignore
-                         tokens: List[str],
+                         tokens: List[Token],
                          verb_label: List[int],
                          tags: List[str] = None) -> Instance:
         """
@@ -270,7 +271,7 @@ class SrlReader(DatasetReader):
         to find arguments for.
         """
         # pylint: disable=arguments-differ
-        fields = {}  # type: Dict[str, Field]
+        fields: Dict[str, Field] = {}
         text_field = TextField(tokens, token_indexers=self._token_indexers)
         fields['tokens'] = text_field
         fields['verb_indicator'] = SequenceLabelField(verb_label, text_field)

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -66,8 +66,8 @@ class SequenceTaggingDatasetReader(DatasetReader):
 
                 tokens_and_tags = [pair.rsplit(self._word_tag_delimiter, 1)
                                    for pair in line.split(self._token_delimiter)]
-                tokens = [Token(x[0]) for x in tokens_and_tags]
-                tags = [x[1] for x in tokens_and_tags]
+                tokens = [Token(token) for token, tag in tokens_and_tags]
+                tags = [tag for token, tag in tokens_and_tags]
 
                 sequence = TextField(tokens, self._token_indexers)
                 sequence_tags = SequenceLabelField(tags, sequence)

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -9,9 +9,10 @@ from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
+from allennlp.data.fields import TextField, SequenceLabelField
 from allennlp.data.instance import Instance
 from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
-from allennlp.data.fields import TextField, SequenceLabelField
+from allennlp.data.tokenizers import Token
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -65,7 +66,7 @@ class SequenceTaggingDatasetReader(DatasetReader):
 
                 tokens_and_tags = [pair.rsplit(self._word_tag_delimiter, 1)
                                    for pair in line.split(self._token_delimiter)]
-                tokens = [x[0] for x in tokens_and_tags]
+                tokens = [Token(x[0]) for x in tokens_and_tags]
                 tags = [x[1] for x in tokens_and_tags]
 
                 sequence = TextField(tokens, self._token_indexers)
@@ -77,7 +78,7 @@ class SequenceTaggingDatasetReader(DatasetReader):
                                      "Is the path correct?".format(file_path))
         return Dataset(instances)
 
-    def text_to_instance(self, tokens: List[str]) -> Instance:  # type: ignore
+    def text_to_instance(self, tokens: List[Token]) -> Instance:  # type: ignore
         """
         We take `pre-tokenized` input here, because we don't have a tokenizer in this class.
         """

--- a/allennlp/data/dataset_readers/snli.py
+++ b/allennlp/data/dataset_readers/snli.py
@@ -10,12 +10,10 @@ from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
+from allennlp.data.fields import Field, TextField, LabelField
 from allennlp.data.instance import Instance
-from allennlp.data.tokenizers.tokenizer import Tokenizer
-from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
-from allennlp.data.fields import TextField, LabelField
-from allennlp.data.fields.field import Field  # pylint: disable=unused-import
-from allennlp.data.tokenizers import WordTokenizer
+from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenIndexer
+from allennlp.data.tokenizers import Tokenizer, WordTokenizer
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -73,9 +71,9 @@ class SnliReader(DatasetReader):
                          hypothesis: str,
                          label: str = None) -> Instance:
         # pylint: disable=arguments-differ
-        fields = {}  # type: Dict[str, Field]
-        premise_tokens, _ = self._tokenizer.tokenize(premise)
-        hypothesis_tokens, _ = self._tokenizer.tokenize(hypothesis)
+        fields: Dict[str, Field] = {}
+        premise_tokens = self._tokenizer.tokenize(premise)
+        hypothesis_tokens = self._tokenizer.tokenize(hypothesis)
         fields['premise'] = TextField(premise_tokens, self._token_indexers)
         fields['hypothesis'] = TextField(hypothesis_tokens, self._token_indexers)
         if label:

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -6,8 +6,10 @@ from typing import Dict, List, Optional
 
 from overrides import overrides
 import numpy
+from spacy.tokens import Token as SpacyToken
 
 from allennlp.data.fields.sequence_field import SequenceField
+from allennlp.data.tokenizers.token import Token
 from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.common.checks import ConfigurationError
@@ -30,13 +32,13 @@ class TextField(SequenceField[Dict[str, numpy.ndarray]]):
     ``SingleIdTokenIndexer`` produces an array of shape (num_tokens,), while a
     ``TokenCharactersIndexer`` produces an array of shape (num_tokens, num_characters).
     """
-    def __init__(self, tokens: List[str], token_indexers: Dict[str, TokenIndexer]) -> None:
+    def __init__(self, tokens: List[Token], token_indexers: Dict[str, TokenIndexer]) -> None:
         self.tokens = tokens
         self._token_indexers = token_indexers
         self._indexed_tokens: Optional[Dict[str, TokenList]] = None
 
-        if not all([isinstance(x, str) for x in tokens]):
-            raise ConfigurationError("TextFields must be passed strings. "
+        if not all([isinstance(x, (Token, SpacyToken)) for x in tokens]):
+            raise ConfigurationError("TextFields must be passed Tokens. "
                                      "Found: {} with types {}.".format(tokens, [type(x) for x in tokens]))
 
     @overrides

--- a/allennlp/data/token_indexers/single_id_token_indexer.py
+++ b/allennlp/data/token_indexers/single_id_token_indexer.py
@@ -29,6 +29,8 @@ class SingleIdTokenIndexer(TokenIndexer[int]):
 
     @overrides
     def count_vocab_items(self, token: Token, counter: Dict[str, Dict[str, int]]):
+        # If `text_id` is set on the token (e.g., if we're using some kind of hash-based word
+        # encoding), we will not be using the vocab for this token.
         if getattr(token, 'text_id', None) is None:
             text = token.text
             if self.lowercase_tokens:
@@ -38,6 +40,8 @@ class SingleIdTokenIndexer(TokenIndexer[int]):
     @overrides
     def token_to_indices(self, token: Token, vocabulary: Vocabulary) -> int:
         if getattr(token, 'text_id', None) is not None:
+            # `text_id` being set on the token means that we aren't using the vocab, we just use
+            # this id instead.
             index = token.text_id
         else:
             text = token.text

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -3,8 +3,10 @@ import itertools
 
 from overrides import overrides
 
+from allennlp.common.checks import ConfigurationError
 from allennlp.common.params import Params
 from allennlp.common.util import pad_sequence_to_length
+from allennlp.data.tokenizers.token import Token
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.data.tokenizers.character_tokenizer import CharacterTokenizer
@@ -34,33 +36,29 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
         self._character_tokenizer = character_tokenizer
 
     @overrides
-    def count_vocab_items(self, token: str, counter: Dict[str, Dict[str, int]]):
-        for character in self._character_tokenizer.tokenize(token)[0]:
-            # If our character tokenizer is using byte encoding, the character might already be an
-            # int.  In that case, we'll bypass the vocabulary entirely.
-            if not isinstance(character, int):
-                counter[self._namespace][character] += 1
+    def count_vocab_items(self, token: Token, counter: Dict[str, Dict[str, int]]):
+        if token.text is None:
+            raise ConfigurationError('TokenCharactersIndexer needs a tokenizer that retains text')
+        for character in self._character_tokenizer.tokenize(token.text):
+            if character.text is not None:
+                counter[self._namespace][character.text] += 1
 
     @overrides
-    def token_to_indices(self, token: str, vocabulary: Vocabulary) -> List[int]:
+    def token_to_indices(self, token: Token, vocabulary: Vocabulary) -> List[int]:
         indices = []
-        for character in self._character_tokenizer.tokenize(token)[0]:
-            # If our character tokenizer is using byte encoding, the character might already be an
-            # int.  In that case, we'll bypass the vocabulary entirely.
-            if isinstance(character, int):
-                index = character
+        if token.text is None:
+            raise ConfigurationError('TokenCharactersIndexer needs a tokenizer that retains text')
+        for character in self._character_tokenizer.tokenize(token.text):
+            if getattr(character, 'text_id', None) is not None:
+                index = character.text_id
             else:
-                index = vocabulary.get_token_index(character, self._namespace)
+                index = vocabulary.get_token_index(character.text, self._namespace)
             indices.append(index)
         return indices
 
     @overrides
     def get_padding_lengths(self, token: List[int]) -> Dict[str, int]:
         return {'num_token_characters': len(token)}
-
-    @overrides
-    def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):
-        return (num_tokens, padding_lengths['num_token_characters'])
 
     @overrides
     def get_padding_token(self) -> List[int]:

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -40,7 +40,9 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
         if token.text is None:
             raise ConfigurationError('TokenCharactersIndexer needs a tokenizer that retains text')
         for character in self._character_tokenizer.tokenize(token.text):
-            if character.text is not None:
+            # If `text_id` is set on the character token (e.g., if we're using byte encoding), we
+            # will not be using the vocab for this character.
+            if getattr(character, 'text_id', None) is None:
                 counter[self._namespace][character.text] += 1
 
     @overrides
@@ -50,6 +52,8 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
             raise ConfigurationError('TokenCharactersIndexer needs a tokenizer that retains text')
         for character in self._character_tokenizer.tokenize(token.text):
             if getattr(character, 'text_id', None) is not None:
+                # `text_id` being set on the token means that we aren't using the vocab, we just
+                # use this id instead.
                 index = character.text_id
             else:
                 index = vocabulary.get_token_index(character.text, self._namespace)

--- a/allennlp/data/token_indexers/token_indexer.py
+++ b/allennlp/data/token_indexers/token_indexer.py
@@ -1,7 +1,8 @@
 from typing import Dict, List, TypeVar, Generic
 
-from allennlp.data.vocabulary import Vocabulary
 from allennlp.common import Params, Registrable
+from allennlp.data.tokenizers.token import Token
+from allennlp.data.vocabulary import Vocabulary
 
 TokenType = TypeVar("TokenType", int, List[int])  # pylint: disable=invalid-name
 
@@ -19,7 +20,7 @@ class TokenIndexer(Generic[TokenType], Registrable):
     """
     default_implementation = 'single_id'
 
-    def count_vocab_items(self, token: str, counter: Dict[str, Dict[str, int]]):
+    def count_vocab_items(self, token: Token, counter: Dict[str, Dict[str, int]]):
         """
         The :class:`Vocabulary` needs to assign indices to whatever strings we see in the training
         data (possibly doing some frequency filtering and using an OOV token).  This method takes
@@ -30,20 +31,11 @@ class TokenIndexer(Generic[TokenType], Registrable):
         """
         raise NotImplementedError
 
-    def token_to_indices(self, token: str, vocabulary: Vocabulary) -> TokenType:
+    def token_to_indices(self, token: Token, vocabulary: Vocabulary) -> TokenType:
         """
         Takes a string token and converts it into indices in some fashion.  This could be returning
         an ID for the token from the vocabulary, or it could be splitting the token into characters
         and return a list of IDs for each character from the vocabulary, or something else.
-        """
-        raise NotImplementedError
-
-    def get_input_shape(self, num_tokens: int, padding_lengths: Dict[str, int]):
-        """
-        Returns the shape of an input array containing tokens representated by this
-        ``TokenIndexer``, not including the batch size.  ``padding_lengths`` contains the
-        same keys returned by :func:`get_padding_lengths`.  For single ID tokens, this shape will
-        just be ``(num_tokens,)``; it will be more complicated for more complex representations.
         """
         raise NotImplementedError
 

--- a/allennlp/data/tokenizers/__init__.py
+++ b/allennlp/data/tokenizers/__init__.py
@@ -3,6 +3,6 @@ This module contains various classes for performing
 tokenization, stemming, and filtering.
 """
 
-from allennlp.data.tokenizers.tokenizer import Tokenizer
+from allennlp.data.tokenizers.tokenizer import Token, Tokenizer
 from allennlp.data.tokenizers.word_tokenizer import WordTokenizer
 from allennlp.data.tokenizers.character_tokenizer import CharacterTokenizer

--- a/allennlp/data/tokenizers/character_tokenizer.py
+++ b/allennlp/data/tokenizers/character_tokenizer.py
@@ -55,7 +55,7 @@ class CharacterTokenizer(Tokenizer):
             # of this.
             tokens = [Token(text_id=c + 1) for c in text.encode(self._byte_encoding)]
         else:
-            tokens = list(map(Token, list(text)))
+            tokens = [Token(t) for t in list(text)]
         for start_token in self._start_tokens:
             if isinstance(start_token, int):
                 token = Token(text_id=start_token, idx=0)

--- a/allennlp/data/tokenizers/token.py
+++ b/allennlp/data/tokenizers/token.py
@@ -1,0 +1,38 @@
+class Token:
+    """
+    A simple token representation, keeping track of the token's text, offset in the passage it was
+    taken from, POS tag, and dependency relation.  These fields match spacy's exactly, so we can
+    just use a spacy token for this.
+
+    Parameters
+    ----------
+    text : ``str``, optional
+        The original text represented by this token.
+    idx : ``int``, optional
+        The character offset of this token into the tokenized passage.
+    pos : ``str``, optional
+        The coarse-grained part of speech of this token.
+    tag : ``str``, optional
+        The fine-grained part of speech of this token.
+    dep : ``str``, optional
+        The dependency relation for this token.
+    text_id : ``int``, optional
+        If your tokenizer returns integers instead of strings (e.g., because you're doing byte
+        encoding, or some hash-based embedding), set this with the integer.  If this is set, we
+        will bypass the vocabulary when indexing this token, regardless of whether ``text`` is also
+        set.  You can `also` set ``text`` with the original text, if you want, so that you can
+        still use a character-level representation in addition to a hash-based word embedding.
+    """
+    def __init__(self,
+                 text: str = None,
+                 idx: int = None,
+                 pos: str = None,
+                 tag: str = None,
+                 dep: str = None,
+                 text_id: int = None) -> None:
+        self.text = text
+        self.idx = idx
+        self.pos_ = pos
+        self.tag_ = tag
+        self.dep_ = dep
+        self.text_id = text_id

--- a/allennlp/data/tokenizers/token.py
+++ b/allennlp/data/tokenizers/token.py
@@ -22,6 +22,9 @@ class Token:
         will bypass the vocabulary when indexing this token, regardless of whether ``text`` is also
         set.  You can `also` set ``text`` with the original text, if you want, so that you can
         still use a character-level representation in addition to a hash-based word embedding.
+
+        The other fields on ``Token`` follow the fields on spacy's ``Token`` object; this is one we
+        added, similar to spacy's ``lex_id``.
     """
     def __init__(self,
                  text: str = None,

--- a/allennlp/data/tokenizers/tokenizer.py
+++ b/allennlp/data/tokenizers/tokenizer.py
@@ -1,6 +1,7 @@
-from typing import List, Tuple
+from typing import List
 
 from allennlp.common import Params, Registrable
+from allennlp.data.tokenizers.token import Token
 
 
 class Tokenizer(Registrable):
@@ -22,17 +23,13 @@ class Tokenizer(Registrable):
     """
     default_implementation = 'word'
 
-    def tokenize(self, text: str) -> Tuple[List[str], List[Tuple[int, int]]]:
+    def tokenize(self, text: str) -> List[Token]:
         """
         The only public method for this class.  Actually implements splitting words into tokens.
 
         Returns
         -------
-        tokens : ``List[str]``
-        offsets : ``List[Tuple[int, int]]``
-            A list of the same lengths as ``tokens``, giving character offsets into the original
-            string for each token.  Not all tokenizers implement this, so this value could be
-            ``None``.
+        tokens : ``List[Token]``
         """
         raise NotImplementedError
 

--- a/allennlp/data/tokenizers/word_filter.py
+++ b/allennlp/data/tokenizers/word_filter.py
@@ -3,6 +3,7 @@ from typing import List
 from overrides import overrides
 
 from allennlp.common import Params, Registrable
+from allennlp.data.tokenizers.token import Token
 
 
 class WordFilter(Registrable):
@@ -15,11 +16,9 @@ class WordFilter(Registrable):
     """
     default_implementation = 'pass_through'
 
-    def should_keep_words(self, words: List[str]) -> List[bool]:
+    def filter_words(self, words: List[Token]) -> List[Token]:
         """
-        Decides whether to remove words from the given list.  To make it easier to deal with data
-        associated with the word list (like character offsets), we return a list of boolean
-        decisions for each word, which the caller can process to actually filter the list.
+        Returns a filtered list of words.
         """
         raise NotImplementedError
 
@@ -36,8 +35,8 @@ class PassThroughWordFilter(WordFilter):
     Does not filter words; it's a no-op.  This is the default word filter.
     """
     @overrides
-    def should_keep_words(self, words: List[str]) -> List[bool]:
-        return [True] * len(words)
+    def filter_words(self, words: List[Token]) -> List[Token]:
+        return words
 
 
 @WordFilter.register('stopwords')
@@ -73,5 +72,5 @@ class StopwordFilter(WordFilter):
                               "'", '"', '&', '$', '#', '@', '(', ')', '?'])
 
     @overrides
-    def should_keep_words(self, words: List[str]) -> List[bool]:
-        return [word not in self.stopwords for word in words]
+    def filter_words(self, words: List[Token]) -> List[Token]:
+        return [word for word in words if word.text not in self.stopwords]

--- a/allennlp/data/tokenizers/word_filter.py
+++ b/allennlp/data/tokenizers/word_filter.py
@@ -73,4 +73,4 @@ class StopwordFilter(WordFilter):
 
     @overrides
     def filter_words(self, words: List[Token]) -> List[Token]:
-        return [word for word in words if word.text not in self.stopwords]
+        return [word for word in words if word.text.lower() not in self.stopwords]

--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -1,9 +1,10 @@
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from overrides import overrides
 import spacy
 
 from allennlp.common import Params, Registrable
+from allennlp.data.tokenizers.token import Token
 
 
 class WordSplitter(Registrable):
@@ -15,7 +16,7 @@ class WordSplitter(Registrable):
     """
     default_implementation = 'spacy'
 
-    def split_words(self, sentence: str) -> Tuple[List[str], List[Tuple[int, int]]]:
+    def split_words(self, sentence: str) -> List[Token]:
         """
         Splits ``sentence`` into tokens, returning the resulting tokens and the character offsets
         for each token in the original string.  Not all ``WordSplitters`` implement character
@@ -23,8 +24,7 @@ class WordSplitter(Registrable):
 
         Returns
         -------
-        tokens : ``List[str]``
-        offsets : ``List[Tuple[int, int]]``
+        tokens : ``List[Token]``
         """
         raise NotImplementedError
 
@@ -33,8 +33,7 @@ class WordSplitter(Registrable):
         choice = params.pop_choice('type', cls.list_available(), default_to_first_choice=True)
         # None of the word splitters take parameters, so we just make sure the parameters are empty
         # here.
-        params.assert_empty('WordSplitter')
-        return cls.by_name(choice)()
+        return cls.by_name(choice).from_params(params)
 
 
 @WordSplitter.register('simple')
@@ -54,7 +53,7 @@ class SimpleWordSplitter(WordSplitter):
         self.beginning_punctuation = set(['"', "'", '(', '[', '{', '#', '$', '“', "‘"])
 
     @overrides
-    def split_words(self, sentence: str) -> Tuple[List[str], List[Tuple[int, int]]]:
+    def split_words(self, sentence: str) -> List[Token]:
         """
         Splits a sentence into word tokens.  We handle four kinds of things: words with punctuation
         that should be ignored as a special case (Mr. Mrs., etc.), contractions/genitives (isn't,
@@ -69,14 +68,14 @@ class SimpleWordSplitter(WordSplitter):
         first check to be sure the token isn't in our list of special cases.
         """
         fields = sentence.split()
-        tokens = []
+        tokens: List[Token] = []
         for field in fields:
-            add_at_end: List[str] = []
+            add_at_end: List[Token] = []
             while self._can_split(field) and field[0] in self.beginning_punctuation:
-                tokens.append(field[0])
+                tokens.append(Token(field[0]))
                 field = field[1:]
             while self._can_split(field) and field[-1] in self.ending_punctuation:
-                add_at_end.insert(0, field[-1])
+                add_at_end.insert(0, Token(field[-1]))
                 field = field[:-1]
 
             # There could (rarely) be several contractions in a word, but we check contractions
@@ -87,16 +86,21 @@ class SimpleWordSplitter(WordSplitter):
                 remove_contractions = False
                 for contraction in self.contractions:
                     if self._can_split(field) and field.lower().endswith(contraction):
-                        add_at_end.insert(0, field[-len(contraction):])
+                        add_at_end.insert(0, Token(field[-len(contraction):]))
                         field = field[:-len(contraction)]
                         remove_contractions = True
             if field:
-                tokens.append(field)
+                tokens.append(Token(field))
             tokens.extend(add_at_end)
-        return tokens, None
+        return tokens
 
     def _can_split(self, token: str):
         return token and token.lower() not in self.special_cases
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'WordSplitter':
+        params.assert_empty(cls.__name__)
+        return cls()
 
 
 @WordSplitter.register('just_spaces')
@@ -111,8 +115,13 @@ class JustSpacesWordSplitter(WordSplitter):
     tokens does not matter.  This will never result in spaces being included as tokens.
     """
     @overrides
-    def split_words(self, sentence: str) -> Tuple[List[str], List[Tuple[int, int]]]:
-        return sentence.split(), None
+    def split_words(self, sentence: str) -> List[Token]:
+        return list(map(Token, sentence.split()))
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'WordSplitter':
+        params.assert_empty(cls.__name__)
+        return cls()
 
 
 @WordSplitter.register('nltk')
@@ -125,10 +134,15 @@ class NltkWordSplitter(WordSplitter):
     code, if you really want it.
     """
     @overrides
-    def split_words(self, sentence: str) -> Tuple[List[str], List[Tuple[int, int]]]:
+    def split_words(self, sentence: str) -> List[Token]:
         # Import is here because it's slow, and by default unnecessary.
         from nltk.tokenize import word_tokenize
-        return word_tokenize(sentence.lower()), None
+        return list(map(Token, word_tokenize(sentence.lower())))
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'WordSplitter':
+        params.assert_empty(cls.__name__)
+        return cls()
 
 
 @WordSplitter.register('spacy')
@@ -137,14 +151,30 @@ class SpacyWordSplitter(WordSplitter):
     A ``WordSplitter`` that uses spaCy's tokenizer.  It's fast and reasonable - this is the
     recommended ``WordSplitter``.
     """
-    en_nlp = None
+    _spacy_tokenizers: Dict[Tuple, Any] = {}
+    def __init__(self,
+                 language: str = 'en',
+                 pos_tags: bool = False,
+                 parse: bool = False,
+                 ner: bool = False) -> None:
+        self.spacy = self._get_spacy_model(language, pos_tags, parse, ner)
 
     @overrides
-    def split_words(self, sentence: str) -> Tuple[List[str], List[Tuple[int, int]]]:
-        if SpacyWordSplitter.en_nlp is None:
-            # Load is here because it's slow, and can be unnecessary.
-            SpacyWordSplitter.en_nlp = spacy.load('en', parser=False, tagger=False, entity=False)
-        tokens = self.en_nlp.tokenizer(sentence)
-        words = [str(token) for token in tokens]
-        offsets = [(token.idx, token.idx + len(token)) for token in tokens]
-        return words, offsets
+    def split_words(self, sentence: str) -> List[Token]:
+        return self.spacy(sentence)  # type: ignore
+
+    def _get_spacy_model(self, language: str, pos_tags: bool, parse: bool, ner: bool) -> Any:
+        options = (language, pos_tags, parse, ner)
+        if options not in self._spacy_tokenizers:
+            spacy_model = spacy.load(language, parser=parse, tagger=pos_tags, entity=ner)
+            self._spacy_tokenizers[options] = spacy_model
+        return self._spacy_tokenizers[options]
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'WordSplitter':
+        language = params.pop('language', 'en')
+        pos_tags = params.pop('pos_tags', False)
+        parse = params.pop('parse', False)
+        ner = params.pop('ner', False)
+        params.assert_empty(cls.__name__)
+        return cls(language, pos_tags, parse, ner)

--- a/allennlp/data/tokenizers/word_stemmer.py
+++ b/allennlp/data/tokenizers/word_stemmer.py
@@ -2,6 +2,7 @@ from nltk.stem import PorterStemmer as NltkPorterStemmer
 from overrides import overrides
 
 from allennlp.common import Params, Registrable
+from allennlp.data.tokenizers.token import Token
 
 
 class WordStemmer(Registrable):
@@ -16,8 +17,10 @@ class WordStemmer(Registrable):
     """
     default_implementation = 'pass_through'
 
-    def stem_word(self, word: str) -> str:
-        """Converts a word to its lemma"""
+    def stem_word(self, word: Token) -> Token:
+        """
+        `Modifies` the ``text`` field in the input token, and also returns the same token.
+        """
         raise NotImplementedError
 
     @classmethod
@@ -33,7 +36,7 @@ class PassThroughWordStemmer(WordStemmer):
     Does not stem words; it's a no-op.  This is the default word stemmer.
     """
     @overrides
-    def stem_word(self, word: str) -> str:
+    def stem_word(self, word: Token) -> Token:
         return word
 
 
@@ -46,5 +49,6 @@ class PorterStemmer(WordStemmer):
         self.stemmer = NltkPorterStemmer()
 
     @overrides
-    def stem_word(self, word: str) -> str:
-        return self.stemmer.stem(word)
+    def stem_word(self, word: Token) -> Token:
+        new_text = self.stemmer.stem(word.text)
+        return Token(new_text, word.idx, word.pos_, word.tag_, word.dep_, getattr(word, 'text_id', None))

--- a/allennlp/data/tokenizers/word_stemmer.py
+++ b/allennlp/data/tokenizers/word_stemmer.py
@@ -19,7 +19,7 @@ class WordStemmer(Registrable):
 
     def stem_word(self, word: Token) -> Token:
         """
-        `Modifies` the ``text`` field in the input token, and also returns the same token.
+        Returns a new ``Token`` with ``word.text`` replaced by a stemmed word.
         """
         raise NotImplementedError
 

--- a/allennlp/data/tokenizers/word_tokenizer.py
+++ b/allennlp/data/tokenizers/word_tokenizer.py
@@ -1,8 +1,9 @@
-from typing import List, Tuple
+from typing import List
 
 from overrides import overrides
 
 from allennlp.common import Params
+from allennlp.data.tokenizers.token import Token
 from allennlp.data.tokenizers.tokenizer import Tokenizer
 from allennlp.data.tokenizers.word_filter import WordFilter, PassThroughWordFilter
 from allennlp.data.tokenizers.word_splitter import WordSplitter, SpacyWordSplitter
@@ -12,19 +13,19 @@ from allennlp.data.tokenizers.word_stemmer import WordStemmer, PassThroughWordSt
 @Tokenizer.register("word")
 class WordTokenizer(Tokenizer):
     """
-    A ``WordTokenizer`` handles the splitting of strings into words (with the use of a
-    WordSplitter) as well as any desired post-processing (e.g., stemming, filtering, etc.).  Note
-    that we leave one particular piece of post-processing for later: the decision of whether or not
-    to lowercase the token.  This is for two reasons: (1) if you want to make two different casing
-    decisions for whatever reason, you won't have to run the tokenizer twice, and more importantly
-    (2) if you want to lowercase words for your word embedding, but retain capitalization in a
-    character-level representation, we need to retain the capitalization here.
+    A ``WordTokenizer`` handles the splitting of strings into words as well as any desired
+    post-processing (e.g., stemming, filtering, etc.).  Note that we leave one particular piece of
+    post-processing for later: the decision of whether or not to lowercase the token.  This is for
+    two reasons: (1) if you want to make two different casing decisions for whatever reason, you
+    won't have to run the tokenizer twice, and more importantly (2) if you want to lowercase words
+    for your word embedding, but retain capitalization in a character-level representation, we need
+    to retain the capitalization here.
 
     Parameters
     ----------
     word_splitter : ``WordSplitter``, optional
         The :class:`WordSplitter` to use for splitting text strings into word tokens.  The default
-        is to use the spacy word splitter.
+        is to use the ``SpacyWordSplitter`` with default parameters.
     word_filter : ``WordFilter``, optional
         The :class:`WordFilter` to use for, e.g., removing stopwords.  Default is to do no
         filtering.
@@ -34,14 +35,30 @@ class WordTokenizer(Tokenizer):
         If given, these tokens will be added to the beginning of every string we tokenize.
     end_tokens : ``List[str]``, optional
         If given, these tokens will be added to the end of every string we tokenize.
+    language : ``str``, optional
+        We use spacy to tokenize strings; this option specifies which language to use.  By default
+        we use English.
+    pos_tags : ``bool``, optional
+        By default we do not load spacy's tagging model, to save loading time and memory.  Set this
+        to ``True`` if you want to have access to spacy's POS tags in the returned tokens.
+    parse : ``bool``, optional
+        By default we do not load spacy's parsing model, to save loading time and memory.  Set this
+        to ``True`` if you want to have access to spacy's dependency parse tags in the returned
+        tokens.
+    ner : ``bool``, optional
+        By default we do not load spacy's parsing model, to save loading time and memory.  Set this
+        to ``True`` if you want to have access to spacy's NER tags in the returned tokens.
     """
+    # In order to avoid loady spacy models a whole bunch of times, we'll save references to them,
+    # keyed by the options we used to create the spacy model, so any particular configuration only
+    # gets loaded once.
     def __init__(self,
-                 word_splitter: WordSplitter = SpacyWordSplitter(),
+                 word_splitter: WordSplitter = None,
                  word_filter: WordFilter = PassThroughWordFilter(),
                  word_stemmer: WordStemmer = PassThroughWordStemmer(),
                  start_tokens: List[str] = None,
                  end_tokens: List[str] = None) -> None:
-        self._word_splitter = word_splitter
+        self._word_splitter = word_splitter or SpacyWordSplitter()
         self._word_filter = word_filter
         self._word_stemmer = word_stemmer
         self._start_tokens = start_tokens or []
@@ -51,31 +68,21 @@ class WordTokenizer(Tokenizer):
         self._end_tokens = end_tokens or []
 
     @overrides
-    def tokenize(self, text: str) -> Tuple[List[str], List[Tuple[int, int]]]:
+    def tokenize(self, text: str) -> List[Token]:
         """
         Does whatever processing is required to convert a string of text into a sequence of tokens.
 
         At a minimum, this uses a ``WordSplitter`` to split words into text.  It may also do
         stemming or stopword removal, depending on the parameters given to the constructor.
         """
-        words, offsets = self._word_splitter.split_words(text)
-        words_to_keep = self._word_filter.should_keep_words(words)
-        filtered_words = []
-        filtered_offsets = []
-        for i, should_keep in enumerate(words_to_keep):
-            if should_keep:
-                filtered_words.append(words[i])
-                filtered_offsets.append(offsets[i])
+        words = self._word_splitter.split_words(text)
+        filtered_words = self._word_filter.filter_words(words)
         stemmed_words = [self._word_stemmer.stem_word(word) for word in filtered_words]
         for start_token in self._start_tokens:
-            stemmed_words.insert(0, start_token)
-            if filtered_offsets is not None:
-                filtered_offsets.insert(0, (0, 0))
+            stemmed_words.insert(0, Token(start_token, 0))
         for end_token in self._end_tokens:
-            stemmed_words.append(end_token)
-            if filtered_offsets is not None:
-                filtered_offsets.append((-1, -1))
-        return stemmed_words, filtered_offsets
+            stemmed_words.append(Token(end_token, -1))
+        return stemmed_words
 
     @classmethod
     def from_params(cls, params: Params) -> 'WordTokenizer':

--- a/allennlp/data/tokenizers/word_tokenizer.py
+++ b/allennlp/data/tokenizers/word_tokenizer.py
@@ -49,9 +49,6 @@ class WordTokenizer(Tokenizer):
         By default we do not load spacy's parsing model, to save loading time and memory.  Set this
         to ``True`` if you want to have access to spacy's NER tags in the returned tokens.
     """
-    # In order to avoid loady spacy models a whole bunch of times, we'll save references to them,
-    # keyed by the options we used to create the spacy model, so any particular configuration only
-    # gets loaded once.
     def __init__(self,
                  word_splitter: WordSplitter = None,
                  word_filter: WordFilter = PassThroughWordFilter(),

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -64,15 +64,15 @@ class SemanticRoleLabelerPredictor(Predictor):
         """
         sentence = inputs["sentence"]
 
-        spacy_doc = self.nlp(sentence)
-        words = [token.text for token in spacy_doc]
+        tokens = self.nlp(sentence)
+        words = [token.text for token in tokens]
         results: JsonDict = {"words": words, "verbs": []}
-        for i, word in enumerate(spacy_doc):
+        for i, word in enumerate(tokens):
             if word.pos_ == "VERB":
                 verb = word.text
                 verb_labels = [0 for _ in words]
                 verb_labels[i] = 1
-                instance = self._dataset_reader.text_to_instance(words, verb_labels)
+                instance = self._dataset_reader.text_to_instance(tokens, verb_labels)
                 output = self._model.decode(self._model.forward_on_instance(instance))
                 tags = output['tags']
 
@@ -84,6 +84,6 @@ class SemanticRoleLabelerPredictor(Predictor):
                         "tags": tags,
                 })
 
-        results["tokens"] = [word.text for word in spacy_doc]
+        results["tokens"] = words
 
         return sanitize(results)

--- a/tests/data/dataset_readers/language_modeling_dataset_test.py
+++ b/tests/data/dataset_readers/language_modeling_dataset_test.py
@@ -13,17 +13,17 @@ class TestLanguageModelingDatasetReader(AllenNlpTestCase):
         # in here, anyway.
         assert len(instances) == 5
 
-        assert instances[0].fields["input_tokens"].tokens == ["This", "is", "a"]
-        assert instances[0].fields["output_tokens"].tokens == ["is", "a", "sentence"]
+        assert [t.text for t in instances[0].fields["input_tokens"].tokens] == ["This", "is", "a"]
+        assert [t.text for t in instances[0].fields["output_tokens"].tokens] == ["is", "a", "sentence"]
 
-        assert instances[1].fields["input_tokens"].tokens == ["sentence", "for", "language"]
-        assert instances[1].fields["output_tokens"].tokens == ["for", "language", "modelling"]
+        assert [t.text for t in instances[1].fields["input_tokens"].tokens] == ["sentence", "for", "language"]
+        assert [t.text for t in instances[1].fields["output_tokens"].tokens] == ["for", "language", "modelling"]
 
-        assert instances[2].fields["input_tokens"].tokens == ["modelling", ".", "Here"]
-        assert instances[2].fields["output_tokens"].tokens == [".", "Here", "'s"]
+        assert [t.text for t in instances[2].fields["input_tokens"].tokens] == ["modelling", ".", "Here"]
+        assert [t.text for t in instances[2].fields["output_tokens"].tokens] == [".", "Here", "'s"]
 
-        assert instances[3].fields["input_tokens"].tokens == ["'s", "another", "one"]
-        assert instances[3].fields["output_tokens"].tokens == ["another", "one", "for"]
+        assert [t.text for t in instances[3].fields["input_tokens"].tokens] == ["'s", "another", "one"]
+        assert [t.text for t in instances[3].fields["output_tokens"].tokens] == ["another", "one", "for"]
 
-        assert instances[4].fields["input_tokens"].tokens == ["for", "extra", "language"]
-        assert instances[4].fields["output_tokens"].tokens == ["extra", "language", "modelling"]
+        assert [t.text for t in instances[4].fields["input_tokens"].tokens] == ["for", "extra", "language"]
+        assert [t.text for t in instances[4].fields["output_tokens"].tokens] == ["extra", "language", "modelling"]

--- a/tests/data/dataset_readers/sequence_tagging_test.py
+++ b/tests/data/dataset_readers/sequence_tagging_test.py
@@ -10,16 +10,16 @@ class TestSequenceTaggingDatasetReader(AllenNlpTestCase):
 
         assert len(dataset.instances) == 4
         fields = dataset.instances[0].fields
-        assert fields["tokens"].tokens == ["cats", "are", "animals", "."]
+        assert [t.text for t in fields["tokens"].tokens] == ["cats", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
         fields = dataset.instances[1].fields
-        assert fields["tokens"].tokens == ["dogs", "are", "animals", "."]
+        assert [t.text for t in fields["tokens"].tokens] == ["dogs", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
         fields = dataset.instances[2].fields
-        assert fields["tokens"].tokens == ["snakes", "are", "animals", "."]
+        assert [t.text for t in fields["tokens"].tokens] == ["snakes", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
         fields = dataset.instances[3].fields
-        assert fields["tokens"].tokens == ["birds", "are", "animals", "."]
+        assert [t.text for t in fields["tokens"].tokens] == ["birds", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
 
     def test_brown_corpus_format(self):
@@ -28,14 +28,14 @@ class TestSequenceTaggingDatasetReader(AllenNlpTestCase):
 
         assert len(dataset.instances) == 4
         fields = dataset.instances[0].fields
-        assert fields["tokens"].tokens == ["cats", "are", "animals", "."]
+        assert [t.text for t in fields["tokens"].tokens] == ["cats", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
         fields = dataset.instances[1].fields
-        assert fields["tokens"].tokens == ["dogs", "are", "animals", "."]
+        assert [t.text for t in fields["tokens"].tokens] == ["dogs", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
         fields = dataset.instances[2].fields
-        assert fields["tokens"].tokens == ["snakes", "are", "animals", "."]
+        assert [t.text for t in fields["tokens"].tokens] == ["snakes", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
         fields = dataset.instances[3].fields
-        assert fields["tokens"].tokens == ["birds", "are", "animals", "."]
+        assert [t.text for t in fields["tokens"].tokens] == ["birds", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]

--- a/tests/data/dataset_readers/snli_reader_test.py
+++ b/tests/data/dataset_readers/snli_reader_test.py
@@ -27,14 +27,14 @@ class TestSnliReader(AllenNlpTestCase):
 
         assert len(dataset.instances) == 3
         fields = dataset.instances[0].fields
-        assert fields["premise"].tokens == instance1["premise"]
-        assert fields["hypothesis"].tokens == instance1["hypothesis"]
+        assert [t.text for t in fields["premise"].tokens] == instance1["premise"]
+        assert [t.text for t in fields["hypothesis"].tokens] == instance1["hypothesis"]
         assert fields["label"].label == instance1["label"]
         fields = dataset.instances[1].fields
-        assert fields["premise"].tokens == instance2["premise"]
-        assert fields["hypothesis"].tokens == instance2["hypothesis"]
+        assert [t.text for t in fields["premise"].tokens] == instance2["premise"]
+        assert [t.text for t in fields["hypothesis"].tokens] == instance2["hypothesis"]
         assert fields["label"].label == instance2["label"]
         fields = dataset.instances[2].fields
-        assert fields["premise"].tokens == instance3["premise"]
-        assert fields["hypothesis"].tokens == instance3["hypothesis"]
+        assert [t.text for t in fields["premise"].tokens] == instance3["premise"]
+        assert [t.text for t in fields["hypothesis"].tokens] == instance3["hypothesis"]
         assert fields["label"].label == instance3["label"]

--- a/tests/data/dataset_readers/squad_reader_test.py
+++ b/tests/data/dataset_readers/squad_reader_test.py
@@ -1,9 +1,9 @@
 # pylint: disable=no-self-use,invalid-name
 from allennlp.common import Params
+from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data.dataset_readers import SquadReader
 from allennlp.data.dataset_readers.squad import _char_span_to_token_span
 from allennlp.data.tokenizers import WordTokenizer
-from allennlp.common.testing import AllenNlpTestCase
 
 
 class TestSquadReader(AllenNlpTestCase):
@@ -14,7 +14,8 @@ class TestSquadReader(AllenNlpTestCase):
             "Carter, at Lenox Hill Hospital in New York. Five months later, she performed for four " +\
             "nights at Revel Atlantic City's Ovation Hall to celebrate the resort's opening, her " +\
             "first performances since giving birth to Blue Ivy."
-        _, offsets = tokenizer.tokenize(passage)
+        tokens = tokenizer.tokenize(passage)
+        offsets = [(t.idx, t.idx + len(t.text)) for t in tokens]
         # "January 7, 2012"
         token_span = _char_span_to_token_span(offsets, (3, 18))[0]
         assert token_span == (1, 4)
@@ -43,7 +44,8 @@ class TestSquadReader(AllenNlpTestCase):
             "to shoot the album cover for her 4, and unexpectedly became pregnant in Paris."
         start = 912
         end = 912 + len("Paris.")
-        _, offsets = tokenizer.tokenize(passage)
+        tokens = tokenizer.tokenize(passage)
+        offsets = [(t.idx, t.idx + len(t.text)) for  t in tokens]
         token_span = _char_span_to_token_span(offsets, (start, end))[0]
         assert token_span == (184, 185)
 
@@ -52,29 +54,29 @@ class TestSquadReader(AllenNlpTestCase):
         instances = reader.read('tests/fixtures/data/squad.json').instances
         assert len(instances) == 5
 
-        assert instances[0].fields["question"].tokens[:3] == ["To", "whom", "did"]
-        assert instances[0].fields["passage"].tokens[:3] == ["Architecturally", ",", "the"]
-        assert instances[0].fields["passage"].tokens[-3:] == ["of", "Mary", "."]
+        assert [t.text for t in instances[0].fields["question"].tokens[:3]] == ["To", "whom", "did"]
+        assert [t.text for t in instances[0].fields["passage"].tokens[:3]] == ["Architecturally", ",", "the"]
+        assert [t.text for t in instances[0].fields["passage"].tokens[-3:]] == ["of", "Mary", "."]
         assert instances[0].fields["span_start"].sequence_index == 102
         assert instances[0].fields["span_end"].sequence_index == 104
 
-        assert instances[1].fields["question"].tokens[:3] == ["What", "sits", "on"]
-        assert instances[1].fields["passage"].tokens[:3] == ["Architecturally", ",", "the"]
-        assert instances[1].fields["passage"].tokens[-3:] == ["of", "Mary", "."]
+        assert [t.text for t in instances[1].fields["question"].tokens[:3]] == ["What", "sits", "on"]
+        assert [t.text for t in instances[1].fields["passage"].tokens[:3]] == ["Architecturally", ",", "the"]
+        assert [t.text for t in instances[1].fields["passage"].tokens[-3:]] == ["of", "Mary", "."]
         assert instances[1].fields["span_start"].sequence_index == 17
         assert instances[1].fields["span_end"].sequence_index == 23
 
         # We're checking this case because I changed the answer text to only have a partial
         # annotation for the last token, which happens occasionally in the training data.  We're
         # making sure we get a reasonable output in that case here.
-        assert instances[3].fields["question"].tokens[:3] == ["Which", "individual", "worked"]
-        assert instances[3].fields["passage"].tokens[:3] == ["In", "1882", ","]
-        assert instances[3].fields["passage"].tokens[-3:] == ["Nuclear", "Astrophysics", "."]
+        assert [t.text for t in instances[3].fields["question"].tokens[:3]] == ["Which", "individual", "worked"]
+        assert [t.text for t in instances[3].fields["passage"].tokens[:3]] == ["In", "1882", ","]
+        assert [t.text for t in instances[3].fields["passage"].tokens[-3:]] == ["Nuclear", "Astrophysics", "."]
         span_start = instances[3].fields["span_start"].sequence_index
         span_end = instances[3].fields["span_end"].sequence_index
         answer_tokens = instances[3].fields["passage"].tokens[span_start:(span_end + 1)]
         expected_answer_tokens = ["Father", "Julius", "Nieuwland"]
-        assert answer_tokens == expected_answer_tokens
+        assert [t.text for t in answer_tokens] == expected_answer_tokens
 
     def test_can_build_from_params(self):
         reader = SquadReader.from_params(Params({}))

--- a/tests/data/dataset_readers/squad_sentence_selection_reader_test.py
+++ b/tests/data/dataset_readers/squad_sentence_selection_reader_test.py
@@ -89,27 +89,29 @@ class TestSquadSentenceSelectionReader(AllenNlpTestCase):
     def assert_list_field_contains_correct_sentences(self, list_field: ListField, sentences: List[str]):
         expected_tokens = set()
         for sentence in sentences:
-            sentence_tokens = tuple(self.tokenizer.tokenize(sentence.replace("\\\"", "\""))[0])
+            sentence_tokens = tuple(t.text for t in self.tokenizer.tokenize(sentence.replace("\\\"", "\"")))
             expected_tokens.add(sentence_tokens)
         actual_tokens = set()
         for field in list_field.field_list:
-            actual_tokens.add(tuple(field.tokens))
+            actual_tokens.add(tuple([t.text for t in field.tokens]))
         assert expected_tokens == actual_tokens
 
     def assert_index_field_points_to_correct_sentence(self, index_field: IndexField, sentence: str):
-        sentence_tokens = tuple(self.tokenizer.tokenize(sentence.replace("\\\"", "\""))[0])
-        tokens_list = [tuple(field.tokens) for field in index_field.sequence_field.field_list]
+        sentence_tokens = tuple(t.text for t in self.tokenizer.tokenize(sentence.replace("\\\"", "\"")))
+        tokens_list = [tuple(t.text for t in field.tokens) for field in index_field.sequence_field.field_list]
         assert index_field.sequence_index == tokens_list.index(sentence_tokens)
 
     def test_default_squad_sentence_selection_reader(self):
         reader = SquadSentenceSelectionReader()
         instances = reader.read(self.squad_file).instances
-        assert instances[0].fields["question"].tokens == self.tokenizer.tokenize(self.question0)[0]
+        tokens = [t.text for t in instances[0].fields['question'].tokens]
+        assert tokens == [t.text for t in self.tokenizer.tokenize(self.question0)]
         self.assert_list_field_contains_correct_sentences(instances[0].fields["sentences"],
                                                           self.sentences[:7])
         self.assert_index_field_points_to_correct_sentence(instances[0].fields['correct_sentence'],
                                                            self.sentences[5])
-        assert instances[1].fields["question"].tokens == self.tokenizer.tokenize(self.question1)[0]
+        tokens = [t.text for t in instances[1].fields['question'].tokens]
+        assert tokens == [t.text for t in self.tokenizer.tokenize(self.question1)]
         self.assert_list_field_contains_correct_sentences(instances[1].fields["sentences"],
                                                           self.sentences[:7])
         self.assert_index_field_points_to_correct_sentence(instances[1].fields['correct_sentence'],

--- a/tests/data/dataset_readers/srl_dataset_reader_test.py
+++ b/tests/data/dataset_readers/srl_dataset_reader_test.py
@@ -9,33 +9,42 @@ class TestSrlReader(AllenNlpTestCase):
         conll_reader = SrlReader()
         dataset = conll_reader.read('tests/fixtures/conll_2012/')
         instances = dataset.instances
+
         fields = instances[0].fields
-        assert fields["tokens"].tokens == ["Mali", "government", "officials", "say",
-                                           "the", "woman", "'s", "confession", "was", "forced", "."]
+        tokens = [t.text for t in fields['tokens'].tokens]
+        assert tokens == ["Mali", "government", "officials", "say", "the", "woman", "'s",
+                          "confession", "was", "forced", "."]
         assert fields["verb_indicator"].labels[3] == 1
         assert fields["tags"].labels == ['B-ARG0', 'I-ARG0', 'I-ARG0', 'B-V', 'B-ARG1',
                                          'I-ARG1', 'I-ARG1', 'I-ARG1', 'I-ARG1', 'I-ARG1', 'O']
+
         fields = instances[1].fields
-        assert fields["tokens"].tokens == ["Mali", "government", "officials", "say",
-                                           "the", "woman", "'s", "confession", "was", "forced", "."]
+        tokens = [t.text for t in fields['tokens'].tokens]
+        assert tokens == ["Mali", "government", "officials", "say", "the", "woman", "'s",
+                          "confession", "was", "forced", "."]
         assert fields["verb_indicator"].labels[8] == 1
         assert fields["tags"].labels == ['O', 'O', 'O', 'O', 'B-ARG1', 'I-ARG1',
                                          'I-ARG1', 'I-ARG1', 'B-V', 'B-ARG2', 'O']
+
         fields = instances[2].fields
-        assert fields["tokens"].tokens == ['The', 'prosecution', 'rested', 'its', 'case', 'last', 'month',
-                                           'after', 'four', 'months', 'of', 'hearings', '.']
+        tokens = [t.text for t in fields['tokens'].tokens]
+        assert tokens == ['The', 'prosecution', 'rested', 'its', 'case', 'last', 'month', 'after',
+                          'four', 'months', 'of', 'hearings', '.']
         assert fields["verb_indicator"].labels[2] == 1
         assert fields["tags"].labels == ['B-ARG0', 'I-ARG0', 'B-V', 'B-ARG1', 'I-ARG1', 'B-ARGM-TMP',
                                          'I-ARGM-TMP', 'B-ARGM-TMP', 'I-ARGM-TMP', 'I-ARGM-TMP',
                                          'I-ARGM-TMP', 'I-ARGM-TMP', 'O']
+
         fields = instances[3].fields
-        assert fields["tokens"].tokens == ['The', 'prosecution', 'rested', 'its', 'case', 'last', 'month',
-                                           'after', 'four', 'months', 'of', 'hearings', '.']
+        tokens = [t.text for t in fields['tokens'].tokens]
+        assert tokens == ['The', 'prosecution', 'rested', 'its', 'case', 'last', 'month', 'after',
+                          'four', 'months', 'of', 'hearings', '.']
         assert fields["verb_indicator"].labels[11] == 1
         assert fields["tags"].labels == ['O', 'O', 'O', 'O', 'O', 'O', 'O', 'O', 'O', 'O', 'O', 'B-V', 'O']
 
         # Tests a sentence with no verbal predicates.
         fields = instances[4].fields
-        assert fields["tokens"].tokens == ["Denise", "Dillon", "Headline", "News", "."]
+        tokens = [t.text for t in fields['tokens'].tokens]
+        assert tokens == ["Denise", "Dillon", "Headline", "News", "."]
         assert fields["verb_indicator"].labels == [0, 0, 0, 0, 0]
         assert fields["tags"].labels == ['O', 'O', 'O', 'O', 'O']

--- a/tests/data/dataset_test.py
+++ b/tests/data/dataset_test.py
@@ -46,10 +46,14 @@ class TestDataset(AllenNlpTestCase):
                                                                     [2, 3, 1, 0, 0, 0]]))
 
     def get_dataset(self):
-        field1 = TextField(list(map(Token, ["this", "is", "a", "sentence", "."])), self.token_indexer)
-        field2 = TextField(list(map(Token, ["this", "is", "a", "different", "sentence", "."])), self.token_indexer)
-        field3 = TextField(list(map(Token, ["here", "is", "a", "sentence", "."])), self.token_indexer)
-        field4 = TextField(list(map(Token, ["this", "is", "short"])), self.token_indexer)
+        field1 = TextField([Token(t) for t in ["this", "is", "a", "sentence", "."]],
+                           self.token_indexer)
+        field2 = TextField([Token(t) for t in ["this", "is", "a", "different", "sentence", "."]],
+                           self.token_indexer)
+        field3 = TextField([Token(t) for t in ["here", "is", "a", "sentence", "."]],
+                           self.token_indexer)
+        field4 = TextField([Token(t) for t in ["this", "is", "short"]],
+                           self.token_indexer)
         instances = [Instance({"text1": field1, "text2": field2}),
                      Instance({"text1": field3, "text2": field4})]
         return Dataset(instances)

--- a/tests/data/dataset_test.py
+++ b/tests/data/dataset_test.py
@@ -3,12 +3,10 @@ import pytest
 import numpy
 
 from allennlp.common.checks import ConfigurationError
-from allennlp.data.dataset import Dataset
-from allennlp.data.fields import TextField, LabelField
-from allennlp.data.instance import Instance
-from allennlp.data.vocabulary import Vocabulary
-from allennlp.data.token_indexers import SingleIdTokenIndexer
 from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Dataset, Instance, Token, Vocabulary
+from allennlp.data.fields import TextField, LabelField
+from allennlp.data.token_indexers import SingleIdTokenIndexer
 
 
 class TestDataset(AllenNlpTestCase):
@@ -24,7 +22,7 @@ class TestDataset(AllenNlpTestCase):
 
     def test_instances_must_have_homogeneous_fields(self):
         instance1 = Instance({"tag": (LabelField(1, skip_indexing=True))})
-        instance2 = Instance({"words": TextField(["hello"], {})})
+        instance2 = Instance({"words": TextField([Token("hello")], {})})
         with pytest.raises(ConfigurationError):
             _ = Dataset([instance1, instance2])
 
@@ -48,10 +46,10 @@ class TestDataset(AllenNlpTestCase):
                                                                     [2, 3, 1, 0, 0, 0]]))
 
     def get_dataset(self):
-        field1 = TextField(["this", "is", "a", "sentence", "."], self.token_indexer)
-        field2 = TextField(["this", "is", "a", "different", "sentence", "."], self.token_indexer)
-        field3 = TextField(["here", "is", "a", "sentence", "."], self.token_indexer)
-        field4 = TextField(["this", "is", "short"], self.token_indexer)
+        field1 = TextField(list(map(Token, ["this", "is", "a", "sentence", "."])), self.token_indexer)
+        field2 = TextField(list(map(Token, ["this", "is", "a", "different", "sentence", "."])), self.token_indexer)
+        field3 = TextField(list(map(Token, ["here", "is", "a", "sentence", "."])), self.token_indexer)
+        field4 = TextField(list(map(Token, ["this", "is", "short"])), self.token_indexer)
         instances = [Instance({"text1": field1, "text2": field2}),
                      Instance({"text1": field3, "text2": field4})]
         return Dataset(instances)

--- a/tests/data/fields/index_field_test.py
+++ b/tests/data/fields/index_field_test.py
@@ -1,16 +1,17 @@
 # pylint: disable=no-self-use,invalid-name
 import numpy
 import pytest
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Token
 from allennlp.data.fields import TextField, IndexField
 from allennlp.data.token_indexers import SingleIdTokenIndexer
-from allennlp.common.testing import AllenNlpTestCase
-from allennlp.common.checks import ConfigurationError
 
 class TestIndexField(AllenNlpTestCase):
-
     def setUp(self):
         super(TestIndexField, self).setUp()
-        self.text = TextField(["here", "is", "a", "sentence", "."],
+        self.text = TextField(list(map(Token, ["here", "is", "a", "sentence", "."])),
                               {"words": SingleIdTokenIndexer("words")})
 
     def test_index_field_inherits_padding_lengths_from_text_field(self):

--- a/tests/data/fields/index_field_test.py
+++ b/tests/data/fields/index_field_test.py
@@ -11,7 +11,7 @@ from allennlp.data.token_indexers import SingleIdTokenIndexer
 class TestIndexField(AllenNlpTestCase):
     def setUp(self):
         super(TestIndexField, self).setUp()
-        self.text = TextField(list(map(Token, ["here", "is", "a", "sentence", "."])),
+        self.text = TextField([Token(t) for t in ["here", "is", "a", "sentence", "."]],
                               {"words": SingleIdTokenIndexer("words")})
 
     def test_index_field_inherits_padding_lengths_from_text_field(self):

--- a/tests/data/fields/label_field_test.py
+++ b/tests/data/fields/label_field_test.py
@@ -2,14 +2,13 @@
 import numpy
 import pytest
 
-from allennlp.data.vocabulary import Vocabulary
-from allennlp.data.fields import LabelField
-from allennlp.common.testing import AllenNlpTestCase
 from allennlp.common.checks import ConfigurationError
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.fields import LabelField
+from allennlp.data.vocabulary import Vocabulary
 
 
 class TestLabelField(AllenNlpTestCase):
-
     def test_as_array_returns_integer_array(self):
         label = LabelField(5, skip_indexing=True)
         array = label.as_array(label.get_padding_lengths())

--- a/tests/data/fields/list_field_test.py
+++ b/tests/data/fields/list_field_test.py
@@ -1,14 +1,13 @@
 # pylint: disable=no-self-use,invalid-name
 import numpy
 
-from allennlp.data.vocabulary import Vocabulary
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Token, Vocabulary
 from allennlp.data.fields import TextField, ListField
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenCharactersIndexer
-from allennlp.common.testing import AllenNlpTestCase
 
 
 class TestListField(AllenNlpTestCase):
-
     def setUp(self):
         self.vocab = Vocabulary()
         self.vocab.add_token_to_namespace("this", "words")
@@ -24,39 +23,30 @@ class TestListField(AllenNlpTestCase):
         self.word_indexer = {"words": SingleIdTokenIndexer("words")}
         self.words_and_characters_indexer = {"words": SingleIdTokenIndexer("words"),
                                              "characters": TokenCharactersIndexer("characters")}
+        self.field1 = TextField(list(map(Token, ["this", "is", "a", "sentence"])),
+                                self.word_indexer)
+        self.field2 = TextField(list(map(Token, ["this", "is", "a", "different", "sentence"])),
+                                self.word_indexer)
+        self.field3 = TextField(list(map(Token, ["this", "is", "another", "sentence"])),
+                                self.word_indexer)
         super(TestListField, self).setUp()
 
     def test_get_padding_lengths(self):
-        field1 = TextField(["this", "is", "a", "sentence"], self.word_indexer)
-        field2 = TextField(["this", "is", "a", "different", "sentence"], self.word_indexer)
-        field3 = TextField(["this", "is", "another", "sentence"], self.word_indexer)
-
-        list_field = ListField([field1, field2, field3])
+        list_field = ListField([self.field1, self.field2, self.field3])
         list_field.index(self.vocab)
         lengths = list_field.get_padding_lengths()
-
         assert lengths == {"num_fields": 3, "num_tokens": 5}
 
     def test_all_fields_padded_to_max_length(self):
-        field1 = TextField(["this", "is", "a", "sentence"], self.word_indexer)
-        field2 = TextField(["this", "is", "a", "different", "sentence"], self.word_indexer)
-        field3 = TextField(["this", "is", "another", "sentence"], self.word_indexer)
-
-        list_field = ListField([field1, field2, field3])
+        list_field = ListField([self.field1, self.field2, self.field3])
         list_field.index(self.vocab)
-
         array_dict = list_field.as_array(list_field.get_padding_lengths())
         numpy.testing.assert_array_almost_equal(array_dict["words"][0], numpy.array([2, 3, 4, 5, 0]))
         numpy.testing.assert_array_almost_equal(array_dict["words"][1], numpy.array([2, 3, 4, 1, 5]))
         numpy.testing.assert_array_almost_equal(array_dict["words"][2], numpy.array([2, 3, 1, 5, 0]))
 
     def test_fields_can_pad_to_greater_than_max_length(self):
-
-        field1 = TextField(["this", "is", "a", "sentence"], self.word_indexer)
-        field2 = TextField(["this", "is", "a", "different", "sentence"], self.word_indexer)
-        field3 = TextField(["this", "is", "another", "sentence"], self.word_indexer)
-
-        list_field = ListField([field1, field2, field3])
+        list_field = ListField([self.field1, self.field2, self.field3])
         list_field.index(self.vocab)
         padding_lengths = list_field.get_padding_lengths()
         padding_lengths["num_tokens"] = 7
@@ -69,11 +59,12 @@ class TestListField(AllenNlpTestCase):
         numpy.testing.assert_array_almost_equal(array_dict["words"][4], numpy.array([0, 0, 0, 0, 0, 0, 0]))
 
     def test_as_array_can_handle_multiple_token_indexers(self):
-        field1 = TextField(["this", "is", "a", "sentence"], self.words_and_characters_indexer)
-        field2 = TextField(["this", "is", "a", "different", "sentence"], self.words_and_characters_indexer)
-        field3 = TextField(["this", "is", "another", "sentence"], self.words_and_characters_indexer)
+        # pylint: disable=protected-access
+        self.field1._token_indexers = self.words_and_characters_indexer
+        self.field2._token_indexers = self.words_and_characters_indexer
+        self.field3._token_indexers = self.words_and_characters_indexer
 
-        list_field = ListField([field1, field2, field3])
+        list_field = ListField([self.field1, self.field2, self.field3])
         list_field.index(self.vocab)
         padding_lengths = list_field.get_padding_lengths()
         array_dict = list_field.as_array(padding_lengths)

--- a/tests/data/fields/list_field_test.py
+++ b/tests/data/fields/list_field_test.py
@@ -23,11 +23,11 @@ class TestListField(AllenNlpTestCase):
         self.word_indexer = {"words": SingleIdTokenIndexer("words")}
         self.words_and_characters_indexer = {"words": SingleIdTokenIndexer("words"),
                                              "characters": TokenCharactersIndexer("characters")}
-        self.field1 = TextField(list(map(Token, ["this", "is", "a", "sentence"])),
+        self.field1 = TextField([Token(t) for t in ["this", "is", "a", "sentence"]],
                                 self.word_indexer)
-        self.field2 = TextField(list(map(Token, ["this", "is", "a", "different", "sentence"])),
+        self.field2 = TextField([Token(t) for t in ["this", "is", "a", "different", "sentence"]],
                                 self.word_indexer)
-        self.field3 = TextField(list(map(Token, ["this", "is", "another", "sentence"])),
+        self.field3 = TextField([Token(t) for t in ["this", "is", "another", "sentence"]],
                                 self.word_indexer)
         super(TestListField, self).setUp()
 

--- a/tests/data/fields/sequence_label_field_test.py
+++ b/tests/data/fields/sequence_label_field_test.py
@@ -4,18 +4,17 @@ from collections import defaultdict
 import pytest
 import numpy
 
-from allennlp.data.vocabulary import Vocabulary
-from allennlp.data.fields import TextField, SequenceLabelField
-from allennlp.data.token_indexers import SingleIdTokenIndexer
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Token, Vocabulary
+from allennlp.data.fields import TextField, SequenceLabelField
+from allennlp.data.token_indexers import SingleIdTokenIndexer
 
 
 class TestSequenceLabelField(AllenNlpTestCase):
-
     def setUp(self):
         super(TestSequenceLabelField, self).setUp()
-        self.text = TextField(["here", "are", "some", "words", "."],
+        self.text = TextField(list(map(Token, ["here", "are", "some", "words", "."])),
                               {"words": SingleIdTokenIndexer("words")})
 
     def test_tag_length_mismatch_raises(self):

--- a/tests/data/fields/sequence_label_field_test.py
+++ b/tests/data/fields/sequence_label_field_test.py
@@ -14,7 +14,7 @@ from allennlp.data.token_indexers import SingleIdTokenIndexer
 class TestSequenceLabelField(AllenNlpTestCase):
     def setUp(self):
         super(TestSequenceLabelField, self).setUp()
-        self.text = TextField(list(map(Token, ["here", "are", "some", "words", "."])),
+        self.text = TextField([Token(t) for t in ["here", "are", "some", "words", "."]],
                               {"words": SingleIdTokenIndexer("words")})
 
     def test_tag_length_mismatch_raises(self):

--- a/tests/data/fields/text_field_test.py
+++ b/tests/data/fields/text_field_test.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import pytest
 import numpy
 
-from allennlp.data.vocabulary import Vocabulary
+from allennlp.data import Token, Vocabulary
 from allennlp.data.fields import TextField
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenCharactersIndexer
 
@@ -26,7 +26,7 @@ class TestTextField(AllenNlpTestCase):
         super(TestTextField, self).setUp()
 
     def test_field_counts_vocab_items_correctly(self):
-        field = TextField(["This", "is", "a", "sentence", "."],
+        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
                           token_indexers={"words": SingleIdTokenIndexer("words")})
         namespace_token_counts = defaultdict(lambda: defaultdict(int))
         field.count_vocab_items(namespace_token_counts)
@@ -38,7 +38,7 @@ class TestTextField(AllenNlpTestCase):
         assert namespace_token_counts["words"]["."] == 1
         assert list(namespace_token_counts.keys()) == ["words"]
 
-        field = TextField(["This", "is", "a", "sentence", "."],
+        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
                           token_indexers={"characters": TokenCharactersIndexer("characters")})
         namespace_token_counts = defaultdict(lambda: defaultdict(int))
         field.count_vocab_items(namespace_token_counts)
@@ -55,7 +55,7 @@ class TestTextField(AllenNlpTestCase):
         assert namespace_token_counts["characters"]["."] == 1
         assert list(namespace_token_counts.keys()) == ["characters"]
 
-        field = TextField(["This", "is", "a", "sentence", "."],
+        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
                           token_indexers={"words": SingleIdTokenIndexer("words"),
                                           "characters": TokenCharactersIndexer("characters")})
         namespace_token_counts = defaultdict(lambda: defaultdict(int))
@@ -88,17 +88,18 @@ class TestTextField(AllenNlpTestCase):
         t_index = vocab.add_token_to_namespace("t", namespace='characters')
         c_index = vocab.add_token_to_namespace("c", namespace='characters')
 
-        field = TextField(["A", "sentence"], {"words": SingleIdTokenIndexer(namespace="words")})
+        field = TextField(list(map(Token, ["A", "sentence"])), {"words": SingleIdTokenIndexer(namespace="words")})
         field.index(vocab)
         # pylint: disable=protected-access
         assert field._indexed_tokens["words"] == [capital_a_index, sentence_index]
 
-        field1 = TextField(["A", "sentence"], {"characters": TokenCharactersIndexer(namespace="characters")})
+        field1 = TextField(list(map(Token, ["A", "sentence"])),
+                           {"characters": TokenCharactersIndexer(namespace="characters")})
         field1.index(vocab)
         assert field1._indexed_tokens["characters"] == [[capital_a_char_index],
                                                         [s_index, e_index, n_index, t_index,
                                                          e_index, n_index, c_index, e_index]]
-        field2 = TextField(["A", "sentence"],
+        field2 = TextField(list(map(Token, ["A", "sentence"])),
                            token_indexers={"words": SingleIdTokenIndexer(namespace="words"),
                                            "characters": TokenCharactersIndexer(namespace="characters")})
         field2.index(vocab)
@@ -110,25 +111,25 @@ class TestTextField(AllenNlpTestCase):
 
     def test_get_padding_lengths_raises_if_no_indexed_tokens(self):
 
-        field = TextField(["This", "is", "a", "sentence", "."],
+        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
                           token_indexers={"words": SingleIdTokenIndexer("words")})
         with pytest.raises(ConfigurationError):
             field.get_padding_lengths()
 
     def test_padding_lengths_are_computed_correctly(self):
-        field = TextField(["This", "is", "a", "sentence", "."],
+        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
                           token_indexers={"words": SingleIdTokenIndexer("words")})
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
         assert padding_lengths == {"num_tokens": 5}
 
-        field = TextField(["This", "is", "a", "sentence", "."],
+        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
                           token_indexers={"characters": TokenCharactersIndexer("characters")})
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
         assert padding_lengths == {"num_tokens": 5, "num_token_characters": 8}
 
-        field = TextField(["This", "is", "a", "sentence", "."],
+        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
                           token_indexers={"characters": TokenCharactersIndexer("characters"),
                                           "words": SingleIdTokenIndexer("words")})
         field.index(self.vocab)
@@ -136,7 +137,7 @@ class TestTextField(AllenNlpTestCase):
         assert padding_lengths == {"num_tokens": 5, "num_token_characters": 8}
 
     def test_as_array_handles_words(self):
-        field = TextField(["This", "is", "a", "sentence", "."],
+        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
                           token_indexers={"words": SingleIdTokenIndexer("words")})
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
@@ -144,7 +145,7 @@ class TestTextField(AllenNlpTestCase):
         numpy.testing.assert_array_almost_equal(array_dict["words"], numpy.array([1, 1, 1, 2, 1]))
 
     def test_as_array_handles_longer_lengths(self):
-        field = TextField(["This", "is", "a", "sentence", "."],
+        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
                           token_indexers={"words": SingleIdTokenIndexer("words")})
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
@@ -153,7 +154,7 @@ class TestTextField(AllenNlpTestCase):
         numpy.testing.assert_array_almost_equal(array_dict["words"], numpy.array([1, 1, 1, 2, 1, 0, 0, 0, 0, 0]))
 
     def test_as_array_handles_characters(self):
-        field = TextField(["This", "is", "a", "sentence", "."],
+        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
                           token_indexers={"characters": TokenCharactersIndexer("characters")})
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
@@ -166,7 +167,7 @@ class TestTextField(AllenNlpTestCase):
         numpy.testing.assert_array_almost_equal(array_dict["characters"], expected_character_array)
 
     def test_as_array_handles_words_and_characters_with_longer_lengths(self):
-        field = TextField(["a", "sentence", "."],
+        field = TextField(list(map(Token, ["a", "sentence", "."])),
                           token_indexers={"words": SingleIdTokenIndexer("words"),
                                           "characters": TokenCharactersIndexer("characters")})
         field.index(self.vocab)
@@ -182,7 +183,3 @@ class TestTextField(AllenNlpTestCase):
                                                              [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                                              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                                              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]))
-
-    def test_text_field_raises_on_non_string_input(self):
-        with pytest.raises(ConfigurationError):
-            _ = TextField([1, 2, 3, 4], {"tokens": SingleIdTokenIndexer()})

--- a/tests/data/fields/text_field_test.py
+++ b/tests/data/fields/text_field_test.py
@@ -26,7 +26,7 @@ class TestTextField(AllenNlpTestCase):
         super(TestTextField, self).setUp()
 
     def test_field_counts_vocab_items_correctly(self):
-        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["This", "is", "a", "sentence", "."]],
                           token_indexers={"words": SingleIdTokenIndexer("words")})
         namespace_token_counts = defaultdict(lambda: defaultdict(int))
         field.count_vocab_items(namespace_token_counts)
@@ -38,7 +38,7 @@ class TestTextField(AllenNlpTestCase):
         assert namespace_token_counts["words"]["."] == 1
         assert list(namespace_token_counts.keys()) == ["words"]
 
-        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["This", "is", "a", "sentence", "."]],
                           token_indexers={"characters": TokenCharactersIndexer("characters")})
         namespace_token_counts = defaultdict(lambda: defaultdict(int))
         field.count_vocab_items(namespace_token_counts)
@@ -55,7 +55,7 @@ class TestTextField(AllenNlpTestCase):
         assert namespace_token_counts["characters"]["."] == 1
         assert list(namespace_token_counts.keys()) == ["characters"]
 
-        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["This", "is", "a", "sentence", "."]],
                           token_indexers={"words": SingleIdTokenIndexer("words"),
                                           "characters": TokenCharactersIndexer("characters")})
         namespace_token_counts = defaultdict(lambda: defaultdict(int))
@@ -88,18 +88,19 @@ class TestTextField(AllenNlpTestCase):
         t_index = vocab.add_token_to_namespace("t", namespace='characters')
         c_index = vocab.add_token_to_namespace("c", namespace='characters')
 
-        field = TextField(list(map(Token, ["A", "sentence"])), {"words": SingleIdTokenIndexer(namespace="words")})
+        field = TextField([Token(t) for t in ["A", "sentence"]],
+                          {"words": SingleIdTokenIndexer(namespace="words")})
         field.index(vocab)
         # pylint: disable=protected-access
         assert field._indexed_tokens["words"] == [capital_a_index, sentence_index]
 
-        field1 = TextField(list(map(Token, ["A", "sentence"])),
+        field1 = TextField([Token(t) for t in ["A", "sentence"]],
                            {"characters": TokenCharactersIndexer(namespace="characters")})
         field1.index(vocab)
         assert field1._indexed_tokens["characters"] == [[capital_a_char_index],
                                                         [s_index, e_index, n_index, t_index,
                                                          e_index, n_index, c_index, e_index]]
-        field2 = TextField(list(map(Token, ["A", "sentence"])),
+        field2 = TextField([Token(t) for t in ["A", "sentence"]],
                            token_indexers={"words": SingleIdTokenIndexer(namespace="words"),
                                            "characters": TokenCharactersIndexer(namespace="characters")})
         field2.index(vocab)
@@ -111,25 +112,25 @@ class TestTextField(AllenNlpTestCase):
 
     def test_get_padding_lengths_raises_if_no_indexed_tokens(self):
 
-        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["This", "is", "a", "sentence", "."]],
                           token_indexers={"words": SingleIdTokenIndexer("words")})
         with pytest.raises(ConfigurationError):
             field.get_padding_lengths()
 
     def test_padding_lengths_are_computed_correctly(self):
-        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["This", "is", "a", "sentence", "."]],
                           token_indexers={"words": SingleIdTokenIndexer("words")})
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
         assert padding_lengths == {"num_tokens": 5}
 
-        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["This", "is", "a", "sentence", "."]],
                           token_indexers={"characters": TokenCharactersIndexer("characters")})
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
         assert padding_lengths == {"num_tokens": 5, "num_token_characters": 8}
 
-        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["This", "is", "a", "sentence", "."]],
                           token_indexers={"characters": TokenCharactersIndexer("characters"),
                                           "words": SingleIdTokenIndexer("words")})
         field.index(self.vocab)
@@ -137,7 +138,7 @@ class TestTextField(AllenNlpTestCase):
         assert padding_lengths == {"num_tokens": 5, "num_token_characters": 8}
 
     def test_as_array_handles_words(self):
-        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["This", "is", "a", "sentence", "."]],
                           token_indexers={"words": SingleIdTokenIndexer("words")})
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
@@ -145,7 +146,7 @@ class TestTextField(AllenNlpTestCase):
         numpy.testing.assert_array_almost_equal(array_dict["words"], numpy.array([1, 1, 1, 2, 1]))
 
     def test_as_array_handles_longer_lengths(self):
-        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["This", "is", "a", "sentence", "."]],
                           token_indexers={"words": SingleIdTokenIndexer("words")})
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
@@ -154,7 +155,7 @@ class TestTextField(AllenNlpTestCase):
         numpy.testing.assert_array_almost_equal(array_dict["words"], numpy.array([1, 1, 1, 2, 1, 0, 0, 0, 0, 0]))
 
     def test_as_array_handles_characters(self):
-        field = TextField(list(map(Token, ["This", "is", "a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["This", "is", "a", "sentence", "."]],
                           token_indexers={"characters": TokenCharactersIndexer("characters")})
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
@@ -167,7 +168,7 @@ class TestTextField(AllenNlpTestCase):
         numpy.testing.assert_array_almost_equal(array_dict["characters"], expected_character_array)
 
     def test_as_array_handles_words_and_characters_with_longer_lengths(self):
-        field = TextField(list(map(Token, ["a", "sentence", "."])),
+        field = TextField([Token(t) for t in ["a", "sentence", "."]],
                           token_indexers={"words": SingleIdTokenIndexer("words"),
                                           "characters": TokenCharactersIndexer("characters")})
         field.index(self.vocab)

--- a/tests/data/iterators/basic_iterator_test.py
+++ b/tests/data/iterators/basic_iterator_test.py
@@ -2,11 +2,11 @@
 from typing import List
 
 from allennlp.common import Params
-from allennlp.data import Dataset, Instance, Vocabulary
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Dataset, Instance, Token, Vocabulary
 from allennlp.data.fields import TextField
 from allennlp.data.iterators import BasicIterator
 from allennlp.data.token_indexers import SingleIdTokenIndexer
-from allennlp.common.testing import AllenNlpTestCase
 
 class IteratorTest(AllenNlpTestCase):
     def setUp(self):
@@ -30,7 +30,8 @@ class IteratorTest(AllenNlpTestCase):
                 ]
         self.dataset = Dataset(self.instances)
 
-    def create_instance(self, tokens: List[str]):
+    def create_instance(self, str_tokens: List[str]):
+        tokens = list(map(Token, str_tokens))
         instance = Instance({'text': TextField(tokens, self.token_indexers)})
         instance.index_fields(self.vocab)
         return instance

--- a/tests/data/iterators/basic_iterator_test.py
+++ b/tests/data/iterators/basic_iterator_test.py
@@ -31,7 +31,7 @@ class IteratorTest(AllenNlpTestCase):
         self.dataset = Dataset(self.instances)
 
     def create_instance(self, str_tokens: List[str]):
-        tokens = list(map(Token, str_tokens))
+        tokens = [Token(t) for t in str_tokens]
         instance = Instance({'text': TextField(tokens, self.token_indexers)})
         instance.index_fields(self.vocab)
         return instance

--- a/tests/data/token_indexers/character_token_indexer_test.py
+++ b/tests/data/token_indexers/character_token_indexer_test.py
@@ -1,25 +1,24 @@
 # pylint: disable=no-self-use,invalid-name
 from collections import defaultdict
 
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Token, Vocabulary
 from allennlp.data.token_indexers import TokenCharactersIndexer
 from allennlp.data.tokenizers.character_tokenizer import CharacterTokenizer
-from allennlp.data.vocabulary import Vocabulary
-from allennlp.common.testing import AllenNlpTestCase
 
 
 class CharacterTokenIndexerTest(AllenNlpTestCase):
-
     def test_count_vocab_items_respects_casing(self):
         indexer = TokenCharactersIndexer("characters")
         counter = defaultdict(lambda: defaultdict(int))
-        indexer.count_vocab_items("Hello", counter)
-        indexer.count_vocab_items("hello", counter)
+        indexer.count_vocab_items(Token("Hello"), counter)
+        indexer.count_vocab_items(Token("hello"), counter)
         assert counter["characters"] == {"h": 1, "H": 1, "e": 2, "l": 4, "o": 2}
 
         indexer = TokenCharactersIndexer("characters", CharacterTokenizer(lowercase_characters=True))
         counter = defaultdict(lambda: defaultdict(int))
-        indexer.count_vocab_items("Hello", counter)
-        indexer.count_vocab_items("hello", counter)
+        indexer.count_vocab_items(Token("Hello"), counter)
+        indexer.count_vocab_items(Token("hello"), counter)
         assert counter["characters"] == {"h": 2, "e": 2, "l": 4, "o": 2}
 
     def test_as_array_produces_token_sequence(self):
@@ -42,5 +41,5 @@ class CharacterTokenIndexerTest(AllenNlpTestCase):
         vocab.add_token_to_namespace("c", namespace='characters')
 
         indexer = TokenCharactersIndexer("characters")
-        indices = indexer.token_to_indices("sentential", vocab)
+        indices = indexer.token_to_indices(Token("sentential"), vocab)
         assert indices == [3, 4, 5, 6, 4, 5, 6, 1, 1, 1]

--- a/tests/data/token_indexers/single_id_token_indexer_test.py
+++ b/tests/data/token_indexers/single_id_token_indexer_test.py
@@ -1,23 +1,23 @@
 # pylint: disable=no-self-use,invalid-name
 from collections import defaultdict
 
-from allennlp.data.token_indexers import SingleIdTokenIndexer
 from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Token
+from allennlp.data.token_indexers import SingleIdTokenIndexer
 
 
 class TestSingleIdTokenIndexer(AllenNlpTestCase):
-
     def test_count_vocab_items_respects_casing(self):
         indexer = SingleIdTokenIndexer("*words")
         counter = defaultdict(lambda: defaultdict(int))
-        indexer.count_vocab_items("Hello", counter)
-        indexer.count_vocab_items("hello", counter)
+        indexer.count_vocab_items(Token("Hello"), counter)
+        indexer.count_vocab_items(Token("hello"), counter)
         assert counter["*words"] == {"hello": 1, "Hello": 1}
 
         indexer = SingleIdTokenIndexer("*words", lowercase_tokens=True)
         counter = defaultdict(lambda: defaultdict(int))
-        indexer.count_vocab_items("Hello", counter)
-        indexer.count_vocab_items("hello", counter)
+        indexer.count_vocab_items(Token("Hello"), counter)
+        indexer.count_vocab_items(Token("hello"), counter)
         assert counter["*words"] == {"hello": 2}
 
     def test_as_array_produces_token_sequence(self):

--- a/tests/data/tokenizers/character_tokenizer_test.py
+++ b/tests/data/tokenizers/character_tokenizer_test.py
@@ -7,7 +7,7 @@ class TestCharacterTokenizer(AllenNlpTestCase):
     def test_splits_into_characters(self):
         tokenizer = CharacterTokenizer(start_tokens=['<S1>', '<S2>'], end_tokens=['</S2>', '</S1>'])
         sentence = "A, small sentence."
-        tokens, _ = tokenizer.tokenize(sentence)
+        tokens = [t.text for t in tokenizer.tokenize(sentence)]
         expected_tokens = ["<S1>", "<S2>", "A", ",", " ", "s", "m", "a", "l", "l", " ", "s", "e",
                            "n", "t", "e", "n", "c", "e", ".", '</S2>', '</S1>']
         assert tokens == expected_tokens
@@ -15,7 +15,7 @@ class TestCharacterTokenizer(AllenNlpTestCase):
     def test_handles_byte_encoding(self):
         tokenizer = CharacterTokenizer(byte_encoding='utf-8', start_tokens=[259], end_tokens=[260])
         word = "åøâáabe"
-        tokens, _ = tokenizer.tokenize(word)
+        tokens = [t.text_id for t in tokenizer.tokenize(word)]
         # Note that we've added one to the utf-8 encoded bytes, to account for masking.
         expected_tokens = [259, 196, 166, 196, 185, 196, 163, 196, 162, 98, 99, 102, 260]
         assert tokens == expected_tokens

--- a/tests/data/tokenizers/word_splitter_test.py
+++ b/tests/data/tokenizers/word_splitter_test.py
@@ -14,33 +14,33 @@ class TestSimpleWordSplitter(AllenNlpTestCase):
         sentence = "this (sentence) has 'crazy' \"punctuation\"."
         expected_tokens = ["this", "(", "sentence", ")", "has", "'", "crazy", "'", '"',
                            "punctuation", '"', "."]
-        tokens, _ = self.word_splitter.split_words(sentence)
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
 
     def test_tokenize_handles_contraction(self):
         sentence = "it ain't joe's problem; would've been yesterday"
         expected_tokens = ["it", "ai", "n't", "joe", "'s", "problem", ";", "would", "'ve", "been",
                            "yesterday"]
-        tokens, _ = self.word_splitter.split_words(sentence)
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
 
     def test_tokenize_handles_multiple_contraction(self):
         sentence = "wouldn't've"
         expected_tokens = ["would", "n't", "'ve"]
-        tokens, _ = self.word_splitter.split_words(sentence)
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
 
     def test_tokenize_handles_final_apostrophe(self):
         sentence = "the jones' house"
         expected_tokens = ["the", "jones", "'", "house"]
-        tokens, _ = self.word_splitter.split_words(sentence)
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
 
     def test_tokenize_handles_special_cases(self):
         sentence = "mr. and mrs. jones, etc., went to, e.g., the store"
         expected_tokens = ["mr.", "and", "mrs.", "jones", ",", "etc.", ",", "went", "to", ",",
                            "e.g.", ",", "the", "store"]
-        tokens, _ = self.word_splitter.split_words(sentence)
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
 
 
@@ -53,43 +53,38 @@ class TestSpacyWordSplitter(AllenNlpTestCase):
         sentence = "this (sentence) has 'crazy' \"punctuation\"."
         expected_tokens = ["this", "(", "sentence", ")", "has", "'", "crazy", "'", '"',
                            "punctuation", '"', "."]
-        tokens, offsets = self.word_splitter.split_words(sentence)
-        assert tokens == expected_tokens
-        for token, (start, end) in zip(tokens, offsets):
-            assert sentence[start:end] == token
+        tokens = self.word_splitter.split_words(sentence)
+        token_text = [t.text for t in tokens]
+        assert token_text == expected_tokens
+        for token in tokens:
+            start = token.idx
+            end = start + len(token.text)
+            assert sentence[start:end] == token.text
 
     def test_tokenize_handles_contraction(self):
         # note that "would've" is kept together, while "ain't" is not.
         sentence = "it ain't joe's problem; would've been yesterday"
         expected_tokens = ["it", "ai", "n't", "joe", "'s", "problem", ";", "would've", "been",
                            "yesterday"]
-        tokens, offsets = self.word_splitter.split_words(sentence)
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
-        for token, (start, end) in zip(tokens, offsets):
-            assert sentence[start:end] == token
 
     def test_tokenize_handles_multiple_contraction(self):
         sentence = "wouldn't've"
         expected_tokens = ["would", "n't", "'ve"]
-        tokens, offsets = self.word_splitter.split_words(sentence)
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
-        for token, (start, end) in zip(tokens, offsets):
-            assert sentence[start:end] == token
 
     def test_tokenize_handles_final_apostrophe(self):
         sentence = "the jones' house"
         expected_tokens = ["the", "jones", "'", "house"]
-        tokens, offsets = self.word_splitter.split_words(sentence)
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
-        for token, (start, end) in zip(tokens, offsets):
-            assert sentence[start:end] == token
 
     def test_tokenize_handles_special_cases(self):
         # note that the etc. doesn't quite work --- we can special case this if we want.
         sentence = "Mr. and Mrs. Jones, etc., went to, e.g., the store"
         expected_tokens = ["Mr.", "and", "Mrs.", "Jones", ",", "etc", ".", ",", "went", "to", ",",
                            "e.g.", ",", "the", "store"]
-        tokens, offsets = self.word_splitter.split_words(sentence)
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
-        for token, (start, end) in zip(tokens, offsets):
-            assert sentence[start:end] == token

--- a/tests/data/tokenizers/word_tokenizer_test.py
+++ b/tests/data/tokenizers/word_tokenizer_test.py
@@ -8,7 +8,7 @@ class TestWordTokenizer(AllenNlpTestCase):
     def test_passes_through_correctly(self):
         tokenizer = WordTokenizer(start_tokens=['@@', '%%'], end_tokens=['^^'])
         sentence = "this (sentence) has 'crazy' \"punctuation\"."
-        tokens, _ = tokenizer.tokenize(sentence)
+        tokens = [t.text for t in tokenizer.tokenize(sentence)]
         expected_tokens = ["@@", "%%", "this", "(", "sentence", ")", "has", "'", "crazy", "'", "\"",
                            "punctuation", "\"", ".", "^^"]
         assert tokens == expected_tokens
@@ -18,5 +18,5 @@ class TestWordTokenizer(AllenNlpTestCase):
                                                       'word_filter': {'type': 'stopwords'}}))
         sentence = "this (sentence) has 'crazy' \"punctuation\"."
         expected_tokens = ["sentenc", "ha", "crazi", "punctuat"]
-        tokens, _ = tokenizer.tokenize(sentence)
+        tokens = [t.text for t in tokenizer.tokenize(sentence)]
         assert tokens == expected_tokens

--- a/tests/data/vocabulary_test.py
+++ b/tests/data/vocabulary_test.py
@@ -17,7 +17,7 @@ from allennlp.common.checks import ConfigurationError
 class TestVocabulary(AllenNlpTestCase):
     def setUp(self):
         token_indexer = SingleIdTokenIndexer("tokens")
-        text_field = TextField(list(map(Token, ["a", "a", "a", "a", "b", "b", "c", "c", "c"])),
+        text_field = TextField([Token(t) for t in ["a", "a", "a", "a", "b", "b", "c", "c", "c"]],
                                {"tokens": token_indexer})
         self.instance = Instance({"text": text_field})
         self.dataset = Dataset([self.instance])
@@ -195,7 +195,7 @@ class TestVocabulary(AllenNlpTestCase):
         # result.
         tokenizer = CharacterTokenizer(byte_encoding='utf-8')
         token_indexer = TokenCharactersIndexer(character_tokenizer=tokenizer)
-        tokens = list(map(Token, ["Øyvind", "für", "汉字"]))
+        tokens = [Token(t) for t in ["Øyvind", "für", "汉字"]]
         text_field = TextField(tokens, {"characters": token_indexer})
         dataset = Dataset([Instance({"sentence": text_field})])
         vocab = Vocabulary.from_dataset(dataset)

--- a/tests/data/vocabulary_test.py
+++ b/tests/data/vocabulary_test.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import pytest
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.data import Dataset, Instance
+from allennlp.data import Dataset, Instance, Token
 from allennlp.data.fields import TextField
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenCharactersIndexer
 from allennlp.data.tokenizers import CharacterTokenizer
@@ -17,7 +17,8 @@ from allennlp.common.checks import ConfigurationError
 class TestVocabulary(AllenNlpTestCase):
     def setUp(self):
         token_indexer = SingleIdTokenIndexer("tokens")
-        text_field = TextField(["a", "a", "a", "a", "b", "b", "c", "c", "c"], {"tokens": token_indexer})
+        text_field = TextField(list(map(Token, ["a", "a", "a", "a", "b", "b", "c", "c", "c"])),
+                               {"tokens": token_indexer})
         self.instance = Instance({"text": text_field})
         self.dataset = Dataset([self.instance])
         super(TestVocabulary, self).setUp()
@@ -194,7 +195,7 @@ class TestVocabulary(AllenNlpTestCase):
         # result.
         tokenizer = CharacterTokenizer(byte_encoding='utf-8')
         token_indexer = TokenCharactersIndexer(character_tokenizer=tokenizer)
-        tokens = ["Øyvind", "für", "汉字"]
+        tokens = list(map(Token, ["Øyvind", "für", "汉字"]))
         text_field = TextField(tokens, {"characters": token_indexer})
         dataset = Dataset([Instance({"sentence": text_field})])
         vocab = Vocabulary.from_dataset(dataset)

--- a/tutorials/notebooks/data_pipeline.ipynb
+++ b/tutorials/notebooks/data_pipeline.ipynb
@@ -55,10 +55,11 @@
     }
    ],
    "source": [
+    "from allennlp.data import Token\n",
     "from allennlp.data.fields import TextField, LabelField\n",
     "from allennlp.data.token_indexers import SingleIdTokenIndexer\n",
     "\n",
-    "review = TextField([\"This\", \"movie\", \"was\", \"awful\", \"!\"], token_indexers={\"tokens\": SingleIdTokenIndexer()})\n",
+    "review = TextField(list(map(Token, [\"This\", \"movie\", \"was\", \"awful\", \"!\"])), token_indexers={\"tokens\": SingleIdTokenIndexer()})\n",
     "review_sentiment = LabelField(\"negative\", label_namespace=\"tags\")\n",
     "\n",
     "# Access the original strings and labels using the methods on the Fields.\n",
@@ -110,7 +111,7 @@
    "source": [
     "from allennlp.data import Dataset\n",
     "# Create another \n",
-    "review2 = TextField([\"This\", \"movie\", \"was\", \"quite\", \"slow\", \"but\", \"good\" \".\"], token_indexers={\"tokens\": SingleIdTokenIndexer()})\n",
+    "review2 = TextField(list(map(Token, [\"This\", \"movie\", \"was\", \"quite\", \"slow\", \"but\", \"good\" \".\"])), token_indexers={\"tokens\": SingleIdTokenIndexer()})\n",
     "review_sentiment2 = LabelField(\"positive\", label_namespace=\"tags\")\n",
     "instance2 = Instance({\"review\": review2, \"label\": review_sentiment2})\n",
     "\n",
@@ -255,7 +256,7 @@
    "source": [
     "from allennlp.data.token_indexers import TokenCharactersIndexer\n",
     "\n",
-    "word_and_character_text_field = TextField([\"Here\", \"are\", \"some\", \"longer\", \"words\", \".\"], \n",
+    "word_and_character_text_field = TextField(list(map(Token, [\"Here\", \"are\", \"some\", \"longer\", \"words\", \".\"])), \n",
     "                                          token_indexers={\"tokens\": SingleIdTokenIndexer(), \"chars\": TokenCharactersIndexer()})\n",
     "mini_dataset = Dataset([Instance({\"sentence\": word_and_character_text_field})])\n",
     "\n",

--- a/tutorials/notebooks/vocabulary.ipynb
+++ b/tutorials/notebooks/vocabulary.ipynb
@@ -200,9 +200,9 @@
    "outputs": [],
    "source": [
     "from allennlp.data.fields import TextField, SequenceLabelField\n",
-    "from allennlp.data import Dataset, Instance\n",
+    "from allennlp.data import Dataset, Instance, Token\n",
     "from allennlp.data.token_indexers import SingleIdTokenIndexer\n",
-    "sentence = TextField(tokens=[\"Barack\", \"Obama\", \"is\", \"a\", \"great\", \"guy\", \".\"],\n",
+    "sentence = TextField(tokens=list(map(Token, [\"Barack\", \"Obama\", \"is\", \"a\", \"great\", \"guy\", \".\"])),\n",
     "                     token_indexers={\"tokens\": SingleIdTokenIndexer()})\n",
     "tags = SequenceLabelField([\"PERSON\", \"PERSON\", \"O\", \"O\", \"O\", \"O\", \"O\"], sentence, label_namespace=\"tags\")\n",
     "toy_dataset = Dataset([Instance({\"sentence\": sentence, \"tags\": tags})])"


### PR DESCRIPTION
Fixes #286, fixes #288.  This turned out to be a bigger change than I was expecting, mostly because a lot of the tests had to be modified.  But this lets us remove of the separate `offset` return value from the tokenizer, because the offsets are just stored in the `Token` object.  It also should make it really easy to do #287.