### PR TITLE
More sanitize cases

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -14,7 +14,7 @@ from allennlp.common.params import Params
 
 JsonDict = Dict[str, Any]  # pylint: disable=invalid-name
 
-def sanitize(x: Any) -> Any:  # pylint: disable=invalid-name
+def sanitize(x: Any) -> Any:  # pylint: disable=invalid-name,too-many-return-statements
     """
     Sanitize turns PyTorch and Numpy types into basic Python types so they
     can be serialized into JSON.
@@ -24,7 +24,7 @@ def sanitize(x: Any) -> Any:  # pylint: disable=invalid-name
         return x
     elif isinstance(x, torch.autograd.Variable):
         return sanitize(x.data)
-    elif isinstance(x, torch.Tensor) or isinstance(x, torch.LongTensor):
+    elif isinstance(x, (torch.Tensor, torch.LongTensor)):
         # tensor needs to be converted to a list (and moved to cpu if necessary)
         return x.cpu().tolist()
     elif isinstance(x, numpy.ndarray):

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -24,7 +24,7 @@ def sanitize(x: Any) -> Any:  # pylint: disable=invalid-name,too-many-return-sta
         return x
     elif isinstance(x, torch.autograd.Variable):
         return sanitize(x.data)
-    elif isinstance(x, (torch.Tensor, torch.LongTensor)):
+    elif isinstance(x, torch._TensorBase):  # pylint: disable=protected-access
         # tensor needs to be converted to a list (and moved to cpu if necessary)
         return x.cpu().tolist()
     elif isinstance(x, numpy.ndarray):

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -22,7 +22,9 @@ def sanitize(x: Any) -> Any:  # pylint: disable=invalid-name
     if isinstance(x, (str, float, int, bool)):
         # x is already serializable
         return x
-    elif isinstance(x, torch.Tensor):
+    elif isinstance(x, torch.autograd.Variable):
+        return sanitize(x.data)
+    elif isinstance(x, torch.Tensor) or isinstance(x, torch.LongTensor):
         # tensor needs to be converted to a list (and moved to cpu if necessary)
         return x.cpu().tolist()
     elif isinstance(x, numpy.ndarray):

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-self-use,invalid-name
+import torch
+
 from allennlp.common import util
 from allennlp.common.testing import AllenNlpTestCase
 
@@ -18,3 +20,7 @@ class TestCommonUtils(AllenNlpTestCase):
         assert util.namespace_match("*tags", "question_tags")
         assert util.namespace_match("tokens", "tokens")
         assert not util.namespace_match("tokens", "stemmed_tokens")
+
+    def test_sanitize(self):
+        assert util.sanitize(torch.Tensor([1, 2])) == [1, 2]
+        assert util.sanitize(torch.LongTensor([1, 2])) == [1, 2]


### PR DESCRIPTION
I ran into a case where I needed to sanitize `Variable` and `LongTensor` (not caught by `Tensor`). I could get rid of the former in my output, but it shouldn't hurt to cover this case too?