### PR TITLE
adding token indexer for custom feature extraction + bypass embedder

### DIFF
--- a/allennlp/data/token_indexers/__init__.py
+++ b/allennlp/data/token_indexers/__init__.py
@@ -8,3 +8,4 @@ from allennlp.data.token_indexers.pos_tag_indexer import PosTagIndexer
 from allennlp.data.token_indexers.single_id_token_indexer import SingleIdTokenIndexer
 from allennlp.data.token_indexers.token_characters_indexer import TokenCharactersIndexer
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
+from allennlp.data.token_indexers.token_feature_indexer import FeatureIndexer

--- a/allennlp/data/token_indexers/token_feature_indexer.py
+++ b/allennlp/data/token_indexers/token_feature_indexer.py
@@ -1,0 +1,54 @@
+import logging
+from typing import Dict, List, Set
+import numpy as np
+from allennlp.common.checks import ConfigurationError
+from overrides import overrides
+
+from allennlp.common.util import pad_sequence_to_length
+from allennlp.common import Params
+from allennlp.data.vocabulary import Vocabulary
+from allennlp.data.tokenizers.token import Token
+from allennlp.data.token_indexers.token_indexer import TokenIndexer
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+class FeatureIndexer(TokenIndexer):
+
+    def __init__(self, feature_extractor, default_value) -> None:
+        self.feature_extractor = feature_extractor
+        self.default_value = default_value
+        self.feature_dim = self.default_value.shape
+
+    @overrides
+    def token_to_indices(self, token: Token, vocabulary: Vocabulary = None):
+        features = self.feature_extractor(token)
+        if not isinstance(features, np.ndarray):
+            raise ConfigurationError('Feature function for FeatureIndexer should return numpy array')
+        if features.shape != self.feature_dim:
+            raise ConfigurationError("feature function should return " \
+            "vectors of dimensionality {}, but got {}".format(self.feature_dim, features.shape))
+        return features
+
+    @overrides
+    def count_vocab_items(self, token, counter):
+        return
+
+    @overrides
+    def get_padding_token(self):
+        return []
+
+    @classmethod
+    def from_params(cls, params: Params):
+        return
+
+    @overrides
+    def get_padding_lengths(self, token):
+        return {}
+
+    @overrides
+    def pad_token_sequence(self,
+                           tokens,
+                           desired_num_tokens,
+                           padding_lengths):
+        return pad_sequence_to_length(tokens, desired_num_tokens,
+                                      default_value=lambda: self.default_value)

--- a/allennlp/modules/token_embedders/bypass_embedder.py
+++ b/allennlp/modules/token_embedders/bypass_embedder.py
@@ -1,0 +1,37 @@
+import logging
+from allennlp.common.params import Params
+from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
+from overrides import overrides
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+@TokenEmbedder.register("bypass_encoder")
+class BypassEmbedder(TokenEmbedder):
+    """
+    An embedding module that does not any processing of the input and just bypasses it forward. It is useful when
+    it is needed to extract arbirary features and they cannot be represented as an integer.
+    It can be used in a combination with :class:`~allennlp.data.token_indexers.FeatureIndexer`, which allows to extract
+    feature vector, given any feature_extractor function.
+
+    Parameters
+    ----------
+    dimensionality : int
+        The size of each feature vector
+
+    Returns
+    -------
+    A BypassEmbedder module.
+
+    """
+    def __init__(self, dimensionality):
+        super(BypassEmbedder, self).__init__()
+        self.dimensionality = dimensionality
+
+    @overrides
+    def forward(self, inputs):
+        return inputs
+
+    @overrides
+    def get_output_dim(self) -> int:
+        return self.dimensionality
+

--- a/tests/data/token_indexers/token_feature_indexer.py
+++ b/tests/data/token_indexers/token_feature_indexer.py
@@ -1,0 +1,30 @@
+# pylint: disable=no-self-use,invalid-name
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Token
+from allennlp.data.token_indexers import FeatureIndexer
+from allennlp.data.tokenizers.word_splitter import SpacyWordSplitter
+import numpy as np
+
+def lowercase_feature_extractor(token: Token):
+    if token.text[0].isupper():
+        return np.array([1.0], dtype=np.float32)
+    else:
+        return np.array([0.0], dtype=np.float32)
+
+class TestPosTagIndexer(AllenNlpTestCase):
+    def setUp(self):
+        super(TestPosTagIndexer, self).setUp()
+        self.tokenizer = SpacyWordSplitter(pos_tags=True)
+
+
+
+    def test_count_extract_features(self):
+        tokens = self.tokenizer.split_words("This is a sentence.")
+        tokens = [Token("<S>")] + [t for t in tokens] + [Token("</S>")]
+        indexer = FeatureIndexer(feature_extractor=lowercase_feature_extractor,
+                                 default_value=np.array([0.0], dtype=np.float32))
+        assert indexer.token_to_indices(tokens[1]) == np.array([1.0], dtype=np.float32)
+        assert indexer.token_to_indices(tokens[2]) == np.array([0.0], dtype=np.float32)
+
+
+

--- a/tests/modules/text_field_embedders/custom_feature_embedder.py
+++ b/tests/modules/text_field_embedders/custom_feature_embedder.py
@@ -1,0 +1,50 @@
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Token, Vocabulary, Dataset, Instance
+from allennlp.data.fields import TextField
+from allennlp.data.token_indexers import SingleIdTokenIndexer, FeatureIndexer
+import numpy as np
+from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
+from allennlp.modules.token_embedders import Embedding
+from allennlp.modules.token_embedders.bypass_embedder import BypassEmbedder
+from allennlp.nn.util import arrays_to_variables
+
+
+def lowercase_feature_extractor(token: Token):
+    if token.text[0].isupper():
+        return np.array([1.0], dtype=np.float32)
+    else:
+        return np.array([0.0], dtype=np.float32)
+
+
+
+class TestCustomFeatureFieldEmbedder(AllenNlpTestCase):
+    def setUp(self):
+        super(TestCustomFeatureFieldEmbedder, self).setUp()
+        self.indexers = {
+            'tokens': SingleIdTokenIndexer(),
+            "is_capitalized": FeatureIndexer(feature_extractor=lowercase_feature_extractor,
+                                         default_value=np.array([0.0], dtype=np.float32)),
+        }
+
+
+    def test_correct_dimensionality(self):
+        sentence1 = TextField([Token(t) for t in ["One", "two"]],
+                          token_indexers=self.indexers)
+        instance1 = Instance({"sentence": sentence1})
+        vocab = Vocabulary()
+        vocab.add_token_to_namespace("One")
+        vocab.add_token_to_namespace("two")
+
+        word_embedding_size = 10
+        word_embedding = Embedding(num_embeddings=vocab.get_vocab_size("tokens"),
+                                   embedding_dim=word_embedding_size)
+        embedder = BasicTextFieldEmbedder({"tokens": word_embedding,
+                                                "is_capitalized": BypassEmbedder(dimensionality=1)})
+        dataset = Dataset([instance1])
+        dataset.index_instances(vocab)
+
+        arrays = dataset.as_array_dict(dataset.get_padding_lengths())
+        torch_arrays = arrays_to_variables(arrays)
+
+        embedded_text = embedder(torch_arrays["sentence"])
+        assert embedded_text.size(2) == word_embedding_size + 1

--- a/tests/modules/token_embedders/bypass_embedder.py
+++ b/tests/modules/token_embedders/bypass_embedder.py
@@ -1,0 +1,14 @@
+import torch
+from torch.autograd import Variable
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.modules.token_embedders.bypass_embedder import BypassEmbedder
+import numpy
+
+class TestBypassEmbedding(AllenNlpTestCase):
+
+    def test_bypass_works(self):
+        embedder = BypassEmbedder(dimensionality = 1)
+        input = numpy.array([[1.0],[1.0],[0.0],[0.0]], dtype=numpy.float32)
+        input_tensor = Variable(torch.FloatTensor(input))
+        embedded = embedder(input_tensor).data.numpy()
+        assert numpy.allclose(embedded, input )


### PR DESCRIPTION
This PR contains few things that I found very useful while experimenting with allennlp library for a QA system development. I mentioned them here #428 with the ideas and help from @matt-gardner .
Mainly the idea is to introduce token indexer that is able to return a feature vector (just a numpy array) for a given token using a provided feature extraction function. For example, if one would need to add a feature like if the token start with lowercase or uppercase letter. In addition to such a token indexer, an embedder (BypassEmbedder) that just propagates the input keeping it untouched.

If it is within the scope of the library I would be happy to polish it to get it merged.