### PR TITLE
Coref util tests

### DIFF
--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -92,6 +92,7 @@ class ConllCorefReader(DatasetReader):
 
         Returns
         ------
+
         An ``Instance`` containing the following ``Fields``:
             text : ``TextField``
                 The text of the full document.

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -92,9 +92,7 @@ class ConllCorefReader(DatasetReader):
 
         Returns
         ------
-
         An ``Instance`` containing the following ``Fields``:
-
             text : ``TextField``
                 The text of the full document.
             span_starts : ``ListField[IndexField]``
@@ -117,6 +115,9 @@ class ConllCorefReader(DatasetReader):
         cluster_dict = {}
         if gold_clusters is not None:
             for cluster_id, cluster in enumerate(gold_clusters):
+                # TODO(Mark): This doesn't take into account gold clusters which have spans
+                # longer than the max_span_width, which means we can get |1| clusters
+                # when we filter below. Check with Kenton.
                 assert len(cluster) > 1
                 for mention in cluster:
                     cluster_dict[tuple(mention)] = cluster_id
@@ -175,15 +176,12 @@ class ConllCorefReader(DatasetReader):
             # End of a sentence. Clear the sentence buffer and
             # add sentence to document sentences.
             document_state.complete_sentence()
-
         else:
             if len(row) < 12:
                 raise ConfigurationError("Encountered a non-empty line with fewer than 12 entries"
                                          " - this does not match the CONLL format.: {}".format(row))
-
             word = self.normalize_word(row[3])
             coref = row[-1]
-
             word_index = document_state.num_total_words
             document_state.add_word(word)
 
@@ -214,9 +212,9 @@ class ConllCorefReader(DatasetReader):
 class _DocumentState:
 
     """
-    Represents the state of a document. Words are collected in
-    a sentence buffer, which are incrementally collected in a
-    list when sentences end, representing all tokens in the document.
+    Represents the state of a document. Words are collected in a sentence buffer,
+    which are incrementally collected in a list when sentences end, representing
+    all tokens in the document.
 
     Additionally, this class contains a per-id stacks to hold the start indices of
     active spans (spans which we are inside of when processing a given word). Spans

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -30,6 +30,7 @@ class CoreferenceResolver(Model):
     to occur in a coreference cluster. For the remaining spans, the model decides which antecedent
     span (if any) they are coreferent with. The resulting coreference links, after applying
     transitivity, imply a clustering of the spans in the document.
+
     Parameters
     ----------
     vocab : ``Vocabulary``
@@ -294,7 +295,7 @@ class CoreferenceResolver(Model):
         similarity_embeddings = antecedent_embeddings * target_embeddings
 
         # Shape: (1, max_antecedents, embedding_size)
-        antecedent_distance_embeddings = self._distance_embedding(util.bucket_distance(antecedent_offsets))
+        antecedent_distance_embeddings = self._distance_embedding(util.bucket_values(antecedent_offsets))
 
         # Shape: (1, 1, max_antecedents, embedding_size)
         antecedent_distance_embeddings = antecedent_distance_embeddings.unsqueeze(0)
@@ -498,7 +499,7 @@ class CoreferenceResolver(Model):
                                                                                                  max_antecedents,
                                                                                                  text_mask.is_cuda)
         # Select tensors relating to the antecedent spans.
-        # Shape: (batch_size, num_spans_to_keep, embedding_size)
+        # Shape: (batch_size, num_spans_to_keep, max_antecedents, embedding_size)
         antecedent_embeddings = util.flattened_index_select(top_span_embeddings, antecedent_indices)
 
         # Shape: (batch_size, num_spans_to_keep, max_antecedents)

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -126,7 +126,7 @@ class CoreferenceResolver(Model):
         head_indices = F.relu(raw_head_indices.float()).long()
 
         # Shape: (batch_size * num_spans * max_span_width)
-        flat_head_indices = util.flatten_batched_indices(head_indices, text_embeddings.size(1))
+        flat_head_indices = util.flatten_and_batch_shift_indices(head_indices, text_embeddings.size(1))
 
         # Shape: (batch_size, num_spans, max_span_width, embedding_size)
         span_text_embeddings = util.batched_index_select(text_embeddings, head_indices, flat_head_indices)
@@ -473,7 +473,7 @@ class CoreferenceResolver(Model):
         top_span_indices = self._prune_and_sort_spans(mention_scores, num_spans_to_keep)
 
         # Shape: (batch_size * num_spans_to_keep)
-        flat_top_span_indices = util.flatten_batched_indices(top_span_indices, span_starts.size(1))
+        flat_top_span_indices = util.flatten_and_batch_shift_indices(top_span_indices, span_starts.size(1))
 
         # Select the span embeddings corresponding to the
         # top spans based on the mention scorer.

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -498,8 +498,8 @@ def _get_combination_dim(combination: str, tensor_dims: List[int]) -> int:
         return first_tensor_dim
 
 
-def flatten_batched_indices(indices: torch.Tensor,
-                            sequence_length: int) -> torch.Tensor:
+def flatten_and_batch_shift_indices(indices: torch.Tensor,
+                                    sequence_length: int) -> torch.Tensor:
     """
     This is a subroutine for :func:`~batched_index_select`. The given ``indices`` of size
     ``(batch_size, d_1, ..., d_n)`` indexes into dimension 2 of a target tensor, which has size
@@ -560,7 +560,7 @@ def batched_index_select(target: torch.Tensor,
         A tensor of shape (batch_size, ...), where each element is an index into the
         ``sequence_length`` dimension of the ``target`` tensor.
     flattened_indices : Optional[torch.Tensor], optional (default = None)
-        An optional tensor representing the result of calling :func:~`flatten_batched_indices`
+        An optional tensor representing the result of calling :func:~`flatten_and_batch_shift_indices`
         on ``indices``. This is helpful in the case that the indices can be flattened once and
         cached for many batch lookups.
 
@@ -572,7 +572,7 @@ def batched_index_select(target: torch.Tensor,
     """
     if flattened_indices is None:
         # Shape: (batch_size * d_1 * ... * d_n)
-        flattened_indices = flatten_batched_indices(indices, target.size(1))
+        flattened_indices = flatten_and_batch_shift_indices(indices, target.size(1))
 
     # Shape: (batch_size * sequence_length, embedding_size)
     flattened_target = target.view(-1, target.size(-1))
@@ -588,10 +588,10 @@ def batched_index_select(target: torch.Tensor,
 def flattened_index_select(target: torch.Tensor,
                            indices: torch.LongTensor) -> torch.Tensor:
     """
-    The given `indices` of size `(set_size, subset_size)` specifies subsets of the `target`
+    The given ``indices`` of size ``(set_size, subset_size)`` specifies subsets of the ``target``
     that each of the set_size rows should select. The `target` has size
-    `(batch_size, sequence_length, embedding_size)`, and the resulting selected tensor has size
-    `(batch_size, set_size, subset_size, embedding_size)`.
+    ``(batch_size, sequence_length, embedding_size)``, and the resulting selected tensor has size
+    ``(batch_size, set_size, subset_size, embedding_size)``.
 
     Parameters
     ----------

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -507,6 +507,17 @@ def flatten_and_batch_shift_indices(indices: torch.Tensor,
     correctly indexes into the flattened target. The sequence length of the target must be
     provided to compute the appropriate offsets.
 
+    example:
+    .. code-block:: python
+        indices = torch.ones([2,3]).long()
+        # Sequence length of the target tensor.
+        sequence_length = 10
+        shifted_indices = flatten_and_batch_shift_indices(indices, sequence_length)
+        # Indices into the second element in the batch are correctly shifted
+        # to take into account that the target tensor will be flattened before
+        # the indices are applied.
+        assert shifted_indices == [1, 1, 1, 11, 11, 11]
+
     Parameters
     ----------
     indices : ``torch.LongTensor``, required.

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -527,6 +527,8 @@ class TestNnUtil(AllenNlpTestCase):
                                 [7, 8]]])
         # Each element is a vector of it's index.
         targets = torch.ones([2, 10, 3]).cumsum(1) - 1
+        # Make the second batch double it's index so they're different.
+        targets[1, :, :] *= 2
         indices = Variable(torch.LongTensor(indices))
         targets = Variable(targets)
         selected = batched_index_select(targets, indices)
@@ -537,15 +539,18 @@ class TestNnUtil(AllenNlpTestCase):
         numpy.testing.assert_array_equal(selected[0, 0, 1, :].data.numpy(), ones * 2)
         numpy.testing.assert_array_equal(selected[0, 1, 0, :].data.numpy(), ones * 3)
         numpy.testing.assert_array_equal(selected[0, 1, 1, :].data.numpy(), ones * 4)
-        numpy.testing.assert_array_equal(selected[1, 0, 0, :].data.numpy(), ones * 5)
-        numpy.testing.assert_array_equal(selected[1, 0, 1, :].data.numpy(), ones * 6)
-        numpy.testing.assert_array_equal(selected[1, 1, 0, :].data.numpy(), ones * 7)
-        numpy.testing.assert_array_equal(selected[1, 1, 1, :].data.numpy(), ones * 8)
+
+        numpy.testing.assert_array_equal(selected[1, 0, 0, :].data.numpy(), ones * 10)
+        numpy.testing.assert_array_equal(selected[1, 0, 1, :].data.numpy(), ones * 12)
+        numpy.testing.assert_array_equal(selected[1, 1, 0, :].data.numpy(), ones * 14)
+        numpy.testing.assert_array_equal(selected[1, 1, 1, :].data.numpy(), ones * 16)
 
     def test_flattened_index_select(self):
         indices = numpy.array([[1, 2],
                                [3, 4]])
         targets = torch.ones([2, 6, 3]).cumsum(1) - 1
+        # Make the second batch double it's index so they're different.
+        targets[1, :, :] *= 2
         indices = Variable(torch.LongTensor(indices))
         targets = Variable(targets)
 
@@ -558,10 +563,11 @@ class TestNnUtil(AllenNlpTestCase):
         numpy.testing.assert_array_equal(selected[0, 0, 1, :].data.numpy(), ones * 2)
         numpy.testing.assert_array_equal(selected[0, 1, 0, :].data.numpy(), ones * 3)
         numpy.testing.assert_array_equal(selected[0, 1, 1, :].data.numpy(), ones * 4)
-        numpy.testing.assert_array_equal(selected[1, 0, 0, :].data.numpy(), ones)
-        numpy.testing.assert_array_equal(selected[1, 0, 1, :].data.numpy(), ones * 2)
-        numpy.testing.assert_array_equal(selected[1, 1, 0, :].data.numpy(), ones * 3)
-        numpy.testing.assert_array_equal(selected[1, 1, 1, :].data.numpy(), ones * 4)
+
+        numpy.testing.assert_array_equal(selected[1, 0, 0, :].data.numpy(), ones * 2)
+        numpy.testing.assert_array_equal(selected[1, 0, 1, :].data.numpy(), ones * 4)
+        numpy.testing.assert_array_equal(selected[1, 1, 0, :].data.numpy(), ones * 6)
+        numpy.testing.assert_array_equal(selected[1, 1, 1, :].data.numpy(), ones * 8)
 
         # Check we only accept 2D indices.
         with pytest.raises(ConfigurationError):

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -18,7 +18,10 @@ from allennlp.nn.util import sequence_cross_entropy_with_logits
 from allennlp.nn.util import sort_batch_by_length
 from allennlp.nn.util import viterbi_decode
 from allennlp.nn.util import weighted_sum
-
+from allennlp.nn.util import flatten_batched_indices
+from allennlp.nn.util import batched_index_select
+from allennlp.nn.util import flattened_index_select
+from allennlp.nn.util import bucket_distance
 
 class TestNnUtil(AllenNlpTestCase):
     def test_arrays_to_variables_handles_recursion(self):
@@ -501,3 +504,71 @@ class TestNnUtil(AllenNlpTestCase):
         mask = Variable(torch.FloatTensor([[1, 1, 0]]))
         replaced = replace_masked_values(tensor, mask.unsqueeze(-1), 2).data.numpy()
         assert_almost_equal(replaced, [[[1, 2, 3, 4], [5, 6, 7, 8], [2, 2, 2, 2]]])
+
+    def test_flatten_batched_indices(self):
+        indices = numpy.array([[[1, 2, 3, 4],
+                                [5, 6, 7, 8],
+                                [9, 9, 9, 9]],
+                               [[2, 1, 0, 7],
+                                [7, 7, 2, 3],
+                                [0, 0, 4, 2]]])
+        indices = Variable(torch.LongTensor(indices))
+        shifted_indices = flatten_batched_indices(indices, 10)
+        numpy.testing.assert_array_equal(shifted_indices.data.numpy(),
+                                                numpy.array([1, 2, 3, 4, 5, 6, 7, 8, 9,
+                                                             9, 9, 9, 12, 11, 10, 17, 17,
+                                                             17, 12, 13, 10, 10, 14, 12]))
+
+    def test_batched_index_select(self):
+        indices = numpy.array([[[1, 2],
+                                [3, 4]],
+                               [[5, 6],
+                                [7, 8]]])
+        # Each element is a vector of it's index.
+        targets = torch.ones([2, 10, 3]).cumsum(1) - 1
+        indices = Variable(torch.LongTensor(indices))
+        targets = Variable(targets)
+        selected = batched_index_select(targets, indices)
+
+        assert list(selected.size()) == [2, 2, 2, 3]
+        ones = numpy.ones([3])
+        numpy.testing.assert_array_equal(selected[0, 0, 0, :].data.numpy(), ones)
+        numpy.testing.assert_array_equal(selected[0, 0, 1, :].data.numpy(), ones * 2)
+        numpy.testing.assert_array_equal(selected[0, 1, 0, :].data.numpy(), ones * 3)
+        numpy.testing.assert_array_equal(selected[0, 1, 1, :].data.numpy(), ones * 4)
+        numpy.testing.assert_array_equal(selected[1, 0, 0, :].data.numpy(), ones * 5)
+        numpy.testing.assert_array_equal(selected[1, 0, 1, :].data.numpy(), ones * 6)
+        numpy.testing.assert_array_equal(selected[1, 1, 0, :].data.numpy(), ones * 7)
+        numpy.testing.assert_array_equal(selected[1, 1, 1, :].data.numpy(), ones * 8)
+
+    def test_flattened_index_select(self):
+        indices = numpy.array([[1, 2],
+                               [3, 4]])
+        targets = torch.ones([2, 6, 3]).cumsum(1) - 1
+        indices = Variable(torch.LongTensor(indices))
+        targets = Variable(targets)
+
+        selected = flattened_index_select(targets, indices)
+
+        assert list(selected.size()) == [2, 2, 2, 3]
+
+        ones = numpy.ones([3])
+        numpy.testing.assert_array_equal(selected[0, 0, 0, :].data.numpy(), ones)
+        numpy.testing.assert_array_equal(selected[0, 0, 1, :].data.numpy(), ones * 2)
+        numpy.testing.assert_array_equal(selected[0, 1, 0, :].data.numpy(), ones * 3)
+        numpy.testing.assert_array_equal(selected[0, 1, 1, :].data.numpy(), ones * 4)
+        numpy.testing.assert_array_equal(selected[1, 0, 0, :].data.numpy(), ones)
+        numpy.testing.assert_array_equal(selected[1, 0, 1, :].data.numpy(), ones * 2)
+        numpy.testing.assert_array_equal(selected[1, 1, 0, :].data.numpy(), ones * 3)
+        numpy.testing.assert_array_equal(selected[1, 1, 1, :].data.numpy(), ones * 4)
+
+        # Check we only accept 2D indices.
+        with pytest.raises(ConfigurationError):
+            flattened_index_select(targets, torch.ones([3, 4, 5]))
+
+    def test_bucket_distance(self):
+        indices = torch.LongTensor([1, 2, 7, 1, 56, 900])
+        bucketed_distances = bucket_distance(indices)
+        numpy.testing.assert_array_equal(bucketed_distances.numpy(),
+                                         numpy.array([1, 2, 5, 1, 8, 9]))
+

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -21,7 +21,8 @@ from allennlp.nn.util import weighted_sum
 from allennlp.nn.util import flatten_batched_indices
 from allennlp.nn.util import batched_index_select
 from allennlp.nn.util import flattened_index_select
-from allennlp.nn.util import bucket_distance
+from allennlp.nn.util import bucket_values
+
 
 class TestNnUtil(AllenNlpTestCase):
     def test_arrays_to_variables_handles_recursion(self):
@@ -568,6 +569,6 @@ class TestNnUtil(AllenNlpTestCase):
 
     def test_bucket_distance(self):
         indices = torch.LongTensor([1, 2, 7, 1, 56, 900])
-        bucketed_distances = bucket_distance(indices)
+        bucketed_distances = bucket_values(indices)
         numpy.testing.assert_array_equal(bucketed_distances.numpy(),
                                          numpy.array([1, 2, 5, 1, 8, 9]))

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -515,9 +515,9 @@ class TestNnUtil(AllenNlpTestCase):
         indices = Variable(torch.LongTensor(indices))
         shifted_indices = flatten_batched_indices(indices, 10)
         numpy.testing.assert_array_equal(shifted_indices.data.numpy(),
-                                                numpy.array([1, 2, 3, 4, 5, 6, 7, 8, 9,
-                                                             9, 9, 9, 12, 11, 10, 17, 17,
-                                                             17, 12, 13, 10, 10, 14, 12]))
+                                         numpy.array([1, 2, 3, 4, 5, 6, 7, 8, 9,
+                                                      9, 9, 9, 12, 11, 10, 17, 17,
+                                                      17, 12, 13, 10, 10, 14, 12]))
 
     def test_batched_index_select(self):
         indices = numpy.array([[[1, 2],
@@ -571,4 +571,3 @@ class TestNnUtil(AllenNlpTestCase):
         bucketed_distances = bucket_distance(indices)
         numpy.testing.assert_array_equal(bucketed_distances.numpy(),
                                          numpy.array([1, 2, 5, 1, 8, 9]))
-

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -18,7 +18,7 @@ from allennlp.nn.util import sequence_cross_entropy_with_logits
 from allennlp.nn.util import sort_batch_by_length
 from allennlp.nn.util import viterbi_decode
 from allennlp.nn.util import weighted_sum
-from allennlp.nn.util import flatten_batched_indices
+from allennlp.nn.util import flatten_and_batch_shift_indices
 from allennlp.nn.util import batched_index_select
 from allennlp.nn.util import flattened_index_select
 from allennlp.nn.util import bucket_values
@@ -506,7 +506,7 @@ class TestNnUtil(AllenNlpTestCase):
         replaced = replace_masked_values(tensor, mask.unsqueeze(-1), 2).data.numpy()
         assert_almost_equal(replaced, [[[1, 2, 3, 4], [5, 6, 7, 8], [2, 2, 2, 2]]])
 
-    def test_flatten_batched_indices(self):
+    def test_flatten_and_batch_shift_indices(self):
         indices = numpy.array([[[1, 2, 3, 4],
                                 [5, 6, 7, 8],
                                 [9, 9, 9, 9]],
@@ -514,7 +514,7 @@ class TestNnUtil(AllenNlpTestCase):
                                 [7, 7, 2, 3],
                                 [0, 0, 4, 2]]])
         indices = Variable(torch.LongTensor(indices))
-        shifted_indices = flatten_batched_indices(indices, 10)
+        shifted_indices = flatten_and_batch_shift_indices(indices, 10)
         numpy.testing.assert_array_equal(shifted_indices.data.numpy(),
                                          numpy.array([1, 2, 3, 4, 5, 6, 7, 8, 9,
                                                       9, 9, 9, 12, 11, 10, 17, 17,
@@ -567,7 +567,7 @@ class TestNnUtil(AllenNlpTestCase):
         with pytest.raises(ConfigurationError):
             flattened_index_select(targets, torch.ones([3, 4, 5]))
 
-    def test_bucket_distance(self):
+    def test_bucket_values(self):
         indices = torch.LongTensor([1, 2, 7, 1, 56, 900])
         bucketed_distances = bucket_values(indices)
         numpy.testing.assert_array_equal(bucketed_distances.numpy(),


### PR DESCRIPTION
Note this is a PR to the `coref-wip` branch.
This just adds some tests for the batch index select functions and removes the zeros function.
Ignore the test that is failing - it's unrelated and I haven't fixed it yet.