### PR TITLE
Fixed casting to FloatTensor in simple_seq2seq.py (#583)

### DIFF
--- a/allennlp/models/encoder_decoders/simple_seq2seq.py
+++ b/allennlp/models/encoder_decoders/simple_seq2seq.py
@@ -216,7 +216,7 @@ class SimpleSeq2Seq(Model):
             # encoder_outputs : (batch_size, input_sequence_length, encoder_output_dim)
             # Ensuring mask is also a FloatTensor. Or else the multiplication within attention will
             # complain.
-            encoder_outputs_mask = encoder_outputs_mask.type(torch.FloatTensor)
+            encoder_outputs_mask = encoder_outputs_mask.float()
             # (batch_size, input_sequence_length)
             input_weights = self._decoder_attention(decoder_hidden_state, encoder_outputs, encoder_outputs_mask)
             # (batch_size, encoder_output_dim)


### PR DESCRIPTION
After applying the change, training code runs on GPU error-free.

(Fixes #585)