### PR TITLE
don't log metrics to console in the middle of an epoch

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -285,7 +285,7 @@ class Trainer:
             if val_metrics:
                 self._tensorboard.add_validation_scalar(name, val_metrics[name], epoch)
 
-    def _metrics_to_console(self,
+    def _metrics_to_console(self,                               # pylint: disable=no-self-use
                             train_metrics: dict,
                             val_metrics: dict = None) -> None:
         """

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -277,16 +277,28 @@ class Trainer:
                                 epoch: int,
                                 train_metrics: dict,
                                 val_metrics: dict = None) -> None:
+        """
+        send all of the train metrics (and validation metrics, if provided) to tensorboard
+        """
+        for name, value in train_metrics.items():
+            self._tensorboard.add_train_scalar(name, value, epoch)
+            if val_metrics:
+                self._tensorboard.add_validation_scalar(name, val_metrics[name], epoch)
+
+    def _metrics_to_console(self,
+                            train_metrics: dict,
+                            val_metrics: dict = None) -> None:
+        """
+        log all the train metrics (and validation metrics, if provided) to the console
+        """
         if val_metrics:
             message_template = "Training %s : %3f    Validation %s : %3f "
         else:
             message_template = "Training %s : %3f "
 
         for name, value in train_metrics.items():
-            self._tensorboard.add_train_scalar(name, value, epoch)
             if val_metrics:
                 logger.info(message_template, name, value, name, val_metrics[name])
-                self._tensorboard.add_validation_scalar(name, val_metrics[name], epoch)
             else:
                 logger.info(message_template, name, value)
 
@@ -379,6 +391,7 @@ class Trainer:
 
             self._save_checkpoint(epoch, is_best=is_best_so_far)
             self._metrics_to_tensorboard(epoch, train_metrics, val_metrics=val_metrics)
+            self._metrics_to_console(train_metrics, val_metrics)
             self._update_learning_rate(epoch, val_metric=this_epoch_val_metric)
 
     def _forward(self, batch: dict, for_training: bool) -> dict:

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -278,18 +278,18 @@ class Trainer:
                                 train_metrics: dict,
                                 val_metrics: dict = None) -> None:
         """
-        send all of the train metrics (and validation metrics, if provided) to tensorboard
+        Sends all of the train metrics (and validation metrics, if provided) to tensorboard.
         """
         for name, value in train_metrics.items():
             self._tensorboard.add_train_scalar(name, value, epoch)
             if val_metrics:
                 self._tensorboard.add_validation_scalar(name, val_metrics[name], epoch)
 
-    def _metrics_to_console(self,                               # pylint: disable=no-self-use
+    def _metrics_to_console(self,  # pylint: disable=no-self-use
                             train_metrics: dict,
                             val_metrics: dict = None) -> None:
         """
-        log all the train metrics (and validation metrics, if provided) to the console
+        Logs all of the train metrics (and validation metrics, if provided) to the console.
         """
         if val_metrics:
             message_template = "Training %s : %3f    Validation %s : %3f "


### PR DESCRIPTION
based on a suggestion I added intermittent "log metrics to tensorflow" in the middle of an epoch. but that method had log statements in it, which means that you get metrics logged to the console in the middle of an epoch, which looks bad and mucks with tqdm and everything.

anyway, I split out the log statements into a separate `_metrics_to_console` function, and I only call it at the end of an epoch. (the metrics still are part of the tqdm description)