### PR TITLE
sphinx coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ env:
     - COVERAGE="true" RUN_TESTS="true"
     - RUN_PYLINT="true"
     - RUN_MYPY="true"
-    - BUILD_DOCS="true"
-    - CHECK_DOCS="true"
+    - BUILD_DOCS="true" CHECK_DOCS="true"
 notifications:
   email: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - RUN_PYLINT="true"
     - RUN_MYPY="true"
     - BUILD_DOCS="true"
+    - CHECK_DOCS="true"
 notifications:
   email: false
 addons:

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -1,3 +1,7 @@
+"""
+Utilities for working with the local dataset cache.
+"""
+
 from typing import Tuple
 import os
 import base64
@@ -42,13 +46,16 @@ def filename_to_url(filename: str) -> Tuple[str, str]:
     url_bytes = base64.b64decode(filename_bytes)
     return url_bytes.decode('utf-8'), etag
 
-def cached_path(url_or_filename: str, cache_dir: str = DATASET_CACHE) -> str:
+def cached_path(url_or_filename: str, cache_dir: str = None) -> str:
     """
     Given something that might be a URL (or might be a local path),
     determine which. If it's a URL, download the file and cache it, and
     return the path to the cached file. If it's already a local path,
     make sure the file exists and then return the path.
     """
+    if cache_dir is None:
+        cache_dir = DATASET_CACHE
+
     parsed = urlparse(url_or_filename)
 
     if parsed.scheme in ('http', 'https'):
@@ -66,11 +73,14 @@ def cached_path(url_or_filename: str, cache_dir: str = DATASET_CACHE) -> str:
 
 
 # TODO(joelgrus): do we want to do checksums or anything like that?
-def get_from_cache(url: str, cache_dir: str = DATASET_CACHE) -> str:
+def get_from_cache(url: str, cache_dir: str = None) -> str:
     """
     Given a URL, look for the corresponding dataset in the local cache.
     If it's not there, download it. Then return the path to the cached file.
     """
+    if cache_dir is None:
+        cache_dir = DATASET_CACHE
+
     os.makedirs(cache_dir, exist_ok=True)
 
     # make HEAD request to check ETag

--- a/allennlp/common/tee_logger.py
+++ b/allennlp/common/tee_logger.py
@@ -1,3 +1,7 @@
+"""
+A logger that maintains logs of both stdout and stderr when models are run.
+"""
+
 from typing import TextIO
 import os
 

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -39,7 +39,7 @@ class Conll2003DatasetReader(DatasetReader):
     The values corresponding to the ``tag_label``
     values will get loaded into the ``"tags"`` ``SequenceLabelField``.
     And if you specify any ``feature_labels`` (you probably shouldn't),
-    the corresponding values will get loaded into their own ``SequenceLabelField``s.
+    the corresponding values will get loaded into their own ``SequenceLabelField`` s.
 
     This dataset reader ignores the "article" divisions and simply treats
     each sentence as an independent ``Instance``. (Technically the reader splits sentences

--- a/allennlp/data/dataset_readers/reading_comprehension/util.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/util.py
@@ -1,3 +1,7 @@
+"""
+Utilities for reading comprehension dataset readers.
+"""
+
 from collections import Counter, defaultdict
 import logging
 import string

--- a/allennlp/data/dataset_readers/seq2seq.py
+++ b/allennlp/data/dataset_readers/seq2seq.py
@@ -27,7 +27,7 @@ class Seq2SeqDatasetReader(DatasetReader):
 
     Expected format for each input line: <source_sequence_string>\t<target_sequence_string>
 
-    The output of ``read`` is a list of ``Instance``s with the fields:
+    The output of ``read`` is a list of ``Instance`` s with the fields:
         source_tokens: ``TextField`` and
         target_tokens: ``TextField``
 

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -1,3 +1,7 @@
+"""
+Helper functions for archiving models and restoring archived models.
+"""
+
 from typing import NamedTuple
 import logging
 import os

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -27,7 +27,7 @@ class CrfTagger(Model):
         Used to embed the tokens ``TextField`` we get as input to the model.
     encoder : ``Seq2SeqEncoder``
         The encoder that we will use in between embedding tokens and predicting output tags.
-    label_namespace : ``str``, optional (default=``"labels"``)
+    label_namespace : ``str``, optional (default=``labels``)
         This is needed to compute the SpanBasedF1Measure metric.
         Unless you did something unusual, the default value should be what you want.
     initializer : ``InitializerApplicator``, optional (default=``InitializerApplicator()``)

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -24,7 +24,7 @@ class CrfTagger(Model):
     vocab : ``Vocabulary``, required
         A Vocabulary, required in order to compute sizes for input/output projections.
     text_field_embedder : ``TextFieldEmbedder``, required
-        Used to embed the ``tokens`` ``TextField`` we get as input to the model.
+        Used to embed the tokens ``TextField`` we get as input to the model.
     encoder : ``Seq2SeqEncoder``
         The encoder that we will use in between embedding tokens and predicting output tags.
     label_namespace : ``str``, optional (default=``"labels"``)

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -33,3 +33,7 @@ if [[ "$BUILD_DOCS" == "true" ]]; then
   make html-strict
   cd ..
 fi
+
+if [[ "$CHECK_DOCS" == "true" ]]; then
+  python scripts/check_docs.py
+fi

--- a/doc/api/allennlp.common.file_utils.rst
+++ b/doc/api/allennlp.common.file_utils.rst
@@ -1,0 +1,8 @@
+allennlp.common.file_utils
+===============================
+
+.. automodule:: allennlp.common.file_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/doc/api/allennlp.common.rst
+++ b/doc/api/allennlp.common.rst
@@ -7,8 +7,11 @@ that's used by datasets, models, trainers, and so on.
 .. toctree::
 
    allennlp.common.checks
+   allennlp.common.file_utils
    allennlp.common.params
    allennlp.common.registrable
+   allennlp.common.squad_eval
+   allennlp.common.tee_logger
    allennlp.common.testing
    allennlp.common.util
 

--- a/doc/api/allennlp.common.squad_eval.rst
+++ b/doc/api/allennlp.common.squad_eval.rst
@@ -1,0 +1,7 @@
+allennlp.common.squad_eval
+===============================
+
+.. automodule:: allennlp.common.squad_eval
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.common.tee_logger.rst
+++ b/doc/api/allennlp.common.tee_logger.rst
@@ -1,0 +1,7 @@
+allennlp.common.tee_logger
+===============================
+
+.. automodule:: allennlp.common.tee_logger
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.data.dataset_readers.conll2003.rst
+++ b/doc/api/allennlp.data.dataset_readers.conll2003.rst
@@ -1,0 +1,7 @@
+allennlp.data.dataset_readers.conll2003
+===============================================
+
+.. automodule:: allennlp.data.dataset_readers.conll2003
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.data.dataset_readers.reading_comprehension.rst
+++ b/doc/api/allennlp.data.dataset_readers.reading_comprehension.rst
@@ -10,3 +10,13 @@ allennlp.data.dataset_readers.reading_comprehension
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. automodule:: allennlp.data.dataset_readers.reading_comprehension.triviaqa
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: allennlp.data.dataset_readers.reading_comprehension.util
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.data.dataset_readers.rst
+++ b/doc/api/allennlp.data.dataset_readers.rst
@@ -9,6 +9,7 @@ allennlp.data.dataset_readers
 .. toctree::
 
   allennlp.data.dataset_readers.dataset_reader
+  allennlp.data.dataset_readers.conll2003
   allennlp.data.dataset_readers.language_modeling
   allennlp.data.dataset_readers.reading_comprehension
   allennlp.data.dataset_readers.semantic_role_labeling

--- a/doc/api/allennlp.data.dataset_readers.rst
+++ b/doc/api/allennlp.data.dataset_readers.rst
@@ -12,5 +12,6 @@ allennlp.data.dataset_readers
   allennlp.data.dataset_readers.language_modeling
   allennlp.data.dataset_readers.reading_comprehension
   allennlp.data.dataset_readers.semantic_role_labeling
+  allennlp.data.dataset_readers.seq2seq
   allennlp.data.dataset_readers.sequence_tagging
   allennlp.data.dataset_readers.snli

--- a/doc/api/allennlp.data.dataset_readers.seq2seq.rst
+++ b/doc/api/allennlp.data.dataset_readers.seq2seq.rst
@@ -1,0 +1,7 @@
+allennlp.data.dataset_readers.seq2seq
+==============================================
+
+.. automodule:: allennlp.data.dataset_readers.seq2seq
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.data.fields.rst
+++ b/doc/api/allennlp.data.fields.rst
@@ -10,6 +10,7 @@ allennlp.data.fields
 * :ref:`IndexField<index-field>`
 * :ref:`LabelField<label-field>`
 * :ref:`ListField<list-field>`
+* :ref:`MetadataField<metadata-field>`
 * :ref:`SequenceField<sequence-field>`
 * :ref:`SequenceLabelField<sequence-label-field>`
 * :ref:`TextField<text-field>`
@@ -34,6 +35,12 @@ allennlp.data.fields
 
 .. _list-field:
 .. automodule:: allennlp.data.fields.list_field
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _metadata-field:
+.. automodule:: allennlp.data.fields.metadata_field
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/allennlp.data.token_indexers.rst
+++ b/doc/api/allennlp.data.token_indexers.rst
@@ -8,6 +8,7 @@ allennlp.data.token_indexers
 
 * :ref:`TokenIndexer<token-indexer>`
 * :ref:`DepLabelIndexer<dep-label-indexer>`
+* :ref:`NerTagIndexer<ner-tag-indexer>`
 * :ref:`PosTagIndexer<pos-tag-indexer>`
 * :ref:`SingleIdTokenIndexer<single-id-token-indexer>`
 * :ref:`TokenCharactersIndexer<token-characters-indexer>`
@@ -20,6 +21,12 @@ allennlp.data.token_indexers
 
 .. _dep-label-indexer:
 .. automodule:: allennlp.data.token_indexers.dep_label_indexer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _ner-tag-indexer:
+.. automodule:: allennlp.data.token_indexers.ner_tag_indexer
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/allennlp.data.token_indexers.rst
+++ b/doc/api/allennlp.data.token_indexers.rst
@@ -7,11 +7,25 @@ allennlp.data.token_indexers
    :show-inheritance:
 
 * :ref:`TokenIndexer<token-indexer>`
+* :ref:`DepLabelIndexer<dep-label-indexer>`
+* :ref:`PosTagIndexer<pos-tag-indexer>`
 * :ref:`SingleIdTokenIndexer<single-id-token-indexer>`
 * :ref:`TokenCharactersIndexer<token-characters-indexer>`
 
 .. _token-indexer:
 .. automodule:: allennlp.data.token_indexers.token_indexer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _dep-label-indexer:
+.. automodule:: allennlp.data.token_indexers.dep_label_indexer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _pos-tag-indexer:
+.. automodule:: allennlp.data.token_indexers.pos_tag_indexer
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/allennlp.data.tokenizers.rst
+++ b/doc/api/allennlp.data.tokenizers.rst
@@ -1,6 +1,10 @@
 allennlp.data.tokenizers
 ================================
 
+.. automodule:: allennlp.data.tokenizers.token
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 .. automodule:: allennlp.data.tokenizers
    :members:

--- a/doc/api/allennlp.models.archival.rst
+++ b/doc/api/allennlp.models.archival.rst
@@ -1,0 +1,7 @@
+allennlp.models.archival
+=========================================
+
+.. automodule:: allennlp.models.archival
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.models.crf_tagger.rst
+++ b/doc/api/allennlp.models.crf_tagger.rst
@@ -1,0 +1,7 @@
+allennlp.models.crf_tagger
+=========================================
+
+.. automodule:: allennlp.models.crf_tagger
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.models.encoder_decoders.rst
+++ b/doc/api/allennlp.models.encoder_decoders.rst
@@ -1,0 +1,12 @@
+allennlp.models.encoder_decoders
+================================
+
+.. automodule:: allennlp.models.encoder_decoders
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: allennlp.models.encoder_decoders.simple_seq2seq
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.models.rst
+++ b/doc/api/allennlp.models.rst
@@ -10,6 +10,7 @@ allennlp.models
 
   allennlp.models.model
   allennlp.models.archival
+  allennlp.models.crf_tagger
   allennlp.models.decomposable_attention
   allennlp.models.encoder_decoders
   allennlp.models.reading_comprehension

--- a/doc/api/allennlp.models.rst
+++ b/doc/api/allennlp.models.rst
@@ -9,7 +9,9 @@ allennlp.models
 .. toctree::
 
   allennlp.models.model
+  allennlp.models.archival
   allennlp.models.decomposable_attention
+  allennlp.models.encoder_decoders
   allennlp.models.reading_comprehension
   allennlp.models.semantic_role_labeler
   allennlp.models.simple_tagger

--- a/doc/api/allennlp.modules.seq2seq_encoders.rst
+++ b/doc/api/allennlp.modules.seq2seq_encoders.rst
@@ -16,4 +16,7 @@ allennlp.modules.seq2seq_encoders
    :undoc-members:
    :show-inheritance:
 
-
+.. automodule:: allennlp.modules.seq2seq_encoders.intra_sentence_attention
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.modules.seq2vec_encoders.rst
+++ b/doc/api/allennlp.modules.seq2vec_encoders.rst
@@ -20,3 +20,8 @@ allennlp.modules.seq2vec_encoders
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. automodule:: allennlp.modules.seq2vec_encoders.boe_encoder
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.service.predictors.rst
+++ b/doc/api/allennlp.service.predictors.rst
@@ -8,12 +8,19 @@ allennlp.service.predictors
 
 * :ref:`Predictor<predictor>`
 * :ref:`BidafPredictor<bidaf>`
+* :ref:`CrfTaggerPredictor<crf-tagger>`
 * :ref:`DecomposableAttentionPredictor<decomposable-attention>`
 * :ref:`SemanticRoleLabelerPredictor<semantic-role-labeler>`
 * :ref:`SimpleTaggerPredictor<simple-tagger>`
 
 .. _predictor:
 .. automodule:: allennlp.service.predictors.predictor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _crf-tagger:
+.. automodule:: allennlp.service.predictors.crf_tagger
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/allennlp.training.metrics.rst
+++ b/doc/api/allennlp.training.metrics.rst
@@ -10,8 +10,10 @@ allennlp.training.metrics
 * :ref:`Average<average>`
 * :ref:`BooleanAccuracy<boolean-accuracy>`
 * :ref:`CategoricalAccuracy<categorical-accuracy>`
+* :ref:`Entropy<entropy>`
 * :ref:`F1Measure<f1-measure>`
 * :ref:`SpanBasedF1Measure<span-based-f1-measure>`
+* :ref:`SquadEmAndF1<squad-em-and-f1>`
 
 
 .. _metric:
@@ -38,6 +40,12 @@ allennlp.training.metrics
    :undoc-members:
    :show-inheritance:
 
+.. _entropy:
+.. automodule:: allennlp.training.metrics.entropy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. _f1-measure:
 .. automodule:: allennlp.training.metrics.f1_measure
    :members:
@@ -46,6 +54,12 @@ allennlp.training.metrics
 
 .. _span-based-f1-measure:
 .. automodule:: allennlp.training.metrics.span_based_f1_measure
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _squad-em-and-f1:
+.. automodule:: allennlp.training.metrics.squad_em_and_f1
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,6 +36,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.coverage',
               'sphinx.ext.doctest',
               'sphinx.ext.linkcode',
               'sphinx.ext.mathjax',

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -26,7 +26,8 @@ MODULES_THAT_NEED_NO_DOCS: Set[str] = {
 }
 
 DOCS_THAT_NEED_NO_MODULES: Set[str] = {
-        'allennlp.commands.main',  # is in __init__.py
+        # Function is defined in allennlp/commands/__init__.py.
+        'allennlp.commands.main',
 }
 
 

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,59 @@
+#! /usr/bin/env python
+# pylint: disable=invalid-name,redefined-outer-name
+from glob import glob
+import os
+import re
+import sys
+from typing import Set
+
+DOCS_DIR = 'doc/api'
+MODULE_REGEX = r"\ballennlp\.[a-z0-9_.]+\b"
+MODULE_GLOB = 'allennlp/**/*.py'
+
+MODULES_THAT_NEED_NO_DOCS: Set[str] = {
+        'allennlp',  # no docs at top level
+}
+
+DOCS_THAT_NEED_NO_MODULES: Set[str] = {
+        'allennlp.commands.main',  # is in __init__.py
+}
+
+
+def documented_modules(docs_dir: str = DOCS_DIR, module_regex: str = MODULE_REGEX) -> Set[str]:
+    modules: Set[str] = set()
+
+    for path in glob(os.path.join(docs_dir, '**/*.rst'), recursive=True):
+        with open(path) as f:
+            text = f.read()
+            for module in re.findall(module_regex, text):
+                modules.add(module)
+
+    return modules
+
+
+def existing_modules(module_glob: str = MODULE_GLOB) -> Set[str]:
+    modules: Set[str] = set()
+
+    for path in glob(module_glob, recursive=True):
+        path = re.sub(".py$", "", path)
+        path = re.sub("/__init__", "", path)
+        path = path.replace("/", ".")
+        modules.add(path)
+
+    return modules
+
+if __name__ == "__main__":
+    success = True
+    existing = existing_modules()
+    documented = documented_modules()
+    for module in existing:
+        if module not in documented and module not in MODULES_THAT_NEED_NO_DOCS:
+            print("undocumented module:", module)
+            success = False
+    for module in documented:
+        if module not in existing and module not in DOCS_THAT_NEED_NO_MODULES:
+            print("documented but nonexistent:", module)
+            success = False
+
+    if not success:
+        sys.exit(1)

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -11,17 +11,17 @@ MODULE_REGEX = r"\ballennlp\.[a-z0-9_.]+\b"
 MODULE_GLOB = 'allennlp/**/*.py'
 
 MODULES_THAT_NEED_NO_DOCS: Set[str] = {
-        # no docs at top level
+        # No docs at top level.
         'allennlp',
 
-        # no docs for custom extensions, which aren't even in python
+        # No docs for custom extensions, which aren't even in python.
         'allennlp.custom_extensions',
         'allennlp.custom_extensions._ext',
         'allennlp.custom_extensions._ext.highway_lstm_layer',
         'allennlp.custom_extensions.build',
 
-        # TODO(joelgrus) figure out how to make these docs build, the cffi part
-        # is causing problems
+        # TODO(joelgrus): Figure out how to make these docs build;
+        # the cffi part is causing problems.
         'allennlp.modules.alternating_highway_lstm',
 }
 

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -11,7 +11,18 @@ MODULE_REGEX = r"\ballennlp\.[a-z0-9_.]+\b"
 MODULE_GLOB = 'allennlp/**/*.py'
 
 MODULES_THAT_NEED_NO_DOCS: Set[str] = {
-        'allennlp',  # no docs at top level
+        # no docs at top level
+        'allennlp',
+
+        # no docs for custom extensions, which aren't even in python
+        'allennlp.custom_extensions',
+        'allennlp.custom_extensions._ext',
+        'allennlp.custom_extensions._ext.highway_lstm_layer',
+        'allennlp.custom_extensions.build',
+
+        # TODO(joelgrus) figure out how to make these docs build, the cffi part
+        # is causing problems
+        'allennlp.modules.alternating_highway_lstm',
 }
 
 DOCS_THAT_NEED_NO_MODULES: Set[str] = {
@@ -46,11 +57,11 @@ if __name__ == "__main__":
     success = True
     existing = existing_modules()
     documented = documented_modules()
-    for module in existing:
+    for module in sorted(existing):
         if module not in documented and module not in MODULES_THAT_NEED_NO_DOCS:
             print("undocumented module:", module)
             success = False
-    for module in documented:
+    for module in sorted(documented):
         if module not in existing and module not in DOCS_THAT_NEED_NO_MODULES:
             print("documented but nonexistent:", module)
             success = False


### PR DESCRIPTION
most of this is just sphinx junk. the interesting parts are

* in [doc/conf.py](https://github.com/allenai/allennlp/pull/440/files#diff-684a0ceb2878d48b19612ca360e277ef) I enabled the sphinx-coverage plugin, which allows you to run "sphinx coverage", which is useful only for telling you what functions you missed in the python modules that are covered. In particular, it's not helpful for telling you that you forgot to add your new module to the docs.

* [scripts/check_docs.py](https://github.com/allenai/allennlp/pull/440/files#diff-803091b6e53da6bf7a2e907676fbd417) is a somewhat hacky script to tell you if you have any modules in your code that are not mentioned in the docs and vice versa. This is not perfect, but it's a lot better than what we have now. I also added a Travis option to run it, and I'll turn that on after I merge.