### PR TITLE
Fixes empty_field method of LabelField and adds a test

### DIFF
--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -78,4 +78,4 @@ class LabelField(Field[numpy.ndarray]):
 
     @overrides
     def empty_field(self):
-        return LabelField(0, self._label_namespace)
+        return LabelField(-1, self._label_namespace, skip_indexing=True)

--- a/tests/data/fields/label_field_test.py
+++ b/tests/data/fields/label_field_test.py
@@ -32,3 +32,7 @@ class TestLabelField(AllenNlpTestCase):
     def test_label_field_raises_with_incorrect_label_type(self):
         with pytest.raises(ConfigurationError):
             _ = LabelField([], skip_indexing=False)
+
+    def test_label_field_empty_field_works(self):
+        label = LabelField("test")
+        label.empty_field()

--- a/tests/data/fields/label_field_test.py
+++ b/tests/data/fields/label_field_test.py
@@ -35,4 +35,5 @@ class TestLabelField(AllenNlpTestCase):
 
     def test_label_field_empty_field_works(self):
         label = LabelField("test")
-        label.empty_field()
+        empty_label = label.empty_field()
+        assert empty_label.label == -1


### PR DESCRIPTION
Fixes #382.

This fixes the empty_field method of LabelField, which currently fails because skip_indexing is not True.