### PR TITLE
Move combine_tensor methods into a common location

### DIFF
--- a/allennlp/modules/similarity_functions/dot_product.py
+++ b/allennlp/modules/similarity_functions/dot_product.py
@@ -1,3 +1,5 @@
+import math
+
 from overrides import overrides
 import torch
 
@@ -8,14 +10,28 @@ from allennlp.modules.similarity_functions.similarity_function import Similarity
 @SimilarityFunction.register("dot_product")
 class DotProductSimilarity(SimilarityFunction):
     """
-    This similarity function simply computes the dot product between each pair of vectors.  It has
-    no parameters.
+    This similarity function simply computes the dot product between each pair of vectors, with an
+    optional scaling to reduce the variance of the output elements.
+
+    Parameters
+    ----------
+    scale_output : ``bool``, optional
+        If ``True``, we will scale the output by ``math.sqrt(tensor.size(-1))``, to reduce the
+        variance in the result.
     """
+    def __init__(self, scale_output: bool = False) -> None:
+        super(DotProductSimilarity, self).__init__()
+        self._scale_output = scale_output
+
     @overrides
     def forward(self, tensor_1: torch.Tensor, tensor_2: torch.Tensor) -> torch.Tensor:
-        return (tensor_1 * tensor_2).sum(dim=-1)
+        result = (tensor_1 * tensor_2).sum(dim=-1)
+        if self._scale_output:
+            result *= math.sqrt(tensor_1.size(-1))
+        return result
 
     @classmethod
     def from_params(cls, params: Params) -> 'DotProductSimilarity':
+        scale_output = params.pop('scale_output', False)
         params.assert_empty(cls.__name__)
-        return cls()
+        return cls(scale_output=scale_output)

--- a/allennlp/modules/similarity_functions/linear.py
+++ b/allennlp/modules/similarity_functions/linear.py
@@ -5,9 +5,8 @@ import torch
 from torch.nn.parameter import Parameter
 
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
 from allennlp.modules.similarity_functions.similarity_function import SimilarityFunction
-from allennlp.nn import Activation
+from allennlp.nn import Activation, util
 
 
 @SimilarityFunction.register("linear")
@@ -50,8 +49,8 @@ class LinearSimilarity(SimilarityFunction):
                  combination: str = 'x,y',
                  activation: Activation = Activation.by_name('linear')()) -> None:
         super(LinearSimilarity, self).__init__()
-        self._combinations = combination.split(',')
-        combined_dim = self._get_combined_dim(tensor_1_dim, tensor_2_dim)
+        self._combination = combination
+        combined_dim = util.get_combined_dim(combination, [tensor_1_dim, tensor_2_dim])
         self._weight_vector = Parameter(torch.Tensor(combined_dim))
         self._bias = Parameter(torch.Tensor(1))
         self._activation = activation
@@ -64,58 +63,9 @@ class LinearSimilarity(SimilarityFunction):
 
     @overrides
     def forward(self, tensor_1: torch.Tensor, tensor_2: torch.Tensor) -> torch.Tensor:
-        combined_tensors = self._combine_tensors(tensor_1, tensor_2)
+        combined_tensors = util.combine_tensors(self._combination, [tensor_1, tensor_2])
         dot_product = torch.matmul(combined_tensors, self._weight_vector)
         return self._activation(dot_product + self._bias)
-
-    def _combine_tensors(self, tensor_1: torch.Tensor, tensor_2: torch.Tensor) -> torch.Tensor:
-        combined_tensor = self._get_combination(self._combinations[0], tensor_1, tensor_2)
-        for combination in self._combinations[1:]:
-            to_concatenate = self._get_combination(combination, tensor_1, tensor_2)
-            combined_tensor = torch.cat([combined_tensor, to_concatenate], dim=-1)
-        return combined_tensor
-
-    def _get_combination(self, combination: str, tensor_1, tensor_2):
-        if combination == 'x':
-            return tensor_1
-        elif combination == 'y':
-            return tensor_2
-        else:
-            if len(combination) != 3:
-                raise ConfigurationError("Invalid combination: " + combination)
-            first_tensor = self._get_combination(combination[0], tensor_1, tensor_2)
-            second_tensor = self._get_combination(combination[2], tensor_1, tensor_2)
-            operation = combination[1]
-            if operation == '*':
-                return first_tensor * second_tensor
-            elif operation == '/':
-                return first_tensor / second_tensor
-            elif operation == '+':
-                return first_tensor + second_tensor
-            elif operation == '-':
-                return first_tensor - second_tensor
-            else:
-                raise ConfigurationError("Invalid operation: " + operation)
-
-    def _get_combined_dim(self, tensor_1_dim: int, tensor_2_dim: int) -> int:
-        combination_dims = [self._get_combination_dim(combination, tensor_1_dim, tensor_2_dim)
-                            for combination in self._combinations]
-        return sum(combination_dims)
-
-    def _get_combination_dim(self, combination: str, tensor_1_dim: int, tensor_2_dim: int) -> int:
-        if combination == 'x':
-            return tensor_1_dim
-        elif combination == 'y':
-            return tensor_2_dim
-        else:
-            if len(combination) != 3:
-                raise ConfigurationError("Invalid combination: " + combination)
-            first_tensor_dim = self._get_combination_dim(combination[0], tensor_1_dim, tensor_2_dim)
-            second_tensor_dim = self._get_combination_dim(combination[2], tensor_1_dim, tensor_2_dim)
-            operation = combination[1]
-            if first_tensor_dim != second_tensor_dim:
-                raise ConfigurationError("Tensor dims must match for operation \"{}\"".format(operation))
-            return first_tensor_dim
 
     @classmethod
     def from_params(cls, params: Params) -> 'LinearSimilarity':

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -436,13 +436,11 @@ def combine_tensors(combination: str, tensors: List[torch.Tensor]) -> torch.Tens
     This function also accepts ``x`` and ``y`` in place of ``1`` and ``2`` in the combination
     string.
     """
+    if len(tensors) > 9:
+        raise ConfigurationError("Double-digit tensor lists not currently supported")
     combination = combination.replace('x', '1').replace('y', '2')
-    combinations = combination.split(',')
-    combined_tensor = _get_combination(combinations[0], tensors)
-    for piece in combinations[1:]:
-        to_concatenate = _get_combination(piece, tensors)
-        combined_tensor = torch.cat([combined_tensor, to_concatenate], dim=-1)
-    return combined_tensor
+    to_concatenate = [_get_combination(piece, tensors) for piece in combination.split(',')]
+    return torch.cat(to_concatenate, dim=-1)
 
 def _get_combination(combination: str, tensors: List[torch.Tensor]) -> torch.Tensor:
     if combination.isdigit():
@@ -482,6 +480,8 @@ def get_combined_dim(combination: str, tensor_dims: List[int]) -> int:
         A list of tensor dimensions, where each dimension is from the `last axis` of the tensors
         that will be input to :func:`combine_tensors`.
     """
+    if len(tensor_dims) > 9:
+        raise ConfigurationError("Double-digit tensor lists not currently supported")
     combination = combination.replace('x', '1').replace('y', '2')
     return sum([_get_combination_dim(piece, tensor_dims) for piece in combination.split(',')])
 


### PR DESCRIPTION
So that I can use them in other places (particularly in a multi-headed attention encoder).

I also added an option for scaling the dot product similarity.