### PR TITLE
Add readiness probe for production deployments.

### DIFF
--- a/scripts/ai2-internal/deploy-production-demo.sh
+++ b/scripts/ai2-internal/deploy-production-demo.sh
@@ -82,6 +82,12 @@ spec:
             - /bin/bash
             - -c
             - "allennlp/run serve"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 3
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This change prevents new pods from being used before they are accepting HTTP requests.  There's a rather long period of time after the container starts where the application is downloading models and initializing AllenNLP but is not accepting requests.