### PR TITLE
introduce `DemoModel` abstraction

### DIFF
--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, NamedTuple
+from typing import Dict
 import argparse
 
 from allennlp.commands.serve import Serve

--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -8,39 +8,6 @@ from allennlp.commands.evaluate import Evaluate
 from allennlp.commands.subcommand import Subcommand
 from allennlp.service.predictors import DemoModel
 
-# This maps from the name of model (as known to the front-end)
-# to the ``DemoModel`` indicating the location of the trained model
-# and the type of the ``Predictor``.  This is necessary, as you might
-# have multiple models (for example, a NER tagger and a POS tagger)
-# that have the same ``Predictor`` wrapper.
-DEFAULT_MODELS = {
-        'machine-comprehension': DemoModel(
-                'https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.09.15-charpad.tar.gz',  # pylint: disable=line-too-long
-                'machine-comprehension'
-        ),
-        'semantic-role-labeling': DemoModel(
-                'https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2017.09.05.tar.gz', # pylint: disable=line-too-long
-                'semantic-role-labeling'
-        ),
-        'textual-entailment': DemoModel(
-                'https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-2017.09.04.tar.gz',  # pylint: disable=line-too-long
-                'textual-entailment'
-        ),
-        'coreference-resolution': DemoModel(
-                'https://s3-us-west-2.amazonaws.com/allennlp/models/coref-model-2017.11.09.tar.gz',  # pylint: disable=line-too-long
-                'coreference-resolution'
-        )
-}
-
-# a mapping from model `type` to the default Predictor for that type
-DEFAULT_PREDICTORS = {
-        'srl': 'semantic-role-labeling',
-        'decomposable_attention': 'textual-entailment',
-        'bidaf': 'machine-comprehension',
-        'simple_tagger': 'simple-tagger',
-        'crf_tagger': 'crf-tagger',
-        'coref': 'coreference-resolution'
-}
 
 def main(prog: str = None,
          model_overrides: Dict[str, DemoModel] = {},
@@ -63,15 +30,12 @@ def main(prog: str = None,
     parser = argparse.ArgumentParser(description="Run AllenNLP", usage='%(prog)s [command]', prog=prog)
     subparsers = parser.add_subparsers(title='Commands', metavar='')
 
-    trained_models = {**DEFAULT_MODELS, **model_overrides}
-    predictors = {**DEFAULT_PREDICTORS, **predictor_overrides}
-
     subcommands = {
             # Default commands
             "train": Train(),
             "evaluate": Evaluate(),
-            "predict": Predict(predictors),
-            "serve": Serve(trained_models),
+            "predict": Predict(predictor_overrides),
+            "serve": Serve(model_overrides),
 
             # Superseded by overrides
             **subcommand_overrides

--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, NamedTuple
 import argparse
 
 from allennlp.commands.serve import Serve
@@ -6,13 +6,30 @@ from allennlp.commands.predict import Predict
 from allennlp.commands.train import Train
 from allennlp.commands.evaluate import Evaluate
 from allennlp.commands.subcommand import Subcommand
+from allennlp.service.predictors import DemoModel
 
-# a mapping from predictor `type` to the location of the trained model of that type
+# This maps from the name of model (as known to the front-end)
+# to the ``DemoModel`` indicating the location of the trained model
+# and the type of the ``Predictor``.  This is necessary, as you might
+# have multiple models (for example, a NER tagger and a POS tagger)
+# that have the same ``Predictor`` wrapper.
 DEFAULT_MODELS = {
-        'machine-comprehension': 'https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.09.15-charpad.tar.gz',  # pylint: disable=line-too-long
-        'semantic-role-labeling': 'https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2017.09.05.tar.gz', # pylint: disable=line-too-long
-        'textual-entailment': 'https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-2017.09.04.tar.gz',  # pylint: disable=line-too-long
-        'coreference-resolution': 'https://s3-us-west-2.amazonaws.com/allennlp/models/coref-model-2017.11.09.tar.gz',  # pylint: disable=line-too-long
+        'machine-comprehension': DemoModel(
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.09.15-charpad.tar.gz',  # pylint: disable=line-too-long
+                'machine-comprehension'
+        ),
+        'semantic-role-labeling': DemoModel(
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2017.09.05.tar.gz', # pylint: disable=line-too-long
+                'semantic-role-labeling'
+        ),
+        'textual-entailment': DemoModel(
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-2017.09.04.tar.gz',  # pylint: disable=line-too-long
+                'textual-entailment'
+        ),
+        'coreference-resolution': DemoModel(
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/coref-model-2017.11.09.tar.gz',  # pylint: disable=line-too-long
+                'coreference-resolution'
+        )
 }
 
 # a mapping from model `type` to the default Predictor for that type
@@ -26,7 +43,7 @@ DEFAULT_PREDICTORS = {
 }
 
 def main(prog: str = None,
-         model_overrides: Dict[str, str] = {},
+         model_overrides: Dict[str, DemoModel] = {},
          predictor_overrides: Dict[str, str] = {},
          subcommand_overrides: Dict[str, Subcommand] = {}) -> None:
     """

--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -32,9 +32,21 @@ from allennlp.common.checks import ConfigurationError
 from allennlp.models.archival import load_archive
 from allennlp.service.predictors import Predictor
 
+# a mapping from model `type` to the default Predictor for that type
+DEFAULT_PREDICTORS = {
+        'srl': 'semantic-role-labeling',
+        'decomposable_attention': 'textual-entailment',
+        'bidaf': 'machine-comprehension',
+        'simple_tagger': 'simple-tagger',
+        'crf_tagger': 'crf-tagger',
+        'coref': 'coreference-resolution'
+}
+
+
 class Predict(Subcommand):
-    def __init__(self, predictors: Dict[str, str]) -> None:
-        self.predictors = predictors
+    def __init__(self, predictor_overrides: Dict[str, str] = {}) -> None:
+        # pylint: disable=dangerous-default-value
+        self.predictors = {**DEFAULT_PREDICTORS, **predictor_overrides}
 
     def add_subparser(self, name: str, parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
         # pylint: disable=protected-access

--- a/allennlp/commands/serve.py
+++ b/allennlp/commands/serve.py
@@ -28,9 +28,36 @@ from allennlp.commands.subcommand import Subcommand
 from allennlp.service import server_sanic
 from allennlp.service.predictors import DemoModel
 
+# This maps from the name of the task
+# to the ``DemoModel`` indicating the location of the trained model
+# and the type of the ``Predictor``.  This is necessary, as you might
+# have multiple models (for example, a NER tagger and a POS tagger)
+# that have the same ``Predictor`` wrapper. The corresponding model
+# will be served at the `/predict/<name-of-task>` API endpoint.
+DEFAULT_MODELS = {
+        'machine-comprehension': DemoModel(
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.09.15-charpad.tar.gz',  # pylint: disable=line-too-long
+                'machine-comprehension'
+        ),
+        'semantic-role-labeling': DemoModel(
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2017.09.05.tar.gz', # pylint: disable=line-too-long
+                'semantic-role-labeling'
+        ),
+        'textual-entailment': DemoModel(
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-2017.09.04.tar.gz',  # pylint: disable=line-too-long
+                'textual-entailment'
+        ),
+        'coreference-resolution': DemoModel(
+                'https://s3-us-west-2.amazonaws.com/allennlp/models/coref-model-2017.11.09.tar.gz',  # pylint: disable=line-too-long
+                'coreference-resolution'
+        )
+}
+
+
 class Serve(Subcommand):
-    def __init__(self, trained_models: Dict[str, DemoModel]) -> None:
-        self.trained_models = trained_models
+    def __init__(self, model_overrides: Dict[str, DemoModel] = {}) -> None:
+        # pylint: disable=dangerous-default-value
+        self.trained_models = {**DEFAULT_MODELS, **model_overrides}
 
     def add_subparser(self, name: str, parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
         # pylint: disable=protected-access

--- a/allennlp/commands/serve.py
+++ b/allennlp/commands/serve.py
@@ -26,9 +26,10 @@ from typing import Dict
 
 from allennlp.commands.subcommand import Subcommand
 from allennlp.service import server_sanic
+from allennlp.service.predictors import DemoModel
 
 class Serve(Subcommand):
-    def __init__(self, trained_models: Dict[str, str]) -> None:
+    def __init__(self, trained_models: Dict[str, DemoModel]) -> None:
         self.trained_models = trained_models
 
     def add_subparser(self, name: str, parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
@@ -44,7 +45,7 @@ class Serve(Subcommand):
 
         return subparser
 
-def _serve(trained_models: Dict[str, str]):
+def _serve(trained_models: Dict[str, DemoModel]):
     def serve_inner(args: argparse.Namespace) -> None:
         server_sanic.run(args.port, args.workers, trained_models)
 

--- a/allennlp/service/predictors/__init__.py
+++ b/allennlp/service/predictors/__init__.py
@@ -6,7 +6,7 @@ want to serve up a model through the web service
 (or using ``allennlp.commands.predict``), you'll need
 a ``Predictor`` that wraps it.
 """
-from .predictor import Predictor
+from .predictor import Predictor, DemoModel
 from .bidaf import BidafPredictor
 from .decomposable_attention import DecomposableAttentionPredictor
 from .semantic_role_labeler import SemanticRoleLabelerPredictor

--- a/allennlp/service/predictors/predictor.py
+++ b/allennlp/service/predictors/predictor.py
@@ -3,7 +3,7 @@ from allennlp.common import Registrable
 from allennlp.common.util import JsonDict, sanitize
 from allennlp.data import DatasetReader, Instance
 from allennlp.models import Model
-from allennlp.models.archival import Archive
+from allennlp.models.archival import Archive, load_archive
 
 
 class Predictor(Registrable):
@@ -61,3 +61,18 @@ class Predictor(Registrable):
         model.eval()
 
         return Predictor.by_name(predictor_name)(model, dataset_reader)
+
+
+class DemoModel:
+    """
+    A demo model is determined by both an archive file
+    (representing the trained model)
+    and a choice of predictor
+    """
+    def __init__(self, archive_file: str, predictor_name: str) -> None:
+        self.archive_file = archive_file
+        self.predictor_name = predictor_name
+
+    def predictor(self) -> Predictor:
+        archive = load_archive(self.archive_file)
+        return Predictor.from_archive(archive, self.predictor_name)

--- a/scripts/cache_models.py
+++ b/scripts/cache_models.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir))))
-from allennlp.commands import DEFAULT_MODELS
+from allennlp.commands.serve import DEFAULT_MODELS
 from allennlp.common.file_utils import cached_path
 
 value = os.environ.get('CACHE_MODELS', 'false')

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -7,8 +7,8 @@ import tempfile
 from unittest import TestCase
 
 from allennlp.common.util import JsonDict
-from allennlp.commands import main, DEFAULT_PREDICTORS
-from allennlp.commands.predict import Predict
+from allennlp.commands import main
+from allennlp.commands.predict import Predict, DEFAULT_PREDICTORS
 from allennlp.service.predictors import Predictor, BidafPredictor
 
 

--- a/tests/commands/serve_test.py
+++ b/tests/commands/serve_test.py
@@ -2,8 +2,7 @@
 import argparse
 from unittest import TestCase
 
-from allennlp.commands import DEFAULT_MODELS
-from allennlp.commands.serve import Serve
+from allennlp.commands.serve import Serve, DEFAULT_MODELS
 
 
 class TestServe(TestCase):

--- a/tests/models/sniff_test.py
+++ b/tests/models/sniff_test.py
@@ -2,8 +2,6 @@
 
 from allennlp.commands import DEFAULT_MODELS
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.models.archival import load_archive
-from allennlp.service.predictors import Predictor
 
 
 class SniffTest(AllenNlpTestCase):
@@ -18,10 +16,7 @@ class SniffTest(AllenNlpTestCase):
 
 
     def test_machine_comprehension(self):
-        predictor = Predictor.from_archive(
-                load_archive(DEFAULT_MODELS['machine-comprehension']),
-                'machine-comprehension'
-        )
+        predictor = DEFAULT_MODELS['machine-comprehension'].predictor()
 
         passage = """The Matrix is a 1999 science fiction action film written and directed by The Wachowskis, starring Keanu Reeves, Laurence Fishburne, Carrie-Anne Moss, Hugo Weaving, and Joe Pantoliano. It depicts a dystopian future in which reality as perceived by most humans is actually a simulated reality called "the Matrix", created by sentient machines to subdue the human population, while their bodies' heat and electrical activity are used as an energy source. Computer programmer Neo" learns this truth and is drawn into a rebellion against the machines, which involves other people who have been freed from the "dream world". """  # pylint: disable=line-too-long
         question = "Who stars in The Matrix?"
@@ -34,10 +29,7 @@ class SniffTest(AllenNlpTestCase):
 
 
     def test_semantic_role_labeling(self):
-        predictor = Predictor.from_archive(
-                load_archive(DEFAULT_MODELS['semantic-role-labeling']),
-                'semantic-role-labeling'
-        )
+        predictor = DEFAULT_MODELS['semantic-role-labeling'].predictor()
 
         sentence = "If you liked the music we were playing last night, you will absolutely love what we're playing tomorrow!"
 
@@ -78,10 +70,7 @@ class SniffTest(AllenNlpTestCase):
         ]
 
     def test_textual_entailment(self):
-        predictor = Predictor.from_archive(
-                load_archive(DEFAULT_MODELS['textual-entailment']),
-                'textual-entailment'
-        )
+        predictor = DEFAULT_MODELS['textual-entailment'].predictor()
 
         result = predictor.predict_json({
                 "premise": "An interplanetary spacecraft is in orbit around a gas giant's icy moon.",
@@ -105,8 +94,8 @@ class SniffTest(AllenNlpTestCase):
         assert result["label_probs"][2] > 0.7  # neutral
 
     def test_coreference_resolution(self):
-        predictor = Predictor.from_archive(load_archive(DEFAULT_MODELS['coreference-resolution']),
-                                           'coreference-resolution')
+        predictor = DEFAULT_MODELS['coreference-resolution'].predictor()
+
         document = "We 're not going to skimp on quality , but we are very focused to make next year . The only problem is that some of the fabrics are wearing out - since I was a newbie I skimped on some of the fabric and the poor quality ones are developing holes . For some , an awareness of this exit strategy permeates the enterprise , allowing them to skimp on the niceties they would more or less have to extend toward a person they were likely to meet again ."
 
         result = predictor.predict_json({"document": document})

--- a/tests/models/sniff_test.py
+++ b/tests/models/sniff_test.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-self-use,line-too-long
 
-from allennlp.commands import DEFAULT_MODELS
+from allennlp.commands.serve import DEFAULT_MODELS
 from allennlp.common.testing import AllenNlpTestCase
 
 


### PR DESCRIPTION
change dict used by run/serve from 

{predictor_name -> archive_file} 
to 
{demo_model_name -> (predictor_name, archive_file)}

which is a better representation and (in particular) allows us to have different demo models that share the same `Predictor` wrapper

(this will allow us to have a single `sentence_tagger` predictor that can be used by the NER model and by (say) a future POS tagger)