### PR TITLE
raise RuntimeError if python < 3.6

### DIFF
--- a/allennlp/__init__.py
+++ b/allennlp/__init__.py
@@ -1,3 +1,10 @@
+# pylint: disable=wrong-import-position
+
+# Make sure that allennlp is running in Python 3.6
+import sys
+if sys.version_info < (3, 6):
+    raise RuntimeError("AllenNLP requires Python 3.6 or later")
+
 # On some systems this prevents the dreaded
 # ImportError: dlopen: cannot load any more object with static TLS
 import spacy, torch, numpy  # pylint: disable=multiple-imports


### PR DESCRIPTION
`allennlp/__init__.py` seems like the right place for it, so it will kick in even if people don't use our `run` script.

https://stackoverflow.com/a/1093331/1076346