### PR TITLE
Bug fixes in loss computation, speed improvements from profiling

### DIFF
--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -62,7 +62,6 @@ class LabelField(Field[numpy.ndarray]):
                                          "Found label: {} with type: {}.".format(label, type(label)))
 
     def _maybe_warn_for_namespace(self, label_namespace: str) -> None:
-
         if not (self._label_namespace.endswith("labels") or self._label_namespace.endswith("tags")):
             if label_namespace not in self._already_warned_namespaces:
                 logger.warning("Your label namespace was '%s'. We recommend you use a namespace "

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -351,7 +351,9 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
                 # TODO(mattg): is this really all that expensive?  If it isn't, it would simplify
                 # the API to remove the `allowed_actions` argument, and it would make computing
                 # metrics easier if this skipping logic happened in the trainer - the trainer could
-                # keep track of when the top action wasn't allowed.
+                # keep track of when the top action wasn't allowed.  NOTE: without batching, when
+                # there are ~80 possible actions in each state, this gives a ~2x slowdown.  So I'm
+                # keeping it for now.  I'll re-evaluate once batching is implemented.
                 continue
             new_action_history = state.action_history + [action]
             # TODO(matt): we might need to normalize this by length eventually.  If the training

--- a/allennlp/nn/decoding/beam_search.py
+++ b/allennlp/nn/decoding/beam_search.py
@@ -35,10 +35,13 @@ class BeamSearch:
                         if step_num == num_steps and keep_final_unfinished_states:
                             finished_states.append(next_state)
                         next_states.append(next_state)
+            # TODO(mattg): do this sort on the GPU, not on the CPU, and copy once.
             to_sort = [(-state.score.data[0], state) for state in next_states]
             to_sort.sort(key=lambda x: x[0])
             states = [state[1] for state in to_sort[:self._beam_size]]
-        finished_to_sort = [(-state.score.data[0], state) for state in finished_states]
+        # The time this one takes is pretty negligible, no particular need to optimize this yet.
+        # Maybe with a larger beam size...
+        finished_to_sort = [(-state.score.data[0] / len(state.action_history), state) for state in finished_states]
         finished_to_sort.sort(key=lambda x: x[0])
         return [state[1] for state in finished_to_sort]
 


### PR DESCRIPTION
I did some profiling to see where the bottlenecks were, and I fixed some of them.  This got me a 2-2.5x speedup.  I don't think there's much more gain to be had apart from with batching.

I also went over the computation we're doing in detail with @DeNeutoy, because I was seeing some odd behavior trying to get this to learn.  We discovered that we weren't using the current input at timestep t as part of the attention over the question, and that we weren't doing the output projection as nicely as we could, either.  I fixed those issues here, and tried to have the model learn my simple word segmentation problem.  I made it even simpler, with just one corrupted example, but I think I'm asking the model to learn too much from too small a dataset.  It clearly is able to learn something, but after adding the first space it gets pretty confused.  I'm going to call this good enough - it looks like the model works as intended, and with a larger dataset with easier actions, we should be good.

Next up: seeing if we can do batched computation, both on the decoder states, and on the input questions.