### PR TITLE
Use bmm to do an efficient weighted sum in cases where it applies

### DIFF
--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -308,6 +308,12 @@ def weighted_sum(matrix: torch.Tensor, attention: torch.Tensor) -> torch.Tensor:
     ``(batch_size, num_queries, embedding_dim)`` and
     ``(batch_size, num_documents, num_queries, embedding_dim)`` respectively.
     """
+    # We'll special-case a few settings here, where there are efficient (but poorly-named)
+    # operations in pytorch that already do the computation we need.
+    if attention.dim() == 2 and matrix.dim() == 3:
+        return attention.unsqueeze(1).bmm(matrix).squeeze(1)
+    if attention.dim() == 3 and matrix.dim() == 3:
+        return attention.bmm(matrix)
     if matrix.dim() - 1 < attention.dim():
         expanded_size = list(matrix.size())
         for i in range(attention.dim() - matrix.dim() + 1):

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -373,6 +373,23 @@ class TestNnUtil(AllenNlpTestCase):
                 numpy.testing.assert_almost_equal(aggregated_array[0, i, j], expected_array,
                                                   decimal=5)
 
+    def test_weighted_sum_handles_3d_attention_with_3d_matrix(self):
+        batch_size = 1
+        length_1 = 5
+        length_2 = 2
+        embedding_dim = 4
+        sentence_array = numpy.random.rand(batch_size, length_2, embedding_dim)
+        attention_array = numpy.random.rand(batch_size, length_1, length_2)
+        sentence_tensor = Variable(torch.from_numpy(sentence_array).float())
+        attention_tensor = Variable(torch.from_numpy(attention_array).float())
+        aggregated_array = weighted_sum(sentence_tensor, attention_tensor).data.numpy()
+        assert aggregated_array.shape == (batch_size, length_1, embedding_dim)
+        for i in range(length_1):
+            expected_array = (attention_array[0, i, 0] * sentence_array[0, 0] +
+                              attention_array[0, i, 1] * sentence_array[0, 1])
+            numpy.testing.assert_almost_equal(aggregated_array[0, i], expected_array,
+                                              decimal=5)
+
     def test_viterbi_decode(self):
         # Test Viterbi decoding is equal to greedy decoding with no pairwise potentials.
         sequence_predictions = torch.nn.functional.softmax(Variable(torch.rand([5, 9])))


### PR DESCRIPTION
Following points made by @kentonl in #364.

I also tried to switch `masked_softmax` to just use `vector += mask.log(); return F.softmax(vector)`.  I ran into trouble there, because it doesn't handle cases where the mask is zero everywhere (or zero for all entries in a row in the matrix, e.g., because a whole row is padded), which is important for some of our uses.  There didn't seem to be an easy way to fix that without just doing what we're already doing.  Maybe I'll figure something out, but I'm not optimistic.