### PR TITLE
Add a `cuda_device` option to `predict`.

### DIFF
--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -49,7 +49,7 @@ def add_subparser(parser: argparse._SubParsersAction,
     return subparser
 
 def get_predictor(args: argparse.Namespace, predictors: Dict[str, str]) -> Predictor:
-    archive = load_archive(args.archive_file)
+    archive = load_archive(args.archive_file, cuda_device=args.cuda_device)
     model_type = archive.config.get("model").get("type")
     if model_type not in predictors:
         raise ConfigurationError("no known predictor for model type {}".format(model_type))

--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -42,6 +42,7 @@ def add_subparser(parser: argparse._SubParsersAction,
                            help='path to input file')
     subparser.add_argument('--output-file', type=argparse.FileType('w'), help='path to output file')
     subparser.add_argument('--silent', action='store_true', help='do not print output to stdout')
+    subparser.add_argument('--cuda_device', type=int, default=-1, help='id of GPU to use (if any)')
 
     subparser.set_defaults(func=predict(predictors))
 
@@ -55,11 +56,15 @@ def get_predictor(args: argparse.Namespace, predictors: Dict[str, str]) -> Predi
     predictor = Predictor.from_archive(archive, predictors[model_type])
     return predictor
 
-def run(predictor: Predictor, input_file: IO, output_file: Optional[IO], print_to_console: bool) -> None:
+def run(predictor: Predictor,
+        input_file: IO,
+        output_file: Optional[IO],
+        print_to_console: bool,
+        cuda_device: int) -> None:
     for line in input_file:
         if not line.isspace():
             data = json.loads(line)
-            result = predictor.predict_json(data)
+            result = predictor.predict_json(data, cuda_device)
             output = json.dumps(result)
 
             if print_to_console:
@@ -83,6 +88,6 @@ def predict(predictors: Dict[str, str]):
             if args.output_file:
                 output_file = stack.enter_context(args.output_file)  # type: ignore
 
-            run(predictor, input_file, output_file, not args.silent)
+            run(predictor, input_file, output_file, not args.silent, args.cuda_device)
 
     return predict_inner

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -100,7 +100,7 @@ class Model(torch.nn.Module, Registrable):
         """
         raise NotImplementedError
 
-    def forward_on_instance(self, instance: Instance) -> Dict[str, numpy.ndarray]:
+    def forward_on_instance(self, instance: Instance, cuda_device: int) -> Dict[str, numpy.ndarray]:
         """
         Takes an :class:`~allennlp.data.instance.Instance`, which typically has raw text in it,
         converts that text into arrays using this model's :class:`Vocabulary`, passes those arrays
@@ -111,7 +111,6 @@ class Model(torch.nn.Module, Registrable):
         # Hack to see what cuda device the model is on, so we know where to put these inputs.  For
         # complicated models, or machines with multiple GPUs, this will not work.  I couldn't find
         # a way to actually query what device a tensor / parameter is on.
-        cuda_device = 0 if next(self.parameters()).is_cuda else -1
         instance.index_fields(self.vocab)
         model_input = arrays_to_variables(instance.as_array_dict(),
                                           add_batch_dimension=True,

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -108,9 +108,6 @@ class Model(torch.nn.Module, Registrable):
         and returns the result.  Before returning the result, we convert any ``torch.autograd.Variables``
         or ``torch.Tensors`` into numpy arrays and remove the batch dimension.
         """
-        # Hack to see what cuda device the model is on, so we know where to put these inputs.  For
-        # complicated models, or machines with multiple GPUs, this will not work.  I couldn't find
-        # a way to actually query what device a tensor / parameter is on.
         instance.index_fields(self.vocab)
         model_input = arrays_to_variables(instance.as_array_dict(),
                                           add_batch_dimension=True,

--- a/allennlp/service/predictors/predictor.py
+++ b/allennlp/service/predictors/predictor.py
@@ -14,9 +14,9 @@ class Predictor(Registrable):
         self._model = model
         self._dataset_reader = dataset_reader
 
-    def predict_json(self, inputs: JsonDict) -> JsonDict:
+    def predict_json(self, inputs: JsonDict, cuda_device: int = 0) -> JsonDict:
         instance = self._json_to_instance(inputs)
-        outputs = self._model.forward_on_instance(instance)
+        outputs = self._model.forward_on_instance(instance, cuda_device)
         return sanitize(outputs)
 
     def _json_to_instance(self, json: JsonDict) -> Instance:

--- a/allennlp/service/predictors/predictor.py
+++ b/allennlp/service/predictors/predictor.py
@@ -14,7 +14,7 @@ class Predictor(Registrable):
         self._model = model
         self._dataset_reader = dataset_reader
 
-    def predict_json(self, inputs: JsonDict, cuda_device: int = 0) -> JsonDict:
+    def predict_json(self, inputs: JsonDict, cuda_device: int = -1) -> JsonDict:
         instance = self._json_to_instance(inputs)
         outputs = self._model.forward_on_instance(instance, cuda_device)
         return sanitize(outputs)

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -48,7 +48,7 @@ class SemanticRoleLabelerPredictor(Predictor):
         raise RuntimeError("this should never be called")
 
     @overrides
-    def predict_json(self, inputs: JsonDict) -> JsonDict:
+    def predict_json(self, inputs: JsonDict, cuda_device: int = -1) -> JsonDict:
         """
         Expects JSON that looks like ``{"sentence": "..."}``
         and returns JSON that looks like
@@ -73,7 +73,7 @@ class SemanticRoleLabelerPredictor(Predictor):
                 verb_labels = [0 for _ in words]
                 verb_labels[i] = 1
                 instance = self._dataset_reader.text_to_instance(tokens, verb_labels)
-                output = self._model.forward_on_instance(instance)
+                output = self._model.forward_on_instance(instance, cuda_device)
                 tags = output['tags']
 
                 description = SemanticRoleLabelerPredictor.make_srl_string(words, tags)

--- a/kubernetes-dev-environment.yaml
+++ b/kubernetes-dev-environment.yaml
@@ -2,10 +2,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: allennlp-dev-env # TODO: make this unique by appending your username
+  name: allennlp-michaels-env # TODO: make this unique by appending your username
   namespace: allennlp
   labels:
-    contact: # TODO: enter your username
+    contact: michaels # TODO: enter your username
 spec:
   template:
     metadata:

--- a/kubernetes-dev-environment.yaml
+++ b/kubernetes-dev-environment.yaml
@@ -2,10 +2,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: allennlp-michaels-env # TODO: make this unique by appending your username
+  name: allennlp-dev-env # TODO: make this unique by appending your username
   namespace: allennlp
   labels:
-    contact: michaels # TODO: enter your username
+    contact: # TODO: enter your username
 spec:
   template:
     metadata:

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -78,7 +78,7 @@ class TestPredict(TestCase):
         @Predictor.register('bidaf-override')  # pylint: disable=unused-variable
         class Bidaf2Predictor(BidafPredictor):
             """same as bidaf predictor but with an extra field"""
-            def predict_json(self, inputs: JsonDict) -> JsonDict:
+            def predict_json(self, inputs: JsonDict, cuda_device: int = -1) -> JsonDict:
                 result = super().predict_json(inputs)
                 result["overridden"] = True
                 return result

--- a/tests/service/server_sanic_test.py
+++ b/tests/service/server_sanic_test.py
@@ -25,7 +25,7 @@ class CountingPredictor(Predictor):
     def __init__(self):                 # pylint: disable=super-init-not-called
         self.calls = defaultdict(int)
 
-    def predict_json(self, inputs: JsonDict) -> JsonDict:
+    def predict_json(self, inputs: JsonDict, cuda_device: int = -1) -> JsonDict:
         key = json.dumps(inputs)
         self.calls[key] += 1
         return inputs


### PR DESCRIPTION
This removes some brittle code that only works on machines with 1 GPU and lets you make predictions with a GPU.

On a `p2.xlarge` with a GPU a BiDAF prediction takes 0.20 seconds.  Without a GPU on the same machine a prediction takes 0.44 seconds.  Not a huge difference, because the code is set up to make one prediction at a time.

Fixes #303.