### PR TITLE
Iterators warning when shuffle is False

### DIFF
--- a/allennlp/data/iterators/adaptive_iterator.py
+++ b/allennlp/data/iterators/adaptive_iterator.py
@@ -113,6 +113,9 @@ class AdaptiveIterator(BucketIterator):
         grouped_instances = self._adaptive_grouping(dataset)
         if shuffle:
             random.shuffle(grouped_instances)
+        else:
+            logger.warning("shuffle parameter is set to False,"
+                           " while these iterators by definition change the order of your data.")
         return grouped_instances
 
     def _adaptive_grouping(self, dataset: Dataset):

--- a/allennlp/data/iterators/adaptive_iterator.py
+++ b/allennlp/data/iterators/adaptive_iterator.py
@@ -115,7 +115,7 @@ class AdaptiveIterator(BucketIterator):
             random.shuffle(grouped_instances)
         else:
             logger.warning("shuffle parameter is set to False,"
-                           " while these iterators by definition change the order of your data.")
+                           " while adaptive iterators by definition change the order of your data.")
         return grouped_instances
 
     def _adaptive_grouping(self, dataset: Dataset):

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -76,7 +76,7 @@ class BucketIterator(BasicIterator):
             random.shuffle(grouped_instances)
         else:
             logger.warning("shuffle parameter is set to False,"
-                           " while these iterators by definition change the order of your data.")
+                           " while bucket iterators by definition change the order of your data.")
         if self._biggest_batch_first:
             grouped_instances.insert(0, penultimate_batch)
             grouped_instances.insert(0, last_batch)

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -1,3 +1,4 @@
+import logging
 import random
 from typing import List, Tuple, Dict, cast
 
@@ -8,6 +9,8 @@ from allennlp.common.util import add_noise_to_dict_values
 from allennlp.data import Dataset, Instance
 from allennlp.data.iterators.basic_iterator import BasicIterator
 from allennlp.data.iterators.data_iterator import DataIterator
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 @DataIterator.register("bucket")
@@ -71,6 +74,9 @@ class BucketIterator(BasicIterator):
             penultimate_batch = grouped_instances.pop()
         if shuffle:
             random.shuffle(grouped_instances)
+        else:
+            logger.warning("shuffle parameter is set to False,"
+                           " while these iterators by definition change the order of your data.")
         if self._biggest_batch_first:
             grouped_instances.insert(0, penultimate_batch)
             grouped_instances.insert(0, last_batch)


### PR DESCRIPTION
Add a warning when passing `shuffle=False` to bucket and adaptive iterators.  Fixes #162. 