### PR TITLE
Multi text field embedder

### DIFF
--- a/allennlp/modules/text_field_embedders/__init__.py
+++ b/allennlp/modules/text_field_embedders/__init__.py
@@ -7,3 +7,4 @@ returns as output an embedded representation of the tokens in that field.
 
 from allennlp.modules.text_field_embedders.text_field_embedder import TextFieldEmbedder
 from allennlp.modules.text_field_embedders.basic_text_field_embedder import BasicTextFieldEmbedder
+from allennlp.modules.text_field_embedders.one_to_many_text_field_embedder import OneToManyTextFieldEmbedder

--- a/allennlp/modules/text_field_embedders/one_to_many_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/one_to_many_text_field_embedder.py
@@ -56,7 +56,7 @@ class OneToManyTextFieldEmbedder(TextFieldEmbedder):
         return torch.cat(embedded_representations, dim=-1)
 
     @classmethod
-    def from_params(cls, vocab: Vocabulary, params: Params) -> 'BasicTextFieldEmbedder':
+    def from_params(cls, vocab: Vocabulary, params: Params) -> 'OneToManyTextFieldEmbedder':
         token_embedders = {}
         keys = list(params.keys())
         for key in keys:

--- a/allennlp/modules/text_field_embedders/one_to_many_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/one_to_many_text_field_embedder.py
@@ -1,0 +1,72 @@
+from typing import Dict, List
+
+import torch
+from overrides import overrides
+
+from allennlp.common import Params
+from allennlp.common.checks import ConfigurationError
+from allennlp.data import Vocabulary
+from allennlp.modules.text_field_embedders.text_field_embedder import TextFieldEmbedder
+from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
+
+
+@TextFieldEmbedder.register("one_to_many")
+class OneToManyTextFieldEmbedder(TextFieldEmbedder):
+    """
+    This is a ``TextFieldEmbedder`` that wraps a collection of :class:`TokenEmbedder` objects.
+    In a :class:`OneToManyTextFieldEmbedder`, a single :class:`~allennlp.data.TokenIndexer` can
+    have multiple associated :class:`~allennlp.modules.token_embedders.TokenEmbedder` 's .
+    This is useful in the case that you wish to represent the same set of token ids in
+    multiple ways - for instance, using multiple different word embeddings.
+
+    As the data produced by a :class:`~allennlp.data.fields.TextField` is a dictionary mapping
+    :class:`~allennlp.data.TokenIndexer` names to these representations, we take a list of
+    ``TokenEmbedders`` for each name, describing the methods used to embed each one.
+    Each ``TokenEmbedder`` then embeds its input, and the result is concatenated in an
+    arbitrary order.
+    """
+    def __init__(self, token_embedders: Dict[str, List[TokenEmbedder]]) -> None:
+        super(OneToManyTextFieldEmbedder, self).__init__()
+        self._token_embedders = token_embedders
+        for key, namespace_embedders in token_embedders.items():
+            for index, embedder in enumerate(namespace_embedders):
+                name = f'token_embedder_{key}_{index}'
+                self.add_module(name, embedder)
+
+    @overrides
+    def get_output_dim(self) -> int:
+        output_dim = 0
+        for namespace_embedders in self._token_embedders.values():
+            for embedder in namespace_embedders:
+                output_dim += embedder.get_output_dim()
+        return output_dim
+
+    def forward(self, text_field_input: Dict[str, torch.Tensor]) -> torch.Tensor:
+        if self._token_embedders.keys() != text_field_input.keys():
+            message = f"Mismatched token keys: {self._token_embedders.keys()}" \
+                      f" and {text_field_input.keys()}"
+            raise ConfigurationError(message)
+        embedded_representations = []
+        keys = sorted(text_field_input.keys())
+        for key in keys:
+            tensor = text_field_input[key]
+            for embedder in self._token_embedders[key]:
+                token_vectors = embedder(tensor)
+                embedded_representations.append(token_vectors)
+        return torch.cat(embedded_representations, dim=-1)
+
+    @classmethod
+    def from_params(cls, vocab: Vocabulary, params: Params) -> 'BasicTextFieldEmbedder':
+        token_embedders = {}
+        keys = list(params.keys())
+        for key in keys:
+            all_embedder_params = params.pop(key)
+            if not isinstance(all_embedder_params, list):
+                raise ConfigurationError("The embedders passed to a OneToManyTextFieldEmbedder "
+                                         "must be lists (they can be of length 1). Edit your "
+                                         "configuration file to contain lists of embedders per "
+                                         "namespace.")
+            token_embedders[key] = [TokenEmbedder.from_params(vocab, embedder_params)
+                                    for embedder_params in all_embedder_params]
+        params.assert_empty(cls.__name__)
+        return cls(token_embedders)

--- a/doc/api/allennlp.modules.text_field_embedders.rst
+++ b/doc/api/allennlp.modules.text_field_embedders.rst
@@ -8,6 +8,7 @@ allennlp.modules.text_field_embedders
 
 * :ref:`TextFieldEmbedder<text-field-embedder>`
 * :ref:`BasicTextFieldEmbedder<basic-text-field-embedder>`
+* :ref:`OneToManyTextFieldEmbedder<one-to-many-field-embedder>`
 
 .. _text-field-embedder:
 .. automodule:: allennlp.modules.text_field_embedders.text_field_embedder
@@ -21,3 +22,8 @@ allennlp.modules.text_field_embedders
    :undoc-members:
    :show-inheritance:
 
+.. _one-to-many-text-field-embedder:
+.. automodule:: allennlp.modules.text_field_embedders.one_to_many_text_field_embedder
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/modules/text_field_embedders/one_to_many_text_field_embedder_test.py
+++ b/tests/modules/text_field_embedders/one_to_many_text_field_embedder_test.py
@@ -1,0 +1,66 @@
+# pylint: disable=no-self-use,invalid-name
+import pytest
+import torch
+
+from torch.autograd import Variable
+
+from allennlp.common import Params
+from allennlp.common.checks import ConfigurationError
+from allennlp.data import Vocabulary
+from allennlp.modules.text_field_embedders import OneToManyTextFieldEmbedder
+from allennlp.common.testing import AllenNlpTestCase
+
+
+class TestOneToManyTextFieldEmbedder(AllenNlpTestCase):
+    def setUp(self):
+        super(TestOneToManyTextFieldEmbedder, self).setUp()
+        self.vocab = Vocabulary()
+        self.vocab.add_token_to_namespace("1")
+        self.vocab.add_token_to_namespace("2")
+        self.vocab.add_token_to_namespace("3")
+        self.vocab.add_token_to_namespace("4")
+        params = Params({
+                "words1": [
+                    {
+                        "type": "embedding",
+                        "embedding_dim": 2
+                    },
+                    {
+                        "type": "embedding",
+                        "embedding_dim": 2
+                    }
+                ],
+                "words2": [{
+                        "type": "embedding",
+                        "embedding_dim": 5
+                        }],
+                "words3": [{
+                        "type": "embedding",
+                        "embedding_dim": 3
+                        }]
+                })
+        self.token_embedder = OneToManyTextFieldEmbedder.from_params(self.vocab, params)
+        self.inputs = {
+                "words1": Variable(torch.LongTensor([[0, 2, 3, 5]])),
+                "words2": Variable(torch.LongTensor([[1, 4, 3, 2]])),
+                "words3": Variable(torch.LongTensor([[1, 5, 1, 2]]))
+                }
+
+    def test_get_output_dim_aggregates_dimension_from_each_embedding(self):
+        assert self.token_embedder.get_output_dim() == 12
+
+    def test_from_params_raises_without_lists_of_token_embedders(self):
+        params = Params({"words1": {"type": "embedding", "embedding_dim": 2}})
+        with pytest.raises(ConfigurationError):
+            OneToManyTextFieldEmbedder.from_params(self.vocab, params)
+
+    def test_forward_asserts_input_field_match(self):
+        self.inputs['words4'] = self.inputs['words3']
+        del self.inputs['words3']
+        with pytest.raises(ConfigurationError):
+            self.token_embedder(self.inputs)
+        self.inputs['words3'] = self.inputs['words4']
+        del self.inputs['words4']
+
+    def test_forward_concats_resultant_embeddings(self):
+        assert self.token_embedder(self.inputs).size() == (1, 4, 12)

--- a/tests/modules/text_field_embedders/one_to_many_text_field_embedder_test.py
+++ b/tests/modules/text_field_embedders/one_to_many_text_field_embedder_test.py
@@ -21,15 +21,14 @@ class TestOneToManyTextFieldEmbedder(AllenNlpTestCase):
         self.vocab.add_token_to_namespace("4")
         params = Params({
                 "words1": [
-                    {
-                        "type": "embedding",
-                        "embedding_dim": 2
-                    },
-                    {
-                        "type": "embedding",
-                        "embedding_dim": 2
-                    }
-                ],
+                        {
+                                "type": "embedding",
+                                "embedding_dim": 2
+                        },
+                        {
+                                "type": "embedding",
+                                "embedding_dim": 2
+                        }],
                 "words2": [{
                         "type": "embedding",
                         "embedding_dim": 5


### PR DESCRIPTION
I encountered the need to embed a single token representation in two ways when playing around with the coref model to see if I can improve the performance. We could obviously replace the `BasicTokenEmbedder` with this, but it is a massively breaking change and also it's good enough for 90% of use cases, so I figured it might be better to separate this. 