### PR TITLE
Implemented batched decoding

### DIFF
--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, Generator, List, Set, Tuple
+from typing import Dict, List, Set, Tuple
 
 from overrides import overrides
 
@@ -9,7 +9,6 @@ from torch.nn.modules.rnn import LSTMCell
 from torch.nn.modules.linear import Linear
 
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
 from allennlp.data import Vocabulary
 from allennlp.data.dataset_readers.seq2seq import START_SYMBOL, END_SYMBOL
 from allennlp.modules import Attention, TextFieldEmbedder, Seq2SeqEncoder
@@ -462,7 +461,6 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
                             allowed_actions: List[Set[int]],
                             max_actions: int = None) -> List[WikiTablesDecoderState]:
         sorted_log_probs, sorted_actions = log_probs.sort(dim=-1, descending=True)
-        group_size, num_actions = sorted_log_probs.size()
         sorted_actions = sorted_actions.data.cpu().numpy().tolist()
         valid_actions = state.get_valid_actions()
         best_next_states: Dict[int, List[Tuple[int, int, int]]] = defaultdict(list)

--- a/allennlp/nn/decoding/beam_search.py
+++ b/allennlp/nn/decoding/beam_search.py
@@ -1,4 +1,5 @@
-from typing import List
+from collections import defaultdict
+from typing import Dict, List
 
 from allennlp.common import Params
 from allennlp.nn.decoding.decoder_step import DecoderStep
@@ -10,6 +11,9 @@ class BeamSearch:
     This class implements beam search over transition sequences given an initial ``DecoderState``
     and a ``DecoderStep``, returning the highest scoring final states found by the beam (the states
     will keep track of the transition sequence themselves).
+
+    The initial ``DecoderState`` is assumed to be `batched`.  The value we return from the search
+    is a dictionary from batch indices to ranked finished states.
     """
     def __init__(self, beam_size: int) -> None:
         self._beam_size = beam_size
@@ -18,37 +22,62 @@ class BeamSearch:
                num_steps: int,
                initial_state: DecoderState,
                decoder_step: DecoderStep,
-               keep_final_unfinished_states: bool = True) -> List[DecoderState]:
-        finished_states = []
+               keep_final_unfinished_states: bool = True) -> Dict[int, List[DecoderState]]:
+        """
+        Parameters
+        ----------
+            num_steps : ``int``
+                How many steps should we take in our search?  This is an upper bound, as it's
+                possible for the search to run out of valid actions before hitting this number, or
+                for all states on the beam to finish.
+            initial_state : ``DecoderState``
+                The starting state of our search.  This is assumed to be `batched`, and our beam
+                search is batch-aware - we'll keep ``beam_size`` states around for each instance in
+                the batch.
+            decoder_step : ``DecoderStep``
+                The ``DecoderStep`` object that defines and scores transitions from one state to
+                the next.
+            keep_final_unfinished_states : ``bool``, optional (default=True)
+                If we run out of steps before a state is "finished", should we return that state in
+                our search results?
+
+        Returns
+        -------
+        best_states : ``Dict[int, List[DecoderState]]``
+            This is a mapping from batch index to the top states for that instance.
+        """
+        finished_states: Dict[int, List[DecoderState]] = defaultdict(list)
         states = [initial_state]
         step_num = 1
-        print(num_steps)
         while states and step_num <= num_steps:
-            next_states = []
-            for state in states:
-                next_state_generator = decoder_step.take_step(state)
-                for _ in range(self._beam_size):
-                    next_state = next(next_state_generator)
-                    if next_state.is_finished():
-                        finished_states.append(next_state)
-                    else:
-                        if step_num == num_steps and keep_final_unfinished_states:
-                            finished_states.append(next_state)
-                        next_states.append(next_state)
-            # TODO(mattg): do this sort on the GPU, not on the CPU, and copy once.
-            # NOTE: we're doing state.score[0] here, hard-coding a group size of 1.  But, our use
-            # of `next_state.is_finished()` already checks for that, as it crashes if the group
-            # size is not 1.
-            to_sort = [(-state.score[0].data[0], state) for state in next_states]
-            to_sort.sort(key=lambda x: x[0])
-            states = [state[1] for state in to_sort[:self._beam_size]]
+            next_states: Dict[int, List[DecoderState]] = defaultdict(list)
+            grouped_state = states[0].combine_states(states)
+            for next_state in decoder_step.take_step(grouped_state, max_actions=self._beam_size):
+                # NOTE: we're doing state.batch_indices[0] here (and similar things below),
+                # hard-coding a group size of 1.  But, our use of `next_state.is_finished()`
+                # already checks for that, as it crashes if the group size is not 1.
+                batch_index = next_state.batch_indices[0]
+                if next_state.is_finished():
+                    finished_states[batch_index].append(next_state)
+                else:
+                    if step_num == num_steps and keep_final_unfinished_states:
+                        finished_states[batch_index].append(next_state)
+                    next_states[batch_index].append(next_state)
+            states = []
+            for batch_index, batch_states in next_states.items():
+                # The states from the generator are already sorted, so we can just take the first
+                # ones here, without an additional sort.
+                states.extend(batch_states[:self._beam_size])
             step_num += 1
-        # The time this one takes is pretty negligible, no particular need to optimize this yet.
-        # Maybe with a larger beam size...
-        finished_to_sort = [(-state.score[0].data[0] / len(state.action_history), state)
-                            for state in finished_states]
-        finished_to_sort.sort(key=lambda x: x[0])
-        return [state[1] for state in finished_to_sort]
+        best_states: Dict[int, List[DecoderState]] = {}
+        for batch_index, batch_states in finished_states.items():
+            # The time this sort takes is pretty negligible, no particular need to optimize this
+            # yet.  Maybe with a larger beam size...
+            finished_to_sort = [(-state.score[0].data[0] / len(state.action_history), state)
+                                for state in batch_states]
+            finished_to_sort.sort(key=lambda x: x[0])
+            best_states[batch_index] = [state[1] for state in finished_to_sort[:self._beam_size]]
+        return best_states
 
     @classmethod
     def from_params(cls, params: Params) -> 'BeamSearch':

--- a/allennlp/nn/decoding/beam_search.py
+++ b/allennlp/nn/decoding/beam_search.py
@@ -26,20 +26,19 @@ class BeamSearch:
         """
         Parameters
         ----------
-            num_steps : ``int``
-                How many steps should we take in our search?  This is an upper bound, as it's
-                possible for the search to run out of valid actions before hitting this number, or
-                for all states on the beam to finish.
-            initial_state : ``DecoderState``
-                The starting state of our search.  This is assumed to be `batched`, and our beam
-                search is batch-aware - we'll keep ``beam_size`` states around for each instance in
-                the batch.
-            decoder_step : ``DecoderStep``
-                The ``DecoderStep`` object that defines and scores transitions from one state to
-                the next.
-            keep_final_unfinished_states : ``bool``, optional (default=True)
-                If we run out of steps before a state is "finished", should we return that state in
-                our search results?
+        num_steps : ``int``
+            How many steps should we take in our search?  This is an upper bound, as it's possible
+            for the search to run out of valid actions before hitting this number, or for all
+            states on the beam to finish.
+        initial_state : ``DecoderState``
+            The starting state of our search.  This is assumed to be `batched`, and our beam search
+            is batch-aware - we'll keep ``beam_size`` states around for each instance in the batch.
+        decoder_step : ``DecoderStep``
+            The ``DecoderStep`` object that defines and scores transitions from one state to the
+            next.
+        keep_final_unfinished_states : ``bool``, optional (default=True)
+            If we run out of steps before a state is "finished", should we return that state in our
+            search results?
 
         Returns
         -------

--- a/allennlp/nn/decoding/decoder_state.py
+++ b/allennlp/nn/decoding/decoder_state.py
@@ -1,34 +1,80 @@
-from typing import List
+from typing import Generic, List, Tuple, TypeVar
 
 import torch
 
+# Note that the bound here is `DecoderState` itself.  This is what lets us have methods that take
+# lists of a `DecoderState` subclass and output structures with the subclass.  Really ugly that we
+# have to do this generic typing _for our own class_, but it makes mypy happy and gives us good
+# type checking in a few important methods.
+T = TypeVar('T', bound='DecoderState')
 
-class DecoderState:
+class DecoderState(Generic[T]):
     """
-    Represents the state of a transition-based decoder.
+    Represents the (batched) state of a transition-based decoder.
+
+    There are two different kinds of batching we need to distinguish here.  First, there's the
+    batch of training instances passed to ``model.forward()``.  We'll use "batch" and
+    ``batch_size`` to refer to this through the docs and code.  We additionally batch together
+    computation for several states at the same time, where each state could be from the same
+    training instance in the original batch, or different instances.  We use "group" and
+    ``group_size`` in the docs and code to refer to this kind of batching, to distinguish it from
+    the batch of training instances.
+
+    So, using this terminology, a single ``DecoderState`` object represents a `grouped` collection
+    of states.  Because different states in this group might finish at different timesteps, we have
+    methods and member variables to handle some bookkeeping around this, to split and regroup
+    things.
 
     Parameters
     ----------
-    action_history : ``List[int]``
-        The list of actions taken so far in this state.
+    batch_indices : ``List[int]``
+        Our internal variables (like scores, action histories, hidden states, whatever) are
+        `grouped`, and our ``group_size`` is likely different from the original ``batch_size``.
+        This variable keeps track of which batch instance each group element came from (e.g., to
+        know what the correct action sequences are, or which encoder outputs to use).
+    action_history : ``List[List[int]]``
+        The list of actions taken so far in this state.  This is also grouped, so each state in the
+        group has a list of actions.
 
         The type annotation says this is an ``int``, but none of the training logic relies on this
         being an ``int``.  In some cases, items from this list will get passed as inputs to
         ``DecodeStep``, so this must return items that are compatible with inputs to your
         ``DecodeStep`` class.
-    score : ``torch.autograd.Variable``
+    score : ``List[torch.autograd.Variable]``
         This state's score.  It's a variable, because typically we'll be computing a loss based on
-        this score, and using it for backprop during training.
+        this score, and using it for backprop during training.  Like the other variables here, it's
+        grouped.
     """
     def __init__(self,
-                 action_history: List[int],
-                 score: torch.autograd.Variable) -> None:
+                 batch_indices: List[int],
+                 action_history: List[List[int]],
+                 score: List[torch.autograd.Variable]) -> None:
+        self.batch_indices = batch_indices
         self.action_history = action_history
         self.score = score
 
     def is_finished(self) -> bool:
         """
-        Is this an end state?  Often this will correspond to having the last action be an end
-        symbol.
+        If this state has a ``group_size`` of 1, this returns whether the single action sequence in
+        this state is finished or not.  If this state has a ``group_size`` other than 1, this
+        method raises an error.
+        """
+        raise NotImplementedError
+
+    def split_finished(self) -> Tuple[T, T]:
+        """
+        This method decides, for each instance in the batch, whether that instance has reached a
+        finished state.  We then group all `finished` and `not finished` instances and create two
+        new states out of them.  If all of the instances are finished, for efficiency reasons, this
+        should return ``(self, None)``, and the reverse if none of the instances are finished.
+
+        The returned tuple is (finished, not_finished).
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def combine_states(cls, states: List[T]) -> T:
+        """
+        Combines a list of states, each with their own group size, into a single state.
         """
         raise NotImplementedError

--- a/allennlp/nn/decoding/decoder_step.py
+++ b/allennlp/nn/decoding/decoder_step.py
@@ -1,4 +1,4 @@
-from typing import Generator, Generic, Set, TypeVar
+from typing import Generator, Generic, List, Set, TypeVar
 
 import torch
 
@@ -22,7 +22,7 @@ class DecoderStep(torch.nn.Module, Generic[StateType]):
     """
     def take_step(self,
                   state: StateType,
-                  allowed_actions: Set = None) -> Generator[StateType, None, None]:
+                  allowed_actions: List[Set] = None) -> Generator[StateType, None, None]:
         """
         The main method in the ``DecoderStep`` API.  This function defines the computation done at
         each step of decoding and yields a ranked list of next states.
@@ -30,11 +30,20 @@ class DecoderStep(torch.nn.Module, Generic[StateType]):
         Parameters
         ----------
         state : ``DecoderState``
-            The current state of the decoder, which we will take a step `from`.
-        allowed_actions : ``Set``
+            The current state of the decoder, which we will take a step `from`.  We may be grouping
+            together computation for several states here.  Because we can have several states for
+            each instance in the original batch being evaluated at the same time, we use
+            ``group_size`` for this kind of batching, and ``batch_size`` for the `original` batch
+            in ``model.forward.``
+        allowed_actions : ``List[Set]``
             If the ``DecoderTrainer`` has constraints on which actions need to be evaluated (e.g.,
             maximum marginal likelihood only needs to evaluate action sequences in a given set),
             you can pass those constraints here, to avoid constructing state objects unnecessarily.
+            This is a list because it is `batched` - every instance in the batch has a set of
+            allowed actions.  Note that the size of this list is the ``group_size`` in the
+            ``DecoderState``, `not` the ``batch_size`` of ``model.forward``.  The training
+            algorithm needs to convert from the `batched` allowed action sequences that it has to a
+            `grouped` allowed action sequence list.
 
         Returns
         -------

--- a/allennlp/nn/decoding/decoder_step.py
+++ b/allennlp/nn/decoding/decoder_step.py
@@ -1,4 +1,4 @@
-from typing import Generator, Generic, List, Set, TypeVar
+from typing import Generic, List, Set, TypeVar
 
 import torch
 

--- a/allennlp/nn/decoding/decoder_step.py
+++ b/allennlp/nn/decoding/decoder_step.py
@@ -22,10 +22,21 @@ class DecoderStep(torch.nn.Module, Generic[StateType]):
     """
     def take_step(self,
                   state: StateType,
-                  allowed_actions: List[Set] = None) -> Generator[StateType, None, None]:
+                  max_actions: int = None,
+                  allowed_actions: List[Set] = None) -> List[StateType]:
         """
         The main method in the ``DecoderStep`` API.  This function defines the computation done at
-        each step of decoding and yields a ranked list of next states.
+        each step of decoding and returns a ranked list of next states.
+
+        The input state is `grouped`, to allow for efficient computation, but the output states
+        should all have a ``group_size`` of 1, to make things easier on the decoding algorithm.
+        They will get regrouped later as needed.
+
+        Because of the way we handle grouping in the decoder states, constructing a new state is
+        actually a relatively expensive operation.  If you know a priori that only some of the
+        states will be needed (either because you have a set of gold action sequences, or you have
+        a fixed beam size), passing that information into this function will keep us from
+        constructing more states than we need, which will greatly speed up your computation.
 
         Parameters
         ----------
@@ -35,10 +46,19 @@ class DecoderStep(torch.nn.Module, Generic[StateType]):
             each instance in the original batch being evaluated at the same time, we use
             ``group_size`` for this kind of batching, and ``batch_size`` for the `original` batch
             in ``model.forward.``
-        allowed_actions : ``List[Set]``
+        max_actions : ``int``, optional
+            If you know that you will only need a certain number of states out of this (e.g., in a
+            beam search), you can pass in the max number of actions that you need, and we will only
+            construct that many states (for each `batch` instance - `not` for each `group`
+            instance!).  This can save a whole lot of computation if you have an action space
+            that's much larger than your beam size.
+        allowed_actions : ``List[Set]``, optional
             If the ``DecoderTrainer`` has constraints on which actions need to be evaluated (e.g.,
             maximum marginal likelihood only needs to evaluate action sequences in a given set),
             you can pass those constraints here, to avoid constructing state objects unnecessarily.
+            If there are no constraints from the trainer, passing a value of ``None`` here will
+            allow all actions to be considered.
+
             This is a list because it is `batched` - every instance in the batch has a set of
             allowed actions.  Note that the size of this list is the ``group_size`` in the
             ``DecoderState``, `not` the ``batch_size`` of ``model.forward``.  The training
@@ -47,8 +67,7 @@ class DecoderStep(torch.nn.Module, Generic[StateType]):
 
         Returns
         -------
-        next_states : ``Generator[DecoderState, None, None]``
-            A generator for next states, ordered by score, which the decoding algorithm can sample
-            from as it wishes.
+        next_states : ``List[DecoderState]``
+            A list of next states, ordered by score.
         """
         raise NotImplementedError

--- a/allennlp/nn/decoding/decoder_trainer.py
+++ b/allennlp/nn/decoding/decoder_trainer.py
@@ -20,13 +20,13 @@ class DecoderTrainer(Registrable):
     maximize the probability of a single target sequence, there are way more efficient ways to do
     that than using this API.
     """
-    # TODO(mattg): figure out how reward functions fit into this.  We could _either_ take a targets
-    # tensor _or_ a reward function over states?  Not really sure...
+    # TODO(mattg): Make `DecoderTrainer` generic over supervision type, so we can either take a
+    # tensor of targets, or a reward function, or something else.
     def decode(self,
                initial_state: DecoderState,
                decode_step: DecoderStep,
-               targets: torch.Tensor = None,
-               target_mask: torch.Tensor = None) -> Dict[str, torch.Tensor]:
+               targets: torch.Tensor,
+               target_mask: torch.Tensor) -> Dict[str, torch.Tensor]:
         raise NotImplementedError
 
     @classmethod

--- a/allennlp/nn/decoding/maximum_marginal_likelihood.py
+++ b/allennlp/nn/decoding/maximum_marginal_likelihood.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
-from typing import Dict, Tuple, Set
+from typing import Dict, List, Set, Tuple
 
 import torch
+from torch.autograd import Variable
 
 from allennlp.common import Params
 from allennlp.nn import util
@@ -33,8 +34,6 @@ class MaximumMarginalLikelihood(DecoderTrainer):
                decode_step: DecoderStep,
                targets: torch.Tensor = None,
                target_mask: torch.Tensor = None) -> Dict[str, torch.Tensor]:
-        if targets.dim() != 2:
-            raise NotImplementedError("This implementation cannot yet handle batched inputs")
         allowed_transitions = self._create_allowed_transitions(targets, target_mask)
         finished_states = []
         states = [initial_state]
@@ -42,34 +41,43 @@ class MaximumMarginalLikelihood(DecoderTrainer):
         while states:
             step_num += 1
             next_states = []
-            for state in states:
-                allowed_actions = allowed_transitions[tuple(state.action_history)]
-                generator = decode_step.take_step(state, allowed_actions)
-                while True:
-                    try:
-                        next_state = next(generator)
-                    except StopIteration:
-                        break
-                    if next_state.is_finished():
-                        finished_states.append(next_state)
-                    else:
-                        next_states.append(next_state)
+            # We group together all current states to get more efficient (batched) computation.
+            grouped_state = states[0].combine_states(states)
+            allowed_actions = self._get_allowed_actions(grouped_state, allowed_transitions)
+            generator = decode_step.take_step(grouped_state, allowed_actions)
+            while True:
+                try:
+                    next_state = next(generator)
+                except StopIteration:
+                    break
+                finished, not_finished = next_state.split_finished()
+                if finished is not None:
+                    finished_states.append(finished)
+                if not_finished is not None:
+                    next_states.append(not_finished)
             states = next_states
 
-        scores = torch.cat([state.score for state in finished_states])
-        return {'loss': -util.logsumexp(scores)}
+        # This is a dictionary of lists - for each batch instance, we want the score of all
+        # finished states.  So this has shape (batch_size, num_target_action_sequences), though
+        # it's not actually a tensor, because different batch instance might have different numbers
+        # of finished states.
+        batch_scores = self._group_scores_by_batch(finished_states)
+        loss = 0
+        for scores in batch_scores.values():  # we don't care about the batch index, just the scores
+            loss += -util.logsumexp(torch.cat(scores))
+        return {'loss': loss / len(batch_scores)}
 
     @staticmethod
     def _create_allowed_transitions(targets: torch.Tensor,
-                                    target_mask: torch.Tensor = None) -> Dict[Tuple[int, ...], Set[int]]:
+                                    target_mask: torch.Tensor = None) -> List[Dict[Tuple[int, ...], Set[int]]]:
         """
         Takes a list of valid target action sequences and creates a mapping from all possible
         (valid) action prefixes to allowed actions given that prefix.  ``targets`` is assumed to be
-        a tensor of shape ``(num_valid_sequences, sequence_length)``.  If the mask is not ``None``,
-        it is assumed to have the same shape, and we will ignore any value in ``targets`` that has
-        a value of ``0`` in the corresponding position in the mask.  We assume that the mask has
-        the format 1*0* for each item in ``targets`` - that is, once we see our first zero, we stop
-        processing that target.
+        a tensor of shape ``(batch_size, num_valid_sequences, sequence_length)``.  If the mask is
+        not ``None``, it is assumed to have the same shape, and we will ignore any value in
+        ``targets`` that has a value of ``0`` in the corresponding position in the mask.  We assume
+        that the mask has the format 1*0* for each item in ``targets`` - that is, once we see our
+        first zero, we stop processing that target.
 
         Because of some implementation details around creating seq2seq datasets, our targets will
         have a start and end symbol added to them.  We want to ignore the start symbol here,
@@ -81,23 +89,49 @@ class MaximumMarginalLikelihood(DecoderTrainer):
 
         We use this to prune the set of actions we consider during decoding, because we only need
         to score the sequences in ``targets``.
-
-        While the example and types above say that this should be a 2D tensor, the implementation
-        logic is actually more flexible - any sequence of sequences is valid here, with any
-        contained types.  So your targets could be strings, for instance, if your ``DecoderStep``
-        and ``DecoderState`` objects know how to handle that.
         """
-        allowed_transitions: Dict[Tuple[int, ...], Set[int]] = defaultdict(set)
+        assert targets.dim() == 3, "targets tensor needs to be batched!"
+        batched_allowed_transitions: List[Dict[Tuple[int, ...], Set[int]]] = []
         targets = targets.data.cpu().numpy().tolist()
         target_mask = target_mask.data.cpu().numpy().tolist()
-        for i, target_sequence in enumerate(targets):
-            history: Tuple[int, ...] = ()
-            for j, action in enumerate(target_sequence[1:]):
-                if target_mask[i][j + 1] == 0:  # +1 because we're starting at index 1, not 0
-                    break
-                allowed_transitions[history].add(action)
-                history = history + (action,)
-        return allowed_transitions
+        for instance_targets, instance_mask in zip(targets, target_mask):
+            allowed_transitions: Dict[Tuple[int, ...], Set[int]] = defaultdict(set)
+            for i, target_sequence in enumerate(instance_targets):
+                history: Tuple[int, ...] = ()
+                for j, action in enumerate(target_sequence[1:]):
+                    if instance_mask[i][j + 1] == 0:  # +1 because we're starting at index 1, not 0
+                        break
+                    allowed_transitions[history].add(action)
+                    history = history + (action,)
+            batched_allowed_transitions.append(allowed_transitions)
+        return batched_allowed_transitions
+
+    @staticmethod
+    def _get_allowed_actions(state: DecoderState,
+                             allowed_transitions: List[Dict[Tuple[int, ...], Set[int]]]) -> List[Set[int]]:
+        """
+        Takes a list of allowed transitions for each element of a batch, and a decoder state that
+        contains the current action history for each element of the batch, and returns a list of
+        allowed actions in the current state, also for each element of the batch.
+        """
+        allowed_actions = []
+        for batch_index, action_history in zip(state.batch_indices, state.action_history):
+            allowed_actions.append(allowed_transitions[batch_index][tuple(action_history)])
+        return allowed_actions
+
+    @staticmethod
+    def _group_scores_by_batch(finished_states: List[DecoderState]) -> Dict[int, List[Variable]]:
+        """
+        Takes a list of finished states and groups all final scores for each batch element into a
+        list.  This is not trivial because the instances in the batch all might "finish" at
+        different times, so we re-batch them during the training process.  We need to recover the
+        original batch grouping so we can compute the loss correctly.
+        """
+        batch_scores: Dict[int, List[Variable]] = defaultdict(list)
+        for state in finished_states:
+            for score, batch_index in zip(state.score, state.batch_indices):
+                batch_scores[batch_index].append(score)
+        return batch_scores
 
     @classmethod
     def from_params(cls, params: Params) -> 'MaximumMarginalLikelihood':

--- a/tests/nn/decoding/maximum_marginal_likelihood_test.py
+++ b/tests/nn/decoding/maximum_marginal_likelihood_test.py
@@ -11,10 +11,21 @@ class TestMaximumMarginalLikelihood(AllenNlpTestCase):
         # `1` is our "start symbol" here - the first index is always assumed to be the start symbol
         # and is ignored.  This is due to how the data processing for seq2seq data works.  If that
         # logic changes, we can revisit this.
-        targets = torch.autograd.Variable(torch.Tensor([[1, 2, 3], [1, 4, 5], [1, 2, 7]]))
-        target_mask = torch.autograd.Variable(torch.Tensor([[1, 1, 1], [1, 1, 1], [1, 1, 0]]))
+        targets = torch.autograd.Variable(torch.Tensor([[[1, 2, 3], [1, 4, 5], [1, 2, 7]],
+                                                        [[1, 9, 10], [1, 3, 5], [1, 3, 3]]]))
+        target_mask = torch.autograd.Variable(torch.Tensor([[[1, 1, 1], [1, 1, 1], [1, 1, 0]],
+                                                            [[0, 0, 0], [1, 1, 1], [1, 1, 1]]]))
         result = MaximumMarginalLikelihood._create_allowed_transitions(targets, target_mask)
-        assert len(result) == 3
-        assert result[()] == set([2, 4])
-        assert result[(2,)] == set([3])  # note that 7 is not in here; it was masked
-        assert result[(4,)] == set([5])
+        # There were two instances in this batch.
+        assert len(result) == 2
+
+        # The first instance had three valid action sequence prefixes.
+        assert len(result[0]) == 3
+        assert result[0][()] == set([2, 4])
+        assert result[0][(2,)] == set([3])  # note that 7 is not in here; it was masked
+        assert result[0][(4,)] == set([5])
+
+        # The second instance had two valid action sequence prefixes.
+        assert len(result[1]) == 2
+        assert result[1][()] == set([3])  # note that 9 is not in here; it was masked
+        assert result[1][(3,)] == set([3, 5])


### PR DESCRIPTION
There are two kinds of batching going on here: we process several training instances at once, _and_ we process several states for each training instance at once.  Hopefully the docs I wrote make this clear enough.

I switched to a simpler copying task, where I'm training the model to copy the input given noisy supervision, and I'm still having trouble getting it to train correctly.  But at least this logic runs, and I _think_ I did everything correctly here.  It gives about an 8x speedup when using a batch size of 60 instead of a batch size of 1 (and that's on top of a minor speed up using a batch size of 1 that I got from batching together several states for each instance).  I haven't tried profiling this at all, and there might be more gains to be had somewhere in here with some careful profiling.