### PR TITLE
Disable Service Workers

### DIFF
--- a/allennlp/service/server_sanic.py
+++ b/allennlp/service/server_sanic.py
@@ -53,6 +53,12 @@ def run(port: int, workers: int,
 def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> Sanic:
     app = Sanic(__name__)  # pylint: disable=invalid-name
 
+    no_cache_headers = {
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": 0
+        }
+
     if build_dir is None:
         # Need path to static assets to be relative to this file.
         dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/allennlp/service/server_sanic.py
+++ b/allennlp/service/server_sanic.py
@@ -55,12 +55,6 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> S
     app = Sanic(__name__)  # pylint: disable=invalid-name
     start_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-    no_cache_headers = {
-            "Cache-Control": "no-cache, no-store, must-revalidate",
-            "Pragma": "no-cache",
-            "Expires": 0
-        }
-
     if build_dir is None:
         # Need path to static assets to be relative to this file.
         dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/allennlp/service/server_sanic.py
+++ b/allennlp/service/server_sanic.py
@@ -195,12 +195,12 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> S
 
         logger.info("prediction: %s", json.dumps(log_blob))
 
-        return response.json(prediction)
+        return response.json(prediction, headers=no_cache_headers)
 
     @app.route('/models')
     async def list_models(req: request.Request) -> response.HTTPResponse:  # pylint: disable=unused-argument, unused-variable
         """list the available models"""
-        return response.json({"models": list(app.predictors.keys())})
+        return response.json({"models": list(app.predictors.keys())}, headers=no_cache_headers)
 
     # As a SPA, we need to return index.html for /model-name and /model-name/permalink
     @app.route('/semantic-role-labeling')

--- a/allennlp/service/server_sanic.py
+++ b/allennlp/service/server_sanic.py
@@ -195,12 +195,12 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> S
 
         logger.info("prediction: %s", json.dumps(log_blob))
 
-        return response.json(prediction, headers=no_cache_headers)
+        return response.json(prediction)
 
     @app.route('/models')
     async def list_models(req: request.Request) -> response.HTTPResponse:  # pylint: disable=unused-argument, unused-variable
         """list the available models"""
-        return response.json({"models": list(app.predictors.keys())}, headers=no_cache_headers)
+        return response.json({"models": list(app.predictors.keys())})
 
     # As a SPA, we need to return index.html for /model-name and /model-name/permalink
     @app.route('/semantic-role-labeling')

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
-import registerServiceWorker from './registerServiceWorker';
 
 ReactDOM.render(<App />, document.getElementById('root'));
-registerServiceWorker();


### PR DESCRIPTION
The bootstrapped ReactJS application enabled service workers, which is something we don't want.  From [the web](https://developers.google.com/web/fundamentals/primers/service-workers/): "A service worker is a script that your browser runs in the background, separate from a web page, opening the door to features that don't need a web page or user interaction. Today, they already include features like push notifications and background sync."

While I'm not sure it's strictly necessary I also set no cache headers for our API responses.