### PR TITLE
Moving SQuAD metrics to a common place

### DIFF
--- a/allennlp/models/bidaf.py
+++ b/allennlp/models/bidaf.py
@@ -283,19 +283,18 @@ class BidirectionalAttentionFlow(Model):
                 best_span_string = passage_str[start_offset:end_offset]
                 output_dict['best_span_str'].append(best_span_string)
                 answer_texts = metadata[i].get('answer_texts', [])
-                exact_match = f1_score = 0
                 if answer_texts:
                     self._squad_metrics(best_span_string, answer_texts)
         return output_dict
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
-        exact_match, f1 = self._squad_metrics.get_metric(reset)
+        exact_match, f1_score = self._squad_metrics.get_metric(reset)
         return {
                 'start_acc': self._span_start_accuracy.get_metric(reset),
                 'end_acc': self._span_end_accuracy.get_metric(reset),
                 'span_acc': self._span_accuracy.get_metric(reset),
                 'em': exact_match,
-                'f1': f1,
+                'f1': f1_score,
                 }
 
     @staticmethod

--- a/allennlp/models/bidaf.py
+++ b/allennlp/models/bidaf.py
@@ -5,14 +5,14 @@ import torch
 from torch.autograd import Variable
 from torch.nn.functional import nll_loss
 
-from allennlp.common import Params, squad_eval
+from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.data import Vocabulary
 from allennlp.models.model import Model
 from allennlp.modules import Highway, MatrixAttention
 from allennlp.modules import Seq2SeqEncoder, SimilarityFunction, TimeDistributed, TextFieldEmbedder
 from allennlp.nn import InitializerApplicator, util
-from allennlp.training.metrics import Average, BooleanAccuracy, CategoricalAccuracy
+from allennlp.training.metrics import BooleanAccuracy, CategoricalAccuracy, SquadEmAndF1
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -121,8 +121,7 @@ class BidirectionalAttentionFlow(Model):
         self._span_start_accuracy = CategoricalAccuracy()
         self._span_end_accuracy = CategoricalAccuracy()
         self._span_accuracy = BooleanAccuracy()
-        self._official_em = Average()
-        self._official_f1 = Average()
+        self._squad_metrics = SquadEmAndF1()
         if dropout > 0:
             self._dropout = torch.nn.Dropout(p=dropout)
         else:
@@ -286,25 +285,17 @@ class BidirectionalAttentionFlow(Model):
                 answer_texts = metadata[i].get('answer_texts', [])
                 exact_match = f1_score = 0
                 if answer_texts:
-                    exact_match = squad_eval.metric_max_over_ground_truths(
-                            squad_eval.exact_match_score,
-                            best_span_string,
-                            answer_texts)
-                    f1_score = squad_eval.metric_max_over_ground_truths(
-                            squad_eval.f1_score,
-                            best_span_string,
-                            answer_texts)
-                self._official_em(100 * exact_match)
-                self._official_f1(100 * f1_score)
+                    self._squad_metrics(best_span_string, answer_texts)
         return output_dict
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
+        exact_match, f1 = self._squad_metrics.get_metric(reset)
         return {
                 'start_acc': self._span_start_accuracy.get_metric(reset),
                 'end_acc': self._span_end_accuracy.get_metric(reset),
                 'span_acc': self._span_accuracy.get_metric(reset),
-                'em': self._official_em.get_metric(reset),
-                'f1': self._official_f1.get_metric(reset),
+                'em': exact_match,
+                'f1': f1,
                 }
 
     @staticmethod

--- a/allennlp/training/metrics/__init__.py
+++ b/allennlp/training/metrics/__init__.py
@@ -10,3 +10,4 @@ from allennlp.training.metrics.boolean_accuracy import BooleanAccuracy
 from allennlp.training.metrics.categorical_accuracy import CategoricalAccuracy
 from allennlp.training.metrics.f1_measure import F1Measure
 from allennlp.training.metrics.span_based_f1_measure import SpanBasedF1Measure
+from allennlp.training.metrics.squad_em_and_f1 import SquadEmAndF1

--- a/allennlp/training/metrics/squad_em_and_f1.py
+++ b/allennlp/training/metrics/squad_em_and_f1.py
@@ -47,10 +47,10 @@ class SquadEmAndF1(Metric):
         over all inputs.
         """
         exact_match = self._total_em / self._count if self._count > 0 else 0
-        f1 = self._total_f1 / self._count if self._count > 0 else 0
+        f1_score = self._total_f1 / self._count if self._count > 0 else 0
         if reset:
             self.reset()
-        return exact_match, f1
+        return exact_match, f1_score
 
     @overrides
     def reset(self):

--- a/allennlp/training/metrics/squad_em_and_f1.py
+++ b/allennlp/training/metrics/squad_em_and_f1.py
@@ -1,0 +1,59 @@
+from typing import Tuple
+
+from overrides import overrides
+
+from allennlp.common import squad_eval
+from allennlp.training.metrics.metric import Metric
+
+
+@Metric.register("squad")
+class SquadEmAndF1(Metric):
+    """
+    This :class:`Metric` takes the best span string computed by a model, along with the answer
+    strings labeled in the data, and computed exact match and F1 score using the official SQuAD
+    evaluation script.
+    """
+    def __init__(self) -> None:
+        self._total_em = 0.0
+        self._total_f1 = 0.0
+        self._count = 0
+
+    @overrides
+    def __call__(self, best_span_string, answer_strings):
+        """
+        Parameters
+        ----------
+        value : ``float``
+            The value to average.
+        """
+        exact_match = squad_eval.metric_max_over_ground_truths(
+                squad_eval.exact_match_score,
+                best_span_string,
+                answer_strings)
+        f1_score = squad_eval.metric_max_over_ground_truths(
+                squad_eval.f1_score,
+                best_span_string,
+                answer_strings)
+        self._total_em += exact_match
+        self._total_f1 += f1_score
+        self._count += 1
+
+    @overrides
+    def get_metric(self, reset: bool = False) -> Tuple[float, float]:
+        """
+        Returns
+        -------
+        Average exact match and F1 score (in that order) as computed by the official SQuAD script
+        over all inputs.
+        """
+        exact_match = self._total_em / self._count if self._count > 0 else 0
+        f1 = self._total_f1 / self._count if self._count > 0 else 0
+        if reset:
+            self.reset()
+        return exact_match, f1
+
+    @overrides
+    def reset(self):
+        self._total_em = 0.0
+        self._total_f1 = 0.0
+        self._count = 0


### PR DESCRIPTION
So that SQuAD models other than BiDAF don't have to duplicate the metric code.

Fixes #245.