### PR TITLE
Actually use type constrained decoding

### DIFF
--- a/allennlp/data/dataset_readers/__init__.py
+++ b/allennlp/data/dataset_readers/__init__.py
@@ -15,4 +15,4 @@ from allennlp.data.dataset_readers.sequence_tagging import SequenceTaggingDatase
 from allennlp.data.dataset_readers.snli import SnliReader
 from allennlp.data.dataset_readers.semantic_role_labeling import SrlReader
 from allennlp.data.dataset_readers.seq2seq import Seq2SeqDatasetReader
-from allennlp.data.dataset_readers.wikitables.wikitables_dataset_reader import WikitablesDatasetReader
+from allennlp.data.dataset_readers.wikitables.wikitables_dataset_reader import WikiTablesDatasetReader

--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -27,12 +27,19 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 @DatasetReader.register("wikitables")
-class WikitablesDatasetReader(DatasetReader):
+class WikiTablesDatasetReader(DatasetReader):
     """
-    Initialize the dataset reader with paths to the tables directory and the directory where DPD
+    This ``DatasetReader`` takes WikiTableQuestions example files and converts them into
+    ``Instances`` suitable for use with the ``WikiTablesSemanticParser``.  The example files have
+    pointers in them to two other files: a file that contains an associated table for each
+    question, and a file that has pre-computed, possible logical forms.  Because of how the
+    ``DatasetReader`` API works, we need to take base directories for those other files in the
+    constructor.
+
+    We initialize the dataset reader with paths to the tables directory and the directory where DPD
     output is stored if you are training. While testing, you can either provide existing table
-    filenames or if your question is about a new table, provide the contnet of the table as a dict
-    (See ``TableKnowledgeGraph.read_from_json`` for the expected format). If you are doing the
+    filenames or if your question is about a new table, provide the content of the table as a dict
+    (See :func:`TableKnowledgeGraph.read_from_json` for the expected format). If you are doing the
     former, you still need to provide a ``tables_directory`` path here.
 
     For training, we assume you are reading in ``data/*.examples`` files, and you have access to
@@ -167,14 +174,14 @@ class WikitablesDatasetReader(DatasetReader):
         return parsed_info
 
     @classmethod
-    def from_params(cls, params: Params) -> 'WikitablesDatasetReader':
+    def from_params(cls, params: Params) -> 'WikiTablesDatasetReader':
         tables_directory = params.pop('tables_directory')
         dpd_output_directory = params.pop('dpd_output_directory', None)
         tokenizer = Tokenizer.from_params(params.pop('tokenizer', {}))
         question_token_indexers = TokenIndexer.dict_from_params(params.pop('question_token_indexers', {}))
         table_token_indexers = TokenIndexer.dict_from_params(params.pop('table_token_indexers', {}))
         params.assert_empty(cls.__name__)
-        return WikitablesDatasetReader(tables_directory=tables_directory,
+        return WikiTablesDatasetReader(tables_directory=tables_directory,
                                        dpd_output_directory=dpd_output_directory,
                                        tokenizer=tokenizer,
                                        question_token_indexers=question_token_indexers,

--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -2,8 +2,9 @@
 Reader for WikitableQuestions (https://github.com/ppasupat/WikiTableQuestions/releases/tag/v1.0.2).
 """
 from typing import Dict, List, Union
-import logging
 import gzip
+import logging
+import os
 import pyparsing
 
 from overrides import overrides
@@ -28,36 +29,44 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 @DatasetReader.register("wikitables")
 class WikitablesDatasetReader(DatasetReader):
     """
-    Initialize the dataset reader with paths to the tables directory and the directory where DPD output is stored
-    if you are training. While testing, you can either provide existing table filenames or if your question is
-    about a new table, provide the contnet of the table as a dict (See ``TableKnowledgeGraph.read_from_json`` for
-    the expected format). If you are doing the former, you still need to provide a ``tables_directory`` path here.
+    Initialize the dataset reader with paths to the tables directory and the directory where DPD
+    output is stored if you are training. While testing, you can either provide existing table
+    filenames or if your question is about a new table, provide the contnet of the table as a dict
+    (See ``TableKnowledgeGraph.read_from_json`` for the expected format). If you are doing the
+    former, you still need to provide a ``tables_directory`` path here.
 
-    For training, we assume you are reading in ``data/*.examples`` files, and you have access to the output from
-    Dynamic Programming on Denotations (DPD) on the training dataset.
+    For training, we assume you are reading in ``data/*.examples`` files, and you have access to
+    the output from Dynamic Programming on Denotations (DPD) on the training dataset.
 
     Parameters
     ----------
     tables_directory : ``str`` (optional)
-        Prefix for the path to the directory in which the tables reside. For example, ``*.examples`` files
-        contain paths like ``csv/204-csv/590.csv``, this is the directory that contains the ``csv`` directory.
+        Prefix for the path to the directory in which the tables reside. For example,
+        ``*.examples`` files contain paths like ``csv/204-csv/590.csv``, this is the directory that
+        contains the ``csv`` directory.
     dpd_output_directory : ``str`` (optional)
         Directory that contains all the gzipped dpd output files. We assume the filenames match the
         example IDs (e.g.: ``nt-0.gz``).
-    utterance_tokenizer : ``Tokenizer`` (optional)
+    tokenizer : ``Tokenizer`` (optional)
         Tokenizer to use for the questions. Will default to ``WordTokenizer()``.
-    utterance_token_indexers : ``Dict[str, TokenIndexer]`` (optional)
+    question_token_indexers : ``Dict[str, TokenIndexer]`` (optional)
         Token indexers for questions. Will default to ``{"tokens": SingleIdTokenIndexer()}``.
+    table_token_indexers : ``Dict[str, TokenIndexer]`` (optional)
+        Token indexers for table entities. Will default to ``question_token_indexers`` (though you
+        very likely want to use something different for these, as you can't rely on having an
+        embedding for every table entity at test time).
     """
     def __init__(self,
                  tables_directory: str = None,
                  dpd_output_directory: str = None,
-                 utterance_tokenizer: Tokenizer = None,
-                 utterance_token_indexers: Dict[str, TokenIndexer] = None) -> None:
+                 tokenizer: Tokenizer = None,
+                 question_token_indexers: Dict[str, TokenIndexer] = None,
+                 table_token_indexers: Dict[str, TokenIndexer] = None) -> None:
         self._tables_directory = tables_directory
         self._dpd_output_directory = dpd_output_directory
-        self._utterance_tokenizer = utterance_tokenizer or WordTokenizer()
-        self._utterance_token_indexers = utterance_token_indexers or {"tokens": SingleIdTokenIndexer()}
+        self._tokenizer = tokenizer or WordTokenizer()
+        self._question_token_indexers = question_token_indexers or {"tokens": SingleIdTokenIndexer()}
+        self._table_token_indexers = table_token_indexers or self._question_token_indexers
 
     @overrides
     def read(self, file_path):
@@ -69,56 +78,58 @@ class WikitablesDatasetReader(DatasetReader):
                 if not line:
                     continue
                 parsed_info = self._parse_line_as_lisp(line)
-                utterance = parsed_info["utterance"]
+                question = parsed_info["question"]
                 # We want the TSV file, but the ``*.examples`` files typically point to CSV.
-                table_filename = "%s/%s" % (self._tables_directory, parsed_info["context"].replace(".csv", ".tsv"))
-                dpd_output_filename = "%s/%s.gz" % (self._dpd_output_directory, parsed_info["id"])
+                table_filename = os.path.join(self._tables_directory,
+                                              parsed_info["context"].replace(".csv", ".tsv"))
+                dpd_output_filename = os.path.join(self._dpd_output_directory,
+                                                   parsed_info["id"] + '.gz')
                 sempre_forms = [line.strip().decode('utf-8') for line in gzip.open(dpd_output_filename)]
-                instances.append(self.text_to_instance(utterance, table_filename, sempre_forms))
+                instances.append(self.text_to_instance(question, table_filename, sempre_forms))
         if not instances:
             raise ConfigurationError("No instances read!")
         return Dataset(instances)
 
     @overrides
     def text_to_instance(self,  # type: ignore
-                         utterance: str,
+                         question: str,
                          table_info: Union[str, JsonDict],
                          dpd_output: List[str] = None) -> Instance:
         """
-        Reads text inputs and makes an instance. WikitableQuestions dataset provides tables as TSV files, which we
-        use for training. For running a demo, we may want to provide tables in a JSON format. To make this method
-        compatible with both, we take ``table_info``, which can either be a filename, or a dict. We check the
-        argument's type and calle the appropriate method in ``TableKnowledgeGraph``.
+        Reads text inputs and makes an instance. WikitableQuestions dataset provides tables as TSV
+        files, which we use for training. For running a demo, we may want to provide tables in a
+        JSON format. To make this method compatible with both, we take ``table_info``, which can
+        either be a filename, or a dict. We check the argument's type and calle the appropriate
+        method in ``TableKnowledgeGraph``.
 
         Parameters
         ----------
-        utterance : ``str``
-            Input utterance
+        question : ``str``
+            Input question
         table_info : ``str`` or ``Dict[str, Any]``
-            Table filename or the table content itself, as a dict. See ``TableKnowledgeGraph.read_from_json`` for
-            the expected format.
+            Table filename or the table content itself, as a dict. See
+            ``TableKnowledgeGraph.read_from_json`` for the expected format.
         dpd_output : List[str] (optional)
-            List of logical forms, produced by dynamic programming on denotations. Not required during test.
+            List of logical forms, produced by dynamic programming on denotations. Not required
+            during test.
         """
         # pylint: disable=arguments-differ
-        tokenized_utterance = self._utterance_tokenizer.tokenize(utterance)
-        utterance_field = TextField(tokenized_utterance, self._utterance_token_indexers)
+        tokenized_question = self._tokenizer.tokenize(question)
+        question_field = TextField(tokenized_question, self._question_token_indexers)
         if isinstance(table_info, str):
             table_knowledge_graph = TableKnowledgeGraph.read_from_file(table_info)
         else:
             table_knowledge_graph = TableKnowledgeGraph.read_from_json(table_info)
-        table_field = KnowledgeGraphField(table_knowledge_graph, self._utterance_token_indexers)
+        table_field = KnowledgeGraphField(table_knowledge_graph, self._table_token_indexers)
+        fields = {'question': question_field, 'table': table_field}
         if dpd_output:
             world = World(table_knowledge_graph)
             expressions = world.process_sempre_forms(dpd_output)
             action_sequences = [world.get_action_sequence(expression) for expression in expressions]
             action_sequences_field = ListField([self._make_action_sequence_field(sequence)
                                                 for sequence in action_sequences])
-            return Instance({"utterance": utterance_field,
-                             "context": table_field,
-                             "action_sequences": action_sequences_field})
-        else:
-            return Instance({"utterance": utterance_field, "context": table_field})
+            fields['target_action_sequences'] = action_sequences_field
+        return Instance(fields)
 
     @staticmethod
     def _make_action_sequence_field(action_sequence: List[str]) -> ListField:
@@ -131,7 +142,7 @@ class WikitablesDatasetReader(DatasetReader):
         """
         Training data in WikitableQuestions comes with examples in the form of lisp strings in the format:
             (example (id <example-id>)
-                     (utterance <utterance>)
+                     (utterance <question>)
                      (context (graph tables.TableKnowledgeGraph <table-filename>))
                      (targetValue (list (description <answer1>) (description <answer2>) ...)))
 
@@ -144,7 +155,7 @@ class WikitablesDatasetReader(DatasetReader):
             if key == "id":
                 parsed_info["id"] = value
             elif key == "utterance":
-                parsed_info["utterance"] = value.replace("\"", "")
+                parsed_info["question"] = value.replace("\"", "")
             elif key == "context":
                 # Skipping "graph" and "tables.TableKnowledgeGraph"
                 parsed_info["context"] = value[-1]
@@ -152,17 +163,19 @@ class WikitablesDatasetReader(DatasetReader):
                 # Skipping "list", and "description" within each nested list.
                 parsed_info["targetValue"] = [x[1] for x in value[1:]]
         # targetValue may not be present if the answer is not provided.
-        assert all([x in parsed_info for x in ["id", "utterance", "context"]]), "Invalid format"
+        assert all([x in parsed_info for x in ["id", "question", "context"]]), "Invalid format"
         return parsed_info
 
     @classmethod
     def from_params(cls, params: Params) -> 'WikitablesDatasetReader':
         tables_directory = params.pop('tables_directory')
         dpd_output_directory = params.pop('dpd_output_directory', None)
-        utterance_tokenizer = Tokenizer.from_params(params.pop('utterance_tokenizer', {}))
-        utterance_token_indexers = TokenIndexer.dict_from_params(params.pop('utterance_token_indexers', {}))
+        tokenizer = Tokenizer.from_params(params.pop('tokenizer', {}))
+        question_token_indexers = TokenIndexer.dict_from_params(params.pop('question_token_indexers', {}))
+        table_token_indexers = TokenIndexer.dict_from_params(params.pop('table_token_indexers', {}))
         params.assert_empty(cls.__name__)
-        return WikitablesDatasetReader(tables_directory,
-                                       dpd_output_directory,
-                                       utterance_tokenizer,
-                                       utterance_token_indexers)
+        return WikitablesDatasetReader(tables_directory=tables_directory,
+                                       dpd_output_directory=dpd_output_directory,
+                                       tokenizer=tokenizer,
+                                       question_token_indexers=question_token_indexers,
+                                       table_token_indexers=table_token_indexers)

--- a/allennlp/data/fields/knowledge_graph_field.py
+++ b/allennlp/data/fields/knowledge_graph_field.py
@@ -20,7 +20,7 @@ class KnowledgeGraphField(Field[Dict[str, numpy.ndarray]]):
     A ``KnowledgeGraphField`` represents a ``KnowledgeGraph`` as a ``Field`` that can be used in a
     ``Model``.  We take the (sorted) list of entities in the graph and output them as arrays using
     ``TokenIndexers``, similar to how text tokens are treated by a ``TextField``.  We have
-    knowledge-graph-specific ``TokenIndexers`, however, that allow for more versatile treatment of
+    knowledge-graph-specific ``TokenIndexers``, however, that allow for more versatile treatment of
     the knowledge graph entities than just treating them as text tokens.
 
     Parameters

--- a/allennlp/data/knowledge_graph.py
+++ b/allennlp/data/knowledge_graph.py
@@ -1,6 +1,6 @@
 """
-A ``KnowledgeGraph`` is a graphical representation of some structured knowledge source: say a table, figure
-or an explicit knowledge base.
+A ``KnowledgeGraph`` is a graphical representation of some structured knowledge source: say a
+table, figure or an explicit knowledge base.
 """
 
 from typing import Dict, List
@@ -9,11 +9,12 @@ from typing import Dict, List
 class KnowledgeGraph:
     """
     ``KnowledgeGraph`` currently stores some basic neighborhood information, and provides  minimal
-    functionality for querying that information, for embedding this knowledge or linking the entities in the
-    knowledge base to some text.
-    The knowledge base itself can be a table (like in WikitableQuestions), a figure (like in NLVR) or some
-    other structured knowledge source. This abstract class needs to be inherited for implementing the
-    functionality appropriate for a given KB.
+    functionality for querying that information, for embedding this knowledge or linking the
+    entities in the knowledge base to some text.
+
+    The knowledge base itself can be a table (like in WikitableQuestions), a figure (like in NLVR)
+    or some other structured knowledge source. This abstract class needs to be inherited for
+    implementing the functionality appropriate for a given KB.
 
     Parameters
     ----------

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -377,6 +377,13 @@ class Vocabulary:
                                        pretrained_files=pretrained_files,
                                        only_include_pretrained_words=only_include_pretrained_words)
 
+    def is_padded(self, namespace: str) -> bool:
+        """
+        Returns whether or not there are padding and OOV tokens added to the given namepsace.
+        """
+        return self._index_to_token[namespace][0] == self._padding_token
+
+
     def add_token_to_namespace(self, token: str, namespace: str = 'tokens') -> int:
         """
         Adds ``token`` to the index, if it is not already present.  Either way, we return the index of

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -31,8 +31,8 @@ class WikiTablesSemanticParser(Model):
     <https://www.semanticscholar.org/paper/Neural-Semantic-Parsing-with-Type-Constraints-for-Krishnamurthy-Dasigi/8c6f58ed0ebf379858c0bbe02c53ee51b3eb398a>`_,
     by Jayant Krishnamurthy, Pradeep Dasigi, and Matt Gardner (EMNLP 2017).
 
-    WORK STILL IN PROGRESS.  This is just copying the SimpleSeq2Seq model for now, and we'll
-    iteratively improve it until we've reproduced the performance of the original parser.
+    WORK STILL IN PROGRESS.  We'll iteratively improve it until we've reproduced the performance of
+    the original parser.
 
     Parameters
     ----------
@@ -77,21 +77,29 @@ class WikiTablesSemanticParser(Model):
         self._beam_search = decoder_beam_search
         self._max_decoding_steps = max_decoding_steps
         self._action_namespace = action_namespace
+        self._action_padding_index = 0 if self.vocab.is_padded(self._action_namespace) else -1
 
         self._start_index = self.vocab.get_token_index(START_SYMBOL, self._action_namespace)
         self._end_index = self.vocab.get_token_index(END_SYMBOL, self._action_namespace)
-        num_actions = self.vocab.get_vocab_size(self._action_namespace)
-        self._decoder_step = WikiTablesDecoderStep(self._encoder.get_output_dim(),
-                                                   action_embedding_dim,
-                                                   num_actions,
-                                                   attention_function,
-                                                   self._start_index)
+        # This is a _global_ mapping because eventually we will have additional allowed actions for
+        # each instance (e.g., instance-specific entities or predicates), and for the current
+        # decoder state (e.g., you can only produce variables inside of a lambda expression).
+        # These are just the actions that are specified by the grammar.
+        self._global_type_productions = _get_type_productions(self.vocab, self._action_namespace)
+        self._decoder_step = WikiTablesDecoderStep(vocab=vocab,
+                                                   action_namespace=action_namespace,
+                                                   encoder_output_dim=self._encoder.get_output_dim(),
+                                                   action_embedding_dim=action_embedding_dim,
+                                                   attention_function=attention_function,
+                                                   start_index=self._start_index)
 
     @overrides
     def forward(self,  # type: ignore
                 question: Dict[str, torch.LongTensor],
+                table: Dict[str, torch.LongTensor],
                 target_action_sequences: torch.LongTensor = None) -> Dict[str, torch.Tensor]:
         # pylint: disable=arguments-differ
+        # pylint: disable=unused-argument
         """
         Decoder logic for producing the entire target sequence.
 
@@ -120,8 +128,7 @@ class WikiTablesSemanticParser(Model):
         if target_action_sequences is not None:
             # Remove batch dimension and trailing dimension (from ListField[LabelField]]).
             target_action_sequences = target_action_sequences.squeeze(-1)
-            # TODO(mattg): might be better to not hard-code the 0 here.
-            target_mask = target_action_sequences > 0
+            target_mask = target_action_sequences != self._action_padding_index
         else:
             target_mask = None
 
@@ -141,14 +148,16 @@ class WikiTablesSemanticParser(Model):
         initial_attended_question = [attended_question[i] for i in range(batch_size)]
         encoder_output_list = [encoder_outputs[i] for i in range(batch_size)]
         question_mask_list = [question_mask[i] for i in range(batch_size)]
-        initial_state = WikiTablesDecoderState(list(range(batch_size)),
-                                               [[] for _ in range(batch_size)],
-                                               initial_score_list,
+        initial_state = WikiTablesDecoderState(batch_indices=list(range(batch_size)),
+                                               action_history=[[] for _ in range(batch_size)],
+                                               score=initial_score_list,
+                                               non_terminal_stack=[[START_SYMBOL] for _ in range(batch_size)],
                                                hidden_state=initial_hidden_state,
                                                memory_cell=initial_memory_cell,
                                                attended_question=initial_attended_question,
                                                encoder_outputs=encoder_output_list,
                                                encoder_output_mask=question_mask_list,
+                                               global_type_productions=self._global_type_productions,
                                                end_index=self._end_index)
         if self.training:
             return self._decoder_trainer.decode(initial_state,
@@ -223,6 +232,37 @@ class WikiTablesSemanticParser(Model):
                    attention_function=attention_function)
 
 
+def _get_type_productions(vocab: Vocabulary, namespace: str) -> Dict[str, List[int]]:
+    """
+    Temporary method, until we get the type declaration (grammar) to build this for us.
+
+    This method takes all of the actions that we saw in the training data and constructs a
+    "grammar" from them, where here "grammar" means "valid productions for any type".  That is, if
+    we see the action "r -> [<e,r>, e]", we add "[<e,r>, e]" to the valid productions for type "r".
+    This is effectively making a context-free assumption, that any production rule we ever see used
+    is valid in any context.  This assumption isn't actually true, especially for terminal
+    productions, but it will do for now.
+
+    We return the list of productions for each type as a ``List[int]``, where the ``int`` is the
+    `id` of the production rule in the vocabulary.  This is another thing that needs to change, as
+    we will have production rules at test time that we've never seen at training time, and thus
+    won't be able to predict them.  But we'll worry about that later.
+    """
+    type_productions: Dict[str, List[int]] = defaultdict(list)
+    for action_index in range(vocab.get_vocab_size(namespace)):
+        action = vocab.get_token_from_index(action_index, namespace)
+        if ' -> ' in action:
+            non_terminal, _ = action.split(' -> ')
+            type_productions[non_terminal].append(action_index)
+        else:
+            # The first action we predict is the type of the logical form, not a production rule.
+            # These actions don't have ' -> ' in them, and are just the type.  They are only valid
+            # productions in the initial state of the decoder.
+            if action != START_SYMBOL and action != END_SYMBOL:
+                type_productions[START_SYMBOL].append(action_index)
+    return type_productions
+
+
 # This syntax is pretty weird and ugly, but it's necessary to make mypy happy with the API that
 # we've defined.  We're using generics to make the types of `combine_states` and `split_finished`
 # come out right.  See the note in `nn.decoding.decoder_state.py` for a little more detail.
@@ -236,6 +276,11 @@ class WikiTablesDecoderState(DecoderState['WikiTablesDecoderState']):
         Passed to super class; see docs there.
     score : ``List[Variable]``
         Passed to super class; see docs there.
+    non_terminal_stack : ``List[List[str]]``
+        Holds the list of non-terminals that still need to be expanded for each element of the
+        group.  This starts out as [START_SYMBOL], and decoding ends when this is empty.  Every
+        time we take an action, we update the non-terminal stack, and we use what's on the stack to
+        decide which actions are valid in the current state.
     hidden_state : ``List[Variable]``
         This holds the LSTM hidden state for each element of the group.  Each variable has shape
         ``(decoder_output_dim,)``.
@@ -261,6 +306,10 @@ class WikiTablesDecoderState(DecoderState['WikiTablesDecoderState']):
         A list of variables, each of shape ``(question_length,)``, containing a mask over question
         tokens for each batch instance.  This is a list over batch elements, for the same reasons
         as above.
+    global_type_productions : ``Dict[str, List[int]]``
+        A mapping from type strings to valid action indices.  The type strings correspond to the
+        non-terminals on the ``non_terminal_stack``, and the action indices (for now) correspond to
+        actions in the action vocabulary.
     end_index : ``int``
         This is the index of the stop symbol, which we need so we know if we've emitted a stop
         action and are thus finished.
@@ -269,34 +318,84 @@ class WikiTablesDecoderState(DecoderState['WikiTablesDecoderState']):
                  batch_indices: List[int],
                  action_history: List[List[int]],
                  score: Variable,
+                 non_terminal_stack: List[List[str]],
                  hidden_state: List[Variable],
                  memory_cell: List[Variable],
                  attended_question: List[Variable],
                  encoder_outputs: Variable,
                  encoder_output_mask: Variable,
+                 global_type_productions: Dict[str, List[int]],
                  end_index: int) -> None:
         super(WikiTablesDecoderState, self).__init__(batch_indices, action_history, score)
+        self.non_terminal_stack = non_terminal_stack
         self.hidden_state = hidden_state
         self.memory_cell = memory_cell
         self.attended_question = attended_question
         self.encoder_outputs = encoder_outputs
         self.encoder_output_mask = encoder_output_mask
+        self.global_type_productions = global_type_productions
         self.end_index = end_index
 
-    def get_valid_actions(self, num_actions: int) -> List[List[int]]:
+    def get_valid_actions(self) -> List[List[int]]:
         """
         Returns a list of valid actions for each element of the group.
         """
-        # TODO(mattg): we're temporarily making all actions allowed at every state, to implement
-        # constrained decoding in pieces.  The `num_actions` argument here is going to be removed
-        # in the next step, where we actually use grammar constraints.
-        return [list(range(num_actions))] * len(self.batch_indices)
+        # TODO(matt): this is going to need to look at more than just the global type productions
+        # eventually - we'll need instance- and state-specific additions.  And we'll probably need
+        # to return strings, instead of integers, because instance-specific production rules won't
+        # be in a global vocabulary.
+        return [self.global_type_productions[stack[-1]] for stack in self.non_terminal_stack]
+
+    @staticmethod
+    def update_non_terminal_stack(stack: List[str], action: str) -> List[str]:
+        """
+        Given a single non-terminal stack (`not` a grouped one), and an action that was taken,
+        update the non-terminal stack.  This involves popping the non-terminal that was expanded
+        off of the stack, then pushing on any non-terminals in the production rule back on the
+        stack.
+        """
+        if ' -> ' in action:
+            non_terminal, production_string = action.split(' -> ')
+            assert stack[-1] == non_terminal
+            new_stack = stack[:-1]
+            productions = WikiTablesDecoderState.get_productions_from_string(production_string)
+            for production in reversed(productions):
+                if WikiTablesDecoderState.is_non_terminal(production):
+                    new_stack.append(production)
+            return new_stack
+        else:
+            # The first action we take is just predicting a type, so doesn't have ' -> ' in it.  In
+            # this case, we had better be trying to expand the START_SYMBOL, and our next
+            # non-terminal stack is just the type that we predicted.
+            assert stack == [START_SYMBOL]
+            return [action]
+
+    @staticmethod
+    def get_productions_from_string(production_string: str) -> List[str]:
+        """
+        Takes a string like '[<d,d>, d]' and parses it into a list like ['<d,d>', 'd'].  For
+        production strings that are not lists, like '<e,d>', we return a single-element list:
+        ['<e,d>'].
+        """
+        if production_string[0] == '[':
+            return production_string[1:-1].split(', ')
+        else:
+            return [production_string]
+
+    @staticmethod
+    def is_non_terminal(production: str) -> bool:
+        # TODO(mattg): these static methods probably belong in some other class.
+        if production[0] == '<':
+            return True
+        if production.startswith('cell'):
+            return False
+        return production[0].islower()
 
     # @overrides  - overrides can't handle the generics we're using here, apparently
     def is_finished(self) -> bool:
         if len(self.batch_indices) != 1:
             raise RuntimeError("is_finished() is only defined with a group_size of 1")
-        return len(self.action_history[0]) > 0 and self.action_history[0][-1] == self.end_index
+        return not self.non_terminal_stack[0]
 
     # @overrides  - overrides can't handle the generics we're using here, apparently
     def split_finished(self) -> Tuple['WikiTablesDecoderState', 'WikiTablesDecoderState']:
@@ -304,11 +403,11 @@ class WikiTablesDecoderState(DecoderState['WikiTablesDecoderState']):
         # all.
         finished_indices = []
         not_finished_indices = []
-        for i, action_history in enumerate(self.action_history):
-            if action_history and action_history[-1] == self.end_index:
-                finished_indices.append(i)
-            else:
+        for i, stack in enumerate(self.non_terminal_stack):
+            if stack:
                 not_finished_indices.append(i)
+            else:
+                finished_indices.append(i)
 
         # Return value is (finished, not_finished)
         if not finished_indices:
@@ -325,18 +424,21 @@ class WikiTablesDecoderState(DecoderState['WikiTablesDecoderState']):
         batch_indices = [batch_index for state in states for batch_index in state.batch_indices]
         action_histories = [action_history for state in states for action_history in state.action_history]
         scores = [score for state in states for score in state.score]
+        non_terminal_stacks = [stack for state in states for stack in state.non_terminal_stack]
         hidden_states = [hidden_state for state in states for hidden_state in state.hidden_state]
         memory_cells = [memory_cell for state in states for memory_cell in state.memory_cell]
         attended_question = [attended for state in states for attended in state.attended_question]
-        return WikiTablesDecoderState(batch_indices,
-                                      action_histories,
-                                      scores,
-                                      hidden_states,
-                                      memory_cells,
-                                      attended_question,
-                                      states[0].encoder_outputs,
-                                      states[0].encoder_output_mask,
-                                      states[0].end_index)
+        return WikiTablesDecoderState(batch_indices=batch_indices,
+                                      action_history=action_histories,
+                                      score=scores,
+                                      non_terminal_stack=non_terminal_stacks,
+                                      hidden_state=hidden_states,
+                                      memory_cell=memory_cells,
+                                      attended_question=attended_question,
+                                      encoder_outputs=states[0].encoder_outputs,
+                                      encoder_output_mask=states[0].encoder_output_mask,
+                                      global_type_productions=states[0].global_type_productions,
+                                      end_index=states[0].end_index)
 
     def _make_new_state_with_group_indices(self, group_indices: List[int]) -> 'WikiTablesDecoderState':
         """
@@ -350,36 +452,41 @@ class WikiTablesDecoderState(DecoderState['WikiTablesDecoderState']):
         group_batch_indices = [self.batch_indices[i] for i in group_indices]
         group_action_histories = [self.action_history[i] for i in group_indices]
         group_scores = [self.score[i] for i in group_indices]
+        group_non_terminal_stacks = [self.non_terminal_stack[i] for i in group_indices]
         group_hidden_states = [self.hidden_state[i] for i in group_indices]
         group_memory_cells = [self.memory_cell[i] for i in group_indices]
         group_attended_question = [self.attended_question[i] for i in group_indices]
-        return WikiTablesDecoderState(group_batch_indices,
-                                      group_action_histories,
-                                      group_scores,
-                                      group_hidden_states,
-                                      group_memory_cells,
-                                      group_attended_question,
-                                      self.encoder_outputs,
-                                      self.encoder_output_mask,
-                                      self.end_index)
+        return WikiTablesDecoderState(batch_indices=group_batch_indices,
+                                      action_history=group_action_histories,
+                                      score=group_scores,
+                                      non_terminal_stack=group_non_terminal_stacks,
+                                      hidden_state=group_hidden_states,
+                                      memory_cell=group_memory_cells,
+                                      attended_question=group_attended_question,
+                                      encoder_outputs=self.encoder_outputs,
+                                      encoder_output_mask=self.encoder_output_mask,
+                                      global_type_productions=self.global_type_productions,
+                                      end_index=self.end_index)
 
 
 class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
     def __init__(self,
+                 vocab: Vocabulary,
+                 action_namespace: str,
                  encoder_output_dim: int,
                  action_embedding_dim: int,
-                 num_actions: int,
                  attention_function: SimilarityFunction,
                  start_index: int) -> None:
         super(WikiTablesDecoderStep, self).__init__()
-        # TODO(mattg): This is unnecessary, and is just here temporarily.
-        self._num_actions = num_actions
-        # Decoder output dim needs to be the same as the encoder output dim since we initialize the
-        # hidden state of the decoder with that of the final hidden states of the encoder.
+        self._vocab = vocab
+        self._action_namespace = action_namespace
+        num_actions = vocab.get_vocab_size(action_namespace)
         self._action_embedder = Embedding(num_actions, action_embedding_dim)
         self._input_attention = Attention(attention_function)
         self._start_index = start_index
 
+        # Decoder output dim needs to be the same as the encoder output dim since we initialize the
+        # hidden state of the decoder with the final hidden state of the encoder.
         output_dim = encoder_output_dim
         input_dim = output_dim
         # Our decoder input will be the concatenation of the decoder hidden state and the previous
@@ -388,8 +495,8 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
         self._input_projection_layer = Linear(output_dim + action_embedding_dim, input_dim)
         # Before making a prediction, we'll compute an attention over the input given our updated
         # hidden state.  Then we concatenate that with the decoder state and project to
-        # `num_actions` to make a prediction.
-        self._output_projection_layer = Linear(output_dim + output_dim, action_embedding_dim)
+        # `action_embedding_dim` to make a prediction.
+        self._output_projection_layer = Linear(output_dim + encoder_output_dim, action_embedding_dim)
 
         # TODO(pradeep): Do not hardcode decoder cell type.
         self._decoder_cell = LSTMCell(input_dim, output_dim)
@@ -412,6 +519,8 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
         actions = [action_history[-1] if action_history else self._start_index
                    for action_history in state.action_history]
         action_input = Variable(hidden_state.data.new(actions).long())
+        # TODO(mattg): probably makes sense to just put this in the state from the previous
+        # iteration, because we're embedding actions to predict things now.
         embedded_input = self._action_embedder(action_input)
 
         # (group_size, decoder_input_dim)
@@ -436,7 +545,7 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
 
         # (group_size, num_actions), giving the index of each valid action for each item in the
         # group.  This is actually just a list of lists, on the CPU, not a CUDA variable.
-        valid_actions = state.get_valid_actions(self._num_actions)
+        valid_actions = state.get_valid_actions()
 
         # action_embeddings: (group_size, num_actions, action_embedding_dim)
         # action_mask: (group_size, num_actions)
@@ -526,6 +635,11 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
             for action_index, action in enumerate(group_actions):
                 # `action` is currently the index in `log_probs`, not the actual action ID.  To get
                 # the action ID, we need to go through `considered_actions`.
+                if action_index >= len(considered_actions[group_index]):
+                    # This was padding.  We can check either `action_index` or `action` here - it's
+                    # really `action` that we care about, but our masking should have sorted all of
+                    # the higher actions to the end, anyway.
+                    continue
                 action = considered_actions[group_index][action]
                 if allowed_actions is not None and action not in allowed_actions[group_index]:
                     # This happens when our _decoder trainer_ wants us to only evaluate certain
@@ -544,13 +658,19 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
                 # regroup them later, as that's a really easy operation.
                 new_action_history = state.action_history[group_index] + [action]
                 new_score = state.score[group_index] + sorted_log_probs[group_index, action_index]
-                new_states.append(WikiTablesDecoderState([state.batch_indices[group_index]],
-                                                         [new_action_history],
-                                                         [new_score],
-                                                         [hidden_state[group_index]],
-                                                         [memory_cell[group_index]],
-                                                         [attended_question[group_index]],
-                                                         state.encoder_outputs,
-                                                         state.encoder_output_mask,
-                                                         state.end_index))
+                action_string = self._vocab.get_token_from_index(action, self._action_namespace)
+                new_non_terminal_stack = state.update_non_terminal_stack(
+                        state.non_terminal_stack[group_index], action_string)
+                new_state = WikiTablesDecoderState(batch_indices=[state.batch_indices[group_index]],
+                                                   action_history=[new_action_history],
+                                                   score=[new_score],
+                                                   non_terminal_stack=[new_non_terminal_stack],
+                                                   hidden_state=[hidden_state[group_index]],
+                                                   memory_cell=[memory_cell[group_index]],
+                                                   attended_question=[attended_question[group_index]],
+                                                   encoder_outputs=state.encoder_outputs,
+                                                   encoder_output_mask=state.encoder_output_mask,
+                                                   global_type_productions=state.global_type_productions,
+                                                   end_index=state.end_index)
+                new_states.append(new_state)
         return new_states

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -1,13 +1,13 @@
 # pylint: disable=no-self-use
-from allennlp.data.dataset_readers import WikitablesDatasetReader
+from allennlp.data.dataset_readers import WikiTablesDatasetReader
 from allennlp.common.testing import AllenNlpTestCase
 
 
-class TestWikitablesDatasetReader(AllenNlpTestCase):
+class TestWikiTablesDatasetReader(AllenNlpTestCase):
     def test_reader_reads(self):
         tables_directory = "tests/fixtures/data/wikitables"
         dpd_output_directory = "tests/fixtures/data/wikitables/dpd_output"
-        reader = WikitablesDatasetReader(tables_directory, dpd_output_directory)
+        reader = WikiTablesDatasetReader(tables_directory, dpd_output_directory)
         dataset = reader.read("tests/fixtures/data/wikitables/sample_data.examples")
         assert len(dataset.instances) == 2
         instance = dataset.instances[0]

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -11,14 +11,16 @@ class TestWikitablesDatasetReader(AllenNlpTestCase):
         dataset = reader.read("tests/fixtures/data/wikitables/sample_data.examples")
         assert len(dataset.instances) == 2
         instance = dataset.instances[0]
-        action_sequence = instance.fields["action_sequences"].field_list[0]
+        action_sequence = instance.fields["target_action_sequences"].field_list[0]
         actions = [l.label for l in action_sequence.field_list]
-        assert [t.text for t in instance.fields["utterance"].tokens] == ["what", "was", "the", "last", "year",
-                                                                         "where", "this", "team", "was", "a",
-                                                                         "part", "of", "the", "usl", "a", "-",
-                                                                         "league", "?"]
+        question_tokens = ["what", "was", "the", "last", "year", "where", "this", "team", "was",
+                           "a", "part", "of", "the", "usl", "a", "-", "league", "?"]
+        assert [t.text for t in instance.fields["question"].tokens] == question_tokens
         assert actions == ['@@START@@', 'd', 'd -> [<d,d>, d]', '<d,d> -> M0', 'd -> [<e,d>, e]',
                            '<e,d> -> [<<#1,#2>,<#2,#1>>, <d,e>]', '<<#1,#2>,<#2,#1>> -> R',
                            '<d,e> -> D1', 'e -> [<r,e>, r]', '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]',
                            '<<#1,#2>,<#2,#1>> -> R', '<e,r> -> C0', 'r -> [<e,r>, e]', '<e,r> -> C1',
                            'e -> cell:usl_a_league', '@@END@@']
+        entities = instance.fields['table'].knowledge_graph.get_all_entities()
+        assert len(entities) == 47
+        assert 'fb:row.row.year' in entities

--- a/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment.json
+++ b/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment.json
@@ -1,9 +1,14 @@
 {
   "dataset_reader": {
-    "type": "toy_wikitables"
+    "type": "wikitables",
+    "tables_directory": "tests/fixtures/data/wikitables/",
+    "dpd_output_directory": "tests/fixtures/data/wikitables/dpd_output/"
   },
-  "train_data_path": "tests/fixtures/data/seq2seq_max_marginal_likelihood.tsv",
-  "validation_data_path": "tests/fixtures/data/seq2seq_max_marginal_likelihood.tsv",
+  "vocabulary": {
+    "non_padded_namespaces": ["actions"]
+  },
+  "train_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
+  "validation_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
   "model": {
     "type": "wikitables_parser",
     "question_embedder": {

--- a/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
@@ -1,64 +1,12 @@
 # pylint: disable=invalid-name
-from typing import List
-
-import tqdm
-
 from allennlp.common.testing import ModelTestCase
-from allennlp.common import Params
-from allennlp.data import Dataset, DatasetReader, Instance, Token
-from allennlp.data.fields import Field, LabelField, ListField, TextField
-from allennlp.data.tokenizers import CharacterTokenizer
-from allennlp.data.token_indexers import SingleIdTokenIndexer
-from allennlp.data.dataset_readers.seq2seq import START_SYMBOL, END_SYMBOL
-
-
-@DatasetReader.register("toy_wikitables")
-class ToyWikiTablesDatasetReader(DatasetReader):
-    def __init__(self):
-        self._tokenizer = CharacterTokenizer()
-        self._token_indexers = {'tokens': SingleIdTokenIndexer()}
-
-    def read(self, file_path):
-        instances = []
-        with open(file_path, "r") as data_file:
-            for line in tqdm.tqdm(data_file):
-                line = line.strip("\n")
-                line_parts = line.split('\t')
-                source_sequence, targets = line_parts[0], line_parts[1:]
-                instances.append(self.text_to_instance(source_sequence, targets))
-        return Dataset(instances)
-
-    def text_to_instance(self,  # type: ignore
-                         source_string: str,
-                         targets: List[str] = None) -> Instance:
-        # pylint: disable=arguments-differ
-        tokenized_source = self._tokenizer.tokenize(source_string)
-        source_field = TextField(tokenized_source, self._token_indexers)
-        if targets is not None:
-            target_field: Field = ListField([self._make_target_field(target)
-                                             for target in targets])
-            return Instance({"question": source_field, "target_action_sequences": target_field})
-        else:
-            return Instance({'question': source_field})
-
-    def _make_target_field(self, target_string) -> ListField:
-        tokenized_target = self._tokenizer.tokenize(target_string)
-        tokenized_target.insert(0, Token(START_SYMBOL))
-        tokenized_target.append(Token(END_SYMBOL))
-        return ListField([LabelField(target_token.text, label_namespace='actions')
-                          for target_token in tokenized_target])
-
-    @classmethod
-    def from_params(cls, params: Params) -> 'ToyWikiTablesDatasetReader':
-        params.assert_empty(cls.__name__)
-        return ToyWikiTablesDatasetReader()
 
 
 class WikiTablesSemanticParserTest(ModelTestCase):
     def setUp(self):
         super(WikiTablesSemanticParserTest, self).setUp()
         self.set_up_model("tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment.json",
-                          "tests/fixtures/data/seq2seq_max_marginal_likelihood.tsv")
+                          "tests/fixtures/data/wikitables/sample_data.examples")
 
     def test_encoder_decoder_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)


### PR DESCRIPTION
This initial version just reads a set of allowed productions from the training data, meaning that it won't generalize to unseen tables at test time, but at least it works!  The next step is to make the valid actions at each step instance-specific, then make them state-specific also.

I don't have good tests for any of the stuff I did in here yet.  I'd like to make good tests for the valid action stuff, and separate out the code a bit, but that'll be easier in the next step.  I'll make something like a `GrammarState`, that contains the `non_terminal_stack` that I used here, and have that object be richer, and testable.