### PR TITLE
ProductionRuleField

### DIFF
--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -168,5 +168,6 @@ class Dataset:
         field_classes = self.instances[0].fields
         final_fields = {}
         for field_name, field_tensor_list in field_tensors.items():
+            print(field_name, field_classes[field_name])
             final_fields[field_name] = field_classes[field_name].batch_tensors(field_tensor_list)
         return final_fields

--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -168,6 +168,5 @@ class Dataset:
         field_classes = self.instances[0].fields
         final_fields = {}
         for field_name, field_tensor_list in field_tensors.items():
-            print(field_name, field_classes[field_name])
             final_fields[field_name] = field_classes[field_name].batch_tensors(field_tensor_list)
         return final_fields

--- a/allennlp/data/fields/__init__.py
+++ b/allennlp/data/fields/__init__.py
@@ -4,12 +4,13 @@ that ends up as an array in a model.
 """
 
 from allennlp.data.fields.field import Field
+from allennlp.data.fields.array_field import ArrayField
 from allennlp.data.fields.index_field import IndexField
+from allennlp.data.fields.knowledge_graph_field import KnowledgeGraphField
 from allennlp.data.fields.label_field import LabelField
 from allennlp.data.fields.list_field import ListField
 from allennlp.data.fields.metadata_field import MetadataField
+from allennlp.data.fields.production_rule_field import ProductionRuleField
 from allennlp.data.fields.sequence_field import SequenceField
 from allennlp.data.fields.sequence_label_field import SequenceLabelField
 from allennlp.data.fields.text_field import TextField
-from allennlp.data.fields.array_field import ArrayField
-from allennlp.data.fields.knowledge_graph_field import KnowledgeGraphField

--- a/allennlp/data/fields/list_field.py
+++ b/allennlp/data/fields/list_field.py
@@ -91,3 +91,8 @@ class ListField(SequenceField[DataArray]):
         # length one makes this all work out, and we'll always be padding to at least length 1,
         # anyway.
         return ListField([self.field_list[0].empty_field()])
+
+    @overrides
+    def batch_tensors(self, tensor_list: List[DataArray]) -> DataArray:  # type: ignore
+        # We defer to the class we're wrapping in a list to handle the batching.
+        return self.field_list[0].batch_tensors(tensor_list)

--- a/allennlp/data/fields/production_rule_field.py
+++ b/allennlp/data/fields/production_rule_field.py
@@ -1,0 +1,145 @@
+from typing import Dict, Set, Tuple
+
+from overrides import overrides
+
+from allennlp.data.tokenizers.token import Token
+from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
+from allennlp.data.vocabulary import Vocabulary
+
+ProductionRuleArray = Dict[str, Tuple[str, bool, Dict[str, numpy.ndarray]]]
+
+class ProductionRuleField(Field[ProductionRuleArray]):
+    """
+    This ``Field`` represents a production rule from a grammar, like "S -> [NP, VP]", "N -> John",
+    or "<b,c> -> [<a,<b,c>>, a]".
+
+    We assume a few things about how these rules are formatted:
+
+        - There is a left-hand side (LHS) and a right-hand side (RHS), where the LHS is always a
+          non-terminal, and the RHS is either a terminal, a non-terminal, or a sequence of
+          non-terminals (for now, you can't mix terminals and non-terminals in the RHS).
+        - The LHS and the RHS are joined by " -> ".
+        - Non-terminal sequences in the RHS are formatted as "[NT1, NT2, ...]".
+        - There are no spaces in terminals or non-terminals.
+        - Terminals never begin with '<' (which indicates a functional type) or '[' (which
+          indicates a non-terminal sequence).
+
+    Given a properly-formatted production rule string, we split it into LHS and RHS, and then use
+    ``TokenIndexers`` to convert these strings into data arrays.  We use (potentially) different
+    ``TokenIndexers`` for terminals and non-terminals, with the assumption being that you're more
+    likely to want to use character-level or featurized representations for terminals, while you
+    likely will be able to just use an embedding for non-terminals.  Using ``TokenIndexers`` here
+    lets us be flexible about these decisions, so you can represent and then embed the rules
+    however you want to.
+
+    We currently treat non-terminal sequences as a single non-terminal token from the
+    ``TokenIndexers`` point of view.  The alternative here would be to represent each non-terminal
+    in the sequence separately, then combine their representations in the model.  That would be
+    messy, and we might allow that eventually, but for now we don't.
+
+    Because we represent terminals and non-terminals differently, and a production rule sequence
+    could have rules with both terminal and non-terminal RHSs, this ``Field`` does not lend itself
+    well to batching its arrays, even in a sequence for a single training instance.  You will have
+    to handle batching differently in models that use ``ProductionRuleFields``.
+
+    In a model, this will get represented as a ``Dict[str, Tuple[str, bool, numpy.ndarray]]``.
+
+    Parameters
+    ----------
+    rule : ``str``
+        The production rule, formatted as described above.
+    terminal_indexers : ``Dict[str, TokenIndexer]``
+        The ``TokenIndexers`` that we will use to convert terminal strings into arrays.
+    nonterminal_indexers : ``Dict[str, TokenIndexer]``
+        The ``TokenIndexers`` that we will use to convert non-terminal strings into arrays.
+    nonterminal_types : ``Set[str]``
+        A set of basic types used in the grammar.  This is for things like NP, VP, S, N, a, b, and
+        c in the examples above.  We use this set to determine whether to use the terminal or the
+        non-terminal token indexers when we are representing the RHS of a production rule.
+    context : Any, optional
+        Additional context that can be used by the token indexers when constructing their
+        representations.  This could be an utterance we're trying to produce a semantic parse for,
+        for instance, and we could use this to determine whether a terminal has any overlap with
+        the utterance as part of a featurized representation of the terminal.
+    """
+    def __init__(self,
+                 rule: str,
+                 terminal_indexers: Dict[str, TokenIndexer],
+                 nonterminal_indexers: Dict[str, TokenIndexer],
+                 nonterminal_types: Set[str],
+                 context: Any = None) -> None:
+        self.rule = rule
+        self._left_side, self._right_side = [Token(side) for side in rule.split(' -> ')]
+        self._right_is_nonterminal = self._is_nonterminal(self._right_side)
+        self._terminal_indexers = terminal_indexers
+        self._nonterminal_indexers = nonterminal_indexers
+        self._right_side_indexers = nonterminal_indexers if self._right_is_nonterminal else terminal_indexers
+        self._nonterminal_types = nonterminal_types
+        self._context = context
+        self._indexed_left_side: Dict[str, TokenType] = None
+        self._indexed_right_side: Dict[str, TokenType] = None
+
+    def _is_nonterminal(self, right_side: str) -> bool:
+        if right_side[0] == '[' or right_side[0] == '<':
+            return True
+        return right_side in nonterminal_types
+
+    @overrides
+    def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
+        for indexer in self._nonterminal_indexers.values():
+            indexer.count_vocab_items(self._left_side, counter)
+        for indexer in self._right_side_indexers.values():
+            indexer.count_vocab_items(self._right_side, counter)
+
+    @overrides
+    def index(self, vocab: Vocabulary):
+        self._indexed_left_side = {}
+        self._indexed_right_side = {}
+        for indexer_name, indexer in self._nonterminal_indexers.items():
+            self._indexed_left_side[indexer_name] = indexer.token_to_indices(self._left_side, vocab)
+        for indexer_name, indexer in self._right_side_indexers.items():
+            self._indexed_right_side[indexer_name] = indexer.token_to_indices(self._right_side, vocab)
+
+    @overrides
+    def get_padding_lengths(self) -> Dict[str, int]:
+        padding_lengths = {}
+        if self._indexed_left_side is None:
+            raise RuntimeError("You must call .index(vocab) on a field before determining padding lengths.")
+        for indexer_name, indexer in self._nonterminal_indexers.items():
+            for padding_key, length in indexer.get_padding_lengths(self._left_side).items()
+                padding_lengths[padding_key] = max(length, padding_lengths.get(padding_key, 0))
+        for indexer_name, indexer in self._right_side_indexers.items():
+            for padding_key, length in indexer.get_padding_lengths(self._right_side).items()
+                padding_lengths[padding_key] = max(length, padding_lengths.get(padding_key, 0))
+        return padding_lengths
+
+    @overrides
+    def as_array(self, padding_lengths: Dict[str, int]) -> ProductionRuleArray:
+        """
+        Here we pad the LHS and RHS representations as necessary, but return a dictionary like:
+        {"left": (self._left_side, is_nonterminal, padded_array),
+        "right": (self._right_side, is_nonterminal, padded_array)}.
+        This is so that you have access to the information you need to embed these representations,
+        or look up valid actions given your current state.
+        """
+        left_side_arrays = {}
+        # Because the TokenIndexers were designed to work on token sequences, and we're just giving
+        # them single tokens, we need to put them into lists and then pull them out again.
+        for indexer_name, indexer in self._nonterminal_indexers.items():
+            padded_left_side = indexer.pad_token_sequence([self._indexed_left_side[indexer_name]],
+                                                          1,
+                                                          padding_lengths)[0]
+            left_side_arrays[indexer_name] = numpy.array(padded_array)
+        right_side_arrays = {}
+        for indexer_name, indexer in self._right_side_indexers.items():
+            padded_right_side = indexer.pad_token_sequence([self._indexed_right_side[indexer_name]],
+                                                          1,
+                                                          padding_lengths)[0]
+            right_side_arrays[indexer_name] = numpy.array(padded_array)
+        return {"left": (self._left_side, True, left_side_arrays),
+                "right": (self._right_side, self._right_is_nonterminal, right_side_arrays)}
+
+    @classmethod
+    @overrides
+    def batch_arrays(cls, array_list: List[ProductionRuleArray]) -> ProductionRuleArray:
+        return array_list  # type: ignore

--- a/doc/api/allennlp.data.fields.rst
+++ b/doc/api/allennlp.data.fields.rst
@@ -7,15 +7,16 @@ allennlp.data.fields
    :show-inheritance:
 
 * :ref:`Field<field>`
+* :ref:`ArrayField<array-field>`
 * :ref:`IndexField<index-field>`
+* :ref:`KnowledgeGraphField<knowledge-graph-field>`
 * :ref:`LabelField<label-field>`
 * :ref:`ListField<list-field>`
 * :ref:`MetadataField<metadata-field>`
+* :ref:`ProductionRuleField<production-rule-field>`
 * :ref:`SequenceField<sequence-field>`
 * :ref:`SequenceLabelField<sequence-label-field>`
 * :ref:`TextField<text-field>`
-* :ref:`ArrayField<array-field>`
-* :ref:`KnowledgeGraphField<knowledge-graph-field>`
 
 .. _field:
 .. automodule:: allennlp.data.fields.field
@@ -23,8 +24,20 @@ allennlp.data.fields
    :undoc-members:
    :show-inheritance:
 
+.. _array-field:
+.. automodule:: allennlp.data.fields.array_field
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. _index-field:
 .. automodule:: allennlp.data.fields.index_field
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _knowledge-graph-field:
+.. automodule:: allennlp.data.fields.knowledge_graph_field
    :members:
    :undoc-members:
    :show-inheritance:
@@ -47,6 +60,12 @@ allennlp.data.fields
    :undoc-members:
    :show-inheritance:
 
+.. _production-rule-field:
+.. automodule:: allennlp.data.fields.production_rule_field
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. _sequence-field:
 .. automodule:: allennlp.data.fields.sequence_field
    :members:
@@ -64,18 +83,3 @@ allennlp.data.fields
    :members:
    :undoc-members:
    :show-inheritance:
-
-<<<<<<< f0bf513d6ff01786a399126e8740fc9970fb7670
-.. _array-field:
-.. automodule:: allennlp.data.fields.array_field
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-=======
-.. _knowledge-graph-field:
-.. automodule:: allennlp.data.fields.knowledge_graph_field
-   :members:
-   :undoc-members:
-   :show-inheritance:
->>>>>>> Wikitables dataset reader and a knowledge graph field (#458)

--- a/tests/data/fields/production_rule_field_test.py
+++ b/tests/data/fields/production_rule_field_test.py
@@ -3,12 +3,12 @@ from collections import defaultdict
 
 import pytest
 import numpy
-
-from allennlp.data import Vocabulary
-from allennlp.data.fields import ProductionRuleField
-from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenCharactersIndexer
+from numpy.testing import assert_array_equal
 
 from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Vocabulary
+from allennlp.data.fields import ListField, ProductionRuleField
+from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenCharactersIndexer
 
 
 class TestProductionRuleField(AllenNlpTestCase):
@@ -19,9 +19,11 @@ class TestProductionRuleField(AllenNlpTestCase):
         self.vp_index = self.vocab.add_token_to_namespace("VP", namespace='rule_labels')
         self.np_vp_index = self.vocab.add_token_to_namespace("[NP, VP]", namespace='rule_labels')
         self.identity_index = self.vocab.add_token_to_namespace("identity", namespace='entities')
-        self.t_index = self.vocab.add_token_to_namespace("t", namespace='characters')
+        self.a_index = self.vocab.add_token_to_namespace("a", namespace='characters')
+        self.c_index = self.vocab.add_token_to_namespace("c", namespace='characters')
         self.e_index = self.vocab.add_token_to_namespace("e", namespace='characters')
         self.s_index = self.vocab.add_token_to_namespace("s", namespace='characters')
+        self.t_index = self.vocab.add_token_to_namespace("t", namespace='characters')
 
         self.oov_index = self.vocab.get_token_index('random OOV string', namespace='entities')
 
@@ -120,36 +122,134 @@ class TestProductionRuleField(AllenNlpTestCase):
         field.index(self.vocab)
         assert field.get_padding_lengths() == {'num_token_characters': 4}
 
-    def test_as_array_produces_correct_output(self):
+    def test_as_tensor_produces_correct_output(self):
         field = self._make_field('S -> [NP, VP]')
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
-        array_dict = field.as_array(padding_lengths)
-        assert array_dict.keys() == {'left', 'right'}
-        assert array_dict['left'] == ('S', True, {'rules': numpy.array(self.s_rule_index)})
-        assert array_dict['right'] == ('[NP, VP]', True, {'rules': numpy.array(self.np_vp_index)})
+        tensor_dict = field.as_tensor(padding_lengths)
+        assert tensor_dict.keys() == {'left', 'right'}
+        assert tensor_dict['left'][0] == 'S'
+        assert tensor_dict['left'][1] is True
+        assert tensor_dict['left'][2].keys() == {'rules'}
+        assert_array_equal(tensor_dict['left'][2]['rules'].data.cpu().numpy(),
+                           numpy.array(self.s_rule_index))
+        assert tensor_dict['right'][0] == '[NP, VP]'
+        assert tensor_dict['right'][1] is True
+        assert tensor_dict['right'][2].keys() == {'rules'}
+        assert_array_equal(tensor_dict['right'][2]['rules'].data.cpu().numpy(),
+                           numpy.array(self.np_vp_index))
 
         field = self._make_field('NP -> test', terminal_indexers=self.character_indexer)
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
-        array_dict = field.as_array(padding_lengths)
-        assert array_dict.keys() == {'left', 'right'}
-        assert array_dict['left'] == ('NP', True, {'rules': numpy.array(self.np_index)})
-        assert array_dict['right'][0] == 'test'
-        assert array_dict['right'][1] is False
-        numpy.testing.assert_array_equal(array_dict['right'][2]['characters'],
-                                         numpy.array([self.t_index, self.e_index,
-                                                      self.s_index, self.t_index]))
+        tensor_dict = field.as_tensor(padding_lengths)
+        assert tensor_dict.keys() == {'left', 'right'}
+        assert tensor_dict['left'][0] == 'NP'
+        assert tensor_dict['left'][1] is True
+        assert tensor_dict['left'][2].keys() == {'rules'}
+        assert_array_equal(tensor_dict['left'][2]['rules'].data.cpu().numpy(),
+                           numpy.array(self.np_index))
+        assert tensor_dict['right'][0] == 'test'
+        assert tensor_dict['right'][1] is False
+        assert tensor_dict['right'][2].keys() == {'characters'}
+        assert_array_equal(tensor_dict['right'][2]['characters'].data.cpu().numpy(),
+                           numpy.array([self.t_index, self.e_index, self.s_index, self.t_index]))
 
-    def test_batch_arrays_does_not_modify_list(self):
+    def test_batch_tensors_does_not_modify_list(self):
         field = self._make_field('S -> [NP, VP]')
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
-        array_dict1 = field.as_array(padding_lengths)
+        tensor_dict1 = field.as_tensor(padding_lengths)
 
         field = self._make_field('S -> test')
         field.index(self.vocab)
         padding_lengths = field.get_padding_lengths()
-        array_dict2 = field.as_array(padding_lengths)
-        array_list = [array_dict1, array_dict2]
-        assert field.batch_arrays(array_list) == array_list
+        tensor_dict2 = field.as_tensor(padding_lengths)
+        tensor_list = [tensor_dict1, tensor_dict2]
+        assert field.batch_tensors(tensor_list) == tensor_list
+
+    def test_doubly_nested_field_works(self):
+        field1 = self._make_field('S -> [NP, VP]', terminal_indexers=self.character_indexer)
+        field2 = self._make_field('NP -> cats', terminal_indexers=self.character_indexer)
+        field3 = self._make_field('VP -> eat', terminal_indexers=self.character_indexer)
+        list_field = ListField([ListField([field1, field2, field3]),
+                                ListField([field1, field2])])
+        list_field.index(self.vocab)
+        padding_lengths = list_field.get_padding_lengths()
+        tensors = list_field.as_tensor(padding_lengths)
+        assert isinstance(tensors, list)
+        assert len(tensors) == 2
+        assert isinstance(tensors[0], list)
+        assert len(tensors[0]) == 3
+        assert isinstance(tensors[1], list)
+        assert len(tensors[1]) == 3
+
+        tensor_dict = tensors[0][0]
+        assert tensor_dict['left'][0] == 'S'
+        assert tensor_dict['left'][1] is True
+        assert tensor_dict['left'][2].keys() == {'rules'}
+        assert_array_equal(tensor_dict['left'][2]['rules'].data.cpu().numpy(),
+                           numpy.array(self.s_rule_index))
+        assert tensor_dict['right'][0] == '[NP, VP]'
+        assert tensor_dict['right'][1] is True
+        assert tensor_dict['right'][2].keys() == {'rules'}
+        assert_array_equal(tensor_dict['right'][2]['rules'].data.cpu().numpy(),
+                           numpy.array(self.np_vp_index))
+
+        tensor_dict = tensors[0][1]
+        assert tensor_dict['left'][0] == 'NP'
+        assert tensor_dict['left'][1] is True
+        assert tensor_dict['left'][2].keys() == {'rules'}
+        assert_array_equal(tensor_dict['left'][2]['rules'].data.cpu().numpy(),
+                           numpy.array(self.np_index))
+        assert tensor_dict['right'][0] == 'cats'
+        assert tensor_dict['right'][1] is False
+        assert tensor_dict['right'][2].keys() == {'characters'}
+        assert_array_equal(tensor_dict['right'][2]['characters'].data.cpu().numpy(),
+                           numpy.array([self.c_index, self.a_index, self.t_index, self.s_index]))
+
+        tensor_dict = tensors[0][2]
+        assert tensor_dict['left'][0] == 'VP'
+        assert tensor_dict['left'][1] is True
+        assert tensor_dict['left'][2].keys() == {'rules'}
+        assert_array_equal(tensor_dict['left'][2]['rules'].data.cpu().numpy(),
+                           numpy.array(self.vp_index))
+        assert tensor_dict['right'][0] == 'eat'
+        assert tensor_dict['right'][1] is False
+        assert tensor_dict['right'][2].keys() == {'characters'}
+        assert_array_equal(tensor_dict['right'][2]['characters'].data.cpu().numpy(),
+                           # Note the padding here - this is important.
+                           numpy.array([self.e_index, self.a_index, self.t_index, 0]))
+
+        tensor_dict = tensors[1][0]
+        assert tensor_dict['left'][0] == 'S'
+        assert tensor_dict['left'][1] is True
+        assert tensor_dict['left'][2].keys() == {'rules'}
+        assert_array_equal(tensor_dict['left'][2]['rules'].data.cpu().numpy(),
+                           numpy.array(self.s_rule_index))
+        assert tensor_dict['right'][0] == '[NP, VP]'
+        assert tensor_dict['right'][1] is True
+        assert tensor_dict['right'][2].keys() == {'rules'}
+        assert_array_equal(tensor_dict['right'][2]['rules'].data.cpu().numpy(),
+                           numpy.array(self.np_vp_index))
+
+        tensor_dict = tensors[1][1]
+        assert tensor_dict['left'][0] == 'NP'
+        assert tensor_dict['left'][1] is True
+        assert tensor_dict['left'][2].keys() == {'rules'}
+        assert_array_equal(tensor_dict['left'][2]['rules'].data.cpu().numpy(),
+                           numpy.array(self.np_index))
+        assert tensor_dict['right'][0] == 'cats'
+        assert tensor_dict['right'][1] is False
+        assert tensor_dict['right'][2].keys() == {'characters'}
+        assert_array_equal(tensor_dict['right'][2]['characters'].data.cpu().numpy(),
+                           numpy.array([self.c_index, self.a_index, self.t_index, self.s_index]))
+
+        # This item was just padding.
+        tensor_dict = tensors[1][2]
+        assert tensor_dict['left'][0] == ''
+        assert tensor_dict['left'][1] is True
+        assert not tensor_dict['left'][2]
+        assert tensor_dict['right'][0] == ''
+        assert tensor_dict['right'][1] is False
+        assert not tensor_dict['right'][2]

--- a/tests/data/fields/production_rule_field_test.py
+++ b/tests/data/fields/production_rule_field_test.py
@@ -1,0 +1,155 @@
+# pylint: disable=no-self-use,invalid-name
+from collections import defaultdict
+
+import pytest
+import numpy
+
+from allennlp.data import Vocabulary
+from allennlp.data.fields import ProductionRuleField
+from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenCharactersIndexer
+
+from allennlp.common.testing import AllenNlpTestCase
+
+
+class TestProductionRuleField(AllenNlpTestCase):
+    def setUp(self):
+        self.vocab = Vocabulary()
+        self.s_rule_index = self.vocab.add_token_to_namespace("S", namespace='rule_labels')
+        self.np_index = self.vocab.add_token_to_namespace("NP", namespace='rule_labels')
+        self.vp_index = self.vocab.add_token_to_namespace("VP", namespace='rule_labels')
+        self.np_vp_index = self.vocab.add_token_to_namespace("[NP, VP]", namespace='rule_labels')
+        self.identity_index = self.vocab.add_token_to_namespace("identity", namespace='entities')
+        self.t_index = self.vocab.add_token_to_namespace("t", namespace='characters')
+        self.e_index = self.vocab.add_token_to_namespace("e", namespace='characters')
+        self.s_index = self.vocab.add_token_to_namespace("s", namespace='characters')
+
+        self.oov_index = self.vocab.get_token_index('random OOV string', namespace='entities')
+
+        self.terminal_indexers = {"entities": SingleIdTokenIndexer("entities")}
+        self.nonterminal_indexers = {"rules": SingleIdTokenIndexer("rule_labels")}
+        self.character_indexer = {'characters': TokenCharactersIndexer('characters')}
+        self.nonterminal_types = {'S', 'NP', 'VP'}
+
+        super(TestProductionRuleField, self).setUp()
+
+    def _make_field(self,
+                    rule_string: str,
+                    terminal_indexers=None,
+                    nonterminal_indexers=None) -> ProductionRuleField:
+        terminal_indexers = terminal_indexers or self.terminal_indexers
+        nonterminal_indexers = nonterminal_indexers or self.nonterminal_indexers
+        return ProductionRuleField(rule_string,
+                                   terminal_indexers=terminal_indexers,
+                                   nonterminal_indexers=nonterminal_indexers,
+                                   nonterminal_types=self.nonterminal_types)
+
+    def test_field_counts_vocab_items_correctly(self):
+        field = self._make_field('S -> [NP, VP]')
+        namespace_token_counts = defaultdict(lambda: defaultdict(int))
+        field.count_vocab_items(namespace_token_counts)
+
+        assert namespace_token_counts["rule_labels"]["S"] == 1
+        assert namespace_token_counts["rule_labels"]["[NP, VP]"] == 1
+        assert len(namespace_token_counts["rule_labels"]) == 2
+        assert list(namespace_token_counts.keys()) == ["rule_labels"]
+
+        field = self._make_field('<e,e> -> identity')
+        namespace_token_counts = defaultdict(lambda: defaultdict(int))
+        field.count_vocab_items(namespace_token_counts)
+
+        assert namespace_token_counts["rule_labels"]["<e,e>"] == 1
+        assert len(namespace_token_counts["rule_labels"]) == 1
+        assert namespace_token_counts["entities"]["identity"] == 1
+        assert len(namespace_token_counts["entities"]) == 1
+        assert set(namespace_token_counts.keys()) == {"rule_labels", "entities"}
+
+        field = self._make_field('S -> VP')
+        namespace_token_counts = defaultdict(lambda: defaultdict(int))
+        field.count_vocab_items(namespace_token_counts)
+
+        assert namespace_token_counts["rule_labels"]["S"] == 1
+        assert namespace_token_counts["rule_labels"]["VP"] == 1
+        assert len(namespace_token_counts["rule_labels"]) == 2
+        assert set(namespace_token_counts.keys()) == {"rule_labels"}
+
+    def test_index_converts_field_correctly(self):
+        # pylint: disable=protected-access
+        field = self._make_field('S -> [NP, VP]')
+        field.index(self.vocab)
+        assert field._indexed_left_side == {'rules': self.s_rule_index}
+        assert field._indexed_right_side == {'rules': self.np_vp_index}
+
+        field = self._make_field('VP -> eats')
+        field.index(self.vocab)
+        assert field._indexed_left_side == {'rules': self.vp_index}
+        assert field._indexed_right_side == {'entities': self.oov_index}
+
+        field = self._make_field('NP -> VP')
+        field.index(self.vocab)
+        assert field._indexed_left_side == {'rules': self.np_index}
+        assert field._indexed_right_side == {'rules': self.vp_index}
+
+        field = self._make_field('S -> identity')
+        field.index(self.vocab)
+        assert field._indexed_left_side == {'rules': self.s_rule_index}
+        assert field._indexed_right_side == {'entities': self.identity_index}
+
+        # pylint: enable=protected-access
+
+    def test_get_padding_lengths_raises_if_not_indexed(self):
+        field = self._make_field('S -> [NP, VP]')
+        with pytest.raises(RuntimeError):
+            field.get_padding_lengths()
+
+    def test_padding_lengths_are_computed_correctly(self):
+        field = self._make_field('S -> [NP, VP]')
+        field.index(self.vocab)
+        assert field.get_padding_lengths() == {}
+
+        field = self._make_field('S -> test', terminal_indexers=self.character_indexer)
+        field.index(self.vocab)
+        assert field.get_padding_lengths() == {'num_token_characters': 4}
+
+        field = self._make_field('S -> test', nonterminal_indexers=self.character_indexer)
+        field.index(self.vocab)
+        assert field.get_padding_lengths() == {'num_token_characters': 1}
+
+        field = self._make_field('S -> test',
+                                 terminal_indexers=self.character_indexer,
+                                 nonterminal_indexers=self.character_indexer)
+        field.index(self.vocab)
+        assert field.get_padding_lengths() == {'num_token_characters': 4}
+
+    def test_as_array_produces_correct_output(self):
+        field = self._make_field('S -> [NP, VP]')
+        field.index(self.vocab)
+        padding_lengths = field.get_padding_lengths()
+        array_dict = field.as_array(padding_lengths)
+        assert array_dict.keys() == {'left', 'right'}
+        assert array_dict['left'] == ('S', True, {'rules': numpy.array(self.s_rule_index)})
+        assert array_dict['right'] == ('[NP, VP]', True, {'rules': numpy.array(self.np_vp_index)})
+
+        field = self._make_field('NP -> test', terminal_indexers=self.character_indexer)
+        field.index(self.vocab)
+        padding_lengths = field.get_padding_lengths()
+        array_dict = field.as_array(padding_lengths)
+        assert array_dict.keys() == {'left', 'right'}
+        assert array_dict['left'] == ('NP', True, {'rules': numpy.array(self.np_index)})
+        assert array_dict['right'][0] == 'test'
+        assert array_dict['right'][1] is False
+        numpy.testing.assert_array_equal(array_dict['right'][2]['characters'],
+                                         numpy.array([self.t_index, self.e_index,
+                                                      self.s_index, self.t_index]))
+
+    def test_batch_arrays_does_not_modify_list(self):
+        field = self._make_field('S -> [NP, VP]')
+        field.index(self.vocab)
+        padding_lengths = field.get_padding_lengths()
+        array_dict1 = field.as_array(padding_lengths)
+
+        field = self._make_field('S -> test')
+        field.index(self.vocab)
+        padding_lengths = field.get_padding_lengths()
+        array_dict2 = field.as_array(padding_lengths)
+        array_list = [array_dict1, array_dict2]
+        assert field.batch_arrays(array_list) == array_list

--- a/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
@@ -8,5 +8,5 @@ class WikiTablesSemanticParserTest(ModelTestCase):
         self.set_up_model("tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment.json",
                           "tests/fixtures/data/wikitables/sample_data.examples")
 
-    def test_encoder_decoder_can_train_save_and_load(self):
+    def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)


### PR DESCRIPTION
@DeNeutoy, @pdasigi, this PR implements the `ProductionRuleField` we talked about.  Eventually, this will be doubly nested somehow (probably in a couple of modified `ListFields`), so we have lists of production rule sequences.

While I was at it, I made a change to how "metadata" is handled in our processing, because the way we represent these arrays is going to break that code, anyway (this PR doesn't have a test that takes a `ProductionRuleField` and passes its output through `arrays_to_variables`, but it wouldn't work, as the tests that are currently failing here demonstrate).  So, @DeNeutoy, any ideas on how to fix `arrays_to_variables`?  Maybe I'll ask you and @joelgrus after our meeting tomorrow, as this might be easier to talk about in person, and the only solutions I can think of are pretty ugly.