### PR TITLE
Letters+digits word splitter

### DIFF
--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -97,7 +97,7 @@ class SimpleWordSplitter(WordSplitter):
 
 
 @WordSplitter.register('letters_digits')
-class LettersDigitsSplitter(WordSplitter):
+class LettersDigitsWordSplitter(WordSplitter):
     """
     A ``WordSplitter`` which keeps runs of (unicode) letters and runs of digits together, while
     every other non-whitespace character becomes a separate word.

--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -1,3 +1,4 @@
+import re
 from typing import List, Tuple
 
 from overrides import overrides
@@ -97,6 +98,21 @@ class SimpleWordSplitter(WordSplitter):
 
     def _can_split(self, token: str):
         return token and token.lower() not in self.special_cases
+
+
+@WordSplitter.register('letters_digits')
+class LettersDigitsSplitter(WordSplitter):
+    """
+    A ``WordSplitter`` which keeps runs of letters and runs of digits together, while every
+    other non-whitespace character becomes a separate word.
+    """
+    @overrides
+    def split_words(self, sentence: str) -> Tuple[List[str], List[Tuple[int, int]]]:
+        # We use the [^\W\d_] pattern as a trick to match unicode letters
+        tokens = [(m.group(), m.start()) for m in re.finditer(r'[^\W\d_]+|\d+|\S', sentence)]
+        words = [word for word, _ in tokens]
+        offsets = [(start, start + len(word)) for word, start in tokens]
+        return words, offsets
 
 
 @WordSplitter.register('just_spaces')

--- a/tests/data/tokenizers/word_splitter_test.py
+++ b/tests/data/tokenizers/word_splitter_test.py
@@ -1,6 +1,8 @@
 # pylint: disable=no-self-use,invalid-name
 
 from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.tokenizers.token import Token
+from allennlp.data.tokenizers.word_splitter import LettersDigitsWordSplitter
 from allennlp.data.tokenizers.word_splitter import SimpleWordSplitter
 from allennlp.data.tokenizers.word_splitter import SpacyWordSplitter
 
@@ -40,6 +42,33 @@ class TestSimpleWordSplitter(AllenNlpTestCase):
         sentence = "mr. and mrs. jones, etc., went to, e.g., the store"
         expected_tokens = ["mr.", "and", "mrs.", "jones", ",", "etc.", ",", "went", "to", ",",
                            "e.g.", ",", "the", "store"]
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
+        assert tokens == expected_tokens
+
+
+class TestLettersDigitsWordSplitter(AllenNlpTestCase):
+    def setUp(self):
+        super(TestLettersDigitsWordSplitter, self).setUp()
+        self.word_splitter = LettersDigitsWordSplitter()
+
+    def test_tokenize_handles_complex_punctuation(self):
+        sentence = "this (sentence) has 'crazy' \"punctuation\"."
+        expected_tokens = ["this", "(", "sentence", ")", "has", "'", "crazy", "'", '"',
+                           "punctuation", '"', "."]
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
+        assert tokens == expected_tokens
+
+    def test_tokenize_handles_unicode_letters(self):
+        sentence = "HAL9000   and    Ångström"
+        expected_tokens = [Token("HAL", 0), Token("9000", 3), Token("and", 10), Token("Ångström", 17)]
+        tokens = self.word_splitter.split_words(sentence)
+        assert [t.text for t in tokens] == [t.text for t in expected_tokens]
+        assert [t.idx for t in tokens] == [t.idx for t in expected_tokens]
+
+    def test_tokenize_handles_splits_all_punctuation(self):
+        sentence = "wouldn't.[have] -3.45(m^2)"
+        expected_tokens = ["wouldn", "'", "t", ".", "[", "have", "]", "-", "3",
+                           ".", "45", "(", "m", "^", "2", ")"]
         tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
 


### PR DESCRIPTION
A basic, unopinionated word splitter which keeps runs of (unicode) letters and runs of digits together, anything else is treated as single-character "words". Showed marginal improvement (compared to the default spacy English tokenizer) in BiDAF on SQuAD.