### PR TITLE
make default models and default predictors configurable

### DIFF
--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -7,7 +7,7 @@ from allennlp.commands.train import add_subparser as add_train_subparser
 from allennlp.commands.evaluate import add_subparser as add_evaluate_subparser
 from allennlp.common.checks import ensure_pythonhashseed_set
 
-# a mapping from model `type` to the location of the trained model of that type
+# a mapping from predictor `type` to the location of the trained model of that type
 DEFAULT_MODELS = {
         'machine-comprehension': 'https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.08.31.tar.gz', # pylint: disable=line-too-long
         'semantic-role-labeling': 'https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2017.09.05.tar.gz', # pylint: disable=line-too-long
@@ -38,7 +38,7 @@ def main(prog: str = None,
     add_train_subparser(subparsers)
     add_evaluate_subparser(subparsers)
     add_predict_subparser(subparsers, predictors=predictors)
-    add_serve_subparser(subparsers, trained_models=trained_models, predictors=predictors)
+    add_serve_subparser(subparsers, trained_models=trained_models)
 
     args = parser.parse_args()
 

--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -1,3 +1,4 @@
+from typing import Dict
 import argparse
 
 from allennlp.commands.serve import add_subparser as add_serve_subparser
@@ -6,17 +7,38 @@ from allennlp.commands.train import add_subparser as add_train_subparser
 from allennlp.commands.evaluate import add_subparser as add_evaluate_subparser
 from allennlp.common.checks import ensure_pythonhashseed_set
 
-def main(prog: str = None) -> None:
+# a mapping from model `type` to the location of the trained model of that type
+DEFAULT_MODELS = {
+        'machine-comprehension': 'https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.08.31.tar.gz', # pylint: disable=line-too-long
+        'semantic-role-labeling': 'https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2017.09.05.tar.gz', # pylint: disable=line-too-long
+        'textual-entailment': 'https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-2017.09.04.tar.gz' # pylint: disable=line-too-long
+}
+
+# a mapping from model `type` to the default Predictor for that type
+DEFAULT_PREDICTORS = {
+        'srl': 'semantic-role-labeling',
+        'decomposable_attention': 'textual-entailment',
+        'bidaf': 'machine-comprehension',
+        'simple_tagger': 'simple-tagger'
+}
+
+def main(prog: str = None,
+         model_overrides: Dict[str, str] = {},
+         predictor_overrides: Dict[str, str] = {}) -> None:
+    # pylint: disable=dangerous-default-value
     ensure_pythonhashseed_set()
 
     parser = argparse.ArgumentParser(description="Run AllenNLP", usage='%(prog)s [command]', prog=prog)
     subparsers = parser.add_subparsers(title='Commands', metavar='')
 
+    trained_models = {**DEFAULT_MODELS, **model_overrides}
+    predictors = {**DEFAULT_PREDICTORS, **predictor_overrides}
+
     # Add sub-commands
     add_train_subparser(subparsers)
     add_evaluate_subparser(subparsers)
-    add_predict_subparser(subparsers)
-    add_serve_subparser(subparsers)
+    add_predict_subparser(subparsers, predictors=predictors)
+    add_serve_subparser(subparsers, trained_models=trained_models, predictors=predictors)
 
     args = parser.parse_args()
 

--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -25,6 +25,18 @@ DEFAULT_PREDICTORS = {
 def main(prog: str = None,
          model_overrides: Dict[str, str] = {},
          predictor_overrides: Dict[str, str] = {}) -> None:
+    """
+    The :mod:``allennlp.run`` command only knows about the registered classes
+    in the ``allennlp`` codebase. In particular, once you start creating your own
+    ``Model``s and so forth, it won't work for them. However, ``allennlp.run`` is
+    simply a wrapper around this function. To use the command line interface with your
+    own custom classes, just create your own script that imports all of the classes you want
+    and then calls ``main()``.
+
+    The default models for ``serve`` and the default predictors for ``predict`` are
+    defined above. If you'd like to add more or use different ones, the
+    ``model_overrides`` and ``predictor_overrides`` arguments will take precedence over the defaults.
+    """
     # pylint: disable=dangerous-default-value
     ensure_pythonhashseed_set()
 

--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -25,12 +25,15 @@ import argparse
 from contextlib import ExitStack
 import json
 import sys
-from typing import Optional, IO
+from typing import Optional, IO, Dict
 
+from allennlp.common.checks import ConfigurationError
 from allennlp.models.archival import load_archive
 from allennlp.service.predictors import Predictor
 
-def add_subparser(parser: argparse._SubParsersAction) -> argparse.ArgumentParser:  # pylint: disable=protected-access
+def add_subparser(parser: argparse._SubParsersAction,
+                  predictors: Dict[str, str]) -> argparse.ArgumentParser:
+    # pylint: disable=protected-access
     description = '''Run the specified model against a JSON-lines input file.'''
     subparser = parser.add_parser(
             'predict', description=description, help='Use a trained model to make predictions.')
@@ -40,13 +43,16 @@ def add_subparser(parser: argparse._SubParsersAction) -> argparse.ArgumentParser
     subparser.add_argument('--output-file', type=argparse.FileType('w'), help='path to output file')
     subparser.add_argument('--silent', action='store_true', help='do not print output to stdout')
 
-    subparser.set_defaults(func=predict)
+    subparser.set_defaults(func=predict(predictors))
 
     return subparser
 
-def get_predictor(args: argparse.Namespace) -> Predictor:
+def get_predictor(args: argparse.Namespace, predictors: Dict[str, str]) -> Predictor:
     archive = load_archive(args.archive_file)
-    predictor = Predictor.from_archive(archive)
+    model_type = archive.config.get("model").get("type")
+    if model_type not in predictors:
+        raise ConfigurationError("no known predictor for model type {}".format(model_type))
+    predictor = Predictor.from_archive(archive, predictors[model_type])
     return predictor
 
 def run(predictor: Predictor, input_file: IO, output_file: Optional[IO], print_to_console: bool) -> None:
@@ -61,19 +67,22 @@ def run(predictor: Predictor, input_file: IO, output_file: Optional[IO], print_t
             if output_file:
                 output_file.write(output + "\n")
 
-def predict(args: argparse.Namespace) -> None:
-    predictor = get_predictor(args)
-    output_file = None
+def predict(predictors: Dict[str, str]):
+    def predict_inner(args: argparse.Namespace) -> None:
+        predictor = get_predictor(args, predictors)
+        output_file = None
 
-    if args.silent and not args.output_file:
-        print("--silent specified without --output-file.")
-        print("Exiting early because no output will be created.")
-        sys.exit(0)
+        if args.silent and not args.output_file:
+            print("--silent specified without --output-file.")
+            print("Exiting early because no output will be created.")
+            sys.exit(0)
 
-    # ExitStack allows us to conditionally context-manage `output_file`, which may or may not exist
-    with ExitStack() as stack:
-        input_file = stack.enter_context(args.input_file)  # type: ignore
-        if args.output_file:
-            output_file = stack.enter_context(args.output_file)  # type: ignore
+        # ExitStack allows us to conditionally context-manage `output_file`, which may or may not exist
+        with ExitStack() as stack:
+            input_file = stack.enter_context(args.input_file)  # type: ignore
+            if args.output_file:
+                output_file = stack.enter_context(args.output_file)  # type: ignore
 
-        run(predictor, input_file, output_file, not args.silent)
+            run(predictor, input_file, output_file, not args.silent)
+
+    return predict_inner

--- a/allennlp/commands/serve.py
+++ b/allennlp/commands/serve.py
@@ -27,8 +27,7 @@ from typing import Dict
 from allennlp.service import server_sanic
 
 def add_subparser(parser: argparse._SubParsersAction,
-                  trained_models: Dict[str, str],
-                  predictors: Dict[str, str]) -> argparse.ArgumentParser:
+                  trained_models: Dict[str, str]) -> argparse.ArgumentParser:
     # pylint: disable=protected-access
     description = '''Run the web service, which provides an HTTP API as well as a web demo.'''
     subparser = parser.add_parser(
@@ -37,12 +36,12 @@ def add_subparser(parser: argparse._SubParsersAction,
     subparser.add_argument('--port', type=int, default=8000)
     subparser.add_argument('--workers', type=int, default=1)
 
-    subparser.set_defaults(func=serve(trained_models, predictors))
+    subparser.set_defaults(func=serve(trained_models))
 
     return subparser
 
-def serve(trained_models: Dict[str, str], predictors: Dict[str, str]):
+def serve(trained_models: Dict[str, str]):
     def serve_inner(args: argparse.Namespace) -> None:
-        server_sanic.run(args.port, args.workers, trained_models, predictors)
+        server_sanic.run(args.port, args.workers, trained_models)
 
     return serve_inner

--- a/allennlp/commands/serve.py
+++ b/allennlp/commands/serve.py
@@ -22,35 +22,27 @@ their predictions.
 """
 
 import argparse
-import json
+from typing import Dict
 
 from allennlp.service import server_sanic
 
-DEFAULT_CONFIG = {
-        'machine-comprehension': 'https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.08.31.tar.gz', # pylint: disable=line-too-long
-        'semantic-role-labeling': 'https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2017.09.05.tar.gz', # pylint: disable=line-too-long
-        'textual-entailment': 'https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-2017.09.04.tar.gz' # pylint: disable=line-too-long
-}
-
-def add_subparser(parser: argparse._SubParsersAction) -> argparse.ArgumentParser:  # pylint: disable=protected-access
+def add_subparser(parser: argparse._SubParsersAction,
+                  trained_models: Dict[str, str],
+                  predictors: Dict[str, str]) -> argparse.ArgumentParser:
+    # pylint: disable=protected-access
     description = '''Run the web service, which provides an HTTP API as well as a web demo.'''
     subparser = parser.add_parser(
             'serve', description=description, help='Run the web service and demo.')
 
     subparser.add_argument('--port', type=int, default=8000)
     subparser.add_argument('--workers', type=int, default=1)
-    subparser.add_argument('--config-file', type=argparse.FileType('r'), default=None,
-                           help="path to a JSON file specifying the configuration for the models")
 
-    subparser.set_defaults(func=serve)
+    subparser.set_defaults(func=serve(trained_models, predictors))
 
     return subparser
 
-def serve(args: argparse.Namespace) -> None:
-    # Read a JSON configuration file, if specified
-    config = DEFAULT_CONFIG
-    if args.config_file is not None:
-        with args.config_file as fopen:
-            config = json.loads(fopen.read())
+def serve(trained_models: Dict[str, str], predictors: Dict[str, str]):
+    def serve_inner(args: argparse.Namespace) -> None:
+        server_sanic.run(args.port, args.workers, trained_models, predictors)
 
-    server_sanic.run(args.port, args.workers, config)
+    return serve_inner

--- a/allennlp/service/predictors/__init__.py
+++ b/allennlp/service/predictors/__init__.py
@@ -6,7 +6,7 @@ want to serve up a model through the web service
 (or using ``allennlp.commands.predict``), you'll need
 a ``Predictor`` that wraps it.
 """
-from .predictor import Predictor, DEFAULT_PREDICTORS
+from .predictor import Predictor
 from .bidaf import BidafPredictor
 from .decomposable_attention import DecomposableAttentionPredictor
 from .semantic_role_labeler import SemanticRoleLabelerPredictor

--- a/allennlp/service/predictors/predictor.py
+++ b/allennlp/service/predictors/predictor.py
@@ -4,13 +4,6 @@ from allennlp.data import DatasetReader, Instance
 from allennlp.models import Model
 from allennlp.models.archival import Archive
 
-# a mapping from model `type` to the default Predictor for that type
-DEFAULT_PREDICTORS = {
-        'srl': 'semantic-role-labeling',
-        'decomposable_attention': 'textual-entailment',
-        'bidaf': 'machine-comprehension',
-        'simple_tagger': 'simple-tagger'
-}
 
 class Predictor(Registrable):
     """
@@ -33,7 +26,7 @@ class Predictor(Registrable):
         raise NotImplementedError
 
     @classmethod
-    def from_archive(cls, archive: Archive, predictor_name: str = None) -> 'Predictor':
+    def from_archive(cls, archive: Archive, predictor_name: str) -> 'Predictor':
         """
         Instantiate a :class:`Predictor` from an :class:`~allennlp.models.archival.Archive`;
         that is, from the result of training a model. Optionally specify which `Predictor`
@@ -47,6 +40,4 @@ class Predictor(Registrable):
         model = archive.model
         model.eval()
 
-        model_name = config.get("model").get("type")
-        predictor_name = predictor_name or DEFAULT_PREDICTORS[model_name]
         return Predictor.by_name(predictor_name)(model, dataset_reader)

--- a/allennlp/service/server_sanic.py
+++ b/allennlp/service/server_sanic.py
@@ -27,21 +27,16 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 def run(port: int, workers: int,
         trained_models: Dict[str, str],
-        predictors: Dict[str, str],
         static_dir: str = None) -> None:
     """Run the server programatically"""
     print("Starting a sanic server on port {}.".format(port))
 
     app = make_app(static_dir)
 
-    for model_name, archive_file in trained_models.items():
-        predictor_name = predictors.get(model_name)
-        if predictor_name is None:
-            logger.warning("no predictor found for model %s, skipping", model_name)
-        else:
-            archive = load_archive(archive_file)
-            predictor = Predictor.from_archive(archive, predictor_name)
-            app.predictors[model_name] = predictor
+    for predictor_name, archive_file in trained_models.items():
+        archive = load_archive(archive_file)
+        predictor = Predictor.from_archive(archive, predictor_name)
+        app.predictors[predictor_name] = predictor
 
     app.run(port=port, host="0.0.0.0", workers=workers)
 

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 from unittest import TestCase
 
-from allennlp.commands import main
+from allennlp.commands import main, DEFAULT_PREDICTORS
 from allennlp.commands.predict import add_subparser, predict
 
 
@@ -15,7 +15,7 @@ class TestPredict(TestCase):
     def test_add_predict_subparser(self):
         parser = argparse.ArgumentParser(description="Testing")
         subparsers = parser.add_subparsers(title='Commands', metavar='')
-        add_subparser(subparsers)
+        add_subparser(subparsers, DEFAULT_PREDICTORS)
 
         raw_args = ["predict",          # command
                     "/path/to/archive", # archive
@@ -25,7 +25,7 @@ class TestPredict(TestCase):
 
         args = parser.parse_args(raw_args)
 
-        assert args.func == predict
+        assert args.func.__name__ == 'predict_inner'
         assert args.archive_file == "/path/to/archive"
         assert args.silent
 

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -75,8 +75,9 @@ class TestPredict(TestCase):
 
     def test_can_override_predictors(self):
 
-        @Predictor.register('bidaf-override')
+        @Predictor.register('bidaf-override')  # pylint: disable=unused-variable
         class Bidaf2Predictor(BidafPredictor):
+            """same as bidaf predictor but with an extra field"""
             def predict_json(self, inputs: JsonDict) -> JsonDict:
                 result = super().predict_json(inputs)
                 result["overridden"] = True
@@ -111,4 +112,3 @@ class TestPredict(TestCase):
             assert set(result.keys()) == {"span_start_logits", "span_end_logits",
                                           "span_start_probs", "span_end_probs", "best_span",
                                           "best_span_str", "overridden"}
-

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -6,8 +6,10 @@ import sys
 import tempfile
 from unittest import TestCase
 
+from allennlp.common.util import JsonDict
 from allennlp.commands import main, DEFAULT_PREDICTORS
-from allennlp.commands.predict import add_subparser, predict
+from allennlp.commands.predict import add_subparser
+from allennlp.service.predictors import Predictor, BidafPredictor
 
 
 class TestPredict(TestCase):
@@ -70,3 +72,43 @@ class TestPredict(TestCase):
             main()
 
         assert cm.exception.code == 2  # argparse code for incorrect usage
+
+    def test_can_override_predictors(self):
+
+        @Predictor.register('bidaf-override')
+        class Bidaf2Predictor(BidafPredictor):
+            def predict_json(self, inputs: JsonDict) -> JsonDict:
+                result = super().predict_json(inputs)
+                result["overridden"] = True
+                return result
+
+        tempdir = tempfile.mkdtemp()
+        infile = os.path.join(tempdir, "inputs.txt")
+        outfile = os.path.join(tempdir, "outputs.txt")
+
+        with open(infile, 'w') as f:
+            f.write("""{"passage": "the seahawks won the super bowl in 2016", """
+                    """ "question": "when did the seahawks win the super bowl?"}\n""")
+            f.write("""{"passage": "the mariners won the super bowl in 2037", """
+                    """ "question": "when did the mariners win the super bowl?"}\n""")
+
+        sys.argv = ["run.py",      # executable
+                    "predict",     # command
+                    "tests/fixtures/bidaf/serialization/model.tar.gz",
+                    infile,     # input_file
+                    "--output-file", outfile,
+                    "--silent"]
+
+        main(predictor_overrides={'bidaf': 'bidaf-override'})
+        assert os.path.exists(outfile)
+
+        with open(outfile, 'r') as f:
+            results = [json.loads(line) for line in f]
+
+        assert len(results) == 2
+        # Overridden predictor should output extra field
+        for result in results:
+            assert set(result.keys()) == {"span_start_logits", "span_end_logits",
+                                          "span_start_probs", "span_end_probs", "best_span",
+                                          "best_span_str", "overridden"}
+

--- a/tests/commands/serve_test.py
+++ b/tests/commands/serve_test.py
@@ -11,7 +11,7 @@ class TestServe(TestCase):
     def test_add_serve(self):
         parser = argparse.ArgumentParser(description="Testing")
         subparsers = parser.add_subparsers(title='Commands', metavar='')
-        add_subparser(subparsers, trained_models=DEFAULT_MODELS, predictors=DEFAULT_PREDICTORS)
+        add_subparser(subparsers, trained_models=DEFAULT_MODELS)
 
         raw_args = ["serve",
                     "--port", "8000"]

--- a/tests/commands/serve_test.py
+++ b/tests/commands/serve_test.py
@@ -2,7 +2,7 @@
 import argparse
 from unittest import TestCase
 
-from allennlp.commands import DEFAULT_MODELS, DEFAULT_PREDICTORS
+from allennlp.commands import DEFAULT_MODELS
 from allennlp.commands.serve import add_subparser
 
 

--- a/tests/commands/serve_test.py
+++ b/tests/commands/serve_test.py
@@ -2,6 +2,7 @@
 import argparse
 from unittest import TestCase
 
+from allennlp.commands import DEFAULT_MODELS, DEFAULT_PREDICTORS
 from allennlp.commands.serve import add_subparser, serve
 
 
@@ -10,12 +11,12 @@ class TestServe(TestCase):
     def test_add_serve(self):
         parser = argparse.ArgumentParser(description="Testing")
         subparsers = parser.add_subparsers(title='Commands', metavar='')
-        add_subparser(subparsers)
+        add_subparser(subparsers, trained_models=DEFAULT_MODELS, predictors=DEFAULT_PREDICTORS)
 
         raw_args = ["serve",
                     "--port", "8000"]
 
         args = parser.parse_args(raw_args)
 
-        assert args.func == serve
+        assert args.func.__name__ == 'serve_inner'
         assert args.port == 8000

--- a/tests/commands/serve_test.py
+++ b/tests/commands/serve_test.py
@@ -3,7 +3,7 @@ import argparse
 from unittest import TestCase
 
 from allennlp.commands import DEFAULT_MODELS, DEFAULT_PREDICTORS
-from allennlp.commands.serve import add_subparser, serve
+from allennlp.commands.serve import add_subparser
 
 
 class TestServe(TestCase):

--- a/tests/service/predictors/bidaf_test.py
+++ b/tests/service/predictors/bidaf_test.py
@@ -13,7 +13,7 @@ class TestBidafPredictor(TestCase):
         }
 
         archive = load_archive('tests/fixtures/bidaf/serialization/model.tar.gz')
-        predictor = Predictor.from_archive(archive)
+        predictor = Predictor.from_archive(archive, 'machine-comprehension')
 
         result = predictor.predict_json(inputs)
 

--- a/tests/service/predictors/decomposable_attention_test.py
+++ b/tests/service/predictors/decomposable_attention_test.py
@@ -13,7 +13,7 @@ class TestDecomposableAttentionPredictor(TestCase):
         }
 
         archive = load_archive('tests/fixtures/decomposable_attention/serialization/model.tar.gz')
-        predictor = Predictor.from_archive(archive)
+        predictor = Predictor.from_archive(archive, 'textual-entailment')
         result = predictor.predict_json(inputs)
 
         assert "label_probs" in result

--- a/tests/service/predictors/srl_test.py
+++ b/tests/service/predictors/srl_test.py
@@ -12,7 +12,7 @@ class TestSrlPredictor(TestCase):
         }
 
         archive = load_archive('tests/fixtures/srl/serialization/model.tar.gz')
-        predictor = Predictor.from_archive(archive)
+        predictor = Predictor.from_archive(archive, 'semantic-role-labeling')
 
         result = predictor.predict_json(inputs)
 

--- a/tests/service/server_sanic_test.py
+++ b/tests/service/server_sanic_test.py
@@ -43,7 +43,8 @@ class TestSanic(AllenNlpTestCase):
 
             self.app = make_app(build_dir=self.TEST_DIR)
             self.app.predictors = {
-                    name: Predictor.from_archive(load_archive(archive_file))
+                    name: Predictor.from_archive(load_archive(archive_file),
+                                                 predictor_name=name)
                     for name, archive_file in TEST_ARCHIVE_FILES.items()
             }
 


### PR DESCRIPTION
this addresses https://github.com/allenai/allennlp/issues/323 and is a better design anyway

here `DEFAULT_MODELS` and `DEFAULT_PREDICTORS` are defined with `allennlp.commands.main()` which now takes optional dicts of overrides.

after this change, if someone implements their own predictors, they can just specify them when they call `main()`

still needs tests