### PR TITLE
Add constrained decoding to the DecoderStep

### DIFF
--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -479,10 +479,10 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
 
     def _embed_actions(self, actions: List[List[int]]) -> Tuple[Variable, Variable]:
         """
-        Returns an embedded representation of the given actions.  The input is assumed to have
-        shape ``(group_size, num_actions)``, though the number of actions for each group element
-        need not be constant.  Because of this, we need to pad the number of actions so we have an
-        evenly-shaped tensor, and we additionally return a mask.
+        Returns an embedded representation of the given actions.  The input is a list of valid
+        actions for each element in the group, which may have variable length.  We pad these to
+        have shape ``(group_size, num_actions)``, and then embed them.  Because of the padding, we
+        additionally return a mask.
 
         Parameters
         ----------
@@ -496,7 +496,7 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
             An embedded representation of all of the given actions.  Shape is ``(group_size,
             num_actions, action_embedding_dim)``, where ``num_actions`` is the maximum length of
             the input ``actions`` lists.
-        action_mask : byte ``Variable``
+        action_mask : long ``Variable``
             A mask of shape ``(group_size, num_actions)`` indicating which ``(group_index,
             action_index)`` pairs were merely added as padding.
         """

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -34,6 +34,26 @@ def get_lengths_from_binary_sequence_mask(mask: torch.Tensor):
     return mask.long().sum(-1)
 
 
+def get_mask_from_sequence_lengths(sequence_lengths: Variable, max_length: int) -> Variable:
+    """
+    Given a variable of shape ``(batch_size,)`` that represents the sequence lengths of each batch
+    element, this function returns a ``(batch_size, max_length)`` mask variable.  For example, if our
+    input was ``[2, 2, 3]``, with a ``max_length`` of 4, we'd return
+    ``[[1, 1, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0]]``.
+
+    We require ``max_length`` here instead of just computing it from the input ``sequence_lengths``
+    because it lets us avoid finding the max, then copying that value from the GPU to the CPU so
+    that we can use it to construct a new tensor.
+
+    Some of our functions are agnostic as to whether they accept ``Tensors`` or ``Variables``, and
+    they just use ``Tensor`` for their type annotations.  We `require` ``Variables`` here, as we
+    call ``sequence_length.data.new()``.
+    """
+    # (batch_size, max_length)
+    ones = Variable(sequence_lengths.data.new(sequence_lengths.size(0), max_length).fill_(1))
+    range_tensor = ones.cumsum(dim=1)
+    return sequence_lengths.unsqueeze(1) >= range_tensor
+
 def sort_batch_by_length(tensor: torch.autograd.Variable, sequence_lengths: torch.autograd.Variable):
     """
     Sort a batch first tensor by some specified lengths.

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -47,12 +47,13 @@ def get_mask_from_sequence_lengths(sequence_lengths: Variable, max_length: int) 
 
     Some of our functions are agnostic as to whether they accept ``Tensors`` or ``Variables``, and
     they just use ``Tensor`` for their type annotations.  We `require` ``Variables`` here, as we
-    call ``sequence_length.data.new()``.
+    call ``sequence_length.data.new()``.  The data type of ``sequence_lengths`` is assumed to be
+    ``long``, but really could be anything, and the data type of the returned mask is ``long``.
     """
     # (batch_size, max_length)
     ones = Variable(sequence_lengths.data.new(sequence_lengths.size(0), max_length).fill_(1))
     range_tensor = ones.cumsum(dim=1)
-    return sequence_lengths.unsqueeze(1) >= range_tensor
+    return (sequence_lengths.unsqueeze(1) >= range_tensor).long()
 
 def sort_batch_by_length(tensor: torch.autograd.Variable, sequence_lengths: torch.autograd.Variable):
     """

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -92,6 +92,15 @@ class TestNnUtil(AllenNlpTestCase):
         lengths = util.get_lengths_from_binary_sequence_mask(binary_mask)
         numpy.testing.assert_array_equal(lengths.numpy(), numpy.array([3, 2, 6, 1]))
 
+    def test_get_mask_from_sequence_lengths(self):
+        sequence_lengths = Variable(torch.LongTensor([4, 3, 1, 4, 2]))
+        mask = util.get_mask_from_sequence_lengths(sequence_lengths, 5).data.numpy()
+        assert_almost_equal(mask, [[1, 1, 1, 1, 0],
+                                   [1, 1, 1, 0, 0],
+                                   [1, 0, 0, 0, 0],
+                                   [1, 1, 1, 1, 0],
+                                   [1, 1, 0, 0, 0]])
+
     def test_get_sequence_lengths_converts_to_long_tensor_and_avoids_variable_overflow(self):
         # Tests the following weird behaviour in Pytorch 0.1.12
         # doesn't happen for our sequence masks:
@@ -522,7 +531,6 @@ class TestNnUtil(AllenNlpTestCase):
         replaced = util.replace_masked_values(tensor, mask.unsqueeze(-1), 2).data.numpy()
         assert_almost_equal(replaced, [[[1, 2, 3, 4], [5, 6, 7, 8], [2, 2, 2, 2]]])
 
-
     def test_logsumexp(self):
         # First a simple example where we add probabilities in log space.
         tensor = Variable(torch.FloatTensor([[.4, .1, .2]]))
@@ -540,7 +548,6 @@ class TestNnUtil(AllenNlpTestCase):
         assert_almost_equal(util.logsumexp(tensor).data.numpy(), [20.0])
         tensor = Variable(torch.FloatTensor([[20.0, 20.0], [-200.0, 200.0]]))
         assert_almost_equal(util.logsumexp(tensor, dim=0).data.numpy(), [20.0, 200.0])
-
 
     def test_flatten_and_batch_shift_indices(self):
         indices = numpy.array([[[1, 2, 3, 4],


### PR DESCRIPTION
So far, this is just setting up a variable number of valid actions, and changing the model to do a dot product with a smaller set of action embeddings, instead of a softmax over all actions.  Next, I will use the grammar and action history to actually select a set of valid actions at each state.