### PR TITLE
don't mutate training data with test data

### DIFF
--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -127,7 +127,7 @@ def train_model(params: Params, serialization_dir: str) -> Model:
     if validation_data_path is not None:
         logger.info("Reading validation data from %s", validation_data_path)
         validation_data = dataset_reader.read(validation_data_path)
-        all_datasets.append(validation_data.instances)
+        all_datasets.append(validation_data)
         datasets_in_vocab.append("validation")
     else:
         validation_data = None
@@ -136,7 +136,7 @@ def train_model(params: Params, serialization_dir: str) -> Model:
     if test_data_path is not None:
         logger.info("Reading test data from %s", test_data_path)
         test_data = dataset_reader.read(test_data_path)
-        all_datasets.append(test_data.instances)
+        all_datasets.append(test_data)
         datasets_in_vocab.append("test")
     else:
         test_data = None

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -143,7 +143,8 @@ def train_model(params: Params, serialization_dir: str) -> Model:
 
     logger.info("Creating a vocabulary using %s data.", ", ".join(datasets_in_vocab))
     vocab = Vocabulary.from_params(params.pop("vocabulary", {}),
-                                   Dataset([instance for dataset in all_datasets for instance in dataset.instances]))
+                                   Dataset([instance for dataset in all_datasets
+                                            for instance in dataset.instances]))
     vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
 
     model = Model.from_params(vocab, params.pop('model'))


### PR DESCRIPTION
My previous version of this was mutating `train_data.instances`, meaning that it was including the validation and test data. 😞  This version doesn't modify the datasets and also avoids copying them.