### PR TITLE
Grammar from type declaration

### DIFF
--- a/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
@@ -114,12 +114,17 @@ SHAPE_FUNCTION_TYPE = ComplexType(OBJECT_TYPE, SHAPE_TYPE)
 COUNT_FUNCTION_TYPE = CountType(ANY_TYPE, NUM_TYPE)
 BOX_FILTER_TYPE = BoxFilterType(BOX_TYPE, ComplexType(ComplexType(BOX_TYPE, ANY_TYPE),
                                                       ComplexType(ANY_TYPE, BOX_TYPE)))
+BOX_FILTER_NUM_TYPE = ComplexType(BOX_TYPE, ComplexType(ComplexType(BOX_TYPE, NUM_TYPE),
+                                                        ComplexType(NUM_TYPE, BOX_TYPE)))
 ASSERT_TYPE = AssertType(ANY_TYPE, ComplexType(ANY_TYPE, TRUTH_TYPE))
+ASSERT_NUM_TYPE = ComplexType(NUM_TYPE, ComplexType(NUM_TYPE, TRUTH_TYPE))
 IDENTITY_TYPE = IdentityType(ANY_TYPE, ANY_TYPE)
 
 
 COMMON_NAME_MAPPING = {"lambda": "\\", "var": "V", "x": "X"}
 COMMON_TYPE_SIGNATURE = {"V": IDENTITY_TYPE, "X": ANY_TYPE}
+
+BASIC_TYPES = {NUM_TYPE, BOX_TYPE, OBJECT_TYPE, COLOR_TYPE, SHAPE_TYPE}
 
 
 def add_common_name_with_type(name, mapping, type_signature):
@@ -148,19 +153,19 @@ add_common_name_with_type("object_in_box", "I", BOX_MEMBERSHIP_TYPE)
 # Assert functions
 add_common_name_with_type("assert_equals", "A0", ASSERT_TYPE)
 add_common_name_with_type("assert_not_equals", "A1", ASSERT_TYPE)
-add_common_name_with_type("assert_greater", "A2", ASSERT_TYPE)
-add_common_name_with_type("assert_greater_equals", "A3", ASSERT_TYPE)
-add_common_name_with_type("assert_lesser", "A4", ASSERT_TYPE)
-add_common_name_with_type("assert_lesser_equals", "A5", ASSERT_TYPE)
+add_common_name_with_type("assert_greater", "A2", ASSERT_NUM_TYPE)
+add_common_name_with_type("assert_greater_equals", "A3", ASSERT_NUM_TYPE)
+add_common_name_with_type("assert_lesser", "A4", ASSERT_NUM_TYPE)
+add_common_name_with_type("assert_lesser_equals", "A5", ASSERT_NUM_TYPE)
 
 
 # Box filter functions
 add_common_name_with_type("filter_equals", "F0", BOX_FILTER_TYPE)
 add_common_name_with_type("filter_not_equals", "F1", BOX_FILTER_TYPE)
-add_common_name_with_type("filter_greater", "F2", BOX_FILTER_TYPE)
-add_common_name_with_type("filter_greater_equals", "F3", BOX_FILTER_TYPE)
-add_common_name_with_type("filter_lesser", "F4", BOX_FILTER_TYPE)
-add_common_name_with_type("filter_lesser_equals", "F5", BOX_FILTER_TYPE)
+add_common_name_with_type("filter_greater", "F2", BOX_FILTER_NUM_TYPE)
+add_common_name_with_type("filter_greater_equals", "F3", BOX_FILTER_NUM_TYPE)
+add_common_name_with_type("filter_lesser", "F4", BOX_FILTER_NUM_TYPE)
+add_common_name_with_type("filter_lesser_equals", "F5", BOX_FILTER_NUM_TYPE)
 
 
 # Object filter functions

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -271,12 +271,11 @@ def _substitute_any_type(_type: Type, basic_types: Set[BasicType]) -> Set[Type]:
         return basic_types
     if isinstance(_type, (BasicType, PlaceholderType)):
         return set([_type])
-    if isinstance(_type, ComplexType):
-        substitutions = set()
-        for first_type in _substitute_any_type(_type.first, basic_types):
-            for second_type in _substitute_any_type(_type.second, basic_types):
-                substitutions.add(ComplexType(first_type, second_type))
-        return substitutions
+    substitutions = set()
+    for first_type in _substitute_any_type(_type.first, basic_types):
+        for second_type in _substitute_any_type(_type.second, basic_types):
+            substitutions.add(ComplexType(first_type, second_type))
+    return substitutions
 
 
 def _substitute_placeholder_type(_type: Type, basic_type: BasicType) -> Type:
@@ -290,9 +289,8 @@ def _substitute_placeholder_type(_type: Type, basic_type: BasicType) -> Type:
         return basic_type
     if isinstance(_type, BasicType):
         return _type
-    if isinstance(_type, ComplexType):
-        return ComplexType(_substitute_placeholder_type(_type.first, basic_type),
-                           _substitute_placeholder_type(_type.second, basic_type))
+    return ComplexType(_substitute_placeholder_type(_type.first, basic_type),
+                       _substitute_placeholder_type(_type.second, basic_type))
 
 
 def _make_production_string(source: Type, target: Union[List[Type], Type]) -> str:
@@ -320,33 +318,55 @@ def get_valid_actions(name_mapping: Dict[str, str],
                       type_signatures: Dict[str, Type],
                       basic_types: Set[Type]) -> Dict[str, Set[str]]:
     """
-    Generates all the valid actions starting from each non-terminal.
+    Generates all the valid actions starting from each non-terminal. For terminals of a specific type, we
+    simply add to valid actions, productions from thee types to the terminals. Among those types, we keep
+    track of all the non-basic types (i.e., function types). For those types, we infer the list of productions
+    that start from a basic type leading to them.
+    For complex types that do not contain ANY_TYPE or placeholder
+    types, this is straight-forward. For example, if the complex type is <e,<r,<d,r>>>, the productions should
+    be [r -> [<d,r>, r], <d,r> -> [<r,<d,r>>, r], <r,<d,r>> -> [<e,<r,<d,r>>>, e]].
+    However, if the complex type contains ANY_TYPE, we substitute it with all possible basic types. If it
+    contains placeholders, the substituyions need to be constrained. For example, for <#1,#1>, <e,r> is not a
+    valid substitution.
     """
-    valid_actions = defaultdict(set)
+    valid_actions: Dict[str, Set[str]] = defaultdict(set)
 
     complex_types = set()
     for name, alias in name_mapping.items():
         if not alias in type_signatures:
             continue
         name_type = type_signatures[alias]
+        # Type to terminal productions.
         for substituted_type in _substitute_any_type(name_type, basic_types):
             valid_actions[str(substituted_type)].add(_make_production_string(substituted_type, name))
+        # Keeping track of complex types.
         if isinstance(name_type, ComplexType) and name_type != ANY_TYPE:
             complex_types.add(name_type)
 
     for complex_type in complex_types:
         if isinstance(complex_type, PlaceholderType):
             if complex_type.first == ANY_TYPE:
-                for basic_type in basic_types:
-                    try:
+                if isinstance(complex_type.first, BasicType):
+                    for basic_type in basic_types:
                         application_type = complex_type.get_application_type(basic_type)
-                    except AttributeError:
-                        # TODO (pradeep): This means this is a reversetype, which we do not deal with yet.
-                        pass
-                    valid_actions[str(application_type)].add(_make_production_string(application_type,
-                                                                                     [complex_type, basic_type]))
-                    for head, production in _get_complex_type_productions(application_type):
-                        valid_actions[head].add(production)
+                        valid_actions[str(application_type)].add(_make_production_string(application_type,
+                                                                                         [complex_type,
+                                                                                          basic_type]))
+                        for head, production in _get_complex_type_productions(application_type):
+                            valid_actions[head].add(production)
+                else:
+                    # This means complex_type.first is ComplexType(ANY_TYPE, ANY_TYPE)
+                    # TODO(pradeep): Assuming this is a reverse type. That is the only type where the
+                    # input type is a ComplexType for now. But this needs to be more general later.
+                    for first_type in basic_types:
+                        for second_type in basic_types:
+                            input_type = ComplexType(first_type, second_type)
+                            application_type = complex_type.get_application_type(input_type)
+                            valid_actions[str(application_type)].add(_make_production_string(application_type,
+                                                                                             [complex_type,
+                                                                                              input_type]))
+                            for head, production in _get_complex_type_productions(application_type):
+                                valid_actions[head].add(production)
             else:
                 for basic_type in basic_types:
                     second_type = _substitute_placeholder_type(complex_type.second, basic_type)

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -319,7 +319,9 @@ def _get_complex_type_productions(complex_type: ComplexType) -> List[Tuple[str, 
     return all_productions
 
 
-def _get_placeholder_actions(complex_type, basic_types, valid_actions) -> None:
+def _get_placeholder_actions(complex_type: ComplexType,
+                             basic_types: Set[Type],
+                             valid_actions: Dict[str, Set[str]]) -> None:
     """
     Takes a ``complex_type`` with placeholders and a set of ``basic_types``, infers the valid actions
     starting at all non-terminals, by substituting placeholders with basic types, and adds them to
@@ -379,7 +381,7 @@ def get_valid_actions(name_mapping: Dict[str, str],
         If you are getting all valid actions for a type declaration, this can be the
         ``COMMON_NAME_MAPPING``.
     type_signatures : ``Dict[str, Type]``
-        The ampping from name aliases to their types. If you are getting all valid actions for a
+        The mapping from name aliases to their types. If you are getting all valid actions for a
         type declaration, this can be the ``COMMON_TYPE_SIGNATURE``.
     basic_types : ``Set[Type]``
         Set of all basic types in the type declaration.

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -9,8 +9,9 @@ two improvements above.
 """
 from typing import Dict, Set, Optional, List, Tuple, Union
 from collections import defaultdict
-from overrides import overrides
+import re
 
+from overrides import overrides
 from nltk.sem.logic import Expression, ApplicationExpression, ConstantExpression, LogicParser, Variable
 from nltk.sem.logic import Type, BasicType, ComplexType, ANY_TYPE
 
@@ -261,7 +262,7 @@ class DynamicTypeLogicParser(LogicParser):
 
 def _substitute_any_type(_type: Type, basic_types: Set[BasicType]) -> Set[Type]:
     """
-    Takes a type, and a set of basic types and substitutes all instances of ANY_TYPE with all possible basic
+    Takes a type and a set of basic types, and substitutes all instances of ANY_TYPE with all possible basic
     types, and returns a set with all possible combinations.
     Note that this substitution is unconstrained. That is, If you have a type with placeholders,
     <#1,#1> for example, this may substitute the placeholders with different basic types. In that case, you'd
@@ -280,11 +281,13 @@ def _substitute_any_type(_type: Type, basic_types: Set[BasicType]) -> Set[Type]:
 
 def _substitute_placeholder_type(_type: Type, basic_type: BasicType) -> Type:
     """
-    Takes a type with placeholders, and a basic type and substitutes all occurrences of the placeholder with
+    Takes a type with placeholders and a basic type, and substitutes all occurrences of the placeholder with
     that type.
     """
     # TODO (pradeep): This assumes there's just one placeholder in the type. So this doesn't work with
     # ``reverse`` yet, which has two placeholders.
+    if len(set(re.findall("#[0-9]+", str(_type)))) > 1:
+        raise NotImplementedError("We do not deal with placeholder types with more than one placeholder yet.")
     if _type == ANY_TYPE:
         return basic_type
     if isinstance(_type, BasicType):
@@ -310,30 +313,82 @@ def _get_complex_type_productions(complex_type: ComplexType) -> List[Tuple[str, 
         all_productions.append((str(complex_type.second), _make_production_string(complex_type.second,
                                                                                   [complex_type,
                                                                                    complex_type.first])))
+        for production in _get_complex_type_productions(complex_type.first):
+            all_productions.append(production)
         complex_type = complex_type.second
     return all_productions
+
+
+def _get_placeholder_actions(complex_type, basic_types, valid_actions) -> None:
+    """
+    Takes a ``complex_type`` with placeholders and a set of ``basic_types``, infers the valid actions
+    starting at all non-terminals, by substituting placeholders with basic types, and adds them to
+    ``valid_actions``. Note that the substitutions need to be constrained. For example, for <#1,#1>, <e,r>
+    is not a valid substitution.
+    """
+    if complex_type.first == ANY_TYPE:
+        if isinstance(complex_type.first, BasicType):
+            for basic_type in basic_types:
+                # Get the return type when the complex_type is applied to the basic type.
+                application_type = complex_type.get_application_type(basic_type)
+                valid_actions[str(application_type)].add(_make_production_string(application_type,
+                                                                                 [complex_type, basic_type]))
+                for head, production in _get_complex_type_productions(application_type):
+                    valid_actions[head].add(production)
+        else:
+            # This means complex_type.first is ComplexType(ANY_TYPE, ANY_TYPE)
+            # TODO(pradeep): Assuming this is a reverse type. That is the only type where the
+            # input type is a ComplexType for now. But this needs to be more general later.
+            assert str(complex_type) == "<<#1,#2>,<#2,#1>>", "Cannot infer actions for %s yet." % complex_type
+            for first_type in basic_types:
+                for second_type in basic_types:
+                    input_type = ComplexType(first_type, second_type)
+                    application_type = complex_type.get_application_type(input_type)
+                    valid_actions[str(application_type)].add(_make_production_string(application_type,
+                                                                                     [complex_type,
+                                                                                      input_type]))
+                    for head, production in _get_complex_type_productions(application_type):
+                        valid_actions[head].add(production)
+    else:
+        for basic_type in basic_types:
+            second_type = _substitute_placeholder_type(complex_type.second, basic_type)
+            production_string = _make_production_string(second_type, [complex_type, complex_type.first])
+            valid_actions[str(second_type)].add(production_string)
+            for head, production in _get_complex_type_productions(second_type):
+                valid_actions[head].add(production)
 
 
 def get_valid_actions(name_mapping: Dict[str, str],
                       type_signatures: Dict[str, Type],
                       basic_types: Set[Type]) -> Dict[str, Set[str]]:
     """
-    Generates all the valid actions starting from each non-terminal. For terminals of a specific type, we
-    simply add to valid actions, productions from thee types to the terminals. Among those types, we keep
-    track of all the non-basic types (i.e., function types). For those types, we infer the list of productions
-    that start from a basic type leading to them.
-    For complex types that do not contain ANY_TYPE or placeholder
-    types, this is straight-forward. For example, if the complex type is <e,<r,<d,r>>>, the productions should
-    be [r -> [<d,r>, r], <d,r> -> [<r,<d,r>>, r], <r,<d,r>> -> [<e,<r,<d,r>>>, e]].
-    However, if the complex type contains ANY_TYPE, we substitute it with all possible basic types. If it
-    contains placeholders, the substituyions need to be constrained. For example, for <#1,#1>, <e,r> is not a
-    valid substitution.
+    Generates all the valid actions starting from each non-terminal. For terminals of a specific
+    type, we simply add to valid actions, productions from the types to the terminals. Among those
+    types, we keep track of all the non-basic types (i.e., function types). For those types, we
+    infer the list of productions that start from a basic type leading to them.
+    For complex types that do not contain ANY_TYPE or placeholder types, this is straight-forward.
+    For example, if the complex type is <e,<r,<d,r>>>, the productions should be [r -> [<d,r>, r],
+    <d,r> -> [<r,<d,r>>, r], <r,<d,r>> -> [<e,<r,<d,r>>>, e]].
+    We do ANY_TYPE substitution here, and make a call to ``_get_placeholder_actions`` for
+    placeholder substitution.
+
+    Parameters
+    ----------
+    name_mapping : ``Dict[str, str]``
+        The mapping of names that appear in your logical form languages to their aliases for NLTK.
+        If you are getting all valid actions for a type declaration, this can be the
+        ``COMMON_NAME_MAPPING``.
+    type_signatures : ``Dict[str, Type]``
+        The ampping from name aliases to their types. If you are getting all valid actions for a
+        type declaration, this can be the ``COMMON_TYPE_SIGNATURE``.
+    basic_types : ``Set[Type]``
+        Set of all basic types in the type declaration.
     """
     valid_actions: Dict[str, Set[str]] = defaultdict(set)
 
     complex_types = set()
     for name, alias in name_mapping.items():
-        if not alias in type_signatures:
+        if name == "lambda":
             continue
         name_type = type_signatures[alias]
         # Type to terminal productions.
@@ -345,35 +400,7 @@ def get_valid_actions(name_mapping: Dict[str, str],
 
     for complex_type in complex_types:
         if isinstance(complex_type, PlaceholderType):
-            if complex_type.first == ANY_TYPE:
-                if isinstance(complex_type.first, BasicType):
-                    for basic_type in basic_types:
-                        application_type = complex_type.get_application_type(basic_type)
-                        valid_actions[str(application_type)].add(_make_production_string(application_type,
-                                                                                         [complex_type,
-                                                                                          basic_type]))
-                        for head, production in _get_complex_type_productions(application_type):
-                            valid_actions[head].add(production)
-                else:
-                    # This means complex_type.first is ComplexType(ANY_TYPE, ANY_TYPE)
-                    # TODO(pradeep): Assuming this is a reverse type. That is the only type where the
-                    # input type is a ComplexType for now. But this needs to be more general later.
-                    for first_type in basic_types:
-                        for second_type in basic_types:
-                            input_type = ComplexType(first_type, second_type)
-                            application_type = complex_type.get_application_type(input_type)
-                            valid_actions[str(application_type)].add(_make_production_string(application_type,
-                                                                                             [complex_type,
-                                                                                              input_type]))
-                            for head, production in _get_complex_type_productions(application_type):
-                                valid_actions[head].add(production)
-            else:
-                for basic_type in basic_types:
-                    second_type = _substitute_placeholder_type(complex_type.second, basic_type)
-                    production_string = _make_production_string(second_type, [complex_type, complex_type.first])
-                    valid_actions[str(second_type)].add(production_string)
-                    for head, production in _get_complex_type_productions(second_type):
-                        valid_actions[head].add(production)
+            _get_placeholder_actions(complex_type, basic_types, valid_actions)
         else:
             for substituted_type in _substitute_any_type(complex_type, basic_types):
                 production_string = _make_production_string(substituted_type.second,

--- a/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
@@ -199,7 +199,13 @@ COUNT_TYPE = CountType(ANY_TYPE, DATE_NUM_TYPE)
 # and, or
 CONJUNCTION_TYPE = ConjunctionType(ANY_TYPE, ANY_TYPE)
 # argmax, argmin
-ARG_EXTREME_TYPE = ArgExtremeType(ANY_TYPE, ANY_TYPE)
+ARG_EXTREME_TYPE = ArgExtremeType(DATE_NUM_TYPE,
+                                  ComplexType(DATE_NUM_TYPE,
+                                              ComplexType(ANY_TYPE,
+                                                          ComplexType(ComplexType(DATE_NUM_TYPE,
+                                                                                  ANY_TYPE),
+                                                                      ANY_TYPE))))
+
 
 
 COMMON_NAME_MAPPING = {"lambda": "\\", "var": "V", "x": "X"}

--- a/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/wikitables_type_declaration.py
@@ -168,6 +168,8 @@ PART_TYPE = NamedBasicType("PART")
 ROW_TYPE = NamedBasicType("ROW")
 # TODO (pradeep): Merging dates and nums. Can define a hierarchy instead.
 DATE_NUM_TYPE = NamedBasicType("DATENUM")
+
+BASIC_TYPES = {CELL_TYPE, PART_TYPE, ROW_TYPE, DATE_NUM_TYPE}
 # Functions like fb:row.row.year.
 COLUMN_TYPE = ComplexType(CELL_TYPE, ROW_TYPE)
 # fb:cell.cell.part

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -42,6 +42,18 @@ class World:
         self._logic_parser = DynamicTypeLogicParser(constant_type_prefixes=type_prefixes,
                                                     type_signatures=self.global_type_signatures)
 
+    def parse_logical_form(self, logical_form: str) -> Expression:
+        """
+        Takes a logical form as a string, maps its tokens using the mapping and returns a parsed expression.
+        """
+        if not logical_form.startswith("("):
+            logical_form = "(%s)" % logical_form
+        parsed_lisp = pyparsing.OneOrMore(pyparsing.nestedExpr()).parseString(logical_form).asList()
+        translated_string = self._process_nested_expression(parsed_lisp)
+        type_signature = self.local_type_signatures.copy()
+        type_signature.update(self.global_type_signatures)
+        return self._logic_parser.parse(translated_string, signature=type_signature)
+
     def _process_nested_expression(self, nested_expression) -> str:
         """
         ``nested_expression`` is the result of parsing a logical form in Lisp format.
@@ -69,18 +81,6 @@ class World:
         else:
             arguments = ["(%s)" % name for name in mapped_names[1:]]
         return "(%s %s)" % (mapped_names[0], " ".join(arguments))
-
-    def parse_logical_form(self, logical_form: str) -> Expression:
-        """
-        Takes a logical form as a string, maps its tokens using the mapping and returns a parsed expression.
-        """
-        if not logical_form.startswith("("):
-            logical_form = "(%s)" % logical_form
-        parsed_lisp = pyparsing.OneOrMore(pyparsing.nestedExpr()).parseString(logical_form).asList()
-        translated_string = self._process_nested_expression(parsed_lisp)
-        type_signature = self.local_type_signatures.copy()
-        type_signature.update(self.global_type_signatures)
-        return self._logic_parser.parse(translated_string, signature=type_signature)
 
     def _map_name(self, name: str) -> str:
         raise NotImplementedError

--- a/tests/data/semparse/type_declarations/type_declaration_test.py
+++ b/tests/data/semparse/type_declarations/type_declaration_test.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-self-use
+# pylint: disable=no-self-use,invalid-name
 from nltk.sem.logic import ComplexType
 
 from allennlp.data.semparse.type_declarations import type_declaration as types
@@ -12,7 +12,7 @@ class TestTypeResolution(AllenNlpTestCase):
         type_b = types.NamedBasicType("B")
         assert type_a.resolve(type_b) is None
 
-    def test_valid_actions(self):
+    def test_get_valid_actions(self):
         type_r = types.NamedBasicType("R")
         type_d = types.NamedBasicType("D")
         type_e = types.NamedBasicType("E")
@@ -27,7 +27,7 @@ class TestTypeResolution(AllenNlpTestCase):
         assert valid_actions["<d,r>"] == {"<d,r> -> [<r,<d,r>>, r]"}
         assert valid_actions["r"] == {"r -> [<d,r>, d]"}
 
-    def test_valid_actions_with_placeholder_type(self):
+    def test_get_valid_actions_with_placeholder_type(self):
         type_r = types.NamedBasicType("R")
         type_d = types.NamedBasicType("D")
         type_e = types.NamedBasicType("E")
@@ -42,12 +42,16 @@ class TestTypeResolution(AllenNlpTestCase):
         assert valid_actions["r"] == {"r -> [<#1,#1>, r]"}
         assert valid_actions["d"] == {"d -> [<#1,#1>, d]"}
 
-    def test_valid_actions_with_any_type(self):
+    def test_get_valid_actions_with_any_type(self):
         type_r = types.NamedBasicType("R")
         type_d = types.NamedBasicType("D")
         type_e = types.NamedBasicType("E")
         name_mapping = {'sample_function': 'F'}
-        # <#1,r>
+        # The purpose of this test is to ensure that ANY_TYPE gets substituted by every possible basic type,
+        # to simulate an intermediate step while getting actions for a placeholder type.
+        # I do not foresee defining a function type with ANY_TYPE. We should just use a ``PlaceholderType``
+        # instead.
+        # <?,r>
         type_signatures = {'F': ComplexType(types.ANY_TYPE, type_r)}
         basic_types = {type_r, type_d, type_e}
         valid_actions = types.get_valid_actions(name_mapping, type_signatures, basic_types)
@@ -57,7 +61,7 @@ class TestTypeResolution(AllenNlpTestCase):
         assert valid_actions["<r,r>"] == {"<r,r> -> sample_function"}
         assert valid_actions["r"] == {"r -> [<e,r>, e]", "r -> [<d,r>, d]", "r -> [<r,r>, r]"}
 
-    def test_valid_actions_with_reverse(self):
+    def test_get_valid_actions_with_reverse(self):
         valid_actions = types.get_valid_actions(wt_types.COMMON_NAME_MAPPING, wt_types.COMMON_TYPE_SIGNATURE,
                                                 wt_types.BASIC_TYPES)
         assert valid_actions['<d,e>'] == {'<d,e> -> [<<#1,#2>,<#2,#1>>, <e,d>]',

--- a/tests/data/semparse/type_declarations/type_declaration_test.py
+++ b/tests/data/semparse/type_declarations/type_declaration_test.py
@@ -1,5 +1,8 @@
 # pylint: disable=no-self-use
+from nltk.sem.logic import ComplexType
+
 from allennlp.data.semparse.type_declarations import type_declaration as types
+from allennlp.data.semparse.type_declarations import wikitables_type_declaration as wt_types
 from allennlp.common.testing import AllenNlpTestCase
 
 
@@ -8,3 +11,57 @@ class TestTypeResolution(AllenNlpTestCase):
         type_a = types.NamedBasicType("A")
         type_b = types.NamedBasicType("B")
         assert type_a.resolve(type_b) is None
+
+    def test_valid_actions(self):
+        type_r = types.NamedBasicType("R")
+        type_d = types.NamedBasicType("D")
+        type_e = types.NamedBasicType("E")
+        name_mapping = {'sample_function': 'F'}
+        # <e,<r,<d,r>>>
+        type_signatures = {'F': ComplexType(type_e, ComplexType(type_r, ComplexType(type_d, type_r)))}
+        basic_types = {type_r, type_d, type_e}
+        valid_actions = types.get_valid_actions(name_mapping, type_signatures, basic_types)
+        assert len(valid_actions) == 4
+        assert valid_actions["<e,<r,<d,r>>>"] == {"<e,<r,<d,r>>> -> sample_function"}
+        assert valid_actions["<r,<d,r>>"] == {"<r,<d,r>> -> [<e,<r,<d,r>>>, e]"}
+        assert valid_actions["<d,r>"] == {"<d,r> -> [<r,<d,r>>, r]"}
+        assert valid_actions["r"] == {"r -> [<d,r>, d]"}
+
+    def test_valid_actions_with_placeholder_type(self):
+        type_r = types.NamedBasicType("R")
+        type_d = types.NamedBasicType("D")
+        type_e = types.NamedBasicType("E")
+        name_mapping = {'sample_function': 'F'}
+        # <#1,#1>
+        type_signatures = {'F': types.IdentityType(types.ANY_TYPE, types.ANY_TYPE)}
+        basic_types = {type_r, type_d, type_e}
+        valid_actions = types.get_valid_actions(name_mapping, type_signatures, basic_types)
+        assert len(valid_actions) == 4
+        assert valid_actions["<#1,#1>"] == {"<#1,#1> -> sample_function"}
+        assert valid_actions["e"] == {"e -> [<#1,#1>, e]"}
+        assert valid_actions["r"] == {"r -> [<#1,#1>, r]"}
+        assert valid_actions["d"] == {"d -> [<#1,#1>, d]"}
+
+    def test_valid_actions_with_any_type(self):
+        type_r = types.NamedBasicType("R")
+        type_d = types.NamedBasicType("D")
+        type_e = types.NamedBasicType("E")
+        name_mapping = {'sample_function': 'F'}
+        # <#1,r>
+        type_signatures = {'F': ComplexType(types.ANY_TYPE, type_r)}
+        basic_types = {type_r, type_d, type_e}
+        valid_actions = types.get_valid_actions(name_mapping, type_signatures, basic_types)
+        assert len(valid_actions) == 4
+        assert valid_actions["<d,r>"] == {"<d,r> -> sample_function"}
+        assert valid_actions["<e,r>"] == {"<e,r> -> sample_function"}
+        assert valid_actions["<r,r>"] == {"<r,r> -> sample_function"}
+        assert valid_actions["r"] == {"r -> [<e,r>, e]", "r -> [<d,r>, d]", "r -> [<r,r>, r]"}
+
+    def test_valid_actions_with_reverse(self):
+        valid_actions = types.get_valid_actions(wt_types.COMMON_NAME_MAPPING, wt_types.COMMON_TYPE_SIGNATURE,
+                                                wt_types.BASIC_TYPES)
+        assert valid_actions['<d,e>'] == {'<d,e> -> [<<#1,#2>,<#2,#1>>, <e,d>]',
+                                          '<d,e> -> fb:cell.cell.date',
+                                          '<d,e> -> fb:cell.cell.number',
+                                          '<d,e> -> fb:cell.cell.num2'
+                                         }

--- a/tests/data/semparse/worlds/nlvr_world_test.py
+++ b/tests/data/semparse/worlds/nlvr_world_test.py
@@ -82,8 +82,8 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
                           1)")
         expression = nlvr_world.parse_logical_form(logical_form)
         action_sequence = nlvr_world.get_action_sequence(expression)
-        assert action_sequence == ['t', 't -> [<e,t>, e]', '<e,t> -> [<#1,<#1,t>>, e]',
-                                   '<#1,<#1,t>> -> assert_greater_equals', 'e -> [<#1,e>, b]', '<#1,e> -> count',
+        assert action_sequence == ['t', 't -> [<e,t>, e]', '<e,t> -> [<e,<e,t>>, e]',
+                                   '<e,<e,t>> -> assert_greater_equals', 'e -> [<#1,e>, b]', '<#1,e> -> count',
                                    'b -> [<e,b>, e]', '<e,b> -> [<<b,e>,<e,b>>, <b,e>]',
                                    '<<b,e>,<e,b>> -> [<b,<<b,#1>,<#1,b>>>, b]',
                                    '<b,<<b,#1>,<#1,b>>> -> filter_equals', 'b -> all_boxes',


### PR DESCRIPTION
I mainly added a method `type_declaration.get_valid_actions()` that takes a name mapping, type signatures and a set of basic types and produces a dict from all non-terminals to productions starting from them.

@matt-gardner I tested this on the NLVR type declaration, and it works, but with wikitables, it has some problems with placeholder types. I also need to test it with table specific mappings.  I'll fix those soon. But I'm making this PR now to show you the API, so that you can continue with the stuff you're doing.