### PR TITLE
Fixes SRL prediction script swapping gold and pred

### DIFF
--- a/scripts/write_srl_predictions_to_conll_format.py
+++ b/scripts/write_srl_predictions_to_conll_format.py
@@ -57,7 +57,7 @@ def main(serialization_directory, device):
         sentence = fields["tokens"].tokens
 
         write_to_conll_eval_file(prediction_file, gold_file,
-                                 verb_index, sentence, gold_tags, predicted_tags)
+                                 verb_index, sentence, predicted_tags, gold_tags)
     prediction_file.close()
     gold_file.close()
 


### PR DESCRIPTION
Fixes a bug in the script write_srl_predictions_to_conll_format.py which was swapping the gold and predicted labels.