### PR TITLE
Fix misreading of newline-like vocab tokens

### DIFF
--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -176,7 +176,7 @@ class SpacyWordSplitter(WordSplitter):
 
     @overrides
     def split_words(self, sentence: str) -> List[Token]:
-        return self.spacy(sentence)  # type: ignore
+        return [t for t in self.spacy(sentence) if not t.is_space]
 
     def _get_spacy_model(self, language: str, pos_tags: bool, parse: bool, ner: bool) -> Any:
         options = (language, pos_tags, parse, ner)

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -256,9 +256,13 @@ class Vocabulary:
             self._token_to_index[namespace] = {}
             self._index_to_token[namespace] = {}
         with codecs.open(filename, 'r', 'utf-8') as input_file:
-            for i, line in enumerate(input_file.readlines()):
+            lines = input_file.read().split('\n')
+            # Be flexible about having final newline or not
+            if lines and lines[-1] == '':
+                lines = lines[:-1]
+            for i, line in enumerate(lines):
                 index = i + 1 if is_padded else i
-                token = line[:-1].replace('@@NEWLINE@@', '\n')
+                token = line.replace('@@NEWLINE@@', '\n')
                 if token == oov_token:
                     token = self._oov_token
                 self._token_to_index[namespace][token] = index

--- a/tests/data/tokenizers/word_splitter_test.py
+++ b/tests/data/tokenizers/word_splitter_test.py
@@ -110,6 +110,12 @@ class TestSpacyWordSplitter(AllenNlpTestCase):
         tokens = [t.text for t in self.word_splitter.split_words(sentence)]
         assert tokens == expected_tokens
 
+    def test_tokenize_removes_whitespace_tokens(self):
+        sentence = "the\n jones'   house  \x0b  55"
+        expected_tokens = ["the", "jones", "'", "house", "55"]
+        tokens = [t.text for t in self.word_splitter.split_words(sentence)]
+        assert tokens == expected_tokens
+
     def test_tokenize_handles_special_cases(self):
         # note that the etc. doesn't quite work --- we can special case this if we want.
         sentence = "Mr. and Mrs. Jones, etc., went to, e.g., the store"

--- a/tests/data/vocabulary_test.py
+++ b/tests/data/vocabulary_test.py
@@ -104,6 +104,7 @@ class TestVocabulary(AllenNlpTestCase):
             vocab_file.write('</S>\n')
             vocab_file.write('<UNK>\n')
             vocab_file.write('a\n')
+            vocab_file.write('tricky\x0bchar\n')
             vocab_file.write('word\n')
             vocab_file.write('another\n')
 
@@ -116,15 +117,17 @@ class TestVocabulary(AllenNlpTestCase):
         assert vocab.get_token_index("</S>") == 2
         assert vocab.get_token_index(DEFAULT_OOV_TOKEN) == 3
         assert vocab.get_token_index("a") == 4
-        assert vocab.get_token_index("word") == 5
-        assert vocab.get_token_index("another") == 6
+        assert vocab.get_token_index("tricky\x0bchar") == 5
+        assert vocab.get_token_index("word") == 6
+        assert vocab.get_token_index("another") == 7
         assert vocab.get_token_from_index(0) == vocab._padding_token
         assert vocab.get_token_from_index(1) == "<S>"
         assert vocab.get_token_from_index(2) == "</S>"
         assert vocab.get_token_from_index(3) == DEFAULT_OOV_TOKEN
         assert vocab.get_token_from_index(4) == "a"
-        assert vocab.get_token_from_index(5) == "word"
-        assert vocab.get_token_from_index(6) == "another"
+        assert vocab.get_token_from_index(5) == "tricky\x0bchar"
+        assert vocab.get_token_from_index(6) == "word"
+        assert vocab.get_token_from_index(7) == "another"
 
     def test_set_from_file_reads_non_padded_files(self):
         # pylint: disable=protected-access


### PR DESCRIPTION
As discussed in https://github.com/allenai/allennlp/issues/338, simple fix for bug in reading newline-like tokens.