### PR TITLE
make API_ROOT depend on window.location.origin

### DIFF
--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { API_ROOT } from './api-config';
 import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
 import SrlComponent from './components/SrlComponent';
 import TeComponent from './components/TeComponent';
@@ -72,7 +73,7 @@ class Demo extends React.Component {
     if (slug && !responseData) {
       // Make an ajax call to get the permadata,
       // and then use it to update the state.
-      fetch('http://localhost:8000/permadata', {
+      fetch(`${API_ROOT}/permadata`, {
         method: 'POST',
         headers: {
           'Accept': 'application/json',

--- a/demo/src/api-config.js
+++ b/demo/src/api-config.js
@@ -1,0 +1,18 @@
+/**
+ * The backend always runs on port 8000. In production we also
+ * serve the frontend from there. However, for development
+ * we want to `npm run serve` the unminified js on port 3000.
+ * This allows us to get the correct API root either way.
+ */
+
+let apiRoot;
+
+const origin = window && window.location && window.location.origin;
+
+if (origin === 'http://localhost:3000') {
+    apiRoot = 'http://localhost:8000';
+} else {
+    apiRoot = origin;
+}
+
+export const API_ROOT = apiRoot;

--- a/demo/src/components/McComponent.js
+++ b/demo/src/components/McComponent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { API_ROOT } from '../api-config';
 import { withRouter } from 'react-router-dom';
 import {PaneLeft, PaneRight} from './Pane'
 import Button from './Button'
@@ -187,7 +188,7 @@ class _McComponent extends React.Component {
         passage: inputs.passageValue,
         question: inputs.questionValue,
       };
-      fetch('http://localhost:8000/predict/machine-comprehension', {
+      fetch(`${API_ROOT}/predict/machine-comprehension`, {
         method: 'POST',
         headers: {
           'Accept': 'application/json',

--- a/demo/src/components/SrlComponent.js
+++ b/demo/src/components/SrlComponent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { API_ROOT } from '../api-config';
 import { withRouter } from 'react-router-dom';
 import { PaneLeft, PaneRight } from './Pane'
 import Button from './Button'
@@ -216,7 +217,7 @@ class _SrlComponent extends React.Component {
 
     var payload = {sentence: inputs.sentenceValue};
 
-    fetch('http://localhost:8000/predict/semantic-role-labeling', {
+    fetch(`${API_ROOT}/predict/semantic-role-labeling`, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',

--- a/demo/src/components/TeComponent.js
+++ b/demo/src/components/TeComponent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { API_ROOT } from '../api-config';
 import { withRouter } from 'react-router-dom';
 import {PaneLeft, PaneRight} from './Pane'
 import Button from './Button'
@@ -306,7 +307,7 @@ class _TeComponent extends React.Component {
         premise: inputs.premiseValue,
         hypothesis: inputs.hypothesisValue,
       };
-      fetch('http://localhost:8000/predict/textual-entailment', {
+      fetch(`${API_ROOT}/predict/textual-entailment`, {
         method: 'POST',
         headers: {
           'Accept': 'application/json',


### PR DESCRIPTION
we want to hardcode the backend as localhost:8000 for development but not for production. this is a quick and dirty way to make that happen