### PR TITLE
Seq length padding fix

### DIFF
--- a/allennlp/modules/seq2seq_encoders/pytorch_seq2seq_wrapper.py
+++ b/allennlp/modules/seq2seq_encoders/pytorch_seq2seq_wrapper.py
@@ -63,7 +63,7 @@ class PytorchSeq2SeqWrapper(Seq2SeqEncoder):
         # running the RNN we zero out the corresponding rows in the result.
 
         # First count how many sequences are empty.
-        batch_size = mask.size()[0]
+        batch_size, total_sequence_length = mask.size()
         num_valid = torch.sum(mask[:, 0]).int().data[0]
 
         # Force every sequence to be length at least one. Need to `.clone()` the mask
@@ -87,6 +87,17 @@ class PytorchSeq2SeqWrapper(Seq2SeqEncoder):
         # they will be at the end.
         if num_valid < batch_size:
             unpacked_sequence_tensor[num_valid:, :, :] = 0.
+
+        # It's possible to need to pass sequences which are padded to longer than the
+        # max length of the sequence to a Seq2SeqEncoder. However, packing and unpacking
+        # the sequences mean that the returned tensor won't include these dimensions, because
+        # the RNN did not need to process them. We add them back on in the form of zeros here.
+        sequence_length_difference = total_sequence_length - unpacked_sequence_tensor.size(1)
+        if sequence_length_difference > 0:
+            zeros = unpacked_sequence_tensor.data.new(batch_size, sequence_length_difference,
+                                                      unpacked_sequence_tensor.size(-1)).fill_(0)
+            unpacked_sequence_tensor = torch.cat([unpacked_sequence_tensor, zeros], 1)
+
 
         # Restore the original indices and return the sequence.
         return unpacked_sequence_tensor.index_select(0, restoration_indices)

--- a/tests/modules/seq2seq_encoders/pytorch_seq2seq_wrapper_test.py
+++ b/tests/modules/seq2seq_encoders/pytorch_seq2seq_wrapper_test.py
@@ -103,6 +103,20 @@ class TestPytorchSeq2SeqWrapper(AllenNlpTestCase):
         assert_almost_equal(encoder_output.data.numpy(),
                             lstm_tensor.index_select(0, restoration_indices).data.numpy())
 
+    def test_forward_does_not_compress_tensors_padded_to_greater_than_the_max_sequence_length(self):
+
+        lstm = LSTM(bidirectional=True, num_layers=3, input_size=3, hidden_size=7, batch_first=True)
+        encoder = PytorchSeq2SeqWrapper(lstm)
+        tensor = torch.rand([5, 8, 3])
+        tensor[:, 7, :] = 0
+        mask = torch.ones(5, 8)
+        mask[:, 7] = 0
+
+        input_tensor = Variable(tensor)
+        mask = Variable(mask)
+        encoder_output = encoder(input_tensor, mask)
+        assert encoder_output.size(1) == 8
+
     def test_wrapper_raises_if_batch_first_is_false(self):
 
         with pytest.raises(ConfigurationError):


### PR DESCRIPTION
Pytorch doesn't like it if you pad to greater than the max sequence length for tensors, but @wilburOne needs this to be preserved.