### PR TITLE
NLVR Type Declaration

### DIFF
--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -133,7 +133,7 @@ class WikiTablesDatasetReader(DatasetReader):
         fields = {'question': question_field, 'table': table_field}
         if dpd_output:
             world = WikiTablesWorld(table_knowledge_graph)
-            expressions = world.process_sempre_forms(dpd_output)
+            expressions = [world.parse_logical_form(form) for form in dpd_output]
             action_sequences = [world.get_action_sequence(expression) for expression in expressions]
             action_sequences_field = ListField([self._make_action_sequence_field(sequence)
                                                 for sequence in action_sequences])

--- a/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
@@ -1,0 +1,149 @@
+from typing import Optional
+from overrides import overrides
+
+from nltk.sem.logic import TRUTH_TYPE, EntityType, Type, ComplexType, ANY_TYPE
+
+from allennlp.data.semparse.type_declarations.type_declaration import NamedBasicType, PlaceholderType
+
+
+class BoxFilterType(PlaceholderType):
+    """
+    This is the type of the functions that filter boxes. The corresponding Python function takes three
+    arguments, and looks like ``filter(initial_set_of_boxes, attribute_function, target_attribute)`` .
+    Hence, the signature of the filter function is <b,<<b,#1>,<#1,b>>>.
+    """
+    @property
+    def _signature(self) -> str:
+        return "<b,<<b,#1>,<#1,b>>>"
+
+    @overrides
+    def resolve(self, other: Type) -> Optional[Type]:
+        if not isinstance(other, ComplexType):
+            return None
+        if not isinstance(other.second, ComplexType):
+            return None
+        if not isinstance(other.second.first, ComplexType) or not isinstance(other.second.second, ComplexType):
+            return None
+        resolved_type = other.resolve(ComplexType(BOX_TYPE, ComplexType(ComplexType(BOX_TYPE, ANY_TYPE),
+                                                                        ComplexType(ANY_TYPE, BOX_TYPE))))
+        if not resolved_type:
+            return None
+        first_placeholder = resolved_type.second.first.second
+        second_placeholder = resolved_type.second.second.first
+        resolved_placeholder = first_placeholder.resolve(second_placeholder)
+        if not resolved_placeholder:
+            return None
+        return BoxFilterType(BOX_TYPE, ComplexType(ComplexType(BOX_TYPE, resolved_placeholder),
+                                                   ComplexType(resolved_placeholder, BOX_TYPE)))
+
+    @overrides
+    def get_application_type(self, argument_type: Type) -> Type:
+        return self.second
+
+
+class AssertType(PlaceholderType):
+    """
+    This is the type of assert operations. Corresponding Python function looks like
+    ``assert(attribute, target_attribute)`` , where the attribute and target attribute can either be numbers,
+    shapes or colors, and the return type is boolean. So the signature of the function is <#1,<#1,t>>.
+    """
+    @property
+    def _signature(self) -> str:
+        return "<#1,<#1,t>>"
+
+    @overrides
+    def resolve(self, other: Type) -> Optional[Type]:
+        if not isinstance(other, ComplexType):
+            return None
+        if not isinstance(other.second, ComplexType):
+            return None
+        resolved_type = other.resolve(ComplexType(ANY_TYPE, ComplexType(ANY_TYPE, TRUTH_TYPE)))
+        if not resolved_type:
+            return None
+        resolved_placeholder = resolved_type.first.resolve(resolved_type.second.first)
+        if not resolved_placeholder:
+            return None
+        return AssertType(resolved_placeholder, ComplexType(resolved_type, TRUTH_TYPE))
+
+    @overrides
+    def get_application_type(self, argument_type: Type) -> Type:
+        return ComplexType(argument_type, TRUTH_TYPE)
+
+
+NUM_TYPE = EntityType()
+BOX_TYPE = NamedBasicType("BOX")
+OBJECT_TYPE = NamedBasicType("OBJECT")
+COLOR_TYPE = NamedBasicType("COLOR")
+SHAPE_TYPE = NamedBasicType("SHAPE")
+OBJECT_FILTER_TYPE = ComplexType(OBJECT_TYPE, OBJECT_TYPE)
+NEGATE_FILTER_TYPE = ComplexType(ComplexType(OBJECT_TYPE, OBJECT_TYPE),
+                                 ComplexType(OBJECT_TYPE, OBJECT_TYPE))
+BOX_MEMBERSHIP_TYPE = ComplexType(BOX_TYPE, OBJECT_TYPE)
+COLOR_FUNCTION_TYPE = ComplexType(OBJECT_TYPE, COLOR_TYPE)
+SHAPE_FUNCTION_TYPE = ComplexType(OBJECT_TYPE, SHAPE_TYPE)
+BOX_FILTER_TYPE = BoxFilterType(BOX_TYPE, ComplexType(ComplexType(BOX_TYPE, ANY_TYPE),
+                                                      ComplexType(ANY_TYPE, BOX_TYPE)))
+ASSERT_TYPE = AssertType(ANY_TYPE, ComplexType(ANY_TYPE, TRUTH_TYPE))
+
+
+COMMON_NAME_MAPPING = {}
+COMMON_TYPE_SIGNATURE = {}
+
+
+def add_common_name_with_type(name, mapping, type_signature):
+    COMMON_NAME_MAPPING[name] = mapping
+    COMMON_TYPE_SIGNATURE[mapping] = type_signature
+
+
+add_common_name_with_type("all_objects", "O", OBJECT_TYPE)
+add_common_name_with_type("all_boxes", "B", BOX_TYPE)
+
+
+# Attribute functions
+add_common_name_with_type("color", "C", COLOR_FUNCTION_TYPE)
+add_common_name_with_type("shape", "S", SHAPE_FUNCTION_TYPE)
+add_common_name_with_type("object_in_box", "I", BOX_MEMBERSHIP_TYPE)
+
+
+# Assert functions
+add_common_name_with_type("assert_equals", "A0", ASSERT_TYPE)
+add_common_name_with_type("assert_not_equals", "A1", ASSERT_TYPE)
+add_common_name_with_type("assert_greater", "A2", ASSERT_TYPE)
+add_common_name_with_type("assert_greater_equals", "A3", ASSERT_TYPE)
+add_common_name_with_type("assert_lesser", "A4", ASSERT_TYPE)
+add_common_name_with_type("assert_lesser_equals", "A5", ASSERT_TYPE)
+
+
+# Box filter functions
+add_common_name_with_type("filter_equals", "F0", BOX_FILTER_TYPE)
+add_common_name_with_type("filter_not_equals", "F1", BOX_FILTER_TYPE)
+add_common_name_with_type("filter_greater", "F2", BOX_FILTER_TYPE)
+add_common_name_with_type("filter_greater_equals", "F3", BOX_FILTER_TYPE)
+add_common_name_with_type("filter_lesser", "F4", BOX_FILTER_TYPE)
+add_common_name_with_type("filter_lesser_equals", "F5", BOX_FILTER_TYPE)
+
+
+# Object filter functions
+add_common_name_with_type("black", "C0", OBJECT_FILTER_TYPE)
+add_common_name_with_type("blue", "C1", OBJECT_FILTER_TYPE)
+add_common_name_with_type("yellow", "C2", OBJECT_FILTER_TYPE)
+add_common_name_with_type("same_color", "C3", OBJECT_FILTER_TYPE)
+add_common_name_with_type("triangle", "S0", OBJECT_FILTER_TYPE)
+add_common_name_with_type("square", "S1", OBJECT_FILTER_TYPE)
+add_common_name_with_type("circle", "S2", OBJECT_FILTER_TYPE)
+add_common_name_with_type("same_shape", "S3", OBJECT_FILTER_TYPE)
+add_common_name_with_type("touch_wall", "T0", OBJECT_FILTER_TYPE)
+add_common_name_with_type("touch_corner", "T1", OBJECT_FILTER_TYPE)
+add_common_name_with_type("touch_top", "T2", OBJECT_FILTER_TYPE)
+add_common_name_with_type("touch_bottom", "T3", OBJECT_FILTER_TYPE)
+add_common_name_with_type("touch_left", "T4", OBJECT_FILTER_TYPE)
+add_common_name_with_type("touch_right", "T5", OBJECT_FILTER_TYPE)
+add_common_name_with_type("above", "L0", OBJECT_FILTER_TYPE)
+add_common_name_with_type("below", "L1", OBJECT_FILTER_TYPE)
+add_common_name_with_type("top", "L2", OBJECT_FILTER_TYPE)
+add_common_name_with_type("bottom", "L3", OBJECT_FILTER_TYPE)
+add_common_name_with_type("small", "Z0", OBJECT_FILTER_TYPE)
+add_common_name_with_type("medium", "Z1", OBJECT_FILTER_TYPE)
+add_common_name_with_type("big", "Z2", OBJECT_FILTER_TYPE)
+
+add_common_name_with_type("negate_filter", "N", NEGATE_FILTER_TYPE)

--- a/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
@@ -96,6 +96,10 @@ class CountType(PlaceholderType):
         return NUM_TYPE
 
 
+# All constants default to ``EntityType`` in NLTK. For domains where constants of different types appear in the
+# logical forms, we have a way of specifying ``constant_type_prefixes`` and passing them to the constructor
+# of ``World``. However, in the NLVR language we defined, we see constants of just one type, number. So we
+# let them default to ``EntityType``.
 NUM_TYPE = EntityType()
 BOX_TYPE = NamedBasicType("BOX")
 OBJECT_TYPE = NamedBasicType("OBJECT")

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -2,8 +2,8 @@
 This module defines some classes that are generally useful for defining a type system for a new domain. We
 inherit the type logic in ``nltk.sem.logic`` and add some functionality on top of it here. There are two main
 improvements:
-    1) Firstly, we allow defining multiple basic types with their own names (see ``NamedBasicType``).
-    2) Secondly, we allow defining function types that have placeholders in them (see ``PlaceholderType``).
+1) Firstly, we allow defining multiple basic types with their own names (see ``NamedBasicType``).
+2) Secondly, we allow defining function types that have placeholders in them (see ``PlaceholderType``).
 We also extend NLTK's ``LogicParser`` to define a ``DynamicTypeLogicParser`` that knows how to deal with the
 two improvements above.
 """

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -29,6 +29,8 @@ class NamedBasicType(BasicType):
         self._string_rep = string_rep
 
     def __str__(self):
+        # TODO (pradeep): This limits the number of basic types we can have to 26. We may want to change this
+        # in the future if we extend to domains where we have more than 26 basic types.
         return self._string_rep.lower()[0]
 
     def str(self):

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -1,0 +1,233 @@
+"""
+This module defines some classes that are generally useful for defining a type system for a new domain. We
+inherit the type logic in ``nltk.sem.logic`` and add some functionality on top of it here. There are two main
+improvements:
+    1) Firstly, we allow defining multiple basic types with their own names (see ``NamedBasicType``).
+    2) Secondly, we allow defining function types that have placeholders in them (see ``PlaceholderType``).
+We also extend NLTK's ``LogicParser`` to define a ``DynamicTypeLogicParser`` that knows how to deal with the
+two improvements above.
+"""
+from typing import Dict, Optional
+from overrides import overrides
+
+from nltk.sem.logic import ApplicationExpression, ConstantExpression, LogicParser, Variable
+from nltk.sem.logic import Type, BasicType, ComplexType, ANY_TYPE
+
+
+class NamedBasicType(BasicType):
+    """
+    A ``BasicType`` that also takes the name of the type as an argument to its constructor. Type resolution
+    uses the output of ``__str__`` as well, so basic types with different representations do not resolve
+    against each other.
+
+    Parameters
+    ----------
+    string_rep : str
+        String representation of the type.
+    """
+    def __init__(self, string_rep) -> None:
+        self._string_rep = string_rep
+
+    def __str__(self):
+        return self._string_rep.lower()[0]
+
+    def str(self):
+        return self._string_rep
+
+
+class PlaceholderType(ComplexType):
+    """
+    ``PlaceholderType`` is a ``ComplexType`` that involves placeholders, and thus its type resolution is
+    context sensitive. This is an abstract class for all placeholder types like reverse, and, or, argmax, etc.
+
+    Note that ANY_TYPE in NLTK's type system doesn't work like a wild card. Once the type of a variable gets
+    resolved to a specific type, NLTK changes the type of that variable to that specific type. Hence, what
+    NLTK calls "ANY_TYPE", is essentially a "yet-to-be-decided" type. This is a problem because we may want the
+    same variable to bind to different types within a logical form, and using ANY_TYPE for this purpose will
+    cause a resolution failure. For example the count function may apply to both rows and cells in the same
+    logical form, and making count of type ``ComplexType(ANY_TYPE, DATE_NUM_TYPE)`` will cause a resolution
+    error. This class lets you define ``ComplexType`` s with placeholders that are actually wild cards.
+
+    The subclasses of this abstract class need to do three things
+    1) Override the property ``_signature`` to define the type signature (this is just the signature's
+    string representation and will not affect type inference or checking). You will see this signature in
+    action sequences.
+    2) Override ``resolve`` to resolve the type appropriately (see the docstring in ``resolve`` for more
+    information).
+    3) Override ``get_application_type`` which returns the return type when this type is applied as a function
+    to an argument of a specified type.
+    For example, if you defined a reverse type by inheriting from this class, ``get_application_type`` gets an
+    argument of type ``<a,b>``, it should return ``<b,a>`` .
+    """
+    @property
+    def _signature(self) -> str:
+        raise NotImplementedError
+
+    @overrides
+    def resolve(self, other: Type) -> Optional[Type]:
+        """
+        This method is central to type inference and checking. When a variable's type is being checked, we
+        compare what we know of its type against what is expected of its type by its context. The expectation
+        is provided as ``other``. We make sure that there are no contradictions between this type and other,
+        and return an updated type which may be more specific than the original type.
+
+        For example, say this type is of the function variable F in F(cell), and we start out with ``<?, d>``
+        (that is, it takes any type and returns ``d`` ). Now we have already resolved cell to be of type
+        ``e`` . Then ``resolve`` gets called with ``other = <e, ?>`` , because we know F is a function that
+        took a constant of type ``e`` . When we resolve ``<e, ?>`` against ``<?, d>`` , there will not be a
+        contradiction, because any type can be successfully resolved against ``?`` . Finally we return
+        ``<e, d>`` as the resolved type.
+
+        As a counter example, if we are trying to resolve ``<?, d>`` against ``<?, e>`` , the resolution fails,
+        and in that case, this method returns ``None`` .
+
+        Note that a successful resolution does not imply equality of types because of one of them may be
+        ANY_TYPE, and so in the subclasses of this type, we explicitly resolve in both directions.
+        """
+        raise NotImplementedError
+
+    def get_application_type(self, argument_type: Type) -> Type:
+        """
+        This method returns the resulting type when this type is applied as a function to an argument of
+        the given type.
+        """
+        raise NotImplementedError
+
+    @overrides
+    def __eq__(self, other) -> bool:
+        return self.__class__ == other.__class__
+
+    @overrides
+    def matches(self, other) -> bool:
+        # self == ANY_TYPE = True iff self.first == ANY_TYPE and self.second == ANY_TYPE.
+        return self == other or self == ANY_TYPE or other == ANY_TYPE
+
+    @overrides
+    def __str__(self):
+        if self == ANY_TYPE:
+            # If the type remains unresolved, we return ? instead of its signature.
+            return "%s" % ANY_TYPE
+        else:
+            return self._signature
+
+    @overrides
+    def str(self):
+        if self == ANY_TYPE:
+            return ANY_TYPE.str()
+        else:
+            return self._signature
+
+
+class TypedConstantExpression(ConstantExpression):
+    # pylint: disable=abstract-method
+    """
+    NLTK assumes all constants are of type ``EntityType`` (e) by default. We define this new class where we
+    can pass a default type to the constructor and use that in the ``_set_type`` method.
+    """
+    def __init__(self, variable, default_type: Type) -> None:
+        super(TypedConstantExpression, self).__init__(variable)
+        self._default_type = default_type
+
+    @overrides
+    def _set_type(self, other_type=ANY_TYPE, signature=None) -> None:
+        if other_type == ANY_TYPE:
+            super(TypedConstantExpression, self)._set_type(self._default_type, signature)
+        else:
+            super(TypedConstantExpression, self)._set_type(other_type, signature)
+
+
+class DynamicTypeApplicationExpression(ApplicationExpression):
+    """
+    NLTK's ``ApplicationExpression`` (which represents function applications like P(x)) has two limitations,
+    which we overcome by inheriting from ``ApplicationExpression`` and overriding two methods.
+
+    Firstly, ``ApplicationExpression`` does not handle the case where P's type involves placeholders
+    (R, V, !=, etc.), which are special cases because their return types depend on the type of their
+    arguments (x). We override the property ``type`` to redefine the type of the application.
+
+    Secondly, NLTK's variables only bind to entities, and thus the variable types are 'e' by default. We
+    get around this issue by replacing x with a function V(X), whose initial type is ANY_TYPE, and later
+    gets resolved based on the type signature of the function whose scope the variable appears in. This
+    variable binding operation is implemented by overriding ``_set_type`` below.
+    """
+    @property
+    def type(self):
+        # This gets called when the tree is being built by ``LogicParser.parse``. So, we do not
+        # have access to the type signatures yet. Thus, we need to look at the name of the function
+        # to return the type.
+        if not self._has_placeholder(str(self.function)):
+            return super(DynamicTypeApplicationExpression, self).type
+        if self.function.type == ANY_TYPE:
+            return ANY_TYPE
+        argument_type = self.argument.type
+        return self.function.type.get_application_type(argument_type)
+
+    def _set_type(self, other_type=ANY_TYPE, signature=None):
+        """
+        We override this method to do just one thing on top of ``ApplicationExpression._set_type``. In
+        lambda expressions of the form /x F(x), where the function is F and the argument is x, we can use
+        the type of F to infer the type of x. That is, if F is of type <a, b>, we can resolve the type of
+        x against a. We do this as the additional step after setting the type of F(x).
+
+        So why does NLTK not already do this? NLTK assumes all variables (x) are of type entity (e). So it
+        does not have to resolve the type of x anymore. However, this would cause type inference failures in
+        our case since x can bind to rows, numbers or cells, each of which has a different type. To deal with
+        this issue, we replaced x with V(X) ((var x) in Sempre) and made X of type ANY_TYPE, and V of type
+        <#1, #1>. We cannot leave X as ANY_TYPE because that would propagate up the tree. We need to set its
+        type when we have the information about F. Hence this method.
+        """
+        super(DynamicTypeApplicationExpression, self)._set_type(other_type, signature)
+        if isinstance(self.argument, ApplicationExpression) and str(self.argument.function) == "V":
+            # pylint: disable=protected-access
+            self.argument.argument._set_type(self.function.type.first)
+
+    @staticmethod
+    def _has_placeholder(variable_name):
+        if variable_name not in COMMON_TYPE_SIGNATURE:
+            return False
+        return isinstance(COMMON_TYPE_SIGNATURE[variable_name], PlaceholderType)
+
+
+class DynamicTypeLogicParser(LogicParser):
+    """
+    ``DynamicTypeLogicParser`` is a ``LogicParser`` that can deal with ``NamedBasicType`` and
+    ``PlaceholderType`` appropriately. Our extension here does two things differently.
+
+    Firstly, we should handle constants of different types. We do this by passing a dict of format
+    ``{name_prefix: type}`` to the constructor. For example, your domain has entities of types unicorns
+    and elves, and you have an entity "Phil" of type unicorn, and "Bob" of type "elf". The names of the two
+    entities should then be "unicorn:phil" and "elf:bob" respectively.
+
+    Secondly, since we defined a new kind of ``ApplicationExpression`` above, the ``LogicParser`` should be
+    able to create this new kind of expression.
+    """
+    def __init__(self,
+                 type_check: bool = True,
+                 constant_type_prefixes: Dict[str, BasicType] = None) -> None:
+        super(DynamicTypeLogicParser, self).__init__(type_check)
+        self._constant_type_prefixes = constant_type_prefixes or {}
+
+    @overrides
+    def make_ApplicationExpression(self, function, argument):
+        return DynamicTypeApplicationExpression(function, argument)
+
+    @overrides
+    def make_VariableExpression(self, name):
+        if ":" in name:
+            prefix = name.split(":")[0]
+            if prefix in self._constant_type_prefixes:
+                return TypedConstantExpression(Variable(name), self._constant_type_prefixes[prefix])
+            else:
+                raise RuntimeError("Unknown prefix: %s. Did you forget to pass it to the constructor?" % prefix)
+        return super(DynamicTypeLogicParser, self).make_VariableExpression(name)
+
+
+COMMON_NAME_MAPPING = {"lambda": "\\"}
+
+
+COMMON_TYPE_SIGNATURE = {}
+
+
+def add_common_name_with_type(name, mapping, type_signature):
+    COMMON_NAME_MAPPING[name] = mapping
+    COMMON_TYPE_SIGNATURE[mapping] = type_signature

--- a/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
@@ -227,10 +227,10 @@ CONJUNCTION_TYPE = ConjunctionType(ANY_TYPE, ANY_TYPE)
 ARG_EXTREME_TYPE = ArgExtremeType(ANY_TYPE, ANY_TYPE)
 
 
-COMMON_NAME_MAPPING = {"lambda": "\\"}
+COMMON_NAME_MAPPING = {"lambda": "\\", "var": "V"}
 
 
-COMMON_TYPE_SIGNATURE = {}
+COMMON_TYPE_SIGNATURE = {"V": IDENTITY_TYPE}
 
 
 def add_common_name_with_type(name, mapping, type_signature):
@@ -247,7 +247,6 @@ add_common_name_with_type("or", "O", CONJUNCTION_TYPE)
 add_common_name_with_type("fb:row.row.next", "N", NEXT_ROW_TYPE)
 add_common_name_with_type("number", "I", NUMBER_FUNCTION_TYPE)
 add_common_name_with_type("date", "D0", DATE_FUNCTION_TYPE)
-add_common_name_with_type("var", "V", IDENTITY_TYPE)
 add_common_name_with_type("fb:cell.cell.part", "P", PART2CELL_TYPE)
 add_common_name_with_type("fb:cell.cell.date", "D1", CELL2DATE_NUM_TYPE)
 add_common_name_with_type("fb:cell.cell.number", "I1", CELL2DATE_NUM_TYPE)

--- a/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
@@ -6,7 +6,6 @@ from overrides import overrides
 
 from nltk.sem.logic import Type, ComplexType, EntityType, ANY_TYPE
 
-from allennlp.data.semparse.type_declarations import type_declaration
 from allennlp.data.semparse.type_declarations.type_declaration import PlaceholderType, NamedBasicType
 
 
@@ -227,31 +226,42 @@ CONJUNCTION_TYPE = ConjunctionType(ANY_TYPE, ANY_TYPE)
 # argmax, argmin
 ARG_EXTREME_TYPE = ArgExtremeType(ANY_TYPE, ANY_TYPE)
 
-type_declaration.add_common_name_with_type("reverse", "R", REVERSE_TYPE)
-type_declaration.add_common_name_with_type("argmax", "A0", ARG_EXTREME_TYPE)
-type_declaration.add_common_name_with_type("argmin", "A1", ARG_EXTREME_TYPE)
-type_declaration.add_common_name_with_type("max", "M0", UNARY_NUM_OP_TYPE)
-type_declaration.add_common_name_with_type("min", "M1", UNARY_NUM_OP_TYPE)
-type_declaration.add_common_name_with_type("and", "A", CONJUNCTION_TYPE)
-type_declaration.add_common_name_with_type("or", "O", CONJUNCTION_TYPE)
-type_declaration.add_common_name_with_type("fb:row.row.next", "N", NEXT_ROW_TYPE)
-type_declaration.add_common_name_with_type("number", "I", NUMBER_FUNCTION_TYPE)
-type_declaration.add_common_name_with_type("date", "D0", DATE_FUNCTION_TYPE)
-type_declaration.add_common_name_with_type("var", "V", IDENTITY_TYPE)
-type_declaration.add_common_name_with_type("fb:cell.cell.part", "P", PART2CELL_TYPE)
-type_declaration.add_common_name_with_type("fb:cell.cell.date", "D1", CELL2DATE_NUM_TYPE)
-type_declaration.add_common_name_with_type("fb:cell.cell.number", "I1", CELL2DATE_NUM_TYPE)
-type_declaration.add_common_name_with_type("fb:cell.cell.num2", "I2", CELL2DATE_NUM_TYPE)
-type_declaration.add_common_name_with_type("fb:row.row.index", "W", ROW_INDEX_TYPE)
-type_declaration.add_common_name_with_type("fb:type.row", "T0", ROW_TYPE)
-type_declaration.add_common_name_with_type("fb:type.object.type", "T", IDENTITY_TYPE)
-type_declaration.add_common_name_with_type("count", "C", COUNT_TYPE)
-type_declaration.add_common_name_with_type("!=", "Q", IDENTITY_TYPE)
-type_declaration.add_common_name_with_type(">", "G0", UNARY_NUM_OP_TYPE)
-type_declaration.add_common_name_with_type(">=", "G1", UNARY_NUM_OP_TYPE)
-type_declaration.add_common_name_with_type("<", "L0", UNARY_NUM_OP_TYPE)
-type_declaration.add_common_name_with_type("<=", "L1", UNARY_NUM_OP_TYPE)
-type_declaration.add_common_name_with_type("sum", "S0", UNARY_NUM_OP_TYPE)
-type_declaration.add_common_name_with_type("avg", "S1", UNARY_NUM_OP_TYPE)
-type_declaration.add_common_name_with_type("-", "F", BINARY_NUM_OP_TYPE)  # subtraction
-type_declaration.add_common_name_with_type("x", "X", ANY_TYPE)
+
+COMMON_NAME_MAPPING = {"lambda": "\\"}
+
+
+COMMON_TYPE_SIGNATURE = {}
+
+
+def add_common_name_with_type(name, mapping, type_signature):
+    COMMON_NAME_MAPPING[name] = mapping
+    COMMON_TYPE_SIGNATURE[mapping] = type_signature
+
+add_common_name_with_type("reverse", "R", REVERSE_TYPE)
+add_common_name_with_type("argmax", "A0", ARG_EXTREME_TYPE)
+add_common_name_with_type("argmin", "A1", ARG_EXTREME_TYPE)
+add_common_name_with_type("max", "M0", UNARY_NUM_OP_TYPE)
+add_common_name_with_type("min", "M1", UNARY_NUM_OP_TYPE)
+add_common_name_with_type("and", "A", CONJUNCTION_TYPE)
+add_common_name_with_type("or", "O", CONJUNCTION_TYPE)
+add_common_name_with_type("fb:row.row.next", "N", NEXT_ROW_TYPE)
+add_common_name_with_type("number", "I", NUMBER_FUNCTION_TYPE)
+add_common_name_with_type("date", "D0", DATE_FUNCTION_TYPE)
+add_common_name_with_type("var", "V", IDENTITY_TYPE)
+add_common_name_with_type("fb:cell.cell.part", "P", PART2CELL_TYPE)
+add_common_name_with_type("fb:cell.cell.date", "D1", CELL2DATE_NUM_TYPE)
+add_common_name_with_type("fb:cell.cell.number", "I1", CELL2DATE_NUM_TYPE)
+add_common_name_with_type("fb:cell.cell.num2", "I2", CELL2DATE_NUM_TYPE)
+add_common_name_with_type("fb:row.row.index", "W", ROW_INDEX_TYPE)
+add_common_name_with_type("fb:type.row", "T0", ROW_TYPE)
+add_common_name_with_type("fb:type.object.type", "T", IDENTITY_TYPE)
+add_common_name_with_type("count", "C", COUNT_TYPE)
+add_common_name_with_type("!=", "Q", IDENTITY_TYPE)
+add_common_name_with_type(">", "G0", UNARY_NUM_OP_TYPE)
+add_common_name_with_type(">=", "G1", UNARY_NUM_OP_TYPE)
+add_common_name_with_type("<", "L0", UNARY_NUM_OP_TYPE)
+add_common_name_with_type("<=", "L1", UNARY_NUM_OP_TYPE)
+add_common_name_with_type("sum", "S0", UNARY_NUM_OP_TYPE)
+add_common_name_with_type("avg", "S1", UNARY_NUM_OP_TYPE)
+add_common_name_with_type("-", "F", BINARY_NUM_OP_TYPE)  # subtraction
+add_common_name_with_type("x", "X", ANY_TYPE)

--- a/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
@@ -6,7 +6,7 @@ from overrides import overrides
 
 from nltk.sem.logic import Type, ComplexType, EntityType, ANY_TYPE
 
-from allennlp.data.semparse.type_declarations.type_declaration import PlaceholderType, NamedBasicType
+from allennlp.data.semparse.type_declarations.type_declaration import PlaceholderType, NamedBasicType, IdentityType
 
 
 class ReverseType(PlaceholderType):
@@ -47,33 +47,6 @@ class ReverseType(PlaceholderType):
     @overrides
     def get_application_type(self, argument_type: Type) -> Type:
         return ComplexType(argument_type.second, argument_type.first)
-
-
-class IdentityType(PlaceholderType):
-    """
-    ``IdentityType`` is a kind of ``PlaceholderType`` that takes an argument of any type and returns
-    an expression of the same type. That is, type signature is <#1, #1>.
-    """
-    @property
-    def _signature(self) -> str:
-        return "<#1,#1>"
-
-    @overrides
-    def resolve(self, other) -> Optional[Type]:
-        """See ``PlaceholderType.resolve``"""
-        if not isinstance(other, ComplexType):
-            return None
-        other_first = other.first.resolve(other.second)
-        if not other_first:
-            return None
-        other_second = other.second.resolve(other_first)
-        if not other_second:
-            return None
-        return IdentityType(other_first, other_second)
-
-    @overrides
-    def get_application_type(self, argument_type: Type) -> Type:
-        return argument_type
 
 
 class ConjunctionType(PlaceholderType):
@@ -227,10 +200,10 @@ CONJUNCTION_TYPE = ConjunctionType(ANY_TYPE, ANY_TYPE)
 ARG_EXTREME_TYPE = ArgExtremeType(ANY_TYPE, ANY_TYPE)
 
 
-COMMON_NAME_MAPPING = {"lambda": "\\", "var": "V"}
+COMMON_NAME_MAPPING = {"lambda": "\\", "var": "V", "x": "X"}
 
 
-COMMON_TYPE_SIGNATURE = {"V": IDENTITY_TYPE}
+COMMON_TYPE_SIGNATURE = {"V": IDENTITY_TYPE, "X": ANY_TYPE}
 
 
 def add_common_name_with_type(name, mapping, type_signature):
@@ -263,4 +236,3 @@ add_common_name_with_type("<=", "L1", UNARY_NUM_OP_TYPE)
 add_common_name_with_type("sum", "S0", UNARY_NUM_OP_TYPE)
 add_common_name_with_type("avg", "S1", UNARY_NUM_OP_TYPE)
 add_common_name_with_type("-", "F", BINARY_NUM_OP_TYPE)  # subtraction
-add_common_name_with_type("x", "X", ANY_TYPE)

--- a/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
@@ -1,104 +1,13 @@
 """
-Defines all the types in the WikitablesQuestions domain. We exploit the type logic in ``nltk.sem.logic``
-here. This module also contains two helper classes that add some functionality on top of NLTK's logic module.
+Defines all the types in the WikitablesQuestions domain.
 """
+from typing import Optional
 from overrides import overrides
 
-from nltk.sem.logic import ApplicationExpression, ConstantExpression, Variable, LogicParser
-from nltk.sem.logic import BasicType, ComplexType, EntityType, ANY_TYPE
+from nltk.sem.logic import Type, ComplexType, EntityType, ANY_TYPE
 
-
-class NamedBasicType(BasicType):
-    """
-    A ``BasicType`` that also takes the name of the type as an argument to its constructor. Type resolution
-    uses the output of ``__str__`` as well, so basic types with different representations do not resolve
-    against each other.
-
-    Parameters
-    ----------
-    string_rep : str
-        String representation of the type.
-    """
-    def __init__(self, string_rep) -> None:
-        self._string_rep = string_rep
-
-    def __str__(self) -> str:
-        return self._string_rep.lower()[0]
-
-    def str(self):
-        return self._string_rep
-
-
-class PlaceholderType(ComplexType):
-    """
-    ``PlaceholderType`` is a ``ComplexType`` that involves placeholders, and thus its type resolution is
-    context sensitive. This is an abstract class for all placeholder types like reverse, and, or, argmax, etc.
-
-    Note that ANY_TYPE in NLTK's type system doesn't work like a wild card. Once the type of a variable gets
-    resolved to a specific type, NLTK changes the type of that variable to that specific type. Hence, what
-    NLTK calls "ANY_TYPE", is essentially a "yet-to-be-decided" type. This is a problem because we may want the
-    same variable to bind to different types within a logical form, and using ANY_TYPE for this purpose will
-    cause a resolution failure. For example the count function may apply to both rows and cells in the same
-    logical form, and making count of type ``ComplexType(ANY_TYPE, DATE_NUM_TYPE)`` will cause a resolution
-    error. This class lets you define ``ComplexType`` s with placeholders that are actually wild cards.
-
-    The subclasses of this abstract class need to do two things
-    1) Override the property ``_signature`` to define the type signature (this is just the signature's
-    string representation and will not affect type inference or checking). You will see this signature in
-    action sequences.
-    2) Override ``resolve`` to resolve the type appropriately (see the docstring in ``resolve`` for more
-    information).
-    """
-    @property
-    def _signature(self):
-        raise NotImplementedError
-
-    @overrides
-    def resolve(self, other):
-        """
-        This method is central to type inference and checking. When a variable's type is being checked, we
-        compare what we know of its type against what is expected of its type by its context. The expectation
-        is provided as ``other``. We make sure that there are no contradictions between this type and other,
-        and return an updated type which may be more specific than the original type.
-
-        For example, say this type is of the function variable F in F(cell), and we start out with ``<?, d>``
-        (that is, it takes any type and returns ``d`` ). Now we have already resolved cell to be of type
-        ``e`` . Then ``resolve`` gets called with ``other = <e, ?>`` , because we know F is a function that
-        took a constant of type ``e`` . When we resolve ``<e, ?>`` against ``<?, d>`` , there will not be a
-        contradiction, because any type can be successfully resolved against ``?`` . Finally we return
-        ``<e, d>`` as the resolved type.
-
-        As a counter example, if we are trying to resolve ``<?, d>`` against ``<?, e>`` , the resolution fails,
-        and in that case, this method returns ``None`` .
-
-        Note that a successful resolution does not imply equality of types because of one of them may be
-        ANY_TYPE, and so in the subclasses of this type, we explicitly resolve in both directions.
-        """
-        raise NotImplementedError
-
-    @overrides
-    def __eq__(self, other):
-        return self.__class__ == other.__class__
-
-    @overrides
-    def matches(self, other):
-        # self == ANY_TYPE = True iff self.first == ANY_TYPE and self.second == ANY_TYPE.
-        return self == other or self == ANY_TYPE or other == ANY_TYPE
-
-    @overrides
-    def __str__(self):
-        if self == ANY_TYPE:
-            # If the type remains unresolved, we return ? instead of its signature.
-            return "%s" % ANY_TYPE
-        else:
-            return self._signature
-
-    @overrides
-    def str(self):
-        if self == ANY_TYPE:
-            return ANY_TYPE.str()
-        else:
-            return self._signature
+from allennlp.data.semparse.type_declarations import type_declaration
+from allennlp.data.semparse.type_declarations.type_declaration import PlaceholderType, NamedBasicType
 
 
 class ReverseType(PlaceholderType):
@@ -116,11 +25,11 @@ class ReverseType(PlaceholderType):
         <<r,?>, <?,e>>  :   None
     """
     @property
-    def _signature(self):
+    def _signature(self) -> str:
         return "<<#1,#2>,<#2,#1>>"
 
     @overrides
-    def resolve(self, other):
+    def resolve(self, other: Type) -> Optional[Type]:
         # Idea: Since its signature is <<#1,#2>,<#2,#1>> no information about types in self is relevant.
         # All that matters is that other.fiirst resolves against the reverse of other.second and vice versa.
         if not isinstance(other, ComplexType):
@@ -136,6 +45,10 @@ class ReverseType(PlaceholderType):
             return None
         return ReverseType(other_first, other_second)
 
+    @overrides
+    def get_application_type(self, argument_type: Type) -> Type:
+        return ComplexType(argument_type.second, argument_type.first)
+
 
 class IdentityType(PlaceholderType):
     """
@@ -143,11 +56,11 @@ class IdentityType(PlaceholderType):
     an expression of the same type. That is, type signature is <#1, #1>.
     """
     @property
-    def _signature(self):
+    def _signature(self) -> str:
         return "<#1,#1>"
 
     @overrides
-    def resolve(self, other):
+    def resolve(self, other) -> Optional[Type]:
         """See ``PlaceholderType.resolve``"""
         if not isinstance(other, ComplexType):
             return None
@@ -159,6 +72,10 @@ class IdentityType(PlaceholderType):
             return None
         return IdentityType(other_first, other_second)
 
+    @overrides
+    def get_application_type(self, argument_type: Type) -> Type:
+        return argument_type
+
 
 class ConjunctionType(PlaceholderType):
     """
@@ -166,11 +83,11 @@ class ConjunctionType(PlaceholderType):
     type. That is, its signature is <#1, <#1, #1>>
     """
     @property
-    def _signature(self):
+    def _signature(self) -> str:
         return "<#1,<#1,#1>>"
 
     @overrides
-    def resolve(self, other):
+    def resolve(self, other: Type) -> Optional[Type]:
         """See ``PlaceholderType.resolve``"""
         if not isinstance(other, ComplexType):
             return None
@@ -187,6 +104,10 @@ class ConjunctionType(PlaceholderType):
             return None
         return ConjunctionType(other_first, other_second)
 
+    @overrides
+    def get_application_type(self, argument_type: Type) -> Type:
+        return ComplexType(argument_type, argument_type)
+
 
 class ArgExtremeType(PlaceholderType):
     """
@@ -195,11 +116,11 @@ class ArgExtremeType(PlaceholderType):
     meaning, of the subset of rows where league == usl_a_league, find the row with the maximum index.
     """
     @property
-    def _signature(self):
+    def _signature(self) -> str:
         return "<d,<d,<#1,<<d,#1>,#1>>>>"
 
     @overrides
-    def resolve(self, other):
+    def resolve(self, other: Type) -> Optional[Type]:
         """See ``PlaceholderType.resolve``"""
         if not isinstance(other, ComplexType):
             return None
@@ -240,17 +161,23 @@ class ArgExtremeType(PlaceholderType):
         except AttributeError:
             return None
 
+    @overrides
+    def get_application_type(self, argument_type: Type) -> Type:
+        # Returning <d,<#1,<<d,#1>,#1>>>.
+        # This is called after the placeholders are resolved.
+        return self.second
+
 
 class CountType(PlaceholderType):
     """
     Type of a function that counts arbitrary things. Signature is <#1,d>.
     """
     @property
-    def _signature(self):
+    def _signature(self) -> str:
         return "<#1,d>"
 
     @overrides
-    def resolve(self, other):
+    def resolve(self, other: Type) -> Type:
         """See ``PlaceholderType.resolve``"""
         if not isinstance(other, ComplexType):
             return None
@@ -258,6 +185,10 @@ class CountType(PlaceholderType):
         if not resolved_second:
             return None
         return CountType(ANY_TYPE, resolved_second)
+
+    @overrides
+    def get_application_type(self, argument_type: Type) -> Type:
+        return DATE_NUM_TYPE
 
 
 CELL_TYPE = EntityType()
@@ -296,136 +227,31 @@ CONJUNCTION_TYPE = ConjunctionType(ANY_TYPE, ANY_TYPE)
 # argmax, argmin
 ARG_EXTREME_TYPE = ArgExtremeType(ANY_TYPE, ANY_TYPE)
 
-COMMON_NAME_MAPPING = {"lambda": "\\"}
-
-COMMON_TYPE_SIGNATURE = {}
-
-def _add_common_name_with_type(name, mapping, type_signature):
-    COMMON_NAME_MAPPING[name] = mapping
-    COMMON_TYPE_SIGNATURE[mapping] = type_signature
-
-_add_common_name_with_type("reverse", "R", REVERSE_TYPE)
-_add_common_name_with_type("argmax", "A0", ARG_EXTREME_TYPE)
-_add_common_name_with_type("argmin", "A1", ARG_EXTREME_TYPE)
-_add_common_name_with_type("max", "M0", UNARY_NUM_OP_TYPE)
-_add_common_name_with_type("min", "M1", UNARY_NUM_OP_TYPE)
-_add_common_name_with_type("and", "A", CONJUNCTION_TYPE)
-_add_common_name_with_type("or", "O", CONJUNCTION_TYPE)
-_add_common_name_with_type("fb:row.row.next", "N", NEXT_ROW_TYPE)
-_add_common_name_with_type("number", "I", NUMBER_FUNCTION_TYPE)
-_add_common_name_with_type("date", "D0", DATE_FUNCTION_TYPE)
-_add_common_name_with_type("var", "V", IDENTITY_TYPE)
-_add_common_name_with_type("fb:cell.cell.part", "P", PART2CELL_TYPE)
-_add_common_name_with_type("fb:cell.cell.date", "D1", CELL2DATE_NUM_TYPE)
-_add_common_name_with_type("fb:cell.cell.number", "I1", CELL2DATE_NUM_TYPE)
-_add_common_name_with_type("fb:cell.cell.num2", "I2", CELL2DATE_NUM_TYPE)
-_add_common_name_with_type("fb:row.row.index", "W", ROW_INDEX_TYPE)
-_add_common_name_with_type("fb:type.row", "T0", ROW_TYPE)
-_add_common_name_with_type("fb:type.object.type", "T", IDENTITY_TYPE)
-_add_common_name_with_type("count", "C", COUNT_TYPE)
-_add_common_name_with_type("!=", "Q", IDENTITY_TYPE)
-_add_common_name_with_type(">", "G0", UNARY_NUM_OP_TYPE)
-_add_common_name_with_type(">=", "G1", UNARY_NUM_OP_TYPE)
-_add_common_name_with_type("<", "L0", UNARY_NUM_OP_TYPE)
-_add_common_name_with_type("<=", "L1", UNARY_NUM_OP_TYPE)
-_add_common_name_with_type("sum", "S0", UNARY_NUM_OP_TYPE)
-_add_common_name_with_type("avg", "S1", UNARY_NUM_OP_TYPE)
-_add_common_name_with_type("-", "F", BINARY_NUM_OP_TYPE)  # subtraction
-_add_common_name_with_type("x", "X", ANY_TYPE)
-
-
-class TypedConstantExpression(ConstantExpression):
-    # pylint: disable=abstract-method
-    """
-    NLTK assumes all constants are of type ``EntityType`` (e) by default. We define this new class where we
-    can pass a default type to the constructor and use that in the ``_set_type`` method.
-    """
-    def __init__(self, variable, default_type):
-        super(TypedConstantExpression, self).__init__(variable)
-        self._default_type = default_type
-
-    @overrides
-    def _set_type(self, other_type=ANY_TYPE, signature=None):
-        if other_type == ANY_TYPE:
-            super(TypedConstantExpression, self)._set_type(self._default_type, signature)
-        else:
-            super(TypedConstantExpression, self)._set_type(other_type, signature)
-
-
-class DynamicTypeApplicationExpression(ApplicationExpression):
-    """
-    NLTK's ``ApplicationExpression`` (which represents function applications like P(x)) has two limitations,
-    which we overcome by inheriting from ``ApplicationExpression`` and overriding two methods.
-
-    Firstly, ``ApplicationExpression`` does not handle the case where P's type involves placeholders
-    (R, V, !=, etc.), which are special cases because their return types depend on the type of their
-    arguments (x). We override the property ``type`` to redefine the type of the application.
-
-    Secondly, NLTK's variables only bind to entities, and thus the variable types are 'e' by default. We
-    get around this issue by replacing x with a function V(X), whose initial type is ANY_TYPE, and later
-    gets resolved based on the type signature of the function whose scope the variable appears in. This
-    variable binding operation is implemented by overriding ``_set_type`` below.
-    """
-    @property
-    def type(self):
-        # This gets called when the tree is being built by ``LogicParser.parse``. So, we do not
-        # have access to the type signatures yet. Thus, we need to look at the name of the function
-        # to return the type.
-        if not self._has_placeholder(str(self.function)):
-            return super(DynamicTypeApplicationExpression, self).type
-        if self.function.type == ANY_TYPE:
-            return ANY_TYPE
-        argument_type = self.argument.type
-        if isinstance(self.function.type, ReverseType):
-            return_type = ComplexType(argument_type.second, argument_type.first)
-        elif isinstance(self.function.type, ConjunctionType):
-            return_type = ComplexType(argument_type, argument_type)
-        elif isinstance(self.function.type, ArgExtremeType):
-            # Returning <d,<#1,<<d,#1>,#1>>>.
-            # This is called after the placeholders are resolved.
-            return_type = self.function.type.second
-        else:
-            # The function is of type IdentityType.
-            return_type = argument_type
-        return return_type
-
-    def _set_type(self, other_type=ANY_TYPE, signature=None):
-        """
-        We override this method to do just one thing on top of ``ApplicationExpression._set_type``. In
-        lambda expressions of the form /x F(x), where the function is F and the argument is x, we can use
-        the type of F to infer the type of x. That is, if F is of type <a, b>, we can resolve the type of
-        x against a. We do this as the additional step after setting the type of F(x).
-
-        So why does NLTK not already do this? NLTK assumes all variables (x) are of type entity (e). So it
-        does not have to resolve the type of x anymore. However, this would cause type inference failures in
-        our case since x can bind to rows, numbers or cells, each of which has a different type. To deal with
-        this issue, we replaced x with V(X) ((var x) in Sempre) and made X of type ANY_TYPE, and V of type
-        <#1, #1>. We cannot leave X as ANY_TYPE because that would propagate up the tree. We need to set its
-        type when we have the information about F. Hence this method.
-        """
-        super(DynamicTypeApplicationExpression, self)._set_type(other_type, signature)
-        if isinstance(self.argument, ApplicationExpression) and str(self.argument.function) == "V":
-            # pylint: disable=protected-access
-            self.argument.argument._set_type(self.function.type.first)
-
-    @staticmethod
-    def _has_placeholder(variable_name):
-        if variable_name not in COMMON_TYPE_SIGNATURE:
-            return False
-        return COMMON_TYPE_SIGNATURE[variable_name] in [REVERSE_TYPE, IDENTITY_TYPE,
-                                                        CONJUNCTION_TYPE, ARG_EXTREME_TYPE]
-
-class DynamicTypeLogicParser(LogicParser):
-    """
-    Since we defined a new kind of ``ApplicationExpression`` above, the ``LogicParser`` should be able to
-    create this new kind of expression. We do that by overriding the ``LogicParser`` as well.
-    """
-    @overrides
-    def make_ApplicationExpression(self, function, argument):
-        return DynamicTypeApplicationExpression(function, argument)
-
-    @overrides
-    def make_VariableExpression(self, name):
-        if name.startswith("part:"):
-            return TypedConstantExpression(Variable(name), PART_TYPE)
-        return super(DynamicTypeLogicParser, self).make_VariableExpression(name)
+type_declaration.add_common_name_with_type("reverse", "R", REVERSE_TYPE)
+type_declaration.add_common_name_with_type("argmax", "A0", ARG_EXTREME_TYPE)
+type_declaration.add_common_name_with_type("argmin", "A1", ARG_EXTREME_TYPE)
+type_declaration.add_common_name_with_type("max", "M0", UNARY_NUM_OP_TYPE)
+type_declaration.add_common_name_with_type("min", "M1", UNARY_NUM_OP_TYPE)
+type_declaration.add_common_name_with_type("and", "A", CONJUNCTION_TYPE)
+type_declaration.add_common_name_with_type("or", "O", CONJUNCTION_TYPE)
+type_declaration.add_common_name_with_type("fb:row.row.next", "N", NEXT_ROW_TYPE)
+type_declaration.add_common_name_with_type("number", "I", NUMBER_FUNCTION_TYPE)
+type_declaration.add_common_name_with_type("date", "D0", DATE_FUNCTION_TYPE)
+type_declaration.add_common_name_with_type("var", "V", IDENTITY_TYPE)
+type_declaration.add_common_name_with_type("fb:cell.cell.part", "P", PART2CELL_TYPE)
+type_declaration.add_common_name_with_type("fb:cell.cell.date", "D1", CELL2DATE_NUM_TYPE)
+type_declaration.add_common_name_with_type("fb:cell.cell.number", "I1", CELL2DATE_NUM_TYPE)
+type_declaration.add_common_name_with_type("fb:cell.cell.num2", "I2", CELL2DATE_NUM_TYPE)
+type_declaration.add_common_name_with_type("fb:row.row.index", "W", ROW_INDEX_TYPE)
+type_declaration.add_common_name_with_type("fb:type.row", "T0", ROW_TYPE)
+type_declaration.add_common_name_with_type("fb:type.object.type", "T", IDENTITY_TYPE)
+type_declaration.add_common_name_with_type("count", "C", COUNT_TYPE)
+type_declaration.add_common_name_with_type("!=", "Q", IDENTITY_TYPE)
+type_declaration.add_common_name_with_type(">", "G0", UNARY_NUM_OP_TYPE)
+type_declaration.add_common_name_with_type(">=", "G1", UNARY_NUM_OP_TYPE)
+type_declaration.add_common_name_with_type("<", "L0", UNARY_NUM_OP_TYPE)
+type_declaration.add_common_name_with_type("<=", "L1", UNARY_NUM_OP_TYPE)
+type_declaration.add_common_name_with_type("sum", "S0", UNARY_NUM_OP_TYPE)
+type_declaration.add_common_name_with_type("avg", "S1", UNARY_NUM_OP_TYPE)
+type_declaration.add_common_name_with_type("-", "F", BINARY_NUM_OP_TYPE)  # subtraction
+type_declaration.add_common_name_with_type("x", "X", ANY_TYPE)

--- a/allennlp/data/semparse/worlds/__init__.py
+++ b/allennlp/data/semparse/worlds/__init__.py
@@ -1,3 +1,2 @@
-from allennlp.data.semparse.worlds.world import World
 from allennlp.data.semparse.worlds.nlvr_world import NlvrWorld
 from allennlp.data.semparse.worlds.wikitables_world import WikiTablesWorld

--- a/allennlp/data/semparse/worlds/__init__.py
+++ b/allennlp/data/semparse/worlds/__init__.py
@@ -1,2 +1,3 @@
+from allennlp.data.semparse.worlds.world import World
 from allennlp.data.semparse.worlds.nlvr_world import NlvrWorld
 from allennlp.data.semparse.worlds.wikitables_world import WikiTablesWorld

--- a/allennlp/data/semparse/worlds/nlvr_world.py
+++ b/allennlp/data/semparse/worlds/nlvr_world.py
@@ -10,6 +10,7 @@ import pyparsing
 
 from allennlp.common import util
 from allennlp.common.util import JsonDict
+from allennlp.data.semparse.worlds import World
 
 
 AttributeType = TypeVar('AttributeType', str, int)  # pylint: disable=invalid-name
@@ -77,7 +78,7 @@ class Box:
         return str(self) == str(other)
 
 
-class NlvrWorld:
+class NlvrWorld(World):
     """
     Class defining the world representation of NLVR. Defines an execution logic for logical forms
     in NLVR.  We just take the structured_rep from the JSON file to initialize this.
@@ -89,6 +90,7 @@ class NlvrWorld:
     """
     # pylint: disable=too-many-public-methods
     def __init__(self, world_representation: List[List[JsonDict]]) -> None:
+        super(NlvrWorld, self).__init__()
         self._boxes = set([Box(object_list, "box%d" % index)
                            for index, object_list in enumerate(world_representation)])
         self._objects: Set[Object] = set()
@@ -444,6 +446,28 @@ class NlvrWorld:
                                 cls.touch_top(objects).intersection(cls.touch_left(objects)),
                                 cls.touch_bottom(objects).intersection(cls.touch_right(objects)),
                                 cls.touch_bottom(objects).intersection(cls.touch_left(objects)))
+
+    @classmethod
+    def top(cls, objects: Set[Object]) -> Set[Object]:
+        """
+        Return the topmost objects (i.e. maximum y_loc).
+        """
+        max_y_loc = max([obj.y_loc for obj in objects])
+        return set([obj for obj in objects if obj.y_loc == max_y_loc])
+
+    @classmethod
+    def bottom(cls, objects: Set[Object]) -> Set[Object]:
+        """
+        Return the bottom most objects(i.e. minimum y_loc).
+        """
+        min_y_loc = min([obj.y_loc for obj in objects])
+        return set([obj for obj in objects if obj.y_loc == min_y_loc])
+
+    def above(self, objects: Set[Object]) -> Set[Object]:
+        """
+        Return the set of objects in the world that are directly above the objects given.
+        """
+        raise NotImplementedError
 
     @classmethod
     def small(cls, objects: Set[Object]) -> Set[Object]:

--- a/allennlp/data/semparse/worlds/wikitables_world.py
+++ b/allennlp/data/semparse/worlds/wikitables_world.py
@@ -36,7 +36,7 @@ class WikiTablesWorld(World):
         """
         Takes the name of a predicate or a constant as used by Sempre, maps it to a unique string such that
         NLTK processes it appropriately. This is needed because NLTK has a naming convention for variables:
-            Function variables: Single upper case letter optionally foolowed by digits
+            Function variables: Single upper case letter optionally followed by digits
             Individual variables: Single lower case letter (except e for events) optionally followed by digits
             Constants: Everything else
 

--- a/allennlp/data/semparse/worlds/wikitables_world.py
+++ b/allennlp/data/semparse/worlds/wikitables_world.py
@@ -4,10 +4,7 @@ executed) here. For WikiTableQuestions, this includes a representation of a tabl
 Sempre variables in all logical forms to NLTK variables, and the types of all predicates and entities.
 """
 import re
-from typing import List
 from overrides import overrides
-
-from nltk.sem.logic import Expression
 
 from allennlp.data.semparse.worlds.world import World
 from allennlp.data.semparse.type_declarations.wikitables_type_declaration import (COMMON_NAME_MAPPING,
@@ -28,21 +25,11 @@ class WikiTablesWorld(World):
     def __init__(self, table_graph: TableKnowledgeGraph) -> None:
         super(WikiTablesWorld, self).__init__(constant_type_prefixes={"part": types.PART_TYPE,
                                                                       "cell": types.CELL_TYPE},
-                                              global_type_signatures=COMMON_TYPE_SIGNATURE)
+                                              global_type_signatures=COMMON_TYPE_SIGNATURE,
+                                              global_name_mapping=COMMON_NAME_MAPPING)
         self.table_graph = table_graph
         # For every new Sempre column name seen, we update this counter to map it to a new NLTK name.
         self._column_counter = 0
-
-    def process_sempre_forms(self, sempre_forms: List[str]) -> List[Expression]:
-        """
-        Processes logical forms in Sempre format (that are either gold annotations or output from DPD)
-        and converts them into ``Expression`` objects in NLTK. The conversion involves mapping names to
-        follow NLTK's variable naming conventions.
-        """
-        expressions = []
-        for sempre_form in sempre_forms:
-            expressions.append(self.parse_logical_form(sempre_form))
-        return expressions
 
     @overrides
     def _map_name(self, name: str) -> str:
@@ -63,18 +50,15 @@ class WikiTablesWorld(World):
                 # Column name
                 translated_name = "C%d" % self._column_counter
                 self._column_counter += 1
-                self.local_type_signatures[translated_name] = types.COLUMN_TYPE
-                self.local_name_mapping[name] = translated_name
+                self._add_name_mapping(name, translated_name, types.COLUMN_TYPE)
             elif name.startswith("fb:cell"):
                 # Cell name
                 translated_name = "cell:%s" % name.split(".")[-1]
-                self.local_type_signatures[translated_name] = types.CELL_TYPE
-                self.local_name_mapping[name] = translated_name
+                self._add_name_mapping(name, translated_name, types.CELL_TYPE)
             elif name.startswith("fb:part"):
                 # part name
                 translated_name = "part:%s" % name.split(".")[-1]
-                self.local_type_signatures[translated_name] = types.PART_TYPE
-                self.local_name_mapping[name] = translated_name
+                self._add_name_mapping(name, translated_name, types.PART_TYPE)
             else:
                 # NLTK throws an error if it sees a "." in constants, which will most likely happen within
                 # numbers as a decimal point. We're changing those to underscores.
@@ -83,6 +67,7 @@ class WikiTablesWorld(World):
                     # The string is a negative number. This makes NLTK interpret this as a negated expression
                     # and force its type to be TRUTH_VALUE (t).
                     translated_name = translated_name.replace("-", "~")
+                self._add_name_mapping(name, translated_name)
         else:
             if name in COMMON_NAME_MAPPING:
                 translated_name = COMMON_NAME_MAPPING[name]

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -1,0 +1,96 @@
+from typing import List, Dict, Union
+import pyparsing
+
+from nltk.sem.logic import Expression, LambdaExpression, Type
+
+from allennlp.data.semparse.type_declarations.type_declaration import DynamicTypeLogicParser
+
+
+class World:
+    """
+    Base class for defining a world in a new domain. This class defines a method to translate a logical form
+    as per a naming convention that works with NLTK's ``LogicParser``. The sub-classes can decide on the
+    convention by overriding the ``_map_name`` method that does token level mapping. This class also defines
+    a method for transforming ``Expressions`` into action sequences.
+    """
+    def __init__(self,
+                 constant_type_prefixes: Dict[str, str] = None,
+                 global_type_signatures: Dict[str, Type] = None):
+        # NLTK has a naming convention for variable types. If the world has predicate or entity names beyond
+        # what's defined in the COMMON_NAME_MAPPING, they need to be added to this dict.
+        # We initialize this dict with common predicate names and update it as we process logical forms.
+        self.local_name_mapping = {}
+        # Similarly, these are the type signatures not in the COMMON_TYPE_SIGNATURE.
+        self.local_type_signatures = {}
+        type_prefixes = constant_type_prefixes or {}
+        self.global_type_signatures = global_type_signatures or {}
+        self._logic_parser = DynamicTypeLogicParser(constant_type_prefixes=type_prefixes,
+                                                    type_signatures=self.global_type_signatures)
+
+    def parse_logical_form(self, logical_form: str) -> Expression:
+        def _process_nested_expression(nested_expression: List[Union[str, List[str]]]) -> str:
+            """
+            ``nested_expression`` is the result of parsing a Lambda-DCS expression in Lisp format.
+            We process it recursively and return a string in the format that NLTK's ``LogicParser``
+            would understand.
+            """
+            expression_is_list = isinstance(nested_expression, list)
+            expression_size = len(nested_expression)
+            if expression_is_list and expression_size == 1 and isinstance(nested_expression[0], list):
+                return _process_nested_expression(nested_expression[0])
+            elements_are_leaves = [isinstance(element, str) for element in nested_expression]
+            if all(elements_are_leaves):
+                mapped_names = [self._map_name(name) for name in nested_expression]
+            else:
+                mapped_names = []
+                for element, is_leaf in zip(nested_expression, elements_are_leaves):
+                    if is_leaf:
+                        mapped_names.append(self._map_name(element))
+                    else:
+                        mapped_names.append(_process_nested_expression(element))
+            if mapped_names[0] == "\\":
+                # This means the predicate is lambda. NLTK wants the variable name to not be within parantheses.
+                # Adding parentheses after the variable.
+                arguments = [mapped_names[1]] + ["(%s)" % name for name in mapped_names[2:]]
+            else:
+                arguments = ["(%s)" % name for name in mapped_names[1:]]
+            return "(%s %s)" % (mapped_names[0], " ".join(arguments))
+        parsed_lisp = pyparsing.OneOrMore(pyparsing.nestedExpr()).parseString(logical_form).asList()
+        translated_string = _process_nested_expression(parsed_lisp)
+        type_signature = self.local_type_signatures.copy()
+        type_signature.update(self.global_type_signatures)
+        return self._logic_parser.parse(translated_string, signature=type_signature)
+
+    def _map_name(self, name: str) -> str:
+        raise NotImplementedError
+
+    @staticmethod
+    def get_action_sequence(expression: Expression) -> List[str]:
+        """
+        Returns the sequence of actions (as strings) that resulted in the given expression.
+        """
+        def _get_transitions(expression: Expression,
+                             current_transitions: List[str]) -> List[str]:
+            expression_type = expression.type
+            try:
+                # ``Expression.visit()`` takes two arguments: the first one is a function applied on each
+                # sub-expression and the second is a combinator that is applied to the list of values returned
+                # from the function applications. We just want the list of all sub-expressions here.
+                sub_expressions = expression.visit(lambda x: x, lambda x: x)
+                transformed_types = [sub_exp.type for sub_exp in sub_expressions]
+                if isinstance(expression, LambdaExpression):
+                    # If the expression is a lambda expression, the list of sub expressions does not include
+                    # the "lambda x" term. We're adding it here so that we will see transitions like
+                    #   <e,d> -> [\x, d] instead of
+                    #   <e,d> -> [d]
+                    transformed_types = ["/X"] + transformed_types
+                current_transitions.append("%s -> %s" % (expression_type,
+                                                         str(transformed_types)))
+                for sub_expression in sub_expressions:
+                    _get_transitions(sub_expression, current_transitions)
+            except NotImplementedError:
+                # This means that the expression is a leaf. We simply make a transition from its type to itself.
+                current_transitions.append("%s -> %s" % (expression_type, expression))
+            return current_transitions
+        # Starting with the type of the whole expression
+        return _get_transitions(expression, [str(expression.type)])

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -399,7 +399,7 @@ class WikiTablesDecoderState(DecoderState['WikiTablesDecoderState']):
         # TODO(mattg): these static methods probably belong in some other class.
         if production[0] == '<':
             return True
-        if production.startswith('cell'):
+        if production.startswith('fb:'):
             return False
         if len(production) > 1 or production == "x":
             return False

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -401,6 +401,8 @@ class WikiTablesDecoderState(DecoderState['WikiTablesDecoderState']):
             return True
         if production.startswith('cell'):
             return False
+        if len(production) > 1 or production == "x":
+            return False
         return production[0].islower()
 
     # @overrides  - overrides can't handle the generics we're using here, apparently

--- a/doc/api/allennlp.data.semparse.type_declarations.rst
+++ b/doc/api/allennlp.data.semparse.type_declarations.rst
@@ -6,7 +6,17 @@ allennlp.data.semparse.type_declarations
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: allennlp.data.semparse.type_declarations.type_declaration
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: allennlp.data.semparse.type_declarations.wikitables_type_declaration
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: allennlp.data.semparse.type_declarations.nlvr_type_declaration
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/allennlp.data.semparse.worlds.rst
+++ b/doc/api/allennlp.data.semparse.worlds.rst
@@ -6,6 +6,11 @@ allennlp.data.semparse.worlds
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: allennlp.data.semparse.worlds.world
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: allennlp.data.semparse.worlds.wikitables_world
    :members:
    :undoc-members:

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -16,11 +16,12 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
         question_tokens = ["what", "was", "the", "last", "year", "where", "this", "team", "was",
                            "a", "part", "of", "the", "usl", "a", "-", "league", "?"]
         assert [t.text for t in instance.fields["question"].tokens] == question_tokens
-        assert actions == ['@@START@@', 'd', 'd -> [<d,d>, d]', '<d,d> -> M0', 'd -> [<e,d>, e]',
-                           '<e,d> -> [<<#1,#2>,<#2,#1>>, <d,e>]', '<<#1,#2>,<#2,#1>> -> R',
-                           '<d,e> -> D1', 'e -> [<r,e>, r]', '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]',
-                           '<<#1,#2>,<#2,#1>> -> R', '<e,r> -> C0', 'r -> [<e,r>, e]', '<e,r> -> C1',
-                           'e -> cell:usl_a_league', '@@END@@']
+        assert actions == ['@@START@@', 'd', 'd -> [<d,d>, d]', '<d,d> -> max', 'd -> [<e,d>, e]',
+                           '<e,d> -> [<<#1,#2>,<#2,#1>>, <d,e>]', '<<#1,#2>,<#2,#1>> -> reverse',
+                           '<d,e> -> fb:cell.cell.date', 'e -> [<r,e>, r]',
+                           '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]', '<<#1,#2>,<#2,#1>> -> reverse',
+                           '<e,r> -> fb:row.row.year', 'r -> [<e,r>, e]', '<e,r> -> fb:row.row.league',
+                           'e -> fb:cell.usl_a_league', '@@END@@']
         entities = instance.fields['table'].knowledge_graph.get_all_entities()
         assert len(entities) == 47
         assert 'fb:row.row.year' in entities

--- a/tests/data/semparse/type_declarations/type_declaration_test.py
+++ b/tests/data/semparse/type_declarations/type_declaration_test.py
@@ -1,0 +1,10 @@
+# pylint: disable=no-self-use
+from allennlp.data.semparse.type_declarations import type_declaration as types
+from allennlp.common.testing import AllenNlpTestCase
+
+
+class TestTypeResolution(AllenNlpTestCase):
+    def test_basic_types_conflict_on_names(self):
+        type_a = types.NamedBasicType("A")
+        type_b = types.NamedBasicType("B")
+        assert type_a.resolve(type_b) is None

--- a/tests/data/semparse/type_declarations/wikitables_type_declaration_test.py
+++ b/tests/data/semparse/type_declarations/wikitables_type_declaration_test.py
@@ -1,15 +1,9 @@
 # pylint: disable=no-self-use
 from allennlp.data.semparse.type_declarations import wikitables_type_declaration as types
-
 from allennlp.common.testing import AllenNlpTestCase
 
 
 class TestPlaceholderTypeResolution(AllenNlpTestCase):
-    def test_basic_types_conflict_on_names(self):
-        type_a = types.NamedBasicType("A")
-        type_b = types.NamedBasicType("B")
-        assert type_a.resolve(type_b) is None
-
     def test_reverse_resolves_correctly(self):
         assert types.REVERSE_TYPE.resolve(types.CELL_TYPE) is None
 

--- a/tests/data/semparse/worlds/nlvr_world_test.py
+++ b/tests/data/semparse/worlds/nlvr_world_test.py
@@ -9,51 +9,84 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
     def setUp(self):
         super().setUp()
         test_filename = "tests/fixtures/data/nlvr/sample_data.json"
-        self.data = [json.loads(line) for line in open(test_filename).readlines()]
+        data = [json.loads(line)["structured_rep"] for line in open(test_filename).readlines()]
+        self.worlds = [NlvrWorld(rep) for rep in data]
 
     def test_logical_form_with_assert_executes_correctly(self):
-        nlvr_world = NlvrWorld(self.data[0]["structured_rep"])
+        nlvr_world = self.worlds[0]
         # Utterance is "There is a circle closely touching a corner of a box." and label is "True".
-        logical_form_true = "assert_greater_equals(count(touch_corner(circle(all_objects))) 1)"
+        logical_form_true = "(assert_greater_equals (count (touch_corner (circle (all_objects)))) 1)"
         # Should evaluate to True.
         assert nlvr_world.execute(logical_form_true)
-        logical_form_false = "assert_equals(count(touch_corner(circle(all_objects))) 0)"
+        logical_form_false = "(assert_equals (count (touch_corner (circle(all_objects)))) 0)"
         # Should evaluate to False.
         assert not nlvr_world.execute(logical_form_false)
 
     def test_logical_form_with_filter_executes_correctly(self):
-        nlvr_world = NlvrWorld(self.data[2]["structured_rep"])
+        nlvr_world = self.worlds[2]
         # Utterance is "There is a box without a blue item." and label is "False".
-        logical_form = "assert_greater_equals(count(filter_equals(all_boxes count(blue(object_in_box)) 0)) 1)"
+        logical_form = "(assert_greater_equals \
+                         (count (filter_equals all_boxes (lambda x (count (blue (object_in_box (var x))))) 0)) \
+                         1)"
         # Should evaluate to False.
         assert not nlvr_world.execute(logical_form)
 
     def test_logical_form_with_same_color_executes_correctly(self):
-        nlvr_world = NlvrWorld(self.data[1]["structured_rep"])
+        nlvr_world = self.worlds[1]
         # Utterance is "There is exactly one tower with two blocks of the same color." and label is "True".
-        logical_form = "assert_equals(count(filter_equals(all_boxes count(same_color(object_in_box)) 2)) 1)"
+        logical_form = "(assert_equals \
+                         (count \
+                          (filter_equals all_boxes (lambda x (count (same_color (object_in_box (var x))))) 2)) \
+                         1)"
         assert nlvr_world.execute(logical_form)
 
     def test_logical_form_with_same_shape_executes_correctly(self):
-        nlvr_world = NlvrWorld(self.data[0]["structured_rep"])
+        nlvr_world = self.worlds[0]
         # Utterance is "There are less than three black objects of the same shape" and label is "False".
-        logical_form = "assert_lesser(count(same_shape(black(all_objects))) 3)"
+        logical_form = "(assert_lesser (count (same_shape (black (all_objects)))) 3)"
         assert not nlvr_world.execute(logical_form)
 
     def test_logical_form_with_touch_wall_executes_correctly(self):
-        nlvr_world = NlvrWorld(self.data[0]["structured_rep"])
+        nlvr_world = self.worlds[0]
         # Utterance is "There are two black circles touching a wall" and label is "False".
-        logical_form = "assert_greater_equals(count(touch_wall(black(circle(all_objects)))) 2)"
+        logical_form = "(assert_greater_equals (count (touch_wall (black (circle (all_objects))))) 2)"
         assert not nlvr_world.execute(logical_form)
 
     def test_logical_form_with_not_executes_correctly(self):
-        nlvr_world = NlvrWorld(self.data[2]["structured_rep"])
+        nlvr_world = self.worlds[2]
         # Utterance is "There are at most two medium triangles not touching a wall." and label is "True".
-        logical_form = "assert_lesser_equals(count(negate_filter(touch_wall medium(triangle(all_objects)))) 2)"
+        logical_form = ("(assert_lesser_equals (count (negate_filter (touch_wall) \
+                                                                     (medium (triangle (all_objects))))) 2)")
         assert nlvr_world.execute(logical_form)
 
     def test_logical_form_with_color_comparison_executes_correctly(self):
-        nlvr_world = NlvrWorld(self.data[0]["structured_rep"])
+        nlvr_world = self.worlds[0]
         # Utterance is "The color of the circle touching the wall is black." and label is "True".
-        logical_form = "assert_equals(color(circle(touch_wall(all_objects))) color_black)"
+        logical_form = "(assert_equals (color (circle (touch_wall (all_objects)))) color_black)"
         assert nlvr_world.execute(logical_form)
+
+    def test_logical_form_with_object_filter_returns_correct_action_sequence(self):
+        nlvr_world = self.worlds[0]
+        logical_form = "(assert_equals (color (circle (touch_wall (all_objects)))) color_black)"
+        expression = nlvr_world.parse_logical_form(logical_form)
+        action_sequence = nlvr_world.get_action_sequence(expression)
+        assert action_sequence == ['t', 't -> [<c,t>, c]', '<c,t> -> [<#1,<#1,t>>, c]',
+                                   '<#1,<#1,t>> -> assert_equals', 'c -> [<o,c>, o]', '<o,c> -> color',
+                                   'o -> [<o,o>, o]', '<o,o> -> circle', 'o -> [<o,o>, o]',
+                                   '<o,o> -> touch_wall', 'o -> all_objects', 'c -> color_black']
+
+    def test_logical_form_with_box_filter_returns_correct_action_sequence(self):
+        nlvr_world = self.worlds[0]
+        logical_form = ("(assert_greater_equals \
+                          (count (filter_equals all_boxes (lambda x (count (blue (object_in_box (var (x)))))) 0)) \
+                          1)")
+        expression = nlvr_world.parse_logical_form(logical_form)
+        action_sequence = nlvr_world.get_action_sequence(expression)
+        assert action_sequence == ['t', 't -> [<e,t>, e]', '<e,t> -> [<#1,<#1,t>>, e]',
+                                   '<#1,<#1,t>> -> assert_greater_equals', 'e -> [<#1,e>, b]', '<#1,e> -> count',
+                                   'b -> [<e,b>, e]', '<e,b> -> [<<b,e>,<e,b>>, <b,e>]',
+                                   '<<b,e>,<e,b>> -> [<b,<<b,#1>,<#1,b>>>, b]',
+                                   '<b,<<b,#1>,<#1,b>>> -> filter_equals', 'b -> all_boxes',
+                                   "<b,e> -> ['lambda x', e]", 'e -> [<#1,e>, o]', '<#1,e> -> count',
+                                   'o -> [<o,o>, o]', '<o,o> -> blue', 'o -> [<b,o>, b]', '<b,o> -> object_in_box',
+                                   'b -> [<#1,#1>, b]', '<#1,#1> -> var', 'b -> x', 'e -> 0', 'e -> 1']

--- a/tests/data/semparse/worlds/wikitables_world_test.py
+++ b/tests/data/semparse/worlds/wikitables_world_test.py
@@ -12,34 +12,35 @@ class TestWikiTablesWorldRepresentation(AllenNlpTestCase):
 
     def test_world_processes_sempre_forms_correctly(self):
         sempre_form = "((reverse fb:row.row.year) (fb:row.row.league fb:cell.usl_a_league))"
-        expression = self.world.process_sempre_forms([sempre_form])[0]
+        expression = self.world.parse_logical_form(sempre_form)
         assert str(expression) == "R(C0,C1(cell:usl_a_league))"
 
     def test_world_returns_correct_actions_with_reverse(self):
         sempre_form = "((reverse fb:row.row.year) (fb:row.row.league fb:cell.usl_a_league))"
-        expression = self.world.process_sempre_forms([sempre_form])[0]
+        expression = self.world.parse_logical_form(sempre_form)
         actions = self.world.get_action_sequence(expression)
         target_action_sequence = ['e', 'e -> [<r,e>, r]', '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]',
-                                  '<<#1,#2>,<#2,#1>> -> R', '<e,r> -> C0', 'r -> [<e,r>, e]',
-                                  '<e,r> -> C1', 'e -> cell:usl_a_league']
+                                  '<<#1,#2>,<#2,#1>> -> reverse', '<e,r> -> fb:row.row.year',
+                                  'r -> [<e,r>, e]', '<e,r> -> fb:row.row.league', 'e -> fb:cell.usl_a_league']
         assert actions == target_action_sequence
 
     def test_world_returns_correct_actions_with_two_reverses(self):
         sempre_form = ("(max ((reverse fb:cell.cell.date) ((reverse fb:row.row.year) "
                        "(fb:row.row.league fb:cell.usl_a_league))))")
-        expression = self.world.process_sempre_forms([sempre_form])[0]
+        expression = self.world.parse_logical_form(sempre_form)
         actions = self.world.get_action_sequence(expression)
-        target_action_sequence = ['d', 'd -> [<d,d>, d]', '<d,d> -> M0', 'd -> [<e,d>, e]',
-                                  '<e,d> -> [<<#1,#2>,<#2,#1>>, <d,e>]', '<<#1,#2>,<#2,#1>> -> R',
-                                  '<d,e> -> D1', 'e -> [<r,e>, r]', '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]',
-                                  '<<#1,#2>,<#2,#1>> -> R', '<e,r> -> C0', 'r -> [<e,r>, e]',
-                                  '<e,r> -> C1', 'e -> cell:usl_a_league']
+        target_action_sequence = ['d', 'd -> [<d,d>, d]', '<d,d> -> max', 'd -> [<e,d>, e]',
+                                  '<e,d> -> [<<#1,#2>,<#2,#1>>, <d,e>]', '<<#1,#2>,<#2,#1>> -> reverse',
+                                  '<d,e> -> fb:cell.cell.date', 'e -> [<r,e>, r]',
+                                  '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]', '<<#1,#2>,<#2,#1>> -> reverse',
+                                  '<e,r> -> fb:row.row.year', 'r -> [<e,r>, e]',
+                                  '<e,r> -> fb:row.row.league', 'e -> fb:cell.usl_a_league']
         assert actions == target_action_sequence
 
     def test_large_scale_processing(self):
         # A sample of 500 logical forms taken randomly from DPD outputs of all questions in training data.
         forms = [x.strip() for x in open("tests/fixtures/data/wikitables/logical_forms_large_sample.txt")]
-        expressions = self.world.process_sempre_forms(forms)
+        expressions = [self.world.parse_logical_form(form) for form in forms]
         for form, expression in zip(forms, expressions):
             action_sequence = self.world.get_action_sequence(expression)
             for action in action_sequence:


### PR DESCRIPTION
This PR mainly contains a type declaration for NLVR, and the functionality to turn NLVR logical forms into action sequences. In the process of doing that, I made several changes:

1) Defined new module `type_declaration` that contains general classes for creating type systems for new domains.
2) Defined a new class `World` that contains generic methods for logical form processing and for making action sequences.
3) Redefined action sequences to contain original names instead of translated names (given by the name mapping).
4) Made some tweaks to the NLVR language to make type checking work correctly. The only major change is that the language now has lambda forms in `filter_*` functions. Actually, we had lambda forms even earlier, because the second argument to the `filter_*` functions was a function. It's just that they did not explicitly say so. Making them explicit turned out to be necessary for type checking.
So what looked like `filter_equals(all_boxes count(object_in_box) 3)`, now looks like `(filter_equals all_boxes (lambda x (count(object_in_box(var x)))) 3)`

@matt-gardner Sorry this turned out to be yet another big PR. Bit I think this shouldn't take too much of your time since its mostly stuff that got moved around.