### PR TITLE
Add support for purely character input in `get_text_field_mask`

### DIFF
--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -302,10 +302,16 @@ def get_text_field_mask(text_field_tensors: Dict[str, torch.Tensor]) -> torch.Lo
     """
     tensor_dims = [(tensor.dim(), tensor) for tensor in text_field_tensors.values()]
     tensor_dims.sort(key=lambda x: x[0])
-    token_tensor = tensor_dims[0][1]
 
-    return (token_tensor != 0).long()
-
+    smallest_dim = tensor_dims[0][0]
+    if smallest_dim == 2:
+        token_tensor = tensor_dims[0][1]
+        return (token_tensor != 0).long()
+    elif smallest_dim == 3:
+        character_tensor = tensor_dims[0][1]
+        return ((character_tensor > 0).long().sum(dim=-1) > 0).long()
+    else:
+        raise ValueError("Expected a tensor with dimension 2 or 3, found {}".format(smallest_dim))
 
 def _last_dimension_applicator(function_to_apply: Callable[[torch.Tensor, Optional[torch.Tensor]], torch.Tensor],
                                tensor: torch.Tensor,

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -297,7 +297,7 @@ def get_text_field_mask(text_field_tensors: Dict[str, torch.Tensor],
     word ids, one for character ids).  In order to get a token mask, we use the tensor in
     the dictionary with the lowest number of dimensions.  After subtracting ``num_wrapping_dims``,
     if this tensor has two dimensions we assume it has shape ``(batch_size, ..., num_tokens)``,
-    and use it for the mask.  If instead it has three dimensions, we assume it has shape 
+    and use it for the mask.  If instead it has three dimensions, we assume it has shape
     ``(batch_size, ..., num_tokens, num_features)``, and sum over the last dimension to produce
     the mask.  Most frequently this will be a character id tensor, but it could also be a
     featurized representation of each token, etc.

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -300,7 +300,7 @@ class TestNnUtil(AllenNlpTestCase):
     def test_get_text_field_mask_returns_a_correct_mask_list_field(self):
         text_field_arrays = {
                 "list_tokens": numpy.asarray([[[1, 2], [3, 0], [2, 0], [0, 0], [0, 0]],
-                                                   [[5, 0], [4, 6], [0, 0], [0, 0], [0, 0]]])
+                                              [[5, 0], [4, 6], [0, 0], [0, 0], [0, 0]]])
                 }
         text_field_tensors = util.arrays_to_variables(text_field_arrays)
         actual_mask = util.get_text_field_mask(text_field_tensors, num_wrapping_dims=1).data.numpy()

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -297,6 +297,16 @@ class TestNnUtil(AllenNlpTestCase):
         assert_almost_equal(util.get_text_field_mask(text_field_tensors).data.numpy(),
                             [[1, 1, 1, 0], [1, 1, 0, 0]])
 
+    def test_get_text_field_mask_returns_a_correct_mask_list_field(self):
+        text_field_arrays = {
+                "list_tokens": numpy.asarray([[[1, 2], [3, 0], [2, 0], [0, 0], [0, 0]],
+                                                   [[5, 0], [4, 6], [0, 0], [0, 0], [0, 0]]])
+                }
+        text_field_tensors = util.arrays_to_variables(text_field_arrays)
+        actual_mask = util.get_text_field_mask(text_field_tensors, num_wrapping_dims=1).data.numpy()
+        expected_mask = (text_field_tensors['list_tokens'].data.numpy() > 0).astype('int32')
+        assert_almost_equal(actual_mask, expected_mask)
+
     def test_last_dim_softmax_does_softmax_on_last_dim(self):
         batch_size = 1
         length_1 = 5

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -288,6 +288,15 @@ class TestNnUtil(AllenNlpTestCase):
         assert_almost_equal(util.get_text_field_mask(text_field_tensors).data.numpy(),
                             [[1, 1, 1, 0, 0], [1, 1, 0, 0, 0]])
 
+    def test_get_text_field_mask_returns_a_correct_mask_character_only_input(self):
+        text_field_arrays = {
+                "token_characters": numpy.asarray([[[1, 2, 3], [3, 0, 1], [2, 1, 0], [0, 0, 0]],
+                                                   [[5, 5, 5], [4, 6, 0], [0, 0, 0], [0, 0, 0]]])
+                }
+        text_field_tensors = util.arrays_to_variables(text_field_arrays)
+        assert_almost_equal(util.get_text_field_mask(text_field_tensors).data.numpy(),
+                            [[1, 1, 1, 0], [1, 1, 0, 0]])
+
     def test_last_dim_softmax_does_softmax_on_last_dim(self):
         batch_size = 1
         length_1 = 5


### PR DESCRIPTION
`get_text_field_mask` was returning the wrong mask for models with purely character input.  This PR fixes it.