### PR TITLE
Add `ScalarMix` module

### DIFF
--- a/allennlp/modules/__init__.py
+++ b/allennlp/modules/__init__.py
@@ -16,3 +16,4 @@ from allennlp.modules.similarity_functions import SimilarityFunction
 from allennlp.modules.text_field_embedders import TextFieldEmbedder
 from allennlp.modules.time_distributed import TimeDistributed
 from allennlp.modules.token_embedders import TokenEmbedder
+from allennlp.modules.scalar_mix import ScalarMix

--- a/allennlp/modules/scalar_mix.py
+++ b/allennlp/modules/scalar_mix.py
@@ -1,0 +1,58 @@
+from typing import List
+import torch
+import numpy
+from torch.nn import ParameterList, Parameter
+
+from allennlp.common.checks import ConfigurationError
+
+class ScalarMix(torch.nn.Module):
+    """
+    Computes a parameterised scalar mixture of N tensors, ``mixture = gamma * sum(s_k * tensor_k)``
+    where ``s = softmax(w)``, with ``w`` and ``gamma`` scalar parameters.
+
+    In addition, if ``do_layer_norm=True`` then apply layer normalization to each tensor
+    before weighting.
+    """
+    def __init__(self, mixture_size: int, do_layer_norm: bool=False):
+        super(ScalarMix, self).__init__()
+
+        self.mixture_size = mixture_size
+        self.do_layer_norm = do_layer_norm
+
+        self.scalar_parameters = ParameterList([Parameter(torch.FloatTensor([0.0]))
+                                               for _ in range(mixture_size)])
+        self.gamma = Parameter(torch.FloatTensor([1.0]))
+
+    def forward(self, tensors: List[torch.Tensor], mask: torch.Tensor=None):
+        if len(tensors) != self.mixture_size:
+            raise ConfigurationError("{} tensors were passed, but the module was initialized to "
+                                     "mix {} tensors.".format(len(tensors), self.mixture_size))
+
+        def _do_layer_norm(tensor, broadcast_mask, num_elements_not_masked):
+            tensor_masked = tensor * broadcast_mask
+            mean = torch.sum(tensor_masked) / num_elements_not_masked
+            variance = torch.sum(((tensor_masked - mean) * broadcast_mask)**2) / num_elements_not_masked
+            return (tensor - mean) / torch.sqrt(variance + 1E-12)
+
+        normed_weights = torch.split(
+                torch.nn.functional.softmax(torch.cat(self.scalar_parameters)),
+                split_size=1
+        )
+
+        if not self.do_layer_norm:
+            pieces = []
+            for weight, tensor in zip(normed_weights, tensors):
+                pieces.append(weight * tensor)
+            return self.gamma * sum(pieces)
+
+        else:
+            mask_float = mask.float()
+            broadcast_mask = mask_float.unsqueeze(-1)
+            input_dim = tensors[0].size(-1)
+            num_elements_not_masked = torch.sum(mask_float) * input_dim
+
+            pieces = []
+            for weight, tensor in zip(normed_weights, tensors):
+                pieces.append(weight * _do_layer_norm(tensor,
+                                                      broadcast_mask, num_elements_not_masked))
+            return self.gamma * sum(pieces)

--- a/allennlp/modules/scalar_mix.py
+++ b/allennlp/modules/scalar_mix.py
@@ -13,7 +13,7 @@ class ScalarMix(torch.nn.Module):
     In addition, if ``do_layer_norm=True`` then apply layer normalization to each tensor
     before weighting.
     """
-    def __init__(self, mixture_size: int, do_layer_norm: bool = False):
+    def __init__(self, mixture_size: int, do_layer_norm: bool = False) -> None:
         super(ScalarMix, self).__init__()
 
         self.mixture_size = mixture_size
@@ -23,7 +23,8 @@ class ScalarMix(torch.nn.Module):
                                                 for _ in range(mixture_size)])
         self.gamma = Parameter(torch.FloatTensor([1.0]))
 
-    def forward(self, tensors: List[torch.Tensor], mask: torch.Tensor = None): # pylint: disable=arguments-differ
+    def forward(self, tensors: List[torch.Tensor],  # pylint: disable=arguments-differ
+                mask: torch.Tensor = None) -> torch.Tensor:
         if len(tensors) != self.mixture_size:
             raise ConfigurationError("{} tensors were passed, but the module was initialized to "
                                      "mix {} tensors.".format(len(tensors), self.mixture_size))

--- a/allennlp/modules/scalar_mix.py
+++ b/allennlp/modules/scalar_mix.py
@@ -25,6 +25,17 @@ class ScalarMix(torch.nn.Module):
 
     def forward(self, tensors: List[torch.Tensor],  # pylint: disable=arguments-differ
                 mask: torch.Tensor = None) -> torch.Tensor:
+        """
+        Compute a weighted average of the ``tensors``.  The input tensors an be any shape
+        with at least two dimensions, but must all be the same shape.
+
+        When ``do_layer_norm=True``, the ``mask`` is required input.  If the ``tensors`` are
+        dimensioned  ``(dim_0, ..., dim_{n-1}, dim_n)``, then the ``mask`` is dimensioned
+        ``(dim_0, ..., dim_{n-1})``, as in the typical case with ``tensors`` of shape
+        ``(batch_size, timesteps, dim)`` and ``mask`` of shape ``(batch_size, timesteps)``.
+
+        When ``do_layer_norm=False`` the ``mask`` is ignored.
+        """
         if len(tensors) != self.mixture_size:
             raise ConfigurationError("{} tensors were passed, but the module was initialized to "
                                      "mix {} tensors.".format(len(tensors), self.mixture_size))

--- a/allennlp/modules/scalar_mix.py
+++ b/allennlp/modules/scalar_mix.py
@@ -1,6 +1,6 @@
 from typing import List
+
 import torch
-import numpy
 from torch.nn import ParameterList, Parameter
 
 from allennlp.common.checks import ConfigurationError
@@ -13,17 +13,17 @@ class ScalarMix(torch.nn.Module):
     In addition, if ``do_layer_norm=True`` then apply layer normalization to each tensor
     before weighting.
     """
-    def __init__(self, mixture_size: int, do_layer_norm: bool=False):
+    def __init__(self, mixture_size: int, do_layer_norm: bool = False):
         super(ScalarMix, self).__init__()
 
         self.mixture_size = mixture_size
         self.do_layer_norm = do_layer_norm
 
         self.scalar_parameters = ParameterList([Parameter(torch.FloatTensor([0.0]))
-                                               for _ in range(mixture_size)])
+                                                for _ in range(mixture_size)])
         self.gamma = Parameter(torch.FloatTensor([1.0]))
 
-    def forward(self, tensors: List[torch.Tensor], mask: torch.Tensor=None):
+    def forward(self, tensors: List[torch.Tensor], mask: torch.Tensor = None): # pylint: disable=arguments-differ
         if len(tensors) != self.mixture_size:
             raise ConfigurationError("{} tensors were passed, but the module was initialized to "
                                      "mix {} tensors.".format(len(tensors), self.mixture_size))

--- a/doc/api/allennlp.modules.rst
+++ b/doc/api/allennlp.modules.rst
@@ -23,5 +23,5 @@ allennlp.modules
    allennlp.modules.text_field_embedders
    allennlp.modules.time_distributed
    allennlp.modules.token_embedders
-
+   allennlp.modules.scalar_mix
 

--- a/doc/api/allennlp.modules.scalar_mix.rst
+++ b/doc/api/allennlp.modules.scalar_mix.rst
@@ -1,0 +1,7 @@
+allennlp.modules.scalar_mix
+=========================================
+
+.. automodule:: allennlp.modules.scalar_mix
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/modules/scalar_mix_test.py
+++ b/tests/modules/scalar_mix_test.py
@@ -1,0 +1,55 @@
+import torch
+from torch.autograd import Variable
+import pytest
+import numpy
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.common.checks import ConfigurationError
+from allennlp.modules import ScalarMix
+
+
+class TestScalarMix(AllenNlpTestCase):
+    def test_scalar_mix_can_run_forward(self):
+        mixture = ScalarMix(3)
+        tensors = [Variable(torch.randn([3, 4, 5])) for _ in range(3)]
+        for k in range(3):
+            mixture.scalar_parameters[k].data[0] = 0.1 * (k + 1)
+        mixture.gamma.data[0] = 0.5
+        result = mixture(tensors)
+
+        weights = [0.1, 0.2, 0.3]
+        normed_weights = numpy.exp(weights) / numpy.sum(numpy.exp(weights))
+        expected_result = sum(normed_weights[k] * tensors[k].data.numpy() for k in range(3))
+        expected_result *= 0.5
+        numpy.testing.assert_almost_equal(expected_result, result.data.numpy())
+
+    def test_scalar_mix_throws_error_on_incorrect_number_of_inputs(self):
+        mixture = ScalarMix(3)
+        tensors = [Variable(torch.randn([3, 4, 5])) for _ in range(5)]
+        with pytest.raises(ConfigurationError):
+            _ = mixture(tensors)
+
+    def test_scalar_mix_layer_norm(self):
+        mixture = ScalarMix(3, do_layer_norm='scalar_norm_reg')
+
+        tensors = [Variable(torch.randn([3, 4, 5])) for _ in range(3)]
+        numpy_mask = numpy.ones((3, 4), dtype='int32')
+        numpy_mask[1, 2:] = 0
+        mask = Variable(torch.from_numpy(numpy_mask))
+
+        weights = [0.1, 0.2, 0.3]
+        for k in range(3):
+            mixture.scalar_parameters[k].data[0] = weights[k]
+        mixture.gamma.data[0] = 0.5
+        result = mixture(tensors, mask)
+
+        normed_weights = numpy.exp(weights) / numpy.sum(numpy.exp(weights))
+        expected_result = numpy.zeros((3, 4, 5))
+        for k in range(3):
+            mean = numpy.mean(tensors[k].data.numpy()[numpy_mask == 1])
+            std = numpy.std(tensors[k].data.numpy()[numpy_mask == 1])
+            normed_tensor = (tensors[k].data.numpy() - mean) / (std + 1E-12)
+            expected_result += (normed_tensor * normed_weights[k])
+        expected_result *= 0.5
+
+        numpy.testing.assert_almost_equal(expected_result, result.data.numpy())

--- a/tests/modules/scalar_mix_test.py
+++ b/tests/modules/scalar_mix_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=no-self-use,invalid-name
 import torch
 from torch.autograd import Variable
 import pytest


### PR DESCRIPTION
Add `ScalarMix` module that computes scalar weighted averages of tensors, with optional layer normalization