### PR TITLE
update CLI casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,6 @@ COPY scripts/ scripts/
 COPY tutorials/ tutorials/
 COPY training_config training_config/
 
-# Run tests to verify the Docker build
-RUN PYTHONDONTWRITEBYTECODE=1 pytest
-
 # Add model caching
 ARG CACHE_MODELS=false
 RUN ./scripts/cache_models.py

--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -1,5 +1,7 @@
 from typing import Dict
 import argparse
+import logging
+import sys
 
 from allennlp.commands.serve import Serve
 from allennlp.commands.predict import Predict
@@ -8,6 +10,20 @@ from allennlp.commands.evaluate import Evaluate
 from allennlp.commands.subcommand import Subcommand
 from allennlp.service.predictors import DemoModel
 
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+# Originally we were inconsistent about using hyphens and underscores
+# in our flag names. We're switching to all-hyphens, but in the near-term
+# we're still allowing the underscore_versions too, so as not to break any
+# code. However, we'll use this lookup to log a warning if someone uses the
+# old names.
+DEPRECATED_FLAGS = {
+        '--serialization_dir': '--serialization-dir',
+        '--archive_file': '--archive-file',
+        '--evaluation_data_set': '--evaluation_data_set',
+        '--cuda_device': '--cuda-device',
+        '--batch_size': '--batch-size'
+}
 
 def main(prog: str = None,
          model_overrides: Dict[str, DemoModel] = {},
@@ -43,6 +59,14 @@ def main(prog: str = None,
 
     for name, subcommand in subcommands.items():
         subcommand.add_subparser(name, subparsers)
+
+    # Check and warn for deprecated args.
+    for arg in sys.argv[1:]:
+        if arg in DEPRECATED_FLAGS:
+            logger.warning("Argument name %s is deprecated (and will likely go away at some point), "
+                           "please use %s instead",
+                           arg,
+                           DEPRECATED_FLAGS[arg])
 
     args = parser.parse_args()
 

--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 DEPRECATED_FLAGS = {
         '--serialization_dir': '--serialization-dir',
         '--archive_file': '--archive-file',
-        '--evaluation_data_set': '--evaluation_data_set',
+        '--evaluation_data_file': '--evaluation-data-file',
         '--cuda_device': '--cuda-device',
         '--batch_size': '--batch-size'
 }

--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -14,11 +14,11 @@ and report any metrics calculated by the model.
 
     optional arguments:
     -h, --help            show this help message and exit
-    --archive_file ARCHIVE_FILE
+    --archive-file ARCHIVE_FILE
                             path to an archived trained model
-    --evaluation_data_file EVALUATION_DATA_FILE
+    --evaluation-data-file EVALUATION_DATA_FILE
                             path to the file containing the evaluation data
-    --cuda_device CUDA_DEVICE
+    --cuda-device CUDA_DEVICE
                             id of GPU to use (if any)
 """
 from typing import Dict, Any
@@ -45,18 +45,27 @@ class Evaluate(Subcommand):
         description = '''Evaluate the specified model + dataset'''
         subparser = parser.add_parser(
                 name, description=description, help='Evaluate the specified model + dataset')
-        subparser.add_argument('--archive_file',
-                               type=str,
-                               required=True,
-                               help='path to an archived trained model')
-        subparser.add_argument('--evaluation_data_file',
-                               type=str,
-                               required=True,
-                               help='path to the file containing the evaluation data')
-        subparser.add_argument('--cuda_device',
-                               type=int,
-                               default=-1,
-                               help='id of GPU to use (if any)')
+
+        archive_file = subparser.add_mutually_exclusive_group(required=True)
+        archive_file.add_argument('--archive-file', type=str, help='path to an archived trained model')
+        archive_file.add_argument('--archive_file', type=str, help=argparse.SUPPRESS)
+
+
+        evaluation_data_file = subparser.add_mutually_exclusive_group(required=True)
+        evaluation_data_file.add_argument('--evaluation-data-file',
+                                          type=str,
+                                          help='path to the file containing the evaluation data')
+        evaluation_data_file.add_argument('--evaluation_data_file',
+                                          type=str,
+                                          help=argparse.SUPPRESS)
+
+        cuda_device = subparser.add_mutually_exclusive_group(required=False)
+        cuda_device.add_argument('--cuda-device',
+                                 type=int,
+                                 default=-1,
+                                 help='id of GPU to use (if any)')
+        cuda_device.add_argument('--cuda_device', type=int, help=argparse.SUPPRESS)
+
         subparser.add_argument('-o', '--overrides',
                                type=str,
                                default="",

--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -53,13 +53,22 @@ class Predict(Subcommand):
         description = '''Run the specified model against a JSON-lines input file.'''
         subparser = parser.add_parser(
                 name, description=description, help='Use a trained model to make predictions.')
+
         subparser.add_argument('archive_file', type=str, help='the archived model to make predictions with')
-        subparser.add_argument('input_file', metavar='input-file', type=argparse.FileType('r'),
-                               help='path to input file')
+        subparser.add_argument('input_file', type=argparse.FileType('r'), help='path to input file')
+
         subparser.add_argument('--output-file', type=argparse.FileType('w'), help='path to output file')
-        subparser.add_argument('--batch_size', type=int, default=1, help='The batch size to use for processing')
+
+        batch_size = subparser.add_mutually_exclusive_group(required=False)
+        batch_size.add_argument('--batch-size', type=int, default=1, help='The batch size to use for processing')
+        batch_size.add_argument('--batch_size', type=int, help=argparse.SUPPRESS)
+
         subparser.add_argument('--silent', action='store_true', help='do not print output to stdout')
-        subparser.add_argument('--cuda_device', type=int, default=-1, help='id of GPU to use (if any)')
+
+        cuda_device = subparser.add_mutually_exclusive_group(required=False)
+        cuda_device.add_argument('--cuda-device', type=int, default=-1, help='id of GPU to use (if any)')
+        cuda_device.add_argument('--cuda_device', type=int, help=argparse.SUPPRESS)
+
         subparser.add_argument('-o', '--overrides',
                                type=str,
                                default="",

--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -6,13 +6,13 @@ predictions using a trained model and its :class:`~allennlp.service.predictors.p
 
     $ python -m allennlp.run predict --help
     usage: run [command] predict [-h] [--output-file OUTPUT_FILE] [--print]
-                                archive_file input-file
+                                archive_file input_file
 
     Run the specified model against a JSON-lines input file.
 
     positional arguments:
     archive_file          the archived model to make predictions with
-    input-file            path to input file
+    input_file            path to input file
 
     optional arguments:
     -h, --help            show this help message and exit

--- a/allennlp/commands/serve.py
+++ b/allennlp/commands/serve.py
@@ -16,9 +16,6 @@ their predictions.
     -h, --help            show this help message and exit
     --port PORT
     --workers WORKERS
-    --config-file CONFIG_FILE
-                            path to a JSON file specifying the configuration for
-                            the models
 """
 
 import argparse

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -15,7 +15,7 @@ which to write the results.
 
    optional arguments:
     -h, --help            show this help message and exit
-    -s SERIALIZATION_DIR, --serialization_dir SERIALIZATION_DIR
+    -s SERIALIZATION_DIR, --serialization-dir SERIALIZATION_DIR
                             directory in which to save the model and its logs
 """
 from typing import List
@@ -50,10 +50,16 @@ class Train(Subcommand):
         subparser.add_argument('param_path',
                                type=str,
                                help='path to parameter file describing the model to be trained')
-        subparser.add_argument('-s', '--serialization_dir',
-                               type=str,
-                               required=True,
-                               help='directory in which to save the model and its logs')
+
+        # This is necessary to preserve backward compatibility
+        serialization = subparser.add_mutually_exclusive_group(required=True)
+        serialization.add_argument('-s', '--serialization-dir',
+                                   type=str,
+                                   help='directory in which to save the model and its logs')
+        serialization.add_argument('--serialization_dir',
+                                   type=str,
+                                   help=argparse.SUPPRESS)
+
         subparser.set_defaults(func=train_model_from_args)
 
         return subparser

--- a/tests/commands/evaluate_test.py
+++ b/tests/commands/evaluate_test.py
@@ -15,12 +15,17 @@ class TestEvaluate(AllenNlpTestCase):
         subparsers = parser.add_subparsers(title='Commands', metavar='')
         Evaluate().add_subparser('evaluate', subparsers)
 
-        raw_args = ["evaluate",
-                    "--archive_file", "tests/fixtures/bidaf/serialization/model.tar.gz",
-                    "--evaluation_data_file", "tests/fixtures/data/squad.json"]
+        snake_args = ["evaluate",
+                      "--archive_file", "tests/fixtures/bidaf/serialization/model.tar.gz",
+                      "--evaluation_data_file", "tests/fixtures/data/squad.json",
+                      "--cuda_device", "-1"]
 
-        args = parser.parse_args(raw_args)
+        kebab_args = ["evaluate",
+                      "--archive-file", "tests/fixtures/bidaf/serialization/model.tar.gz",
+                      "--evaluation-data-file", "tests/fixtures/data/squad.json",
+                      "--cuda-device", "-1"]
 
-        metrics = evaluate_from_args(args)
-
-        assert metrics.keys() == {'span_acc', 'end_acc', 'start_acc', 'em', 'f1'}
+        for raw_args in [snake_args, kebab_args]:
+            args = parser.parse_args(raw_args)
+            metrics = evaluate_from_args(args)
+            assert metrics.keys() == {'span_acc', 'end_acc', 'start_acc', 'em', 'f1'}

--- a/tests/commands/main_test.py
+++ b/tests/commands/main_test.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import logging
 import sys
 
 from allennlp.commands import main
@@ -17,6 +18,28 @@ class TestMain(TestCase):
             main()
 
         assert cm.exception.code == 2  # argparse code for incorrect usage
+
+    def test_warn_on_deprecated_flags(self):
+        sys.argv = ["[executable]",
+                    "evaluate",
+                    "--archive_file", "tests/fixtures/bidaf/serialization/model.tar.gz",
+                    "--evaluation_data_file", "tests/fixtures/data/squad.json",
+                    "--cuda_device", "-1"]
+
+
+        with self.assertLogs(level=logging.WARNING) as context:
+            main()
+            assert set(context.output) == {
+                    'WARNING:allennlp.commands:Argument name --archive_file is deprecated '
+                    '(and will likely go away at some point), please use --archive-file instead',
+
+                    'WARNING:allennlp.commands:Argument name --evaluation_data_file is deprecated '
+                    '(and will likely go away at some point), please use --evaluation-data-file instead',
+
+                    'WARNING:allennlp.commands:Argument name --cuda_device is deprecated '
+                    '(and will likely go away at some point), please use --cuda-device instead',
+            }
+
 
     def test_subcommand_overrides(self):
         def do_nothing(_):

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -19,17 +19,32 @@ class TestPredict(TestCase):
         subparsers = parser.add_subparsers(title='Commands', metavar='')
         Predict(DEFAULT_PREDICTORS).add_subparser('predict', subparsers)
 
-        raw_args = ["predict",          # command
-                    "/path/to/archive", # archive
-                    "/dev/null",    # input_file
-                    "--output-file", "/dev/null",
-                    "--silent"]
+        snake_args = ["predict",          # command
+                      "/path/to/archive", # archive
+                      "/dev/null",        # input_file
+                      "--output-file", "/dev/null",  # this one was always kebab-case
+                      "--batch_size", "10",
+                      "--cuda_device", "0",
+                      "--silent"]
 
-        args = parser.parse_args(raw_args)
+        kebab_args = ["predict",          # command
+                      "/path/to/archive", # archive
+                      "/dev/null",        # input_file
+                      "--output-file", "/dev/null",
+                      "--batch-size", "10",
+                      "--cuda-device", "0",
+                      "--silent"]
 
-        assert args.func.__name__ == 'predict_inner'
-        assert args.archive_file == "/path/to/archive"
-        assert args.silent
+        for raw_args in [snake_args, kebab_args]:
+            args = parser.parse_args(raw_args)
+
+            assert args.func.__name__ == 'predict_inner'
+            assert args.archive_file == "/path/to/archive"
+            assert args.output_file.name == "/dev/null"
+            assert args.batch_size == 10
+            assert args.cuda_device == 0
+            assert args.silent
+
 
     def test_works_with_known_model(self):
         tempdir = tempfile.mkdtemp()

--- a/tests/commands/train_test.py
+++ b/tests/commands/train_test.py
@@ -72,13 +72,14 @@ class TestTrain(AllenNlpTestCase):
         subparsers = parser.add_subparsers(title='Commands', metavar='')
         Train().add_subparser('train', subparsers)
 
-        raw_args = ["train", "path/to/params", "-s", "serialization_dir"]
+        for serialization_arg in ["-s", "--serialization_dir", "--serialization-dir"]:
+            raw_args = ["train", "path/to/params", serialization_arg, "serialization_dir"]
 
-        args = parser.parse_args(raw_args)
+            args = parser.parse_args(raw_args)
 
-        assert args.func == train_model_from_args
-        assert args.param_path == "path/to/params"
-        assert args.serialization_dir == "serialization_dir"
+            assert args.func == train_model_from_args
+            assert args.param_path == "path/to/params"
+            assert args.serialization_dir == "serialization_dir"
 
         # config is required
         with self.assertRaises(SystemExit) as cm:  # pylint: disable=invalid-name

--- a/tutorials/getting_started/training_a_model.md
+++ b/tutorials/getting_started/training_a_model.md
@@ -39,10 +39,10 @@ this many epochs, training halts. And if you have a GPU you can change `cuda_dev
 Change any of those if you want to, and then run
 
 ```
-$ python -m allennlp.run train tutorials/getting_started/simple_tagger.json --serialization_dir /tmp/tutorials/getting_started
+$ python -m allennlp.run train tutorials/getting_started/simple_tagger.json --serialization-dir /tmp/tutorials/getting_started
 ```
 
-The `serialization_dir` argument specifies the directory where the model's vocabulary and checkpointed weights will be saved.
+The `serialization-dir` argument specifies the directory where the model's vocabulary and checkpointed weights will be saved.
 
 This command will download the datasets and cache them locally,
 log all of the parameters it's using,
@@ -100,7 +100,7 @@ is shared publicly on Amazon S3.
 We can use the `evaluate` command, giving it the archived model and the evaluation dataset:
 
 ```
-$ python -m allennlp.run evaluate --archive_file /tmp/tutorials/getting_started/model.tar.gz --evaluation_data_file https://allennlp.s3.amazonaws.com/datasets/getting-started/sentences.small.test
+$ python -m allennlp.run evaluate --archive-file /tmp/tutorials/getting_started/model.tar.gz --evaluation-data-file https://allennlp.s3.amazonaws.com/datasets/getting-started/sentences.small.test
 ```
 
 When you run this it will load the archived model, download and cache the evaluation dataset, and then make predictions:


### PR DESCRIPTION
this addresses https://github.com/allenai/allennlp/issues/511

it does the following things (I will use cuda_device as an example, but it does something similar for every multi-word argument)

(1) creates a `cuda_device` "mutually exclusive group"
(2) changes the existing argument to `cuda-device` under that group
(3) also includes a `cuda_device` argument under that group with `help=argparse.SUPPRESS`

this means that if you run (say) `allennlp/run predict --help` it only shows the option

```
  --cuda-device CUDA_DEVICE
                        id of GPU to use (if any)
```

however, if you pass in the argument as `--cuda_device` it will still work (in order not to break anyone's existing code). This all feels slightly clunky, but breaking existing workflows seems like a non starter.

IN ADDITION, there is a dict of { old_flag: new_flag }, and if you call `allennlp/run` using one of the old flags it will log a warning that it's deprecated and that you should switch. And then at some point in the far future we can clean up all the underscore flags, maybe.

--

Anyway, this might seem like a lot of ado about not much, but I think having a consistent API is important (this issue has always sort of bugged me, just never enough to do anything about it), and I think `kebab-case` is the right way to handle command line flags.

Like the title says, at this point this is just for discussion, I'm curious how people feel about it.