### PR TITLE
Grad checks

### DIFF
--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -85,7 +85,7 @@ def evaluate(model: Model,
     logger.info("Iterating over dataset")
     generator_tqdm = tqdm.tqdm(generator, total=iterator.get_num_batches(dataset))
     for batch in generator_tqdm:
-        model.forward(**batch)
+        model(**batch)
         metrics = model.get_metrics()
         description = ', '.join(["%s: %.2f" % (name, value) for name, value in metrics.items()]) + " ||"
         generator_tqdm.set_description(description)

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -1,5 +1,6 @@
 import os
 
+import numpy
 from numpy.testing import assert_allclose
 import torch
 
@@ -46,6 +47,15 @@ class ModelTestCase(AllenNlpTestCase):
         reader = DatasetReader.from_params(params['dataset_reader'])
         iterator = DataIterator.from_params(params['iterator'])
 
+
+        model_dataset = reader.read(params['validation_data_path'])
+        model_dataset.index_instances(model.vocab)
+        model_batch = next(iterator(model_dataset, shuffle=False, cuda_device=cuda_device))
+
+        # Check gradients are None for non-trainable parameters and check that
+        # trainable parameters receive some gradient if they are trainable.
+        self.check_model_computes_gradients_correctly(model, model_batch)
+
         # We'll check that even if we index the dataset with each model separately, we still get
         # the same result out.
         model_dataset = reader.read(params['validation_data_path'])
@@ -76,8 +86,8 @@ class ModelTestCase(AllenNlpTestCase):
             for module in model_.modules():
                 if hasattr(module, 'stateful') and module.stateful:
                     module.reset_states()
-        model_predictions = model.forward(**model_batch)
-        loaded_model_predictions = loaded_model.forward(**loaded_batch)
+        model_predictions = model(**model_batch)
+        loaded_model_predictions = loaded_model(**loaded_batch)
 
         # Check loaded model's loss exists and we can compute gradients, for continuing training.
         loaded_model_loss = loaded_model_predictions["loss"]
@@ -103,16 +113,31 @@ class ModelTestCase(AllenNlpTestCase):
         else:
             assert field1 == field2
 
+    @staticmethod
+    def check_model_computes_gradients_correctly(model, model_batch):
+        model.zero_grad()
+        result = model(**model_batch)
+        result["loss"].backward()
+
+        for parameter in model.parameters():
+            zeros = torch.zeros(parameter.size())
+            if parameter.requires_grad:
+                # Some parameters will only be partially updated,
+                # like embeddings, so we just check that any gradient is non-zero.
+                assert (parameter.grad.data.cpu() != zeros).any()
+            else:
+                assert parameter.grad is None
+
     def ensure_batch_predictions_are_consistent(self):
         self.model.eval()
         single_predictions = []
         for i, instance in enumerate(self.dataset.instances):
             dataset = Dataset([instance])
             tensors = dataset.as_tensor_dict(dataset.get_padding_lengths(), for_training=False)
-            result = self.model.forward(**tensors)
+            result = self.model(**tensors)
             single_predictions.append(result)
         batch_tensors = self.dataset.as_tensor_dict(self.dataset.get_padding_lengths(), for_training=False)
-        batch_predictions = self.model.forward(**batch_tensors)
+        batch_predictions = self.model(**batch_tensors)
         for i, instance_predictions in enumerate(single_predictions):
             for key, single_predicted in instance_predictions.items():
                 tolerance = 1e-6

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -47,7 +47,6 @@ class ModelTestCase(AllenNlpTestCase):
         reader = DatasetReader.from_params(params['dataset_reader'])
         iterator = DataIterator.from_params(params['iterator'])
 
-
         model_dataset = reader.read(params['validation_data_path'])
         model_dataset.index_instances(model.vocab)
         model_batch = next(iterator(model_dataset, shuffle=False, cuda_device=cuda_device))
@@ -119,9 +118,11 @@ class ModelTestCase(AllenNlpTestCase):
         result = model(**model_batch)
         result["loss"].backward()
 
-        for parameter in model.parameters():
+        for name, parameter in model.named_parameters():
             zeros = torch.zeros(parameter.size())
             if parameter.requires_grad:
+                print(parameter)
+                print(name)
                 # Some parameters will only be partially updated,
                 # like embeddings, so we just check that any gradient is non-zero.
                 assert (parameter.grad.data.cpu() != zeros).any()

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -46,14 +46,6 @@ class ModelTestCase(AllenNlpTestCase):
         reader = DatasetReader.from_params(params['dataset_reader'])
         iterator = DataIterator.from_params(params['iterator'])
 
-        model_dataset = reader.read(params['validation_data_path'])
-        model_dataset.index_instances(model.vocab)
-        model_batch = next(iterator(model_dataset, shuffle=False, cuda_device=cuda_device))
-
-        # Check gradients are None for non-trainable parameters and check that
-        # trainable parameters receive some gradient if they are trainable.
-        self.check_model_computes_gradients_correctly(model, model_batch)
-
         # We'll check that even if we index the dataset with each model separately, we still get
         # the same result out.
         model_dataset = reader.read(params['validation_data_path'])
@@ -62,6 +54,10 @@ class ModelTestCase(AllenNlpTestCase):
         loaded_dataset = reader.read(params['validation_data_path'])
         loaded_dataset.index_instances(loaded_model.vocab)
         loaded_batch = next(iterator(loaded_dataset, shuffle=False, cuda_device=cuda_device))
+
+        # Check gradients are None for non-trainable parameters and check that
+        # trainable parameters receive some gradient if they are trainable.
+        self.check_model_computes_gradients_correctly(model, model_batch)
 
         # The datasets themselves should be identical.
         for key in model_batch.keys():
@@ -117,11 +113,9 @@ class ModelTestCase(AllenNlpTestCase):
         result = model(**model_batch)
         result["loss"].backward()
 
-        for name, parameter in model.named_parameters():
+        for parameter in model.parameters():
             zeros = torch.zeros(parameter.size())
             if parameter.requires_grad:
-                print(parameter)
-                print(name)
                 # Some parameters will only be partially updated,
                 # like embeddings, so we just check that any gradient is non-zero.
                 assert (parameter.grad.data.cpu() != zeros).any()

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -1,6 +1,5 @@
 import os
 
-import numpy
 from numpy.testing import assert_allclose
 import torch
 

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -106,7 +106,7 @@ class CrfTagger(Model):
 
         if tags is not None:
             # Add negative log-likelihood as loss
-            log_likelihood = self.crf.forward(logits, tags, mask)
+            log_likelihood = self.crf(logits, tags, mask)
             output["loss"] = -log_likelihood
 
             # Represent viterbi tags as "class probabilities" that we can

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -128,7 +128,7 @@ class Model(torch.nn.Module, Registrable):
         dataset = Dataset(instances)
         dataset.index_instances(self.vocab)
         model_input = dataset.as_tensor_dict(cuda_device=cuda_device, for_training=False)
-        outputs = self.decode(self.forward(**model_input))
+        outputs = self.decode(self(**model_input))
 
         instance_separated_output: List[Dict[str, numpy.ndarray]] = [{} for _ in dataset.instances]
         for name, output in list(outputs.items()):

--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -98,7 +98,7 @@ class Elmo(torch.nn.Module, Registrable):
         # compute the elmo representations
         representations = []
         for scalar_mix in self._scalar_mixes:
-            representation_with_bos_eos = scalar_mix.forward(layer_activations, mask_with_bos_eos)
+            representation_with_bos_eos = scalar_mix(layer_activations, mask_with_bos_eos)
             representation_without_bos_eos, mask_without_bos_eos = remove_sentence_boundaries(
                     representation_with_bos_eos, mask_with_bos_eos
             )

--- a/allennlp/modules/elmo_lstm.py
+++ b/allennlp/modules/elmo_lstm.py
@@ -13,6 +13,7 @@ import numpy
 from allennlp.modules.lstm_cell_with_projection import LstmCellWithProjection
 from allennlp.common.checks import ConfigurationError
 from allennlp.modules.encoder_base import _EncoderBase
+from allennlp.common.file_utils import cached_path
 
 
 class ElmoLstm(_EncoderBase):
@@ -242,7 +243,7 @@ class ElmoLstm(_EncoderBase):
 
         Note that this method also sets ``requires_grad=False`` to all class parameters.
         """
-        with h5py.File(weight_file, 'r') as fin:
+        with h5py.File(cached_path(weight_file), 'r') as fin:
             for i_layer, lstms in enumerate(
                     zip(self.forward_layers, self.backward_layers)
             ):

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -831,7 +831,7 @@ def remove_sentence_boundaries(tensor: torch.Tensor,
     new_mask = Variable(tensor.data.new(new_shape[0], new_shape[1]).fill_(0)).long()
     for i, j in enumerate(sequence_lengths):
         if j > 2:
-            tensor_without_boundary_tokens.data[i, :(j - 2), :] = tensor.data[i, 1:(j - 1), :]
+            tensor_without_boundary_tokens[i, :(j - 2), :] = tensor[i, 1:(j - 1), :]
             new_mask[i, :(j - 2)] = 1
 
     return tensor_without_boundary_tokens, new_mask

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -173,7 +173,7 @@ class Trainer:
         Does a forward pass on the given batch and returns the ``loss`` value in the result.
         If ``for_training`` is `True` also applies regularization penalty.
         """
-        output_dict = self._model.forward(**batch)
+        output_dict = self._model(**batch)
 
         try:
             loss = output_dict["loss"]

--- a/scripts/evaluate_squad_model.py
+++ b/scripts/evaluate_squad_model.py
@@ -54,7 +54,7 @@ def main(config_file):
     result_dict = {}
     for batch in tqdm.tqdm(generator):
         tensor_batch = arrays_to_variables(batch, cuda_device, for_training=False)
-        result = model.forward(**tensor_batch)
+        result = model(**tensor_batch)
         best_span_tensor = result['best_span']
         for i in range(best_span_tensor.size(0)):
             best_spans.append(best_span_tensor[i].data.cpu().tolist())

--- a/scripts/write_srl_predictions_to_conll_format.py
+++ b/scripts/write_srl_predictions_to_conll_format.py
@@ -40,7 +40,7 @@ def main(serialization_directory, device):
     model_predictions = []
     for batch in tqdm.tqdm(iterator(dataset, num_epochs=1, shuffle=False)):
         tensor_batch = arrays_to_variables(batch, device, for_training=False)
-        result = model.forward(**tensor_batch)
+        result = model(**tensor_batch)
         predictions = model.decode(result)
         model_predictions.extend(predictions["tags"])
 

--- a/tests/models/crf_tagger_test.py
+++ b/tests/models/crf_tagger_test.py
@@ -23,7 +23,7 @@ class CrfTaggerTest(ModelTestCase):
 
     def test_forward_pass_runs_correctly(self):
         training_tensors = self.dataset.as_tensor_dict()
-        output_dict = self.model.forward(**training_tensors)
+        output_dict = self.model(**training_tensors)
         tags = output_dict['tags']
         assert len(tags) == 2
         assert len(tags[0]) == 7

--- a/tests/models/decomposable_attention_test.py
+++ b/tests/models/decomposable_attention_test.py
@@ -18,7 +18,7 @@ class TestDecomposableAttention(ModelTestCase):
 
     def test_forward_pass_runs_correctly(self):
         training_tensors = self.dataset.as_tensor_dict()
-        output_dict = self.model.forward(**training_tensors)
+        output_dict = self.model(**training_tensors)
         assert_almost_equal(numpy.sum(output_dict["label_probs"][0].data.numpy(), -1), 1, decimal=6)
 
     @flaky

--- a/tests/models/encoder_decoders/simple_seq2seq_test.py
+++ b/tests/models/encoder_decoders/simple_seq2seq_test.py
@@ -34,7 +34,7 @@ class SimpleSeq2SeqWithoutAttentionTest(ModelTestCase):
 
     def test_decode_runs_correctly(self):
         training_tensors = self.dataset.as_tensor_dict()
-        output_dict = self.model.forward(**training_tensors)
+        output_dict = self.model(**training_tensors)
         decode_output_dict = self.model.decode(output_dict)
         # ``decode`` should have added a ``predicted_tokens`` field to ``output_dict``. Checking if it's there.
         assert "predicted_tokens" in decode_output_dict

--- a/tests/models/reading_comprehension/bidaf_test.py
+++ b/tests/models/reading_comprehension/bidaf_test.py
@@ -20,7 +20,7 @@ class BidirectionalAttentionFlowTest(ModelTestCase):
 
     def test_forward_pass_runs_correctly(self):
         training_tensors = self.dataset.as_tensor_dict()
-        output_dict = self.model.forward(**training_tensors)
+        output_dict = self.model(**training_tensors)
 
         metrics = self.model.get_metrics(reset=True)
         # We've set up the data such that there's a fake answer that consists of the whole

--- a/tests/models/semantic_role_labeler_test.py
+++ b/tests/models/semantic_role_labeler_test.py
@@ -29,14 +29,14 @@ class SemanticRoleLabelerTest(ModelTestCase):
 
     def test_forward_pass_runs_correctly(self):
         training_tensors = self.dataset.as_tensor_dict()
-        output_dict = self.model.forward(**training_tensors)
+        output_dict = self.model(**training_tensors)
         class_probs = output_dict['class_probabilities'][0].data.numpy()
         numpy.testing.assert_almost_equal(numpy.sum(class_probs, -1),
                                           numpy.ones(class_probs.shape[0]))
 
     def test_decode_runs_correctly(self):
         training_tensors = self.dataset.as_tensor_dict()
-        output_dict = self.model.forward(**training_tensors)
+        output_dict = self.model(**training_tensors)
         decode_output_dict = self.model.decode(output_dict)
         lengths = get_lengths_from_binary_sequence_mask(decode_output_dict["mask"]).data.tolist()
         # Hard to check anything concrete which we haven't checked in the above

--- a/tests/models/simple_tagger_test.py
+++ b/tests/models/simple_tagger_test.py
@@ -28,7 +28,7 @@ class SimpleTaggerTest(ModelTestCase):
 
     def test_forward_pass_runs_correctly(self):
         training_tensors = self.dataset.as_tensor_dict()
-        output_dict = self.model.forward(**training_tensors)
+        output_dict = self.model(**training_tensors)
         output_dict = self.model.decode(output_dict)
         class_probs = output_dict['class_probabilities'][0].data.numpy()
         numpy.testing.assert_almost_equal(numpy.sum(class_probs, -1), numpy.array([1, 1, 1, 1]))

--- a/tests/modules/conditional_random_field_test.py
+++ b/tests/modules/conditional_random_field_test.py
@@ -55,7 +55,7 @@ class TestConditionalRandomField(AllenNlpTestCase):
         return total
 
     def test_forward_works_without_mask(self):
-        log_likelihood = self.crf.forward(self.logits, self.tags).data[0]
+        log_likelihood = self.crf(self.logits, self.tags).data[0]
 
         # Now compute the log-likelihood manually
         manual_log_likelihood = 0.0
@@ -82,7 +82,7 @@ class TestConditionalRandomField(AllenNlpTestCase):
                 [1, 1, 0]
         ]))
 
-        log_likelihood = self.crf.forward(self.logits, self.tags, mask).data[0]
+        log_likelihood = self.crf(self.logits, self.tags, mask).data[0]
 
         # Now compute the log-likelihood manually
         manual_log_likelihood = 0.0

--- a/tests/modules/seq2seq_encoders/pytorch_seq2seq_wrapper_test.py
+++ b/tests/modules/seq2seq_encoders/pytorch_seq2seq_wrapper_test.py
@@ -38,7 +38,7 @@ class TestPytorchSeq2SeqWrapper(AllenNlpTestCase):
         mask[3, 2:] = 0
         mask[4, :] = 0
 
-        results = encoder.forward(tensor, mask)
+        results = encoder(tensor, mask)
 
         for i in (0, 1, 3):
             assert not (results[i] == 0.).data.all()

--- a/tests/modules/seq2vec_encoders/pytorch_seq2vec_wrapper_test.py
+++ b/tests/modules/seq2vec_encoders/pytorch_seq2vec_wrapper_test.py
@@ -74,7 +74,7 @@ class TestPytorchSeq2VecWrapper(AllenNlpTestCase):
         mask[3, 2:] = 0
         mask[4, :] = 0
 
-        results = encoder.forward(tensor, mask)
+        results = encoder(tensor, mask)
 
         for i in (0, 1, 3):
             assert not (results[i] == 0.).data.all()

--- a/tests/modules/token_embedders/elmo_token_embedder_test.py
+++ b/tests/modules/token_embedders/elmo_token_embedder_test.py
@@ -12,7 +12,7 @@ class TestElmoTokenEmbedder(ModelTestCase):
 
     def test_tagger_with_elmo_token_embedder_forward_pass_runs_correctly(self):
         training_tensors = self.dataset.as_tensor_dict()
-        output_dict = self.model.forward(**training_tensors)
+        output_dict = self.model(**training_tensors)
         tags = output_dict['tags']
         assert len(tags) == 2
         assert len(tags[0]) == 7


### PR DESCRIPTION
- Checks that parameters are getting gradients which need them in the model test cases.
- Removes all `.forward` references as Pytorch 0.3 has our bug fixes for modules which return dictionaries
- Fixes a bug in the sentence boundary function for ELMo which was not correctly recording inplace operations in the `Variable`

Fixes #456 
Fixes #494