### PR TITLE
add optional test data to train

### DIFF
--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -158,14 +158,20 @@ def train_model(params: Params, serialization_dir: str) -> Model:
                                   train_data,
                                   validation_data,
                                   trainer_params)
+
+    evaluate_on_test = params.pop("evaluate_on_test", False)
     params.assert_empty('base train command')
     trainer.train()
 
     # Now tar up results
     archive_model(serialization_dir)
 
-    if test_data:
+    if test_data and evaluate_on_test:
         test_data = test_data.index_instances(vocab)
         evaluate(model, test_data, iterator, cuda_device=trainer._cuda_device)  # pylint: disable=protected-access
+
+    elif test_data:
+        logger.info("To evaluate on the test set after training, pass the "
+                    "'evaluate_on_test' flag, or use the 'allennlp evaluate' command.")
 
     return model

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -36,6 +36,7 @@ from allennlp.data.iterators.data_iterator import DataIterator
 from allennlp.models.archival import archive_model
 from allennlp.models.model import Model
 from allennlp.training.trainer import Trainer
+from allennlp.commands.evaluate import evaluate
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -118,17 +119,29 @@ def train_model(params: Params, serialization_dir: str) -> Model:
     train_data_path = params.pop('train_data_path')
     logger.info("Reading training data from %s", train_data_path)
     train_data = dataset_reader.read(train_data_path)
+    all_instances = train_data.instances
+    datasets_in_vocab = ["train"]
 
     validation_data_path = params.pop('validation_data_path', None)
     if validation_data_path is not None:
         logger.info("Reading validation data from %s", validation_data_path)
         validation_data = dataset_reader.read(validation_data_path)
-        combined_data = Dataset(train_data.instances + validation_data.instances)
+        all_instances.extend(validation_data.instances)
+        datasets_in_vocab.append("validation")
     else:
         validation_data = None
-        combined_data = train_data
 
-    vocab = Vocabulary.from_params(params.pop("vocabulary", {}), combined_data)
+    test_data_path = params.pop("test_data_path", None)
+    if test_data_path is not None:
+        logger.info("Reading test data from %s", test_data_path)
+        test_data = dataset_reader.read(test_data_path)
+        all_instances.extend(test_data.instances)
+        datasets_in_vocab.append("test")
+    else:
+        test_data = None
+
+    logger.info("Creating a vocabulary using {} data.".format(", ".join(datasets_in_vocab)))
+    vocab = Vocabulary.from_params(params.pop("vocabulary", {}), Dataset(all_instances))
     vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
 
     model = Model.from_params(vocab, params.pop('model'))
@@ -150,5 +163,9 @@ def train_model(params: Params, serialization_dir: str) -> Model:
 
     # Now tar up results
     archive_model(serialization_dir)
+
+    if test_data:
+        test_data = test_data.index_instances(vocab)
+        evaluate(model, test_data, iterator, cuda_device=trainer._cuda_device)  # pylint: disable=protected-access
 
     return model

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -140,7 +140,7 @@ def train_model(params: Params, serialization_dir: str) -> Model:
     else:
         test_data = None
 
-    logger.info("Creating a vocabulary using {} data.".format(", ".join(datasets_in_vocab)))
+    logger.info("Creating a vocabulary using %s data.", ", ".join(datasets_in_vocab))
     vocab = Vocabulary.from_params(params.pop("vocabulary", {}), Dataset(all_instances))
     vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
 


### PR DESCRIPTION
It was annoying to add the test vocab to the vocabulary creation, so I made it possible to read the test data like we do for the other datasets. Given that we load it in, I figured it would make sense to call `evaluate` on it if a user passed it. 