### PR TITLE
Fix patience

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -265,12 +265,11 @@ class Trainer:
         uses patience and the validation metric to determine if training should stop early
         """
         if len(prev_metrics) > self._patience:
-            # Is the worst validation performance in past self._patience
-            # epochs is better than current value?
+            # Is the best score in the past N epochs worse than the best score overall?
             if self._validation_metric_decreases:
-                return max(prev_metrics[-self._patience:]) < latest_metric
+                return min(prev_metrics[-self._patience:]) > min(prev_metrics)
             else:
-                return min(prev_metrics[-self._patience:]) > latest_metric
+                return max(prev_metrics[-self._patience:]) < max(prev_metrics)
 
         return False
 
@@ -375,11 +374,10 @@ class Trainer:
                 val_metrics = self._get_metrics(val_loss, num_batches, reset=True)
 
                 # Check validation metric for early stopping
-                this_epoch_val_metric = val_metrics[self._validation_metric]
-                if self._should_stop_early(this_epoch_val_metric, validation_metric_per_epoch):
+                validation_metric_per_epoch.append(this_epoch_val_metric)
+                if self._should_stop_early(validation_metric_per_epoch):
                     logger.info("Ran out of patience.  Stopping training.")
                     break
-                validation_metric_per_epoch.append(this_epoch_val_metric)
 
                 # Check validation metric to see if it's the best so far
                 if self._validation_metric_decreases:

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -260,7 +260,7 @@ class Trainer:
 
         return self._get_metrics(train_loss, batch_num, reset=True)
 
-    def _should_stop_early(self, latest_metric: float, prev_metrics: List[float]) -> bool:
+    def _should_stop_early(self, prev_metrics: List[float]) -> bool:
         """
         uses patience and the validation metric to determine if training should stop early
         """
@@ -374,6 +374,7 @@ class Trainer:
                 val_metrics = self._get_metrics(val_loss, num_batches, reset=True)
 
                 # Check validation metric for early stopping
+                this_epoch_val_metric = val_metrics[self._validation_metric]
                 validation_metric_per_epoch.append(this_epoch_val_metric)
                 if self._should_stop_early(validation_metric_per_epoch):
                     logger.info("Ran out of patience.  Stopping training.")

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -260,16 +260,16 @@ class Trainer:
 
         return self._get_metrics(train_loss, batch_num, reset=True)
 
-    def _should_stop_early(self, prev_metrics: List[float]) -> bool:
+    def _should_stop_early(self, metric_history: List[float]) -> bool:
         """
         uses patience and the validation metric to determine if training should stop early
         """
-        if len(prev_metrics) > self._patience:
+        if len(metric_history) > self._patience:
             # Is the best score in the past N epochs worse than the best score overall?
             if self._validation_metric_decreases:
-                return min(prev_metrics[-self._patience:]) > min(prev_metrics)
+                return min(metric_history[-self._patience:]) > min(metric_history)
             else:
-                return max(prev_metrics[-self._patience:]) < max(prev_metrics)
+                return max(metric_history[-self._patience:]) < max(metric_history)
 
         return False
 

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -61,23 +61,23 @@ class TestTrainer(AllenNlpTestCase):
         assert val_metrics_per_epoch[0] != 0.
         new_trainer.train()
 
-    def test_should_stop_early_positive(self):
+    def test_should_stop_early_with_increasing_metric(self):
         new_trainer = Trainer(self.model, self.optimizer,
                               self.iterator, self.dataset,
                               validation_dataset=self.dataset,
                               num_epochs=3, serialization_dir=self.TEST_DIR,
                               patience=5, validation_metric="+test")
-        assert new_trainer._should_stop_early([.5, .3, .2, .1, .4, .4])
-        assert not new_trainer._should_stop_early([.3, .3, .1, .2, .5, .3])
+        assert new_trainer._should_stop_early([.5, .3, .2, .1, .4, .4]) #pylint: disable=protected-access
+        assert not new_trainer._should_stop_early([.3, .3, .3, .2, .5, .1]) #pylint: disable=protected-access
 
-    def test_should_stop_early_negative(self):
+    def test_should_stop_early_with_decreasing_metric(self):
         new_trainer = Trainer(self.model, self.optimizer,
                               self.iterator, self.dataset,
                               validation_dataset=self.dataset,
                               num_epochs=3, serialization_dir=self.TEST_DIR,
                               patience=5, validation_metric="-test")
-        assert new_trainer._should_stop_early([.02, .3, .2, .1, .4, .4])
-        assert not new_trainer._should_stop_early([.3, .3, .2, .1, .4, .4])
+        assert new_trainer._should_stop_early([.02, .3, .2, .1, .4, .4]) #pylint: disable=protected-access
+        assert not new_trainer._should_stop_early([.3, .3, .2, .1, .4, .5]) #pylint: disable=protected-access
 
 
     def test_train_driver_raises_on_model_with_no_loss_key(self):

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -61,6 +61,25 @@ class TestTrainer(AllenNlpTestCase):
         assert val_metrics_per_epoch[0] != 0.
         new_trainer.train()
 
+    def test_should_stop_early_positive(self):
+        new_trainer = Trainer(self.model, self.optimizer,
+                              self.iterator, self.dataset,
+                              validation_dataset=self.dataset,
+                              num_epochs=3, serialization_dir=self.TEST_DIR,
+                              patience=5, validation_metric="+test")
+        assert new_trainer._should_stop_early([.5, .3, .2, .1, .4, .4])
+        assert not new_trainer._should_stop_early([.3, .3, .1, .2, .5, .3])
+
+    def test_should_stop_early_negative(self):
+        new_trainer = Trainer(self.model, self.optimizer,
+                              self.iterator, self.dataset,
+                              validation_dataset=self.dataset,
+                              num_epochs=3, serialization_dir=self.TEST_DIR,
+                              patience=5, validation_metric="-test")
+        assert new_trainer._should_stop_early([.02, .3, .2, .1, .4, .4])
+        assert not new_trainer._should_stop_early([.3, .3, .2, .1, .4, .4])
+
+
     def test_train_driver_raises_on_model_with_no_loss_key(self):
 
         class FakeModel(torch.nn.Module):


### PR DESCRIPTION
This fixes early-stopping / patience in the trainer. Patience should be defined as "Stop if you haven't improved the metric in N epochs", but the previous definition was "Stop if the current score is worse than the worse in N epochs". This lead to cases where training would stop even if the metric had increased recently.