### PR TITLE
make viterbi test more specific

### DIFF
--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -394,7 +394,7 @@ class TestNnUtil(AllenNlpTestCase):
         for i in range(5):
             transition_matrix[i, i] = float("-inf")
         indices, _ = viterbi_decode(sequence_predictions, transition_matrix)
-        assert indices == [4, 3, 4, 3, 4, 3]
+        # assert indices == [4, 3, 4, 3, 4, 3]
 
         # Test that unbalanced pairwise potentials break ties
         # between paths with equal unary potentials.
@@ -404,10 +404,12 @@ class TestNnUtil(AllenNlpTestCase):
                                                   [0, 0, 0, 4, 4],
                                                   [0, 0, 0, 4, 4],
                                                   [0, 0, 0, 4, 4]])
-        # The 5th tag has a penalty for appearing sequentially.
+        # The 5th tag has a penalty for appearing sequentially
+        # or for transitioning to the 4th tag, making the best
+        # path uniquely to take the 4th tag only.
         transition_matrix = torch.zeros([5, 5])
         transition_matrix[4, 4] = -10
-
+        transition_matrix[4, 3] = -10
         indices, _ = viterbi_decode(sequence_predictions, transition_matrix)
         assert indices == [3, 3, 3, 3, 3, 3]
 

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -394,7 +394,7 @@ class TestNnUtil(AllenNlpTestCase):
         for i in range(5):
             transition_matrix[i, i] = float("-inf")
         indices, _ = viterbi_decode(sequence_predictions, transition_matrix)
-        # assert indices == [4, 3, 4, 3, 4, 3]
+        assert indices == [4, 3, 4, 3, 4, 3]
 
         # Test that unbalanced pairwise potentials break ties
         # between paths with equal unary potentials.


### PR DESCRIPTION
I noticed that the constraints part of the vitterbi test had two equally likely sequences, so I fixed it to only have one. 