### PR TITLE
add batch prediction to model and predictor

### DIFF
--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -3,13 +3,13 @@
 an AllenNLP model.
 """
 
-from typing import Dict, Union
+from typing import Dict, Union, List
 import os
 import logging
 
 from allennlp.common.params import Params
 from allennlp.common.registrable import Registrable
-from allennlp.data import Instance, Vocabulary
+from allennlp.data import Instance, Vocabulary, Dataset
 from allennlp.nn.util import arrays_to_variables, device_mapping
 from allennlp.nn.regularizers import RegularizerApplicator
 
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 # When training a model, many sets of weights are saved. By default we want to
 # save/load this set of weights.
 _DEFAULT_WEIGHTS = "best.th"
+
 
 class Model(torch.nn.Module, Registrable):
     """
@@ -116,7 +117,32 @@ class Model(torch.nn.Module, Registrable):
         outputs = self.decode(self.forward(**model_input))
 
         for name, output in list(outputs.items()):
+            # We are predicting on a single instance and we added a batch
+            # dimension, so here we remove it.
             output = output[0]
+            if isinstance(output, torch.autograd.Variable):
+                output = output.data.cpu().numpy()
+            outputs[name] = output
+        return outputs
+
+    def forward_on_batch(self, instances: List[Instance],
+                         cuda_device: int) -> Dict[str, numpy.ndarray]:
+        """
+        Takes a list of  :class:`~allennlp.data.instance.Instance`s, converts that text into
+        arrays using this model's :class:`Vocabulary`, passes those arrays through
+        :func:`self.forward()` and :func:`self.decode()` (which by default does nothing)
+        and returns the result.  Before returning the result, we convert any
+        ``torch.autograd.Variables`` or ``torch.Tensors`` into numpy arrays.
+        """
+
+        dataset = Dataset(instances)
+        dataset.index_instances(self.vocab)
+        model_input = arrays_to_variables(dataset.as_array_dict(),
+                                          cuda_device=cuda_device,
+                                          for_training=False)
+        outputs = self.decode(self.forward(**model_input))
+
+        for name, output in list(outputs.items()):
             if isinstance(output, torch.autograd.Variable):
                 output = output.data.cpu().numpy()
             outputs[name] = output

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -134,7 +134,9 @@ class Model(torch.nn.Module, Registrable):
         :func:`self.forward()` and :func:`self.decode()` (which by default does nothing)
         and returns the result.  Before returning the result, we convert any
         ``torch.autograd.Variables`` or ``torch.Tensors`` into numpy arrays and separate the
-        batched output into a list of individual dicts per instance.
+        batched output into a list of individual dicts per instance. Note that typically
+        this will be faster on a GPU (and conditionally, on a CPU) than repeated calls to
+        :func:`forward_on_instance`.
         """
 
         dataset = Dataset(instances)

--- a/allennlp/service/predictors/predictor.py
+++ b/allennlp/service/predictors/predictor.py
@@ -1,3 +1,4 @@
+from typing import List
 from allennlp.common import Registrable
 from allennlp.common.util import JsonDict, sanitize
 from allennlp.data import DatasetReader, Instance
@@ -24,6 +25,25 @@ class Predictor(Registrable):
         Converts a JSON object into an :class:`~allennlp.data.instance.Instance`.
         """
         raise NotImplementedError
+
+    def predict_batch_json(self, inputs: List[JsonDict], cuda_device: int = -1) -> JsonDict:
+        instances = self._batch_json_to_instance(inputs)
+        outputs = self._model.forward_on_batch(instances, cuda_device)
+        return sanitize(outputs)
+
+    def _batch_json_to_instance(self, json: List[JsonDict]) -> List[Instance]:
+        """
+        Converts a list of JSON objects into a list of :class:`~allennlp.data.instance.Instance`s.
+        By default, this expects that a "batch" consists of a list of JSON blobs which would
+        individually be predicted by :func:`predict_json`. In order to use this method for
+        batch prediction, :func:`_json_to_instance` should be implemented by the subclass, or
+        if the instances have some dependency on each other, this method should be overridden
+        directly.
+        """
+        instances = []
+        for blob in json:
+            instances.append(self._json_to_instance(blob))
+        return instances
 
     @classmethod
     def from_archive(cls, archive: Archive, predictor_name: str) -> 'Predictor':

--- a/allennlp/service/predictors/predictor.py
+++ b/allennlp/service/predictors/predictor.py
@@ -26,12 +26,12 @@ class Predictor(Registrable):
         """
         raise NotImplementedError
 
-    def predict_batch_json(self, inputs: List[JsonDict], cuda_device: int = -1) -> JsonDict:
-        instances = self._batch_json_to_instance(inputs)
-        outputs = self._model.forward_on_batch(instances, cuda_device)
+    def predict_batch_json(self, inputs: List[JsonDict], cuda_device: int = -1) -> List[JsonDict]:
+        instances = self._batch_json_to_instances(inputs)
+        outputs = self._model.forward_on_instances(instances, cuda_device)
         return sanitize(outputs)
 
-    def _batch_json_to_instance(self, json: List[JsonDict]) -> List[Instance]:
+    def _batch_json_to_instances(self, json: List[JsonDict]) -> List[Instance]:
         """
         Converts a list of JSON objects into a list of :class:`~allennlp.data.instance.Instance`s.
         By default, this expects that a "batch" consists of a list of JSON blobs which would

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -48,6 +48,10 @@ class SemanticRoleLabelerPredictor(Predictor):
         raise RuntimeError("this should never be called")
 
     @overrides
+    def _batch_json_to_instance(self, json: JsonDict) -> List[Instance]:
+        raise NotImplementedError("The SRL Predictor does not currently support batch prediction.")
+
+    @overrides
     def predict_json(self, inputs: JsonDict, cuda_device: int = -1) -> JsonDict:
         """
         Expects JSON that looks like ``{"sentence": "..."}``

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -48,7 +48,7 @@ class SemanticRoleLabelerPredictor(Predictor):
         raise RuntimeError("this should never be called")
 
     @overrides
-    def _batch_json_to_instance(self, json: JsonDict) -> List[Instance]:
+    def _batch_json_to_instance(self, json: List[JsonDict]) -> List[Instance]:
         raise NotImplementedError("The SRL Predictor does not currently support batch prediction.")
 
     @overrides

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -48,7 +48,7 @@ class SemanticRoleLabelerPredictor(Predictor):
         raise RuntimeError("this should never be called")
 
     @overrides
-    def _batch_json_to_instance(self, json: List[JsonDict]) -> List[Instance]:
+    def _batch_json_to_instances(self, json: List[JsonDict]) -> List[Instance]:
         raise NotImplementedError("The SRL Predictor does not currently support batch prediction.")
 
     @overrides

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -62,6 +62,37 @@ class TestPredict(TestCase):
                                           "span_start_probs", "span_end_probs", "best_span",
                                           "best_span_str"}
 
+    def test_batch_prediction_works_with_known_model(self):
+        tempdir = tempfile.mkdtemp()
+        infile = os.path.join(tempdir, "inputs.txt")
+        outfile = os.path.join(tempdir, "outputs.txt")
+
+        with open(infile, 'w') as f:
+            f.write("""{"passage": "the seahawks won the super bowl in 2016", """
+                    """ "question": "when did the seahawks win the super bowl?"}\n""")
+            f.write("""{"passage": "the mariners won the super bowl in 2037", """
+                    """ "question": "when did the mariners win the super bowl?"}\n""")
+
+        sys.argv = ["run.py",  # executable
+                    "predict",  # command
+                    "tests/fixtures/bidaf/serialization/model.tar.gz",
+                    infile,  # input_file
+                    "--output-file", outfile,
+                    "--silent",
+                    "--batch_size", '2']
+
+        main()
+
+        assert os.path.exists(outfile)
+        with open(outfile, 'r') as f:
+            results = [json.loads(line) for line in f]
+
+        assert len(results) == 2
+        for result in results:
+            assert set(result.keys()) == {"span_start_logits", "span_end_logits",
+                                          "span_start_probs", "span_end_probs", "best_span",
+                                          "best_span_str"}
+
     def test_fails_without_required_args(self):
         sys.argv = ["run.py",            # executable
                     "predict",           # command

--- a/tests/service/predictors/bidaf_test.py
+++ b/tests/service/predictors/bidaf_test.py
@@ -51,17 +51,14 @@ class TestBidafPredictor(TestCase):
         archive = load_archive('tests/fixtures/bidaf/serialization/model.tar.gz')
         predictor = Predictor.from_archive(archive, 'machine-comprehension')
 
-        result = predictor.predict_batch_json(inputs)
+        results = predictor.predict_batch_json(inputs)
+        assert len(results) == 2
 
-        batch_best_span = result.get("best_span")
-        batch_best_span_str = result.get("best_span_str")
-        batch_start_probs = result.get("span_start_probs")
-        batch_end_probs = result.get("span_end_probs")
-
-        for best_span, best_span_str, start_probs, end_probs in zip(batch_best_span,
-                                                                    batch_best_span_str,
-                                                                    batch_start_probs,
-                                                                    batch_end_probs):
+        for result in results:
+            best_span = result.get("best_span")
+            best_span_str = result.get("best_span_str")
+            start_probs = result.get("span_start_probs")
+            end_probs = result.get("span_end_probs")
             assert best_span is not None
             assert isinstance(best_span, list)
             assert len(best_span) == 2

--- a/tests/service/predictors/decomposable_attention_test.py
+++ b/tests/service/predictors/decomposable_attention_test.py
@@ -41,7 +41,6 @@ class TestDecomposableAttentionPredictor(TestCase):
             assert e / sumexps == approx(p)
 
     def test_batch_prediction(self):
-
         batch_inputs = [
                 {
                         "premise": "I always write unit tests for my code.",

--- a/tests/service/predictors/decomposable_attention_test.py
+++ b/tests/service/predictors/decomposable_attention_test.py
@@ -39,3 +39,42 @@ class TestDecomposableAttentionPredictor(TestCase):
         sumexps = sum(exps)
         for e, p in zip(exps, label_probs):
             assert e / sumexps == approx(p)
+
+    def test_batch_prediction(self):
+
+        batch_inputs = [
+                {
+                        "premise": "I always write unit tests for my code.",
+                        "hypothesis": "One time I didn't write any unit tests for my code."
+                },
+                {
+                        "premise": "I also write batched unit tests for throughput!",
+                        "hypothesis": "Batch tests are slower."
+                },
+        ]
+
+        archive = load_archive('tests/fixtures/decomposable_attention/serialization/model.tar.gz')
+        predictor = Predictor.from_archive(archive, 'textual-entailment')
+        result = predictor.predict_batch_json(batch_inputs)
+        # Logits should be 3 floats that softmax to label_probs
+        batch_label_logits = result.get("label_logits")
+        # Label probs should be 3 floats that sum to one
+        batch_label_probs = result.get("label_probs")
+
+        for label_probs, label_logits in zip(batch_label_probs, batch_label_logits):
+            assert label_probs is not None
+            assert isinstance(label_probs, list)
+            assert len(label_probs) == 3
+            assert all(isinstance(x, float) for x in label_probs)
+            assert all(x >= 0 for x in label_probs)
+            assert sum(label_probs) == approx(1.0)
+
+            assert label_logits is not None
+            assert isinstance(label_logits, list)
+            assert len(label_logits) == 3
+            assert all(isinstance(x, float) for x in label_logits)
+
+            exps = [math.exp(x) for x in label_logits]
+            sumexps = sum(exps)
+            for e, p in zip(exps, label_probs):
+                assert e / sumexps == approx(p)

--- a/tests/service/predictors/decomposable_attention_test.py
+++ b/tests/service/predictors/decomposable_attention_test.py
@@ -54,13 +54,15 @@ class TestDecomposableAttentionPredictor(TestCase):
 
         archive = load_archive('tests/fixtures/decomposable_attention/serialization/model.tar.gz')
         predictor = Predictor.from_archive(archive, 'textual-entailment')
-        result = predictor.predict_batch_json(batch_inputs)
-        # Logits should be 3 floats that softmax to label_probs
-        batch_label_logits = result.get("label_logits")
-        # Label probs should be 3 floats that sum to one
-        batch_label_probs = result.get("label_probs")
+        results = predictor.predict_batch_json(batch_inputs)
+        print(results)
+        assert len(results) == 2
 
-        for label_probs, label_logits in zip(batch_label_probs, batch_label_logits):
+        for result in results:
+            # Logits should be 3 floats that softmax to label_probs
+            label_logits = result.get("label_logits")
+            # Label probs should be 3 floats that sum to one
+            label_probs = result.get("label_probs")
             assert label_probs is not None
             assert isinstance(label_probs, list)
             assert len(label_probs) == 3


### PR DESCRIPTION
- Adds batch prediction to the `Model` and `Predictor`. 
- I left adding batch prediction to the sanic server because that seems fairly separate, although easily possible.

Currently, `Model.forward_on_batch` returns a dict like {"key": [list of predictions for batch]}, but I could imagine it might be better to have [{"key": batch1prediction}, {"key": batch2prediction}] as then the output from a single element in the batch would match the output of `Model.forward_on_instance`. If people have strong opinions either way i'll change it.

@lucylw FYI - this is what you need to have the stream prediction from JSON you wanted.