### PR TITLE
Use a Python base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM ubuntu:16.04
+FROM python:3.6.3-jessie
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-# Add nvidia and conda binaries to path.
-ENV PATH /usr/local/nvidia/bin/:/opt/conda/bin:$PATH
+ENV PATH /usr/local/nvidia/bin/:$PATH
 ENV PYTHONHASHSEED 2157
 
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib64:$LD_LIBRARY_PATH
@@ -26,15 +25,6 @@ RUN apt-get update --fix-missing && apt-get install -y \
     libevent-dev \
     build-essential && \
     rm -rf /var/lib/apt/lists/*
-
-# Install Anaconda.
-RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
-    rm ~/miniconda.sh
-
-# Use python 3.6
-RUN conda install python=3.6
 
 # Install npm
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV LANG=C.UTF-8
 ENV PATH /usr/local/nvidia/bin/:$PATH
 ENV PYTHONHASHSEED 2157
 
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib64:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib64
 
 WORKDIR /stage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,9 @@ numpy
 pillow # A dependency of tensorboard-pytorch which is not recorded.
 tensorboard-pytorch
 
+# Required by torch.utils.ffi
+cffi==1.11.2
+
 # aws commandline tools for running on Docker remotely.
 awscli>=1.11.91
 


### PR DESCRIPTION
* Remove conda.
* Use Debian instead of Ubuntu.

This trims another 200 MB from our Docker file.

```
~/h/a/allennlp (python-docker $%) docker images                                                                                                                                                                                     (allennlp) 
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
allennlp/allennlp   python-jesse        74f6e1cbc41e        36 minutes ago      2.45GB
allennlp/allennlp   latest              547826cf4c97        About an hour ago   2.64GB
python              3.6.3-jessie        be512ebcbac9        5 days ago          690MB
```