### PR TITLE
Fix some typos and total epoch logging

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -151,7 +151,7 @@ class Trainer:
             num_validation_batches = self._iterator.get_num_batches(self._validation_dataset)
         validation_metric_per_epoch: List[float] = []
         for epoch in range(epoch_counter, self._num_epochs):
-            logger.info("Epoch %d/%d", epoch, self._num_epochs)
+            logger.info("Epoch %d/%d", epoch, self._num_epochs - 1)
             train_loss = 0.0
             val_loss = 0.0
             # Set the model to "train" mode.
@@ -189,11 +189,11 @@ class Trainer:
                 batch_num_total = num_training_batches * epoch + batch_num
                 if self._serialization_dir and batch_num_total % self._summary_interval == 0:
                     for name, param in self._model.named_parameters():
-                        train_log.add_scalar("paramter_mean/" + name, param.data.mean(), batch_num_total)
-                        train_log.add_scalar("parameter_mean/" + name, param.data.std(), batch_num_total)
+                        train_log.add_scalar("parameter_mean/" + name, param.data.mean(), batch_num_total)
+                        train_log.add_scalar("parameter_std/" + name, param.data.std(), batch_num_total)
                         if param.grad is not None:
                             train_log.add_scalar("gradient_mean/" + name, param.grad.data.mean(), batch_num_total)
-                            train_log.add_scalar("gradient_mean/" + name, param.grad.data.std(), batch_num_total)
+                            train_log.add_scalar("gradient_std/" + name, param.grad.data.std(), batch_num_total)
                     train_log.add_scalar("loss/loss_train", metrics["loss"], batch_num_total)
                 if self._no_tqdm and time.time() - last_log > self._log_interval:
                     logger.info("Batch %d/%d: %s", batch_num, num_training_batches, description)


### PR DESCRIPTION
I missed this when reviewing https://github.com/allenai/allennlp/pull/318, there were some silly typos in the lower casing of the tensorboard logging prefixes. Also in the logging of epoch numbers, we're now going from 0/20 to 19/20, maybe it makes more sense to say 0/19 to 19/19? Not sure, but I put that change is in there as well.