### PR TITLE
Using F.softmax directly to do the softmax, with more efficient fixes

### DIFF
--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -187,8 +187,7 @@ class TestNnUtil(AllenNlpTestCase):
         mask_1d = Variable(torch.FloatTensor([[1.0, 0.0, 1.0, 1.0]]))
         vector_1d_softmaxed = masked_softmax(vector_1d, mask_1d).data.numpy()
         assert_array_almost_equal(vector_1d_softmaxed,
-                                  numpy.array([[0.01321289, 0.0,
-                                                0.26538793, 0.72139918]]))
+                                  numpy.array([[0.01321289, 0.0, 0.26538793, 0.72139918]]))
 
         # Testing the masked 1D case where the input is all 0s and the mask
         # is not all 0s.
@@ -204,8 +203,7 @@ class TestNnUtil(AllenNlpTestCase):
         mask_1d = Variable(torch.FloatTensor([[0.0, 0.0, 0.0, 0.0]]))
         vector_1d_softmaxed = masked_softmax(vector_1d, mask_1d).data.numpy()
         assert_array_almost_equal(vector_1d_softmaxed,
-                                  numpy.array([[0.0, 0.0,
-                                                0.0, 0.0]]))
+                                  numpy.array([[0.0, 0.0, 0.0, 0.0]]))
 
         # Testing the masked 1D case where the input is all 0s and
         # the mask is all 0s.
@@ -213,8 +211,7 @@ class TestNnUtil(AllenNlpTestCase):
         mask_1d = Variable(torch.FloatTensor([[0.0, 0.0, 0.0, 0.0]]))
         vector_1d_softmaxed = masked_softmax(vector_1d, mask_1d).data.numpy()
         assert_array_almost_equal(vector_1d_softmaxed,
-                                  numpy.array([[0.0, 0.0,
-                                                0.0, 0.0]]))
+                                  numpy.array([[0.0, 0.0, 0.0, 0.0]]))
 
         # Testing the general masked batched case.
         matrix = Variable(torch.FloatTensor([[1.0, 2.0, 5.0], [1.0, 2.0, 3.0]]))
@@ -274,6 +271,14 @@ class TestNnUtil(AllenNlpTestCase):
         vector_1d_softmaxed = masked_log_softmax(vector_1d, mask_1d).data.numpy()
         assert_array_almost_equal(numpy.exp(vector_1d_softmaxed),
                                   numpy.array([[0., 0., 0., 1.]]))
+
+        # Testing the masked 1D case where the input is not all 0s
+        # and the mask is all 0s.
+        vector_1d = Variable(torch.FloatTensor([[0.0, 2.0, 3.0, 4.0]]))
+        mask_1d = Variable(torch.FloatTensor([[0.0, 0.0, 0.0, 0.0]]))
+        vector_1d_softmaxed = masked_softmax(vector_1d, mask_1d).data.numpy()
+        assert_array_almost_equal(numpy.exp(vector_1d_softmaxed),
+                                  numpy.array([[1.0, 1.0, 1.0, 1.0]]))
 
     def test_get_text_field_mask_returns_a_correct_mask(self):
         text_field_arrays = {


### PR DESCRIPTION
Also due to things pointed out by @kentonl in #364 (as well as a reminder in the pytorch slack channel that there's an easy way to renormalize after-the-fact).  I was able to remove our manual softmax operation by being smarter about how to use the mask (the exact operation is different in the `masked_softmax` vs. the `masked_log_softmax` cases).