### PR TITLE
Fix masked softmax

### DIFF
--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -160,8 +160,11 @@ def masked_softmax(vector, mask):
     of ``0.0``. This behavior may cause ``NaN`` if this is used as the last layer of a model
     that uses categorical cross-entropy loss.
     """
-    result = torch.nn.functional.softmax(vector)
-    if mask is not None:
+    if mask is None:
+        result = torch.nn.functional.softmax(vector)
+    else:
+        # To limit numerical errors from large vector elements outside mask, we zero these out
+        result = torch.nn.functional.softmax(vector * mask)
         result = result * mask
         result = result / (result.sum(dim=1, keepdim=True) + 1e-13)
     return result

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -203,6 +203,14 @@ class TestNnUtil(AllenNlpTestCase):
         assert_array_almost_equal(vector_1d_softmaxed,
                                   numpy.array([[0.0, 0.0, 0.0, 0.0]]))
 
+        # Testing the masked 1D case where there are large elements in the
+        # padding.
+        vector_1d = Variable(torch.FloatTensor([[1.0, 1.0, 1e5]]))
+        mask_1d = Variable(torch.FloatTensor([[1.0, 1.0, 0.0]]))
+        vector_1d_softmaxed = util.masked_softmax(vector_1d, mask_1d).data.numpy()
+        assert_array_almost_equal(vector_1d_softmaxed,
+                                  numpy.array([[0.5, 0.5, 0]]))
+
         # Testing the general masked batched case.
         matrix = Variable(torch.FloatTensor([[1.0, 2.0, 5.0], [1.0, 2.0, 3.0]]))
         mask = Variable(torch.FloatTensor([[1.0, 0.0, 1.0], [1.0, 1.0, 1.0]]))


### PR DESCRIPTION
As discussed per email, a possible simple fix (or at least substantial improvement without much loss of efficiency) for an issue with large elements outside the mask messing up the softmax calculations:
```
>>> import torch
>>> from allennlp.nn import util
>>> x1 = torch.autograd.Variable(torch.Tensor([[1,1,2],[1,1,100]]))
>>> mask = torch.autograd.Variable(torch.Tensor([[1,1,0],[1,1,0]]))
>>> util.masked_softmax(x1, mask)
Variable containing:
 0.5000  0.5000  0.0000
 0.0000  0.0000  0.0000
[torch.FloatTensor of size 2x3]
```