### PR TITLE
Add an optional prediction map to SpanBasedF1Measure

### DIFF
--- a/allennlp/training/metrics/span_based_f1_measure.py
+++ b/allennlp/training/metrics/span_based_f1_measure.py
@@ -79,7 +79,9 @@ class SpanBasedF1Measure(Metric):
         if mask is None:
             mask = ones_like(gold_labels)
         # Get the data from the Variables.
-        predictions, gold_labels, mask, prediction_map = self.unwrap_to_tensors(predictions, gold_labels, mask, prediction_map)
+        predictions, gold_labels, mask, prediction_map = self.unwrap_to_tensors(predictions,
+                                                                                gold_labels,
+                                                                                mask, prediction_map)
 
         num_classes = predictions.size(-1)
         if (gold_labels >= num_classes).any():
@@ -92,7 +94,7 @@ class SpanBasedF1Measure(Metric):
         if prediction_map is not None:
             argmax_predictions = torch.gather(prediction_map, 1, argmax_predictions)
             gold_labels = torch.gather(prediction_map, 1, gold_labels.long())
-        
+
         argmax_predictions = argmax_predictions.float()
 
         # Iterate over timesteps in batch.

--- a/allennlp/training/metrics/span_based_f1_measure.py
+++ b/allennlp/training/metrics/span_based_f1_measure.py
@@ -71,9 +71,10 @@ class SpanBasedF1Measure(Metric):
         mask: ``torch.Tensor``, optional (default = None).
             A masking tensor the same size as ``gold_labels``.
         prediction_map: ``torch.Tensor``, optional (default = None).
-            If provided, this provides a mapping from the indexes of ``predictions`` to the indexes of
-            the labels in the vocabulary. This is useful if each Instance is choosing from a different
-            set of labels.
+            A tensor of size (batch_size, num_classes) which provides a mapping from the index of predictions
+            to the indexes of the label vocabulary. If provided, the output label at each timestep will be
+            ``vocabulary.get_index_to_token_vocabulary(prediction_map[batch, argmax(predictions[batch, t]))``,
+            rather than simply ``vocabulary.get_index_to_token_vocabulary(argmax(predictions[batch, t]))``.
         """
         if mask is None:
             mask = ones_like(gold_labels)
@@ -90,7 +91,7 @@ class SpanBasedF1Measure(Metric):
 
         if prediction_map is not None:
             argmax_predictions = torch.gather(prediction_map, 1, argmax_predictions)
-            gold_labels = torch.gather(prediction_map, 1, gold_labels)
+            gold_labels = torch.gather(prediction_map, 1, gold_labels.long())
         
         argmax_predictions = argmax_predictions.float()
 

--- a/allennlp/training/metrics/span_based_f1_measure.py
+++ b/allennlp/training/metrics/span_based_f1_measure.py
@@ -72,9 +72,12 @@ class SpanBasedF1Measure(Metric):
             A masking tensor the same size as ``gold_labels``.
         prediction_map: ``torch.Tensor``, optional (default = None).
             A tensor of size (batch_size, num_classes) which provides a mapping from the index of predictions
-            to the indexes of the label vocabulary. If provided, the output label at each timestep will be
+            to the indices of the label vocabulary. If provided, the output label at each timestep will be
             ``vocabulary.get_index_to_token_vocabulary(prediction_map[batch, argmax(predictions[batch, t]))``,
             rather than simply ``vocabulary.get_index_to_token_vocabulary(argmax(predictions[batch, t]))``.
+            This is useful in cases where each Instance in the dataset is associated with a different possible
+            subset of labels from a large label-space (IE FrameNet, where each frame has a different set of
+            possible roles associated with it).
         """
         if mask is None:
             mask = ones_like(gold_labels)

--- a/tests/training/metrics/span_based_f1_measure_test.py
+++ b/tests/training/metrics/span_based_f1_measure_test.py
@@ -49,8 +49,8 @@ class SpanBasedF1Test(AllenNlpTestCase):
         # In this example, datapoint1 only has access to ARG1 and V labels,
         # whereas datapoint2 only has access to ARG2 and V labels.
 
-        gold_labels = [["O", "B-ARG1", "I-ARG1", "O", "B-V", "O"],
-                       ["B-ARG2", "I-ARG2", "O", "B-V", "I-V", "O"]]
+        # gold_labels = [["O", "B-ARG1", "I-ARG1", "O", "B-V", "O"],
+        #               ["B-ARG2", "I-ARG2", "O", "B-V", "I-V", "O"]]
         gold_indices = [[0, 1, 2, 0, 3, 0],
                         [1, 2, 0, 3, 4, 0]]
         prediction_map_indices = [[0, 1, 2, 5, 6],
@@ -74,7 +74,7 @@ class SpanBasedF1Test(AllenNlpTestCase):
         prediction_tensor[1, 5, 1] = 1 # (False Positive - ARG2)
 
         metric = SpanBasedF1Measure(self.vocab, "tags")
-        metric(prediction_tensor, gold_tensor, prediction_map = prediction_map_tensor)
+        metric(prediction_tensor, gold_tensor, prediction_map=prediction_map_tensor)
 
         assert metric._true_positives["ARG1"] == 1
         assert metric._true_positives["ARG2"] == 0
@@ -90,7 +90,7 @@ class SpanBasedF1Test(AllenNlpTestCase):
         assert "O" not in metric._false_positives.keys()
 
         # Check things are accumulating correctly.
-        metric(prediction_tensor, gold_tensor, prediction_map = prediction_map_tensor)
+        metric(prediction_tensor, gold_tensor, prediction_map=prediction_map_tensor)
         assert metric._true_positives["ARG1"] == 2
         assert metric._true_positives["ARG2"] == 0
         assert metric._true_positives["V"] == 4

--- a/tests/training/metrics/span_based_f1_measure_test.py
+++ b/tests/training/metrics/span_based_f1_measure_test.py
@@ -45,6 +45,82 @@ class SpanBasedF1Test(AllenNlpTestCase):
         spans = metric._extract_spans(indices)
         assert spans == {((6, 7), "ARG2"), ((9, 9), "ARG2")}
 
+    def test_span_metrics_are_computed_correcly_with_prediction_map(self):
+        # In this example, datapoint1 only has access to ARG1 and V labels,
+        # whereas datapoint2 only has access to ARG2 and V labels.
+
+        gold_labels = [["O", "B-ARG1", "I-ARG1", "O", "B-V", "O"],
+                       ["B-ARG2", "I-ARG2", "O", "B-V", "I-V", "O"]]
+        gold_indices = [[0, 1, 2, 0, 3, 0],
+                        [1, 2, 0, 3, 4, 0]]
+        prediction_map_indices = [[0, 1, 2, 5, 6],
+                                  [0, 3, 4, 5, 6]]
+
+        gold_tensor = torch.Tensor(gold_indices)
+        prediction_map_tensor = torch.Tensor(prediction_map_indices)
+
+        prediction_tensor = torch.rand([2, 6, 5])
+        prediction_tensor[0, 0, 0] = 1
+        prediction_tensor[0, 1, 1] = 1 # (True Positive - ARG1
+        prediction_tensor[0, 2, 2] = 1 # *)
+        prediction_tensor[0, 3, 0] = 1
+        prediction_tensor[0, 4, 3] = 1 # (True Positive - V)
+        prediction_tensor[0, 5, 1] = 1 # (False Positive - ARG1)
+        prediction_tensor[1, 0, 0] = 1 # (False Negative - ARG2
+        prediction_tensor[1, 1, 0] = 1 # *)
+        prediction_tensor[1, 2, 0] = 1
+        prediction_tensor[1, 3, 3] = 1 # (True Positive - V
+        prediction_tensor[1, 4, 4] = 1 # *)
+        prediction_tensor[1, 5, 1] = 1 # (False Positive - ARG2)
+
+        metric = SpanBasedF1Measure(self.vocab, "tags")
+        metric(prediction_tensor, gold_tensor, prediction_map = prediction_map_tensor)
+
+        assert metric._true_positives["ARG1"] == 1
+        assert metric._true_positives["ARG2"] == 0
+        assert metric._true_positives["V"] == 2
+        assert "O" not in metric._true_positives.keys()
+        assert metric._false_negatives["ARG1"] == 0
+        assert metric._false_negatives["ARG2"] == 1
+        assert metric._false_negatives["V"] == 0
+        assert "O" not in metric._false_negatives.keys()
+        assert metric._false_positives["ARG1"] == 1
+        assert metric._false_positives["ARG2"] == 1
+        assert metric._false_positives["V"] == 0
+        assert "O" not in metric._false_positives.keys()
+
+        # Check things are accumulating correctly.
+        metric(prediction_tensor, gold_tensor, prediction_map = prediction_map_tensor)
+        assert metric._true_positives["ARG1"] == 2
+        assert metric._true_positives["ARG2"] == 0
+        assert metric._true_positives["V"] == 4
+        assert "O" not in metric._true_positives.keys()
+        assert metric._false_negatives["ARG1"] == 0
+        assert metric._false_negatives["ARG2"] == 2
+        assert metric._false_negatives["V"] == 0
+        assert "O" not in metric._false_negatives.keys()
+        assert metric._false_positives["ARG1"] == 2
+        assert metric._false_positives["ARG2"] == 2
+        assert metric._false_positives["V"] == 0
+        assert "O" not in metric._false_positives.keys()
+
+        metric_dict = metric.get_metric()
+
+        numpy.testing.assert_almost_equal(metric_dict["recall-ARG2"], 0.0)
+        numpy.testing.assert_almost_equal(metric_dict["precision-ARG2"], 0.0)
+        numpy.testing.assert_almost_equal(metric_dict["f1-measure-ARG2"], 0.0)
+        numpy.testing.assert_almost_equal(metric_dict["recall-ARG1"], 1.0)
+        numpy.testing.assert_almost_equal(metric_dict["precision-ARG1"], 0.5)
+        numpy.testing.assert_almost_equal(metric_dict["f1-measure-ARG1"], 0.666666666)
+        numpy.testing.assert_almost_equal(metric_dict["recall-V"], 1.0)
+        numpy.testing.assert_almost_equal(metric_dict["precision-V"], 1.0)
+        numpy.testing.assert_almost_equal(metric_dict["f1-measure-V"], 1.0)
+        numpy.testing.assert_almost_equal(metric_dict["recall-overall"], 0.75)
+        numpy.testing.assert_almost_equal(metric_dict["precision-overall"], 0.6)
+        numpy.testing.assert_almost_equal(metric_dict["f1-measure-overall"], 0.666666666)
+
+
+
     def test_span_metrics_are_computed_correctly(self):
         gold_labels = ["O", "B-ARG1", "I-ARG1", "O", "B-ARG2", "I-ARG2", "O", "O", "O"]
         gold_indices = [self.vocab.get_token_index(x, "tags") for x in gold_labels]


### PR DESCRIPTION
This adds an optional prediction_map to the SpanBasedF1Measure. If provided, this gives a mapping from the ''num_classes'' dimension of ''predictions'' to the indices of the label vocabulary. In other words, the label at each timestep is ``vocabulary.get_index_to_token_vocabulary(prediction_map[batch, argmax(predictions[batch, t]))``, rather than simply ``vocabulary.get_index_to_token_vocabulary(argmax(predictions[batch, t]))``.

This is useful when you have a task where each datapoint can select from a different subset of possible labels (for instance, FrameNet Frame Semantic Parsing, where each Frame has a different set of Roles associated with it).