### PR TITLE
REFERENCE: Bidaf + Self Attention

### DIFF
--- a/allennlp/models/bidaf_self_attention.py
+++ b/allennlp/models/bidaf_self_attention.py
@@ -1,0 +1,303 @@
+import logging
+from typing import Any, Dict, List
+
+import torch
+import torch.nn.functional as F
+from torch.autograd import Variable
+from torch.nn.functional import nll_loss
+
+from allennlp.common import Params, squad_eval
+from allennlp.data import Vocabulary
+from allennlp.models.model import Model
+from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder
+from allennlp.modules.tri_linear_attention import TriLinearAttention
+from allennlp.modules.variational_dropout import VariationalDropout
+from allennlp.nn import InitializerApplicator, util
+from allennlp.training.metrics import Average, BooleanAccuracy, CategoricalAccuracy
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+@Model.register("bidaf-self-atten")
+class BidafPlusSelfAttention(Model):
+
+    def __init__(self, vocab: Vocabulary,
+                 text_field_embedder: TextFieldEmbedder,
+                 phrase_layer: Seq2SeqEncoder,
+                 residual_encoder: Seq2SeqEncoder,
+                 span_start_encoder: Seq2SeqEncoder,
+                 span_end_encoder: Seq2SeqEncoder,
+                 initializer: InitializerApplicator,
+                 dropout: float = 0.2,
+                 mask_lstms: bool = True) -> None:
+        super(BidafPlusSelfAttention, self).__init__(vocab)
+
+        self._text_field_embedder = text_field_embedder
+        self._phrase_layer = phrase_layer
+        self._matrix_attention = TriLinearAttention(200)
+
+        self._merge_atten = TimeDistributed(torch.nn.Linear(200 * 4, 200))
+
+        self._residual_encoder = residual_encoder
+        self._self_atten = TriLinearAttention(200)
+        self._merge_self_atten = torch.nn.Linear(200 * 3, 200)
+
+        self._span_start_encoder = span_start_encoder
+        self._span_end_encoder = span_end_encoder
+
+        self._span_start_predictor = TimeDistributed(torch.nn.Linear(200, 1))
+        self._span_end_predictor = TimeDistributed(torch.nn.Linear(200, 1))
+
+        initializer(self)
+
+        self._span_start_accuracy = CategoricalAccuracy()
+        self._span_end_accuracy = CategoricalAccuracy()
+        self._span_accuracy = BooleanAccuracy()
+        self._official_em = Average()
+        self._official_f1 = Average()
+        if dropout > 0:
+            # self._dropout = torch.nn.Dropout(p=dropout)
+            self._dropout = VariationalDropout(p=dropout)
+        else:
+            raise ValueError()
+            # self._dropout = lambda x: x
+        self._mask_lstms = mask_lstms
+
+    def forward(self,  # type: ignore
+                question: Dict[str, torch.LongTensor],
+                passage: Dict[str, torch.LongTensor],
+                span_start: torch.IntTensor = None,
+                span_end: torch.IntTensor = None,
+                metadata: List[Dict[str, Any]] = None) -> Dict[str, torch.Tensor]:
+        # pylint: disable=arguments-differ
+        """
+        Parameters
+        ----------
+        question : Dict[str, torch.LongTensor]
+            From a ``TextField``.
+        passage : Dict[str, torch.LongTensor]
+            From a ``TextField``.  The model assumes that this passage contains the answer to the
+            question, and predicts the beginning and ending positions of the answer within the
+            passage.
+        span_start : ``torch.IntTensor``, optional
+            From an ``IndexField``.  This is one of the things we are trying to predict - the
+            beginning position of the answer with the passage.  This is an `inclusive` index.  If
+            this is given, we will compute a loss that gets included in the output dictionary.
+        span_end : ``torch.IntTensor``, optional
+            From an ``IndexField``.  This is one of the things we are trying to predict - the
+            ending position of the answer with the passage.  This is an `inclusive` index.  If
+            this is given, we will compute a loss that gets included in the output dictionary.
+        metadata : ``List[Dict[str, Any]]``, optional
+            If present, this should contain the question ID, original passage text, and token
+            offsets into the passage for each instance in the batch.  We use this for computing
+            official metrics using the official SQuAD evaluation script.  The length of this list
+            should be the batch size, and each dictionary should have the keys ``id``,
+            ``original_passage``, and ``token_offsets``.  If you only want the best span string and
+            don't care about official metrics, you can omit the ``id`` key.
+
+        Returns
+        -------
+        An output dictionary consisting of:
+        span_start_logits : torch.FloatTensor
+            A tensor of shape ``(batch_size, passage_length)`` representing unnormalised log
+            probabilities of the span start position.
+        span_start_probs : torch.FloatTensor
+            The result of ``softmax(span_start_logits)``.
+        span_end_logits : torch.FloatTensor
+            A tensor of shape ``(batch_size, passage_length)`` representing unnormalised log
+            probabilities of the span end position (inclusive).
+        span_end_probs : torch.FloatTensor
+            The result of ``softmax(span_end_logits)``.
+        best_span : torch.IntTensor
+            The result of a constrained inference over ``span_start_logits`` and
+            ``span_end_logits`` to find the most probable span.  Shape is ``(batch_size, 2)``.
+        loss : torch.FloatTensor, optional
+            A scalar loss to be optimised.
+        best_span_str : List[str]
+            If sufficient metadata was provided for the instances in the batch, we also return the
+            string from the original passage that the model thinks is the best answer to the
+            question.
+        """
+        embedded_question = self._dropout(self._text_field_embedder(question))
+        embedded_passage = self._dropout(self._text_field_embedder(passage))
+        batch_size = embedded_question.size(0)
+        passage_length = embedded_passage.size(1)
+        question_mask = util.get_text_field_mask(question).float()
+        passage_mask = util.get_text_field_mask(passage).float()
+        question_lstm_mask = question_mask if self._mask_lstms else None
+        passage_lstm_mask = passage_mask if self._mask_lstms else None
+
+        encoded_question = self._dropout(self._phrase_layer(embedded_question, question_lstm_mask))
+        encoded_passage = self._dropout(self._phrase_layer(embedded_passage, passage_lstm_mask))
+        encoding_dim = encoded_question.size(-1)
+
+        # Shape: (batch_size, passage_length, question_length)
+        passage_question_similarity = self._matrix_attention(encoded_passage, encoded_question)
+        # Shape: (batch_size, passage_length, question_length)
+        passage_question_attention = util.last_dim_softmax(passage_question_similarity, question_mask)
+        # Shape: (batch_size, passage_length, encoding_dim)
+        passage_question_vectors = util.weighted_sum(encoded_question, passage_question_attention)
+
+        # We replace masked values with something really negative here, so they don't affect the
+        # max below.
+        masked_similarity = util.replace_masked_values(passage_question_similarity,
+                                                       question_mask.unsqueeze(1),
+                                                       -1e7)
+        # Shape: (batch_size, passage_length)
+        question_passage_similarity = masked_similarity.max(dim=-1)[0].squeeze(-1)
+        # Shape: (batch_size, passage_length)
+        question_passage_attention = util.masked_softmax(question_passage_similarity, passage_mask)
+        # Shape: (batch_size, encoding_dim)
+        question_passage_vector = util.weighted_sum(encoded_passage, question_passage_attention)
+        # Shape: (batch_size, passage_length, encoding_dim)
+        tiled_question_passage_vector = question_passage_vector.unsqueeze(1).expand(batch_size,
+                                                                                    passage_length,
+                                                                                    encoding_dim)
+
+        # Shape: (batch_size, passage_length, encoding_dim * 4)
+        final_merged_passage = torch.cat([encoded_passage,
+                                          passage_question_vectors,
+                                          encoded_passage * passage_question_vectors,
+                                          encoded_passage * tiled_question_passage_vector],
+                                         dim=-1)
+
+        final_merged_passage = F.relu(self._merge_atten(final_merged_passage))
+
+        residual_layer = self._dropout(self._residual_encoder(self._dropout(final_merged_passage), passage_mask))
+        self_atten_matrix = self._self_atten(residual_layer, residual_layer)
+
+        mask = passage_mask.resize(batch_size, passage_length, 1) * passage_mask.resize(batch_size, 1, passage_length)
+
+        # torch.eye does not have a gpu implementation, so we are forced to use the cpu one and .cuda()
+        # Not sure if this matters for performance
+        self_mask = Variable(torch.eye(passage_length, passage_length).cuda()).resize(1, passage_length, passage_length)
+        mask = mask * (1 - self_mask)
+
+        self_atten_probs = util.last_dim_softmax(self_atten_matrix, mask)
+
+        # Batch matrix multiplication:
+        # (batch, passage_len, passage_len) * (batch, passage_len, dim) -> (batch, passage_len, dim)
+        self_atten_vecs = torch.matmul(self_atten_probs, residual_layer)
+
+        residual_layer = F.relu(self._merge_self_atten(torch.cat(
+            [self_atten_vecs, residual_layer, residual_layer * self_atten_vecs], dim=-1)))
+
+        final_merged_passage += residual_layer
+
+        final_merged_passage = self._dropout(final_merged_passage)
+
+        start_rep = self._span_start_encoder(final_merged_passage, passage_lstm_mask)
+        span_start_logits = self._span_start_predictor(start_rep).squeeze(-1)
+        span_start_probs = util.masked_softmax(span_start_logits, passage_mask)
+
+        end_rep = self._span_end_encoder(torch.cat([final_merged_passage, start_rep], dim=-1), passage_lstm_mask)
+        span_end_logits = self._span_end_predictor(end_rep).squeeze(-1)
+        span_end_probs = util.masked_softmax(span_end_logits, passage_mask)
+
+        span_start_logits = util.replace_masked_values(span_start_logits, passage_mask, -1e7)
+        span_end_logits = util.replace_masked_values(span_end_logits, passage_mask, -1e7)
+
+        best_span = self._get_best_span(span_start_logits, span_end_logits)
+
+
+        output_dict = {"span_start_logits": span_start_logits,
+                       "span_start_probs": span_start_probs,
+                       "span_end_logits": span_end_logits,
+                       "span_end_probs": span_end_probs,
+                       "best_span": best_span}
+        if span_start is not None:
+            loss = nll_loss(util.masked_log_softmax(span_start_logits, passage_mask), span_start.squeeze(-1))
+            self._span_start_accuracy(span_start_logits, span_start.squeeze(-1))
+            loss += nll_loss(util.masked_log_softmax(span_end_logits, passage_mask), span_end.squeeze(-1))
+            self._span_end_accuracy(span_end_logits, span_end.squeeze(-1))
+            self._span_accuracy(best_span, torch.stack([span_start, span_end], -1))
+            output_dict["loss"] = loss
+        if metadata is not None:
+            output_dict['best_span_str'] = []
+            for i in range(batch_size):
+                passage_str = metadata[i]['original_passage']
+                offsets = metadata[i]['token_offsets']
+                predicted_span = tuple(best_span[i].data.cpu().numpy())
+                start_offset = offsets[predicted_span[0]][0]
+                end_offset = offsets[predicted_span[1]][1]
+                best_span_string = passage_str[start_offset:end_offset]
+                output_dict['best_span_str'].append(best_span_string)
+                answer_texts = metadata[i].get('answer_texts', [])
+                exact_match = f1_score = 0
+                if answer_texts:
+                    exact_match = squad_eval.metric_max_over_ground_truths(
+                            squad_eval.exact_match_score,
+                            best_span_string,
+                            answer_texts)
+                    f1_score = squad_eval.metric_max_over_ground_truths(
+                            squad_eval.f1_score,
+                            best_span_string,
+                            answer_texts)
+                self._official_em(100 * exact_match)
+                self._official_f1(100 * f1_score)
+        return output_dict
+
+    def get_metrics(self, reset: bool = False) -> Dict[str, float]:
+        return {
+                'start_acc': self._span_start_accuracy.get_metric(reset),
+                'end_acc': self._span_end_accuracy.get_metric(reset),
+                'span_acc': self._span_accuracy.get_metric(reset),
+                'em': self._official_em.get_metric(reset),
+                'f1': self._official_f1.get_metric(reset),
+                }
+
+    @staticmethod
+    def _get_best_span(span_start_logits: Variable, span_end_logits: Variable) -> Variable:
+        if span_start_logits.dim() != 2 or span_end_logits.dim() != 2:
+            raise ValueError("Input shapes must be (batch_size, passage_length)")
+        batch_size, passage_length = span_start_logits.size()
+        max_span_log_prob = [-1e20] * batch_size
+        span_start_argmax = [0] * batch_size
+        best_word_span = Variable(span_start_logits.data.new()
+                                  .resize_(batch_size, 2).fill_(0)).long()
+
+        span_start_logits = span_start_logits.data.cpu().numpy()
+        span_end_logits = span_end_logits.data.cpu().numpy()
+
+        for b in range(batch_size):  # pylint: disable=invalid-name
+            for j in range(passage_length):
+                val1 = span_start_logits[b, span_start_argmax[b]]
+                if val1 < span_start_logits[b, j]:
+                    span_start_argmax[b] = j
+                    val1 = span_start_logits[b, j]
+
+                val2 = span_end_logits[b, j]
+
+                if val1 + val2 > max_span_log_prob[b]:
+                    best_word_span[b, 0] = span_start_argmax[b]
+                    best_word_span[b, 1] = j
+                    max_span_log_prob[b] = val1 + val2
+        return best_word_span
+
+    @classmethod
+    def from_params(cls, vocab: Vocabulary, params: Params) -> 'BidirectionalAttentionFlow':
+        embedder_params = params.pop("text_field_embedder")
+        text_field_embedder = TextFieldEmbedder.from_params(vocab, embedder_params)
+        phrase_layer = Seq2SeqEncoder.from_params(params.pop("phrase_layer"))
+        residual_encoder = Seq2SeqEncoder.from_params(params.pop("residual_encoder"))
+        span_start_encoder = Seq2SeqEncoder.from_params(params.pop("span_start_encoder"))
+        span_end_encoder = Seq2SeqEncoder.from_params(params.pop("span_end_encoder"))
+        initializer = InitializerApplicator.from_params(params.pop("initializer", []))
+        dropout = params.pop('dropout', 0.2)
+
+        # TODO: Remove the following when fully deprecated
+        evaluation_json_file = params.pop('evaluation_json_file', None)
+        if evaluation_json_file is not None:
+            logger.warning("the 'evaluation_json_file' model parameter is deprecated, please remove")
+
+        mask_lstms = params.pop('mask_lstms', True)
+        params.assert_empty(cls.__name__)
+        return cls(vocab=vocab,
+                   text_field_embedder=text_field_embedder,
+                   phrase_layer=phrase_layer,
+                   residual_encoder=residual_encoder,
+                   span_start_encoder=span_start_encoder,
+                   span_end_encoder=span_end_encoder,
+                   initializer=initializer,
+                   dropout=dropout,
+                   mask_lstms=mask_lstms)

--- a/allennlp/models/bidaf_self_attention.py
+++ b/allennlp/models/bidaf_self_attention.py
@@ -40,7 +40,7 @@ class BidafPlusSelfAttention(Model):
 
         self._residual_encoder = residual_encoder
         self._self_atten = TriLinearAttention(200)
-        self._merge_self_atten = torch.nn.Linear(200 * 3, 200)
+        self._merge_self_atten = TimeDistributed(torch.nn.Linear(200 * 3, 200))
 
         self._span_start_encoder = span_start_encoder
         self._span_end_encoder = span_end_encoder

--- a/allennlp/modules/tri_linear_attention.py
+++ b/allennlp/modules/tri_linear_attention.py
@@ -1,0 +1,56 @@
+import math
+import torch
+from overrides import overrides
+from torch.nn import Parameter
+
+
+class TriLinearAttention(torch.nn.Module):
+    """
+    TriLinear attention as used by BiDaF, this is less flexible more memory efficient then
+    the `linear` implementation since we do not create a massive
+    (batch, context_len, question_len, dim) matrix
+    """
+
+    def __init__(self, input_dim: int) -> None:
+        super(TriLinearAttention, self).__init__()
+        self.input_dim = input_dim
+        self._x_weights = Parameter(torch.Tensor(input_dim, 1))
+        self._y_weights = Parameter(torch.Tensor(input_dim, 1))
+        self._dot_weights = Parameter(torch.Tensor(1, 1, input_dim))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        std = math.sqrt(6 / (self.input_dim*3 + 1))
+        self._y_weights.data.uniform_(-std, std)
+        self._x_weights.data.uniform_(-std, std)
+        self._dot_weights.data.uniform_(-std, std)
+
+
+    @overrides
+    def forward(self, matrix_1: torch.Tensor, matrix_2: torch.Tensor) -> torch.Tensor:
+        batch_dim = matrix_1.size(0)
+        t1 = matrix_1.size(1)
+        t2 = matrix_2.size(1)
+
+        # (batch * time1, dim) * (dim, 1) -> (batch*tim1, 1)
+        x_factors = torch.matmul(matrix_1.resize(batch_dim*t1, self.input_dim), self._x_weights)
+        x_factors = x_factors.contiguous().view(batch_dim, t1, 1)  # ->  (batch, tim1, 1)
+
+        # (batch * time2, dim) * (dim, 1) -> (batch*tim2, 1)
+        y_factors = torch.matmul(matrix_2.resize(batch_dim*t2, self.input_dim), self._y_weights)
+        y_factors = y_factors.contiguous().view(batch_dim, 1, t2)  # ->  (batch, 1, tim2)
+
+        weighted_x = matrix_1 * self._dot_weights  # still (batch, time1, dim)
+
+        matrix_2_t = torch.transpose(matrix_2, 1, 2)  # -> (batch, dim, time2)
+
+        # Batch multiplication,
+        # (batch, time1, dim), (batch, dim, time2) -> (batch, time1, time2)
+        dot_factors = torch.matmul(weighted_x, matrix_2_t)
+
+        # broadcasting will correctly repeat the x/y factors as needed
+        return dot_factors + x_factors + y_factors
+
+    @classmethod
+    def from_params(cls):
+        raise NotImplementedError()

--- a/allennlp/modules/variational_dropout.py
+++ b/allennlp/modules/variational_dropout.py
@@ -1,0 +1,59 @@
+from torch.autograd import Variable
+from torch.autograd.function import InplaceFunction
+from torch.nn import Module
+
+
+class VariationalDropoutFn(InplaceFunction):
+    """" (untested) VariationalDropoutFn made largely by copy-pasting torch's dropout function."""
+
+    @staticmethod
+    def _make_noise(input):
+        return input.new().resize_(input.size(0), 1, input.size(2))
+
+    @classmethod
+    def forward(cls, ctx, input, p=0.5, train=False, inplace=False):
+        if p < 0 or p > 1:
+            raise ValueError("dropout probability has to be between 0 and 1, "
+                             "but got {}".format(p))
+        ctx.p = p
+        ctx.train = train
+        ctx.inplace = inplace
+
+        if ctx.inplace:
+            ctx.mark_dirty(input)
+            output = input
+        else:
+            output = input.clone()
+
+        if ctx.p > 0 and ctx.train:
+            ctx.noise = cls._make_noise(input)
+            if ctx.p == 1:
+                ctx.noise.fill_(0)
+            else:
+                ctx.noise.bernoulli_(1 - ctx.p).div_(1 - ctx.p)
+            ctx.noise = ctx.noise.expand_as(input)
+            output.mul_(ctx.noise)
+
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        if ctx.p > 0 and ctx.train:
+            return grad_output.mul(Variable(ctx.noise)), None, None, None
+        else:
+            return grad_output, None, None, None
+
+
+class VariationalDropout(Module):
+    def __init__(self, p=0.5, inplace=False):
+        super(VariationalDropout, self).__init__()
+        if p < 0 or p > 1:
+            raise ValueError("dropout probability has to be between 0 and 1, "
+                             "but got {}".format(p))
+        self.p = p
+        self.inplace = inplace
+
+    def forward(self, input):
+        return VariationalDropoutFn.apply(input, self.p, self.training, self.inplace)
+
+

--- a/experiment_config/bidaf_self_atten.json
+++ b/experiment_config/bidaf_self_atten.json
@@ -1,0 +1,99 @@
+{
+  "dataset_reader": {
+    "type": "squad",
+    "token_indexers": {
+      "tokens": {
+        "type": "single_id",
+        "lowercase_tokens": true
+      },
+      "token_characters": {
+        "type": "characters",
+        "character_tokenizer": {
+          "byte_encoding": "utf-8",
+          "start_tokens": [259],
+          "end_tokens": [260]
+        }
+      }
+    }
+  },
+  "train_data_path": "/home/chrisc/data/squad/train-v1.1.json",
+  "validation_data_path": "/home/chrisc/data/squad/dev-v1.1.json",
+  "model": {
+    "type": "bidaf-self-atten",
+    "text_field_embedder": {
+      "tokens": {
+        "type": "embedding",
+        "pretrained_file": "/home/chrisc/data/glove/glove.840B.300d.txt.gz",
+        "embedding_dim": 300,
+        "trainable": false
+      },
+      "token_characters": {
+        "type": "character_encoding",
+        "embedding": {
+          "num_embeddings": 262,
+          "embedding_dim": 20
+        },
+        "encoder": {
+          "type": "cnn",
+          "embedding_dim": 20,
+          "num_filters": 100,
+          "ngram_filter_sizes": [5]
+        },
+        "dropout": 0.2
+      }
+    },
+    "phrase_layer": {
+      "type": "gru",
+      "bidirectional": true,
+      "input_size": 400,
+      "hidden_size": 100,
+      "num_layers": 1
+    },
+    "residual_encoder": {
+      "type": "gru",
+      "bidirectional": true,
+      "input_size": 200,
+      "hidden_size": 100,
+      "num_layers": 1
+    },
+    "span_start_encoder": {
+      "type": "gru",
+      "bidirectional": true,
+      "input_size": 200,
+      "hidden_size": 100,
+      "num_layers": 1
+    },
+    "span_end_encoder": {
+      "type": "gru",
+      "bidirectional": true,
+      "input_size": 400,
+      "hidden_size": 100,
+      "num_layers": 1
+    },
+    "dropout": 0.2
+  },
+  "iterator": {
+    "type": "bucket",
+    "sorting_keys": [["passage", "num_tokens"], ["question", "num_tokens"]],
+    "batch_size": 45
+  },
+
+  "trainer": {
+    "num_epochs": 26,
+    "patience": 10,
+    "validation_metric": "+em",
+    "cuda_device": 0,
+    "learning_rate_scheduler":  {
+      "type": "reduce_on_plateau",
+      "factor": 0.5,
+      "mode": "max",
+      "patience": 2,
+
+    },
+    "no_tqdm": true,
+    "optimizer": {
+      "type": "adam",
+      "betas": [0.9, 0.9]
+    }
+  }
+}


### PR DESCRIPTION
Reimplementation of our refined BiDAF model w/self attention. Currently the best I was able to get on SQuAD was around 79.4 F1 as seen on Tensorboard. The original implementation reached 80.7 F1 on the dev set.

Some known differences:
- My attempt using Adadelta failed badly, it actually started doing worse on the train set over time. Adadelta was fair bit better in my version so that might be important
- No exponential moving averages
- No length constraints when choosing the best span

The self-attention part causes OOMs, so I implemented a more bidaf-specific memory efficient version.

(This is still needs more work, just creating the pull request for reference.)