### PR TITLE
Use production rule field

### DIFF
--- a/allennlp/common/checks.py
+++ b/allennlp/common/checks.py
@@ -24,3 +24,12 @@ class ConfigurationError(Exception):
 def log_pytorch_version_info():
     import torch
     logger.info("Pytorch version: " + torch.__version__)
+
+
+def check_dimensions_match(dimension_1: int,
+                           dimension_2: int,
+                           dim_1_name: str,
+                           dim_2_name: str) -> None:
+    if dimension_1 != dimension_2:
+        raise ConfigurationError(f"{dim_1_name} must match {dim_2_name}, but got {dimension_1} "
+                                 f"and {dimension_2} instead")

--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -184,8 +184,7 @@ class WikiTablesDatasetReader(DatasetReader):
                 print(expression)
                 print(sequence)
                 for production_rule in sequence:
-                    field = IndexField(action_map[production_rule], action_field)
-                    index_fields.append(field)
+                    index_fields.append(IndexField(action_map[production_rule], action_field))
                 action_sequence_fields.append(ListField(index_fields))
             fields['target_action_sequences'] = ListField(action_sequence_fields)
         return Instance(fields)

--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -132,9 +132,10 @@ class WikiTablesDatasetReader(DatasetReader):
         else:
             table_knowledge_graph = TableKnowledgeGraph.read_from_json(table_info)
         table_field = KnowledgeGraphField(table_knowledge_graph, self._table_token_indexers)
-        fields = {'question': question_field, 'table': table_field}
+        world = WikiTablesWorld(table_knowledge_graph)
+        world_field = MetadataField(world)
+        fields = {'question': question_field, 'table': table_field, 'world': world_field}
         if dpd_output:
-            world = WikiTablesWorld(table_knowledge_graph)
             expressions = [world.parse_logical_form(form) for form in dpd_output]
             action_sequences = [world.get_action_sequence(expression) for expression in expressions]
             action_sequence_fields: List[ListField[ProductionRuleField]] = []

--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -2,7 +2,7 @@
 Reader for WikitableQuestions (https://github.com/ppasupat/WikiTableQuestions/releases/tag/v1.0.2).
 """
 
-from typing import Any, Dict, List, Union
+from typing import Dict, List, Union
 import gzip
 import logging
 import os
@@ -23,7 +23,6 @@ from allennlp.data.fields import Field, IndexField, KnowledgeGraphField, ListFie
 from allennlp.data.fields import MetadataField, ProductionRuleField, TextField
 from allennlp.data.semparse.knowledge_graphs import TableKnowledgeGraph
 from allennlp.data.semparse.type_declarations import wikitables_type_declaration as wt_types
-from allennlp.data.semparse.type_declarations import type_declaration as types
 from allennlp.data.semparse.worlds import WikiTablesWorld
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 
@@ -135,7 +134,7 @@ class WikiTablesDatasetReader(DatasetReader):
         ----------
         question : ``str``
             Input question
-        table_info : ``str`` or ``Dict[str, Any]``
+        table_info : ``str`` or ``JsonDict``
             Table filename or the table content itself, as a dict. See
             ``TableKnowledgeGraph.read_from_json`` for the expected format.
         dpd_output : List[str] (optional)
@@ -178,11 +177,8 @@ class WikiTablesDatasetReader(DatasetReader):
             # ProductionRuleFields.
             action_map = {action.rule: i for i, action in enumerate(action_field.field_list)}  # type: ignore
             action_sequence_fields: List[Field] = []
-            for form, expression, sequence in zip(dpd_output, expressions, action_sequences):
+            for sequence in action_sequences:
                 index_fields: List[Field] = []
-                print(form)
-                print(expression)
-                print(sequence)
                 for production_rule in sequence:
                     index_fields.append(IndexField(action_map[production_rule], action_field))
                 action_sequence_fields.append(ListField(index_fields))

--- a/allennlp/data/fields/knowledge_graph_field.py
+++ b/allennlp/data/fields/knowledge_graph_field.py
@@ -1,7 +1,6 @@
 """
 ``KnowledgeGraphField`` is a ``Field`` which stores a knowledge graph representation.
 """
-from collections import defaultdict
 from typing import Dict, List
 
 import torch
@@ -13,6 +12,7 @@ from allennlp.data.semparse import KnowledgeGraph
 from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
 from allennlp.data.tokenizers.token import Token
 from allennlp.data.vocabulary import Vocabulary
+from allennlp.nn import util
 
 TokenList = List[TokenType]  # pylint: disable=invalid-name
 
@@ -104,13 +104,6 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
         return KnowledgeGraphField(KnowledgeGraph({}), self._token_indexers)
 
     @overrides
-    def batch_tensors(self, tensor_list: List[Dict[str, torch.Tensor]]) -> torch.Tensor:
+    def batch_tensors(self, tensor_list: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
         # pylint: disable=no-self-use
-        # This is creating a dict of {token_indexer_key: batch_tensor} for each token indexer used
-        # to index this field.
-        token_indexer_key_to_batch_dict: Dict[str, List[torch.Tensor]] = defaultdict(list)
-        for encoding_name_dict in tensor_list:
-            for indexer_name, tensor in encoding_name_dict.items():
-                token_indexer_key_to_batch_dict[indexer_name].append(tensor)
-        return {indexer_name: torch.stack(tensor_list)
-                for indexer_name, tensor_list in token_indexer_key_to_batch_dict.items()}
+        return util.batch_tensor_dicts(tensor_list)

--- a/allennlp/data/fields/list_field.py
+++ b/allennlp/data/fields/list_field.py
@@ -93,6 +93,6 @@ class ListField(SequenceField[DataArray]):
         return ListField([self.field_list[0].empty_field()])
 
     @overrides
-    def batch_tensors(self, tensor_list: List[DataArray]) -> DataArray:  # type: ignore
+    def batch_tensors(self, tensor_list: List[DataArray]) -> DataArray:
         # We defer to the class we're wrapping in a list to handle the batching.
         return self.field_list[0].batch_tensors(tensor_list)

--- a/allennlp/data/semparse/knowledge_graphs/knowledge_graph.py
+++ b/allennlp/data/semparse/knowledge_graphs/knowledge_graph.py
@@ -3,7 +3,7 @@ A ``KnowledgeGraph`` is a graphical representation of some structured knowledge 
 table, figure or an explicit knowledge base.
 """
 
-from typing import Dict, List, Set
+from typing import Dict, List
 
 
 class KnowledgeGraph:
@@ -37,6 +37,8 @@ class KnowledgeGraph:
         """
         return self._neighbors[entity]
 
-    def get_all_entities(self) -> Set[str]:
-        # This is technically a KeysView, not a Set, but it's close enough.
-        return self._neighbors.keys()  # type: ignore
+    def get_all_entities(self) -> List[str]:
+        # We return a sorted list here so we get guaranteed consistent ordering, for
+        # reproducibility's sake.  The ordering will affect the name mapping that we do, which
+        # affects the intermediate nltk logical forms.
+        return sorted(self._neighbors.keys())

--- a/allennlp/data/semparse/knowledge_graphs/knowledge_graph.py
+++ b/allennlp/data/semparse/knowledge_graphs/knowledge_graph.py
@@ -3,7 +3,7 @@ A ``KnowledgeGraph`` is a graphical representation of some structured knowledge 
 table, figure or an explicit knowledge base.
 """
 
-from typing import Dict, List
+from typing import Dict, List, Set
 
 
 class KnowledgeGraph:
@@ -37,5 +37,5 @@ class KnowledgeGraph:
         """
         return self._neighbors[entity]
 
-    def get_all_entities(self):
+    def get_all_entities(self) -> Set[str]:
         return self._neighbors.keys()

--- a/allennlp/data/semparse/knowledge_graphs/knowledge_graph.py
+++ b/allennlp/data/semparse/knowledge_graphs/knowledge_graph.py
@@ -42,3 +42,8 @@ class KnowledgeGraph:
         # reproducibility's sake.  The ordering will affect the name mapping that we do, which
         # affects the intermediate nltk logical forms.
         return sorted(self._neighbors.keys())
+
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return self.__dict__ == other.__dict__
+        return NotImplemented

--- a/allennlp/data/semparse/knowledge_graphs/knowledge_graph.py
+++ b/allennlp/data/semparse/knowledge_graphs/knowledge_graph.py
@@ -38,4 +38,5 @@ class KnowledgeGraph:
         return self._neighbors[entity]
 
     def get_all_entities(self) -> Set[str]:
-        return self._neighbors.keys()
+        # This is technically a KeysView, not a Set, but it's close enough.
+        return self._neighbors.keys()  # type: ignore

--- a/allennlp/data/semparse/type_declarations/__init__.py
+++ b/allennlp/data/semparse/type_declarations/__init__.py
@@ -1,0 +1,1 @@
+from allennlp.data.semparse.type_declarations.grammar_state import GrammarState

--- a/allennlp/data/semparse/type_declarations/grammar_state.py
+++ b/allennlp/data/semparse/type_declarations/grammar_state.py
@@ -1,0 +1,22 @@
+class GrammarState:
+    """
+    A ``GrammarState`` specifies the currently valid actions at every step of decoding.
+
+    If we had a global, context-free grammar, this would not be necessary - the currently valid
+    actions would always be the same, and we would not need to represent the current state.
+    However, our grammar is not context free (we have lambda expressions that introduce
+    context-dependent production rules), and it is not global (each instance can have its own
+    entities of a particular type, or even its own functions).
+
+    We thus recognize three different sources of valid actions, and we treat them separately.  The
+    first are actions that come from the type declaration; these are computed once by the model and
+    shared across all ``GrammarStates`` produced by that model.  The second are actions that come
+    from the current instance; these are computed for each instance in ``model.forward``, and are
+    shared across all decoding states for that instance.  The last are actions that come from the
+    current state of the decoder; these are updated after every action taken by the decoder, though
+    only some actions initiate changes.
+
+    In practice, though, we use the ``World`` class to get the first two sources of valid actions
+    at the same time, and let ``World`` deal with only computing the global actions once.  There is
+    one ``World`` for each instance.
+    """

--- a/allennlp/data/semparse/type_declarations/grammar_state.py
+++ b/allennlp/data/semparse/type_declarations/grammar_state.py
@@ -1,22 +1,124 @@
+from typing import Dict, List
+
+
 class GrammarState:
     """
     A ``GrammarState`` specifies the currently valid actions at every step of decoding.
 
-    If we had a global, context-free grammar, this would not be necessary - the currently valid
+    If we had a global context-free grammar, this would not be necessary - the currently valid
     actions would always be the same, and we would not need to represent the current state.
     However, our grammar is not context free (we have lambda expressions that introduce
     context-dependent production rules), and it is not global (each instance can have its own
-    entities of a particular type, or even its own functions).
+    entities of a particular type, or its own functions).
 
-    We thus recognize three different sources of valid actions, and we treat them separately.  The
-    first are actions that come from the type declaration; these are computed once by the model and
-    shared across all ``GrammarStates`` produced by that model.  The second are actions that come
-    from the current instance; these are computed for each instance in ``model.forward``, and are
-    shared across all decoding states for that instance.  The last are actions that come from the
-    current state of the decoder; these are updated after every action taken by the decoder, though
-    only some actions initiate changes.
+    We thus recognize three different sources of valid actions.  The first are actions that come
+    from the type declaration; these are defined once by the model and shared across all
+    ``GrammarStates`` produced by that model.  The second are actions that come from the current
+    instance; these are defined by the ``World`` that corresponds to each instance, and are shared
+    across all decoding states for that instance.  The last are actions that come from the current
+    state of the decoder; these are updated after every action taken by the decoder, though only
+    some actions initiate changes.
 
-    In practice, though, we use the ``World`` class to get the first two sources of valid actions
-    at the same time, and let ``World`` deal with only computing the global actions once.  There is
-    one ``World`` for each instance.
+    In practice, we use the ``World`` class to get the first two sources of valid actions at the
+    same time, and we take as input a ``valid_actions`` dictionary that is computed by the
+    ``World``.  These will not change during the course of decoding.  The ``GrammarState`` object
+    itself maintains the context-dependent valid actions.
+
+    Parameters
+    ----------
+    nonterminal_stack : ``List[str]``
+        Holds the list of non-terminals that still need to be expanded.  This starts out as
+        [START_SYMBOL], and decoding ends when this is empty.  Every time we take an action, we
+        update the non-terminal stack and the context-dependent valid actions, and we use what's on
+        the stack to decide which actions are valid in the current state.
+    lambda_stack : ``Dict[str, List[str]]``
+        The lambda stack keeps track of when we're in the scope of a lambda function.  The
+        dictionary is keyed by the lambda variable (e.g., "x"), and the value is a nonterminal
+        stack much like ``nonterminal_stack``.  When the stack becomes empty, we remove the lambda
+        entry.
+    valid_actions : ``Dict[str, List[int]]``
+        A mapping from non-terminals (represented as strings) to all valid (global and
+        instance-specific) productions from that non-terminal (represented as a list of integers).
+    action_indices : ``Dict[str, int]``
+        We use integers to represent productions in the ``valid_actions`` dictionary for efficiency
+        reasons in the decoder.  However, we sometimes need access to the strings themselves, so we
+        take this mapping from production rule strings to integers.
     """
+
+    def __init__(self,
+                 nonterminal_stack: List[str],
+                 lambda_stack: Dict[str, List[str]],
+                 valid_actions: Dict[str, List[int]],
+                 action_indices: Dict[str, int]):
+        self._nonterminal_stack = nonterminal_stack
+        self._lambda_stack = lambda_stack
+        self._valid_actions = valid_actions
+        self._action_indices = action_indices
+
+    def is_finished(self) -> bool:
+        """
+        Have we finished producing our logical form?  We have finished producing the logical form
+        if and only if there are no more non-terminals on the stack.
+        """
+        return not self._nonterminal_stack
+
+    def get_valid_actions(self) -> List[int]:
+        """
+        Returns a list of valid actions (represented as integers)
+        """
+        return self._valid_actions[self._nonterminal_stack[-1]]
+
+    def take_action(self, action: str) -> 'GrammarState':
+        """
+        Takes an action in the current grammar state, returning a new grammar state with whatever
+        updates are necessary.
+
+        This will update the non-terminal stack and the context-dependent actions.  Updating the
+        non-terminal stack involves popping the non-terminal that was expanded off of the stack,
+        then pushing on any non-terminals in the production rule back on the stack.  We push the
+        non-terminals on in `reverse` order, so that the first non-terminal in the production rule
+        gets popped off the stack first.
+
+        For example, if our current ``nonterminal_stack`` is ``["r", "<e,r>", "d"]``, and
+        ``action`` is ``d -> [<e,d>, e]``, the resulting stack will be ``["r", "<e,r>", "e",
+        "<e,d>"]``.
+        """
+        non_terminal, production_string = action.split(' -> ')
+        assert self._nonterminal_stack[-1] == non_terminal
+        new_stack = self._nonterminal_stack[:-1]
+        productions = self.get_productions_from_string(production_string)
+        for production in reversed(productions):
+            if self.is_nonterminal(production):
+                new_stack.append(production)
+        new_lambda_stack = {**lambda_stack}  # TODO(mattg): finish this
+        new_state = GrammarState(nonterminal_stack=new_stack,
+                                 lambda_stack=new_lambda_stack,
+                                 valid_actions=valid_actions,
+                                 action_indices=action_indices)
+        return new_stack
+
+    @staticmethod
+    def get_productions_from_string(production_string: str) -> List[str]:
+        """
+        Takes a string like '[<d,d>, d]' and parses it into a list like ['<d,d>', 'd'].  For
+        production strings that are not lists, like '<e,d>', we return a single-element list:
+        ['<e,d>'].
+        """
+        if production_string[0] == '[':
+            return production_string[1:-1].split(', ')
+        else:
+            return [production_string]
+
+    @staticmethod
+    def is_nonterminal(production: str) -> bool:
+        # TODO(mattg): ProductionRuleField has a similar method, as does another place or two.  We
+        # should centralize this logic somewhere, probably in the type declaration, or the
+        # ``World`` object.
+        if production[0] == '<':
+            return True
+        if production.startswith('fb:'):
+            return False
+        if len(production) > 1 or production == "x":
+            return False
+        return production[0].islower()
+

--- a/allennlp/data/semparse/type_declarations/grammar_state.py
+++ b/allennlp/data/semparse/type_declarations/grammar_state.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 
 class GrammarState:
@@ -50,7 +50,7 @@ class GrammarState:
 
     def __init__(self,
                  nonterminal_stack: List[str],
-                 lambda_stacks: Dict[str, List[str]],
+                 lambda_stacks: Dict[Tuple[str, str], List[str]],
                  valid_actions: Dict[str, List[int]],
                  action_indices: Dict[str, int]) -> None:
         self._nonterminal_stack = nonterminal_stack

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -411,3 +411,6 @@ def get_valid_actions(name_mapping: Dict[str, str],
                 for head, production in _get_complex_type_productions(substituted_type.second):
                     valid_actions[head].add(production)
     return valid_actions
+
+
+START_TYPE = NamedBasicType('@START@')

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -7,7 +7,7 @@ improvements:
 We also extend NLTK's ``LogicParser`` to define a ``DynamicTypeLogicParser`` that knows how to deal with the
 two improvements above.
 """
-from typing import Dict, Set, Optional, List, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 from collections import defaultdict
 import re
 
@@ -355,8 +355,8 @@ def _get_placeholder_actions(complex_type: ComplexType,
                     application_type = complex_type.get_application_type(input_type)
                     production = _make_production_string(application_type, [complex_type, input_type])
                     valid_actions[application_type].add(production)
-            for head, production in _get_complex_type_productions(application_type):
-                valid_actions[head].add(production)
+                    for head, production in _get_complex_type_productions(application_type):
+                        valid_actions[head].add(production)
     else:
         for basic_type in basic_types:
             second_type = _substitute_placeholder_type(complex_type.second, basic_type)
@@ -370,7 +370,7 @@ def get_valid_actions(name_mapping: Dict[str, str],
                       type_signatures: Dict[str, Type],
                       basic_types: Set[Type],
                       valid_starting_types: Set[Type] = None,
-                      num_nested_lambdas: int = 0) -> Dict[str, Set[str]]:
+                      num_nested_lambdas: int = 0) -> Dict[str, List[str]]:
     """
     Generates all the valid actions starting from each non-terminal. For terminals of a specific
     type, we simply add a production from the type to the terminal. Among those types, we keep
@@ -421,12 +421,10 @@ def get_valid_actions(name_mapping: Dict[str, str],
         # Type to terminal productions.
         for substituted_type in _substitute_any_type(name_type, basic_types):
             valid_actions[substituted_type].add(_make_production_string(substituted_type, name))
-            print(str(substituted_type), substituted_type, name)
         # Keeping track of complex types.
         if isinstance(name_type, ComplexType) and name_type != ANY_TYPE:
             complex_types.add(name_type)
 
-    print('COMPLEX TYPES')
     for complex_type in complex_types:
         if isinstance(complex_type, PlaceholderType):
             _get_placeholder_actions(complex_type, basic_types, valid_actions)
@@ -443,15 +441,11 @@ def get_valid_actions(name_mapping: Dict[str, str],
     for i in range(num_nested_lambdas):
         lambda_var = chr(ord('x') + i)
         for key, values in valid_actions.items():
-            if str(key) == 'e':
-                print('e:', values)
             if isinstance(key, ComplexType) and not isinstance(key, PlaceholderType):
-                production_string = _make_production_string(key.first,
-                                                            ['lambda ' + lambda_var, key.second])
+                production_string = _make_production_string(key, ['lambda ' + lambda_var, key.second])
                 values.add(production_string)
-                print(str(key), production_string)
 
-    valid_action_strings = {str(key): value for key, value in valid_actions.items()}
+    valid_action_strings = {str(key): sorted(value) for key, value in valid_actions.items()}
     return valid_action_strings
 
 

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -264,6 +264,11 @@ class DynamicTypeLogicParser(LogicParser):
                 raise RuntimeError("Unknown prefix: %s. Did you forget to pass it to the constructor?" % prefix)
         return super(DynamicTypeLogicParser, self).make_VariableExpression(name)
 
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return self.__dict__ == other.__dict__
+        return NotImplemented
+
 
 def _substitute_any_type(_type: Type, basic_types: Set[BasicType]) -> Set[Type]:
     """

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -420,7 +420,7 @@ def get_valid_actions(name_mapping: Dict[str, str],
 
     complex_types = set()
     for name, alias in name_mapping.items():
-        if name == "lambda":
+        if name in ["lambda", "x", "y", "z"]:
             continue
         name_type = type_signatures[alias]
         # Type to terminal productions.

--- a/allennlp/data/semparse/type_declarations/type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/type_declaration.py
@@ -446,7 +446,11 @@ def get_valid_actions(name_mapping: Dict[str, str],
     for i in range(num_nested_lambdas):
         lambda_var = chr(ord('x') + i)
         for key, values in valid_actions.items():
-            if isinstance(key, ComplexType) and not isinstance(key, PlaceholderType):
+            # We'll only allow lambdas to be functions that take and return basic types as their
+            # arguments, for now.  This is also how we treat lambda variable generation at the
+            # moment, so this check is just enforcing some consistency.  If we need more general
+            # handling of lambdas we'll need to rethink a few things.
+            if isinstance(key, ComplexType) and key.first in basic_types and key.second in basic_types:
                 production_string = _make_production_string(key, ['lambda ' + lambda_var, key.second])
                 values.add(production_string)
 

--- a/allennlp/data/semparse/worlds/nlvr_world.py
+++ b/allennlp/data/semparse/worlds/nlvr_world.py
@@ -2,17 +2,17 @@
 This module defines classes Object and Box (the two entities in the NLVR domain) and an NlvrWorld,
 which mainly contains an execution method and related helper methods.
 """
-
 from collections import defaultdict
 import operator
 from typing import Any, List, Dict, Set, Callable, TypeVar, Union
-from overrides import overrides
 import pyparsing
+
+from nltk.sem.logic import Type
+from overrides import overrides
 
 from allennlp.common import util
 from allennlp.common.util import JsonDict
-from allennlp.data.semparse.type_declarations.nlvr_type_declaration import (COMMON_NAME_MAPPING,
-                                                                            COMMON_TYPE_SIGNATURE)
+from allennlp.data.semparse.type_declarations import nlvr_type_declaration as types
 from allennlp.data.semparse.worlds.world import World
 
 
@@ -94,8 +94,8 @@ class NlvrWorld(World):
     # pylint: disable=too-many-public-methods
     # TODO(pradeep): Define more spatial relationship methods: above, below, left_of, right_of..
     def __init__(self, world_representation: List[List[JsonDict]]) -> None:
-        super(NlvrWorld, self).__init__(global_type_signatures=COMMON_TYPE_SIGNATURE,
-                                        global_name_mapping=COMMON_NAME_MAPPING)
+        super(NlvrWorld, self).__init__(global_type_signatures=types.COMMON_TYPE_SIGNATURE,
+                                        global_name_mapping=types.COMMON_NAME_MAPPING)
         self._boxes = set([Box(object_list, "box%d" % index)
                            for index, object_list in enumerate(world_representation)])
         self._objects: Set[Object] = set()
@@ -103,8 +103,12 @@ class NlvrWorld(World):
             self._objects.update(box.objects)
 
     @overrides
+    def get_basic_types(self) -> Set[Type]:
+        return types.BASIC_TYPES
+
+    @overrides
     def _map_name(self, name: str) -> str:
-        return COMMON_NAME_MAPPING[name] if name in COMMON_NAME_MAPPING else name
+        return types.COMMON_NAME_MAPPING[name] if name in types.COMMON_NAME_MAPPING else name
 
     def _apply_function_list(self,
                              functions: List[str],

--- a/allennlp/data/semparse/worlds/wikitables_world.py
+++ b/allennlp/data/semparse/worlds/wikitables_world.py
@@ -3,12 +3,15 @@ We store all the information related to a world (i.e. the context in which logic
 executed) here. For WikiTableQuestions, this includes a representation of a table, mapping from
 Sempre variables in all logical forms to NLTK variables, and the types of all predicates and entities.
 """
+from typing import List, Set
 import re
+
+from nltk.sem.logic import Type
 from overrides import overrides
 
+from allennlp.data.tokenizers import Token
 from allennlp.data.semparse.worlds.world import World
-from allennlp.data.semparse.type_declarations.wikitables_type_declaration import (COMMON_NAME_MAPPING,
-                                                                                  COMMON_TYPE_SIGNATURE)
+from allennlp.data.semparse.type_declarations import type_declaration as base_types
 from allennlp.data.semparse.type_declarations import wikitables_type_declaration as types
 from allennlp.data.semparse.knowledge_graphs import TableKnowledgeGraph
 
@@ -21,15 +24,54 @@ class WikiTablesWorld(World):
     ----------
     table_graph : ``TableKnowledgeGraph``
         Context associated with this world.
+    question_tokens : ``List[Token]``
+        The tokenized question, which we use to augment our parser output space.  In particular,
+        because there are an infinite number of numbers that we can output, we restrict the space
+        of numbers that we consider to just the numbers that appear in the question, plus a few
+        small numbers.
     """
-    def __init__(self, table_graph: TableKnowledgeGraph) -> None:
+    def __init__(self, table_graph: TableKnowledgeGraph, question_tokens: List[Token]) -> None:
         super(WikiTablesWorld, self).__init__(constant_type_prefixes={"part": types.PART_TYPE,
                                                                       "cell": types.CELL_TYPE},
-                                              global_type_signatures=COMMON_TYPE_SIGNATURE,
-                                              global_name_mapping=COMMON_NAME_MAPPING)
+                                              global_type_signatures=types.COMMON_TYPE_SIGNATURE,
+                                              global_name_mapping=types.COMMON_NAME_MAPPING,
+                                              num_nested_lambdas=1)
         self.table_graph = table_graph
+
         # For every new Sempre column name seen, we update this counter to map it to a new NLTK name.
         self._column_counter = 0
+
+        # This adds all of the cell and column names to our local name mapping, so we can get them
+        # as valid actions in the parser.
+        for entity in table_graph.get_all_entities():
+            self._map_name(entity)
+
+        numbers = self._get_numbers_from_tokens(question_tokens) + list(str(i) for i in range(10))
+        for number in numbers:
+            self._add_name_mapping(number, number, types.CELL_TYPE)
+
+    def _get_numbers_from_tokens(self, tokens: List[Token]) -> List[str]:
+        """
+        Finds numbers in the input tokens and returns them as strings.
+
+        Eventually, we'd want this to detect things like ordinals ("first", "third") and cardinals
+        ("one", "two"), but for now we just look for literal digits, and make up for missing
+        ordinals and cardinals by adding all single-digit numbers as possible numbers to output.
+        """
+        numbers = []
+        for token in tokens:
+            # We'll use a check for float(text) to find numbers, because text.isdigit() doesn't
+            # catch things like "-3" or "0.07".
+            try:
+                float(token.text)
+                numbers.append(token)
+            except ValueError:
+                pass
+        return numbers
+
+    @overrides
+    def get_basic_types(self) -> Set[Type]:
+        return types.BASIC_TYPES
 
     @overrides
     def _map_name(self, name: str) -> str:
@@ -45,7 +87,7 @@ class WikiTablesWorld(World):
         name : str
             Token from Sempre's logical form.
         """
-        if name not in COMMON_NAME_MAPPING and name not in self.local_name_mapping:
+        if name not in types.COMMON_NAME_MAPPING and name not in self.local_name_mapping:
             if name.startswith("fb:row.row"):
                 # Column name
                 translated_name = "C%d" % self._column_counter
@@ -69,8 +111,8 @@ class WikiTablesWorld(World):
                     translated_name = translated_name.replace("-", "~")
                 self._add_name_mapping(name, translated_name)
         else:
-            if name in COMMON_NAME_MAPPING:
-                translated_name = COMMON_NAME_MAPPING[name]
+            if name in types.COMMON_NAME_MAPPING:
+                translated_name = types.COMMON_NAME_MAPPING[name]
             else:
                 translated_name = self.local_name_mapping[name]
         return translated_name

--- a/allennlp/data/semparse/worlds/wikitables_world.py
+++ b/allennlp/data/semparse/worlds/wikitables_world.py
@@ -11,7 +11,6 @@ from overrides import overrides
 
 from allennlp.data.tokenizers import Token
 from allennlp.data.semparse.worlds.world import World
-from allennlp.data.semparse.type_declarations import type_declaration as base_types
 from allennlp.data.semparse.type_declarations import wikitables_type_declaration as types
 from allennlp.data.semparse.knowledge_graphs import TableKnowledgeGraph
 
@@ -58,6 +57,7 @@ class WikiTablesWorld(World):
         ("one", "two"), but for now we just look for literal digits, and make up for missing
         ordinals and cardinals by adding all single-digit numbers as possible numbers to output.
         """
+        # pylint: disable=no-self-use
         numbers = []
         for token in tokens:
             # We'll use a check for float(text) to find numbers, because text.isdigit() doesn't

--- a/allennlp/data/semparse/worlds/wikitables_world.py
+++ b/allennlp/data/semparse/worlds/wikitables_world.py
@@ -64,7 +64,7 @@ class WikiTablesWorld(World):
             # catch things like "-3" or "0.07".
             try:
                 float(token.text)
-                numbers.append(token)
+                numbers.append(token.text)
             except ValueError:
                 pass
         return numbers

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Set
 import pyparsing
 
 from nltk.sem.logic import Expression, LambdaExpression, BasicType, Type

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -67,14 +67,12 @@ class World:
 
     def all_possible_actions(self) -> List[str]:
         all_actions = set()
-        type_set = set()
-        for type_, action_set in self.get_valid_actions().items():
+        for action_set in self.get_valid_actions().values():
             all_actions.update(action_set)
-            type_set.add(type_)
         for i in range(self._num_nested_lambdas):
             lambda_var = chr(ord('x') + i)
-            for type_ in type_set:
-                production = f"{type_} -> {lambda_var}"
+            for basic_type in self.get_basic_types():
+                production = f"{basic_type} -> {lambda_var}"
                 all_actions.add(production)
         return sorted(all_actions)
 

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -69,6 +69,11 @@ class World:
         all_actions = set()
         for action_set in self.get_valid_actions().values():
             all_actions.update(action_set)
+        for i in range(self._num_nested_lambdas):
+            lambda_var = chr(ord('x') + i)
+            for basic_type in self.get_basic_types():
+                production = f"{basic_type} -> {lambda_var}"
+                all_actions.add(production)
         return sorted(all_actions)
 
     def get_basic_types(self) -> Set[Type]:

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -67,12 +67,14 @@ class World:
 
     def all_possible_actions(self) -> List[str]:
         all_actions = set()
-        for action_set in self.get_valid_actions().values():
+        type_set = set()
+        for type_, action_set in self.get_valid_actions().items():
             all_actions.update(action_set)
+            type_set.add(type_)
         for i in range(self._num_nested_lambdas):
             lambda_var = chr(ord('x') + i)
-            for basic_type in self.get_basic_types():
-                production = f"{basic_type} -> {lambda_var}"
+            for type_ in type_set:
+                production = f"{type_} -> {lambda_var}"
                 all_actions.add(production)
         return sorted(all_actions)
 

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -59,15 +59,17 @@ class World:
         # Python 3.5 syntax for merging two dictionaries.
         return {**self.global_type_signatures, **self.local_type_signatures}
 
-    def all_possible_actions(self) -> Set[str]:
-        valid_actions_dict = types.get_valid_actions(self.get_name_mapping(),
-                                                     self.get_type_signatures(),
-                                                     self.get_basic_types(),
-                                                     num_nested_lambdas=self._num_nested_lambdas)
+    def get_valid_actions(self) -> Dict[str, List[str]]:
+        return types.get_valid_actions(self.get_name_mapping(),
+                                       self.get_type_signatures(),
+                                       self.get_basic_types(),
+                                       num_nested_lambdas=self._num_nested_lambdas)
+
+    def all_possible_actions(self) -> List[str]:
         all_actions = set()
-        for key, action_set in valid_actions_dict.items():
+        for action_set in self.get_valid_actions().values():
             all_actions.update(action_set)
-        return all_actions
+        return sorted(all_actions)
 
     def get_basic_types(self) -> Set[Type]:
         raise NotImplementedError

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -162,3 +162,8 @@ class World:
                 original_name = self.reverse_name_mapping[original_name]
             current_transitions.append("%s -> %s" % (expression_type, original_name))
         return current_transitions
+
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return self.__dict__ == other.__dict__
+        return NotImplemented

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -5,7 +5,7 @@ import torch
 from torch.nn.modules.linear import Linear
 
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
+from allennlp.common.checks import check_dimensions_match
 from allennlp.data import Vocabulary
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder, ConditionalRandomField
 from allennlp.models.model import Model
@@ -54,11 +54,8 @@ class CrfTagger(Model):
 
         self.span_metric = SpanBasedF1Measure(vocab, tag_namespace=label_namespace)
 
-        if text_field_embedder.get_output_dim() != encoder.get_input_dim():
-            raise ConfigurationError("The output dimension of the text_field_embedder must match the "
-                                     "input dimension of the phrase_encoder. Found {} and {}, "
-                                     "respectively.".format(text_field_embedder.get_output_dim(),
-                                                            encoder.get_input_dim()))
+        check_dimensions_match(text_field_embedder.get_output_dim(), encoder.get_input_dim(),
+                               "text field embedding dim", "encoder input dim")
         initializer(self)
 
     @overrides

--- a/allennlp/models/decomposable_attention.py
+++ b/allennlp/models/decomposable_attention.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 import torch
 
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
+from allennlp.common.checks import check_dimensions_match
 from allennlp.data import Vocabulary
 from allennlp.models.model import Model
 from allennlp.modules import FeedForward, MatrixAttention
@@ -82,14 +82,10 @@ class DecomposableAttention(Model):
 
         self._num_labels = vocab.get_vocab_size(namespace="labels")
 
-        if text_field_embedder.get_output_dim() != attend_feedforward.get_input_dim():
-            raise ConfigurationError("Output dimension of the text_field_embedder (dim: {}), "
-                                     "must match the input_dim of the FeedForward layer "
-                                     "attend_feedforward, (dim: {}). ".format(text_field_embedder.get_output_dim(),
-                                                                              attend_feedforward.get_input_dim()))
-        if aggregate_feedforward.get_output_dim() != self._num_labels:
-            raise ConfigurationError("Final output dimension (%d) must equal num labels (%d)" %
-                                     (aggregate_feedforward.get_output_dim(), self._num_labels))
+        check_dimensions_match(text_field_embedder.get_output_dim(), attend_feedforward.get_input_dim(),
+                               "text field embedding dim", "attend feedforward input dim")
+        check_dimensions_match(aggregate_feedforward.get_output_dim(), self._num_labels,
+                               "final output dimension", "number of labels")
 
         self._accuracy = CategoricalAccuracy()
         self._loss = torch.nn.CrossEntropyLoss()

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -114,14 +114,14 @@ class WikiTablesSemanticParser(Model):
             ``KnowledgeGraphField``.  This output is similar to a ``TextField`` output, where each
             entity in the table is treated as a "token", and we will use a ``TextFieldEmbedder`` to
             get embeddings for each entity.
-        world : ``ListWikiTablesWorld``
+        world : ``List[WikiTablesWorld]``
             We use a ``MetadataField`` to get the ``World`` for each input instance.  Because of
             how ``MetadataField`` works, this gets passed to us as a ``List[WikiTablesWorld]``,
         actions : ``List[List[ProductionRuleArray]]``
             A list of all possible actions for each ``World`` in the batch, indexed into a
             ``ProductionRuleArray`` using a ``ProductionRuleField``.  We will embed all of these
             and use the embeddings to determine which action to take at each timestep in the
-            decoder.n
+            decoder.
         target_action_sequences : torch.Tensor, optional (default = None)
            A list of possibly valid action sequences, where each action is an index into the list
            of possible actions.  This tensor has shape ``(batch_size, num_action_sequences,
@@ -336,7 +336,7 @@ class WikiTablesSemanticParser(Model):
                 #      "right": (RHS_string, right_is_nonterminal, padded_RHS_tensor_dict)
                 #     }
                 # Technically, the left hand side is _always_ a non-terminal (by definition, you
-                # can't expand a non-terminal), but we'll do this check anyway, in case you did
+                # can't expand a terminal), but we'll do this check anyway, in case you did
                 # something really crazy.
                 if production_rule['left'][1]:  # this is a nonterminal production
                     nonterminals[production_rule['left'][0]] = production_rule['left'][2]

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -139,7 +139,6 @@ class WikiTablesSemanticParser(Model):
         final_encoder_output = encoder_outputs[:, -1]  # (batch_size, encoder_output_dim)
         memory_cell = Variable(encoder_outputs.data.new(batch_size, self._encoder.get_output_dim()).fill_(0))
 
-
         initial_score = Variable(embedded_input.data.new(batch_size).fill_(0))
         attended_question = self._decoder_step.attend_on_question(final_encoder_output,
                                                                   encoder_outputs,

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -215,7 +215,7 @@ class WikiTablesSemanticParser(Model):
         for key, action_strings in valid_actions.items():
             translated_valid_actions[key] = [action_mapping[action_string]
                                              for action_string in action_strings]
-        return GrammarState([START_SYMBOL], {}, translated_valid_actions)
+        return GrammarState([START_SYMBOL], {}, translated_valid_actions, action_mapping)
 
     def _embed_actions(self, actions: List[List[ProductionRuleArray]]) -> Tuple[torch.Tensor,
                                                                                 Dict[Tuple[int, int], int],

--- a/allennlp/models/reading_comprehension/bidaf.py
+++ b/allennlp/models/reading_comprehension/bidaf.py
@@ -6,7 +6,7 @@ from torch.autograd import Variable
 from torch.nn.functional import nll_loss
 
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
+from allennlp.common.checks import check_dimensions_match
 from allennlp.data import Vocabulary
 from allennlp.models.model import Model
 from allennlp.modules import Highway, MatrixAttention
@@ -94,27 +94,14 @@ class BidirectionalAttentionFlow(Model):
         span_end_input_dim = encoding_dim * 4 + span_end_encoding_dim
         self._span_end_predictor = TimeDistributed(torch.nn.Linear(span_end_input_dim, 1))
 
-        # Bidaf has lots of layer dimensions which need to match up - these
-        # aren't necessarily obvious from the configuration files, so we check
-        # here.
-        if modeling_layer.get_input_dim() != 4 * encoding_dim:
-            raise ConfigurationError("The input dimension to the modeling_layer must be "
-                                     "equal to 4 times the encoding dimension of the phrase_layer. "
-                                     "Found {} and 4 * {} respectively.".format(modeling_layer.get_input_dim(),
-                                                                                encoding_dim))
-        if text_field_embedder.get_output_dim() != phrase_layer.get_input_dim():
-            raise ConfigurationError("The output dimension of the text_field_embedder (embedding_dim + "
-                                     "char_cnn) must match the input dimension of the phrase_encoder. "
-                                     "Found {} and {}, respectively.".format(text_field_embedder.get_output_dim(),
-                                                                             phrase_layer.get_input_dim()))
-
-        if span_end_encoder.get_input_dim() != encoding_dim * 4 + modeling_dim * 3:
-            raise ConfigurationError("The input dimension of the span_end_encoder should be equal to "
-                                     "4 * phrase_layer.output_dim + 3 * modeling_layer.output_dim. "
-                                     "Found {} and (4 * {} + 3 * {}) "
-                                     "respectively.".format(span_end_encoder.get_input_dim(),
-                                                            encoding_dim,
-                                                            modeling_dim))
+        # Bidaf has lots of layer dimensions which need to match up - these aren't necessarily
+        # obvious from the configuration files, so we check here.
+        check_dimensions_match(modeling_layer.get_input_dim(), 4 * encoding_dim,
+                               "modeling layer input dim", "4 * encoding dim")
+        check_dimensions_match(text_field_embedder.get_output_dim(), phrase_layer.get_input_dim(),
+                               "text field embedder output dim", "phrase layer input dim")
+        check_dimensions_match(span_end_encoder.get_input_dim(), 4 * encoding_dim + 3 * modeling_dim,
+                               "span end encoder input dim", "4 * encoding dim + 3 * modeling dim")
 
         self._span_start_accuracy = CategoricalAccuracy()
         self._span_end_accuracy = CategoricalAccuracy()

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -7,7 +7,7 @@ from torch.nn.modules.linear import Linear
 import torch.nn.functional as F
 
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
+from allennlp.common.checks import check_dimensions_match
 from allennlp.data import Vocabulary
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder
 from allennlp.models.model import Model
@@ -50,11 +50,8 @@ class SimpleTagger(Model):
         self.tag_projection_layer = TimeDistributed(Linear(self.stacked_encoder.get_output_dim(),
                                                            self.num_classes))
 
-        if text_field_embedder.get_output_dim() != stacked_encoder.get_input_dim():
-            raise ConfigurationError("The output dimension of the text_field_embedder must match the "
-                                     "input dimension of the phrase_encoder. Found {} and {}, "
-                                     "respectively.".format(text_field_embedder.get_output_dim(),
-                                                            stacked_encoder.get_input_dim()))
+        check_dimensions_match(text_field_embedder.get_output_dim(), stacked_encoder.get_input_dim(),
+                               "text field embedding dim", "encoder input dim")
         self.metrics = {
                 "accuracy": CategoricalAccuracy(),
                 "accuracy3": CategoricalAccuracy(top_k=3)

--- a/allennlp/nn/decoding/maximum_marginal_likelihood.py
+++ b/allennlp/nn/decoding/maximum_marginal_likelihood.py
@@ -75,13 +75,8 @@ class MaximumMarginalLikelihood(DecoderTrainer):
         that the mask has the format 1*0* for each item in ``targets`` - that is, once we see our
         first zero, we stop processing that target.
 
-        Because of some implementation details around creating seq2seq datasets, our targets will
-        have a start and end symbol added to them.  We want to ignore the start symbol here,
-        because it's not actually a target, it's an input.
-
-        For example, if ``targets`` is the following tensor: ``[[S, 2, 3], [S, 4, 5]]``, the return
-        value will be: ``{(): set([2, 4]), (2,): set([3]), (4,): set([5])}`` (note that ``S``,
-        which we use to refer to the start symbol, does not appear in the return value).
+        For example, if ``targets`` is the following tensor: ``[[1, 2, 3], [1, 4, 5]]``, the return
+        value will be: ``{(): set([1]), (1,): set([2, 4]), (1, 2): set([3]), (1, 4): set([5])}``.
 
         We use this to prune the set of actions we consider during decoding, because we only need
         to score the sequences in ``targets``.
@@ -100,8 +95,8 @@ class MaximumMarginalLikelihood(DecoderTrainer):
             allowed_transitions: Dict[Tuple[int, ...], Set[int]] = defaultdict(set)
             for i, target_sequence in enumerate(instance_targets):
                 history: Tuple[int, ...] = ()
-                for j, action in enumerate(target_sequence[1:]):
-                    if instance_mask and instance_mask[i][j + 1] == 0:  # +1 because we start at index 1, not 0
+                for j, action in enumerate(target_sequence):
+                    if instance_mask and instance_mask[i][j] == 0:
                         break
                     allowed_transitions[history].add(action)
                     history = history + (action,)

--- a/allennlp/nn/decoding/maximum_marginal_likelihood.py
+++ b/allennlp/nn/decoding/maximum_marginal_likelihood.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 import torch
 from torch.autograd import Variable
@@ -32,7 +32,7 @@ class MaximumMarginalLikelihood(DecoderTrainer):
     def decode(self,
                initial_state: DecoderState,
                decode_step: DecoderStep,
-               targets: Union[torch.Tensor, List[List[List[Action]]]],
+               targets: Union[torch.Tensor, List[List[List[int]]]],
                target_mask: Optional[torch.Tensor] = None) -> Dict[str, torch.Tensor]:
         allowed_transitions = self._create_allowed_transitions(targets, target_mask)
         finished_states = []
@@ -86,7 +86,7 @@ class MaximumMarginalLikelihood(DecoderTrainer):
         We use this to prune the set of actions we consider during decoding, because we only need
         to score the sequences in ``targets``.
         """
-        batched_allowed_transitions: List[Dict[Tuple[Action, ...], Set[Action]]] = []
+        batched_allowed_transitions: List[Dict[Tuple[int, ...], Set[int]]] = []
 
         if not isinstance(targets, list):
             assert targets.dim() == 3, "targets tensor needs to be batched!"

--- a/allennlp/nn/decoding/maximum_marginal_likelihood.py
+++ b/allennlp/nn/decoding/maximum_marginal_likelihood.py
@@ -44,13 +44,17 @@ class MaximumMarginalLikelihood(DecoderTrainer):
             # We group together all current states to get more efficient (batched) computation.
             grouped_state = states[0].combine_states(states)
             allowed_actions = self._get_allowed_actions(grouped_state, allowed_transitions)
+            num_states = 0
             for next_state in decode_step.take_step(grouped_state, allowed_actions=allowed_actions):
+                num_states += 1
                 finished, not_finished = next_state.split_finished()
                 if finished is not None:
                     finished_states.append(finished)
                 if not_finished is not None:
                     next_states.append(not_finished)
             states = next_states
+            if num_states != sum(len(actions) for actions in allowed_actions):
+                raise RuntimeError("Not all allowed states taken!")
 
         # This is a dictionary of lists - for each batch instance, we want the score of all
         # finished states.  So this has shape (batch_size, num_target_action_sequences), though

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -1,7 +1,7 @@
 """
 Assorted utilities for working with neural networks in AllenNLP.
 """
-
+from collections import defaultdict
 from typing import Dict, List, Optional, Any, Tuple, Callable
 import logging
 
@@ -33,11 +33,39 @@ def get_lengths_from_binary_sequence_mask(mask: torch.Tensor):
     return mask.long().sum(-1)
 
 
+def batch_tensor_dicts(tensor_dicts: List[Dict[str, torch.Tensor]],
+                       remove_trailing_dimension: bool = False) -> Dict[str, torch.Tensor]:
+    """
+    Takes a list of tensor dictionaries, where each dictionary is assumed to have matching keys,
+    and returns a single dictionary with all tensors with the same key batched together.
+
+    Parameters
+    ----------
+    tensor_dicts : ``List[Dict[str, torch.Tensor]]``
+        The list of tensor dictionaries to batch.
+    remove_trailing_dimension : ``bool``
+        If ``True``, we will check for a trailing dimension of size 1 on the tensors that are being
+        batched, and remove it if it find it.
+    """
+    key_to_tensors: Dict[str, List[torch.Tensor]] = defaultdict(list)
+    for tensor_dict in tensor_dicts:
+        for key, tensor in tensor_dict.items():
+            key_to_tensors[key].append(tensor)
+    batched_tensors = {}
+    for key, tensor_list in key_to_tensors.items():
+        batched_tensor = torch.stack(tensor_list)
+        if remove_trailing_dimension:
+            if set(tensor.size(-1) for tensor in tensor_list) == set([1]):
+                batched_tensor = batched_tensor.squeeze(-1)
+        batched_tensors[key] = batched_tensor
+    return batched_tensors
+
+
 def get_mask_from_sequence_lengths(sequence_lengths: Variable, max_length: int) -> Variable:
     """
     Given a variable of shape ``(batch_size,)`` that represents the sequence lengths of each batch
-    element, this function returns a ``(batch_size, max_length)`` mask variable.  For example, if our
-    input was ``[2, 2, 3]``, with a ``max_length`` of 4, we'd return
+    element, this function returns a ``(batch_size, max_length)`` mask variable.  For example, if
+    our input was ``[2, 2, 3]``, with a ``max_length`` of 4, we'd return
     ``[[1, 1, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0]]``.
 
     We require ``max_length`` here instead of just computing it from the input ``sequence_lengths``
@@ -627,20 +655,21 @@ def batched_index_select(target: torch.Tensor,
                          indices: torch.LongTensor,
                          flattened_indices: Optional[torch.LongTensor] = None) -> torch.Tensor:
     """
-    The given `indices` of size ``(batch_size, d_1, ..., d_n)`` indexes into the sequence dimension
-    (dimension 2) of the target, which has size ``(batch_size, sequence_length, embedding_size)``.
+    The given ``indices`` of size ``(batch_size, d_1, ..., d_n)`` indexes into the sequence
+    dimension (dimension 2) of the target, which has size ``(batch_size, sequence_length,
+    embedding_size)``.
 
     This function returns selected values in the target with respect to the provided indices, which
-    have size ``(batch_size, d_1, ..., d_n, embedding_size)``. This can use the optionally precomputed
-    :func:`~flattened_indices` with size ``(batch_size * d_1 * ... * d_n)`` if given.
+    have size ``(batch_size, d_1, ..., d_n, embedding_size)``. This can use the optionally
+    precomputed :func:`~flattened_indices` with size ``(batch_size * d_1 * ... * d_n)`` if given.
 
     An example use case of this function is looking up the start and end indices of spans in a
     sequence tensor. This is used in the
     :class:`~allennlp.models.coreference_resolution.CoreferenceResolver`. Model to select
-    contextual word representations corresponding to the start and end indices of mentions. The
-    key reason this can't be done with basic torch functions is that we want to be able to use
-    look-up tensors with an arbitrary number of dimensions (for example, in the coref model,
-    we don't know a-priori how many spans we are looking up).
+    contextual word representations corresponding to the start and end indices of mentions. The key
+    reason this can't be done with basic torch functions is that we want to be able to use look-up
+    tensors with an arbitrary number of dimensions (for example, in the coref model, we don't know
+    a-priori how many spans we are looking up).
 
     Parameters
     ----------
@@ -698,7 +727,7 @@ def flattened_index_select(target: torch.Tensor,
         A Tensor of shape (batch_size, set_size, subset_size, embedding_size).
     """
     if indices.dim() != 2:
-        raise ConfigurationError("Indices passed to flatten_index_select had shape {} but "
+        raise ConfigurationError("Indices passed to flattened_index_select had shape {} but "
                                  "only 2 dimensional inputs are supported.".format(indices.size()))
     # Shape: (batch_size, set_size * subset_size, embedding_size)
     flattened_selected = target.index_select(1, indices.view(-1))

--- a/doc/api/allennlp.data.semparse.type_declarations.rst
+++ b/doc/api/allennlp.data.semparse.type_declarations.rst
@@ -20,3 +20,8 @@ allennlp.data.semparse.type_declarations
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. automodule:: allennlp.data.semparse.type_declarations.grammar_state
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -21,14 +21,248 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
 
         # The content of this will be tested indirectly by checking the actions; we'll just make
         # sure we get a WikiTablesWorld object in here.
-        assert isinstance(instance.fields['world'], WikiTablesWorld)
+        assert isinstance(instance.fields['world'].as_tensor({}), WikiTablesWorld)
 
         actions = [action_field.rule for action_field in instance.fields['actions'].field_list]
-        assert len(actions == 0)
-        assert actions == []
+        assert len(actions) == 186
+
+        # This is going to be long, but I think it's worth it, to be sure that all of the actions
+        # we're expecting are present, and there are no extras.
+        assert sorted(actions) == [
+                # Placeholder types
+                "<#1,#1> -> !=",
+                "<#1,#1> -> fb:type.object.type",
+                "<#1,#1> -> var",
+                "<#1,<#1,#1>> -> and",
+                "<#1,<#1,#1>> -> or",
+                "<#1,d> -> count",
+                "<<#1,#2>,<#2,#1>> -> reverse",
+
+                # These complex types are largely just here to build up a few specific functions:
+                # argmin and argmax.  The lambdas inside this are probably unnecessary, but are a
+                # side-effect of how we add lambdas wherever we can.
+                "<<d,d>,d> -> ['lambda x', d]",
+                "<<d,d>,d> -> [<d,<<d,d>,d>>, d]",
+                "<<d,e>,e> -> ['lambda x', e]",
+                "<<d,e>,e> -> [<e,<<d,e>,e>>, e]",
+                "<<d,p>,p> -> ['lambda x', p]",
+                "<<d,p>,p> -> [<p,<<d,p>,p>>, p]",
+                "<<d,r>,r> -> ['lambda x', r]",
+                "<<d,r>,r> -> [<r,<<d,r>,r>>, r]",
+                "<d,<<d,d>,d>> -> ['lambda x', <<d,d>,d>]",
+                "<d,<<d,d>,d>> -> [<d,<d,<<d,d>,d>>>, d]",
+                "<d,<d,<#1,<<d,#1>,#1>>>> -> argmax",
+                "<d,<d,<#1,<<d,#1>,#1>>>> -> argmin",
+                "<d,<d,<<d,d>,d>>> -> ['lambda x', <d,<<d,d>,d>>]",
+                "<d,<d,<<d,d>,d>>> -> [<d,<d,<#1,<<d,#1>,#1>>>>, d]",
+                "<d,<d,d>> -> -",
+                "<d,<d,d>> -> ['lambda x', <d,d>]",
+                "<d,<e,<<d,e>,e>>> -> ['lambda x', <e,<<d,e>,e>>]",
+                "<d,<e,<<d,e>,e>>> -> [<d,<d,<#1,<<d,#1>,#1>>>>, d]",
+                "<d,<p,<<d,p>,p>>> -> ['lambda x', <p,<<d,p>,p>>]",
+                "<d,<p,<<d,p>,p>>> -> [<d,<d,<#1,<<d,#1>,#1>>>>, d]",
+                "<d,<r,<<d,r>,r>>> -> ['lambda x', <r,<<d,r>,r>>]",
+                "<d,<r,<<d,r>,r>>> -> [<d,<d,<#1,<<d,#1>,#1>>>>, d]",
+
+                # Operations that manipulate numbers.
+                # TODO(mattg): question for Pradeep: why aren't these two-argument functions?
+                "<d,d> -> <",
+                "<d,d> -> <=",
+                "<d,d> -> >",
+                "<d,d> -> >=",
+                "<d,d> -> ['lambda x', d]",
+                "<d,d> -> [<#1,<#1,#1>>, d]",
+                "<d,d> -> [<<#1,#2>,<#2,#1>>, <d,d>]",
+                "<d,d> -> [<d,<d,d>>, d]",
+                # These are single-argument functions because the "d" type here actually represents
+                # a set, and we're performing some aggregation over the set and returning a single
+                # number (actually a set with a single number in it).
+                "<d,d> -> avg",
+                "<d,d> -> max",
+                "<d,d> -> min",
+                "<d,d> -> sum",
+                "<d,e> -> ['lambda x', e]",
+                "<d,e> -> [<<#1,#2>,<#2,#1>>, <e,d>]",
+                # TODO(mattg): isn't this backwards?  Aren't these functions that take cells and
+                # return numbers?
+                "<d,e> -> fb:cell.cell.date",
+                "<d,e> -> fb:cell.cell.num2",
+                "<d,e> -> fb:cell.cell.number",
+                "<d,p> -> ['lambda x', p]",
+                "<d,p> -> [<<#1,#2>,<#2,#1>>, <p,d>]",
+                "<d,r> -> ['lambda x', r]",
+                "<d,r> -> [<<#1,#2>,<#2,#1>>, <r,d>]",
+                "<d,r> -> fb:row.row.index",
+
+                # Now we get to the CELL_TYPE, which is represented by "e".
+                "<e,<<d,e>,e>> -> ['lambda x', <<d,e>,e>]",
+                "<e,<<d,e>,e>> -> [<d,<e,<<d,e>,e>>>, d]",
+                "<e,<e,<e,d>>> -> ['lambda x', <e,<e,d>>]",
+                # TODO(mattg): why is this so complicated?
+                "<e,<e,<e,d>>> -> date",
+                "<e,<e,d>> -> ['lambda x', <e,d>]",
+                "<e,<e,d>> -> [<e,<e,<e,d>>>, e]",
+                "<e,d> -> ['lambda x', d]",
+                "<e,d> -> [<<#1,#2>,<#2,#1>>, <d,e>]",
+                "<e,d> -> [<e,<e,d>>, e]",
+                "<e,d> -> number",
+                "<e,e> -> ['lambda x', e]",
+                "<e,e> -> [<#1,<#1,#1>>, e]",
+                "<e,e> -> [<<#1,#2>,<#2,#1>>, <e,e>]",
+                "<e,p> -> ['lambda x', p]",
+                "<e,p> -> [<<#1,#2>,<#2,#1>>, <p,e>]",
+                "<e,r> -> ['lambda x', r]",
+                "<e,r> -> [<<#1,#2>,<#2,#1>>, <r,e>]",
+
+                # These are instance-specific production rules.  These are the columns in the
+                # table.
+                # TODO(mattg): this also seems backwards.
+                "<e,r> -> fb:row.row.avg_attendance",
+                "<e,r> -> fb:row.row.division",
+                "<e,r> -> fb:row.row.league",
+                "<e,r> -> fb:row.row.open_cup",
+                "<e,r> -> fb:row.row.playoffs",
+                "<e,r> -> fb:row.row.regular_season",
+                "<e,r> -> fb:row.row.year",
+
+                # PART_TYPE rules.
+                # TODO(mattg): what is a cell part?
+                "<p,<<d,p>,p>> -> ['lambda x', <<d,p>,p>]",
+                "<p,<<d,p>,p>> -> [<d,<p,<<d,p>,p>>>, d]",
+                "<p,d> -> ['lambda x', d]",
+                "<p,d> -> [<<#1,#2>,<#2,#1>>, <d,p>]",
+                "<p,e> -> ['lambda x', e]",
+                "<p,e> -> [<<#1,#2>,<#2,#1>>, <e,p>]",
+                "<p,e> -> fb:cell.cell.part",
+                "<p,p> -> ['lambda x', p]",
+                "<p,p> -> [<#1,<#1,#1>>, p]",
+                "<p,p> -> [<<#1,#2>,<#2,#1>>, <p,p>]",
+                "<p,r> -> ['lambda x', r]",
+                "<p,r> -> [<<#1,#2>,<#2,#1>>, <r,p>]",
+
+                # Functions that operate on rows.
+                "<r,<<d,r>,r>> -> ['lambda x', <<d,r>,r>]",
+                "<r,<<d,r>,r>> -> [<d,<r,<<d,r>,r>>>, d]",
+                "<r,d> -> ['lambda x', d]",
+                "<r,d> -> [<<#1,#2>,<#2,#1>>, <d,r>]",
+                "<r,e> -> ['lambda x', e]",
+                "<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]",
+                "<r,p> -> ['lambda x', p]",
+                "<r,p> -> [<<#1,#2>,<#2,#1>>, <p,r>]",
+                "<r,r> -> ['lambda x', r]",
+                "<r,r> -> [<#1,<#1,#1>>, r]",
+                "<r,r> -> [<<#1,#2>,<#2,#1>>, <r,r>]",
+                "<r,r> -> fb:row.row.next",
+
+                # All valid start types - we just say that any BASIC_TYPE is a valid start type.
+                "@START@ -> d",
+                "@START@ -> e",
+                "@START@ -> p",
+                "@START@ -> r",
+
+                # Now we get to productions for the basic types.  The first part of each section
+                # here has rules for expanding the basic type with function applications; after
+                # that we get to terminal productions (and a "BASIC_TYPE -> x" rule for lambda
+                # variable productions).
+
+                # Date and numbers.  We don't have any terminal productions for these, as for some
+                # reason terminal numbers are actually represented as CELL_TYPE.
+                "d -> [<#1,#1>, d]",
+                "d -> [<#1,d>, d]",
+                "d -> [<#1,d>, e]",
+                "d -> [<#1,d>, p]",
+                "d -> [<#1,d>, r]",
+                "d -> [<<d,d>,d>, <d,d>]",
+                "d -> [<d,d>, d]",
+                "d -> [<e,d>, e]",
+                "d -> [<p,d>, p]",
+                "d -> [<r,d>, r]",
+                "d -> x",
+
+                # CELL_TYPE productions.  We have some numbers here, whatever numbers showed up in
+                # the question (as digits), as well as some which are hard-coded to cover
+                # ordinals and cardinals that are written out as text.
+                "e -> 0",
+                "e -> 1",
+                "e -> 2",
+                "e -> 3",
+                "e -> 4",
+                "e -> 5",
+                "e -> 6",
+                "e -> 7",
+                "e -> 8",
+                "e -> 9",
+                "e -> [<#1,#1>, e]",
+                "e -> [<<d,e>,e>, <d,e>]",
+                "e -> [<d,e>, d]",
+                "e -> [<e,e>, e]",
+                "e -> [<p,e>, p]",
+                "e -> [<r,e>, r]",
+                # And these are the cells that we saw in the table.
+                "e -> fb:cell.10_727",
+                "e -> fb:cell.11th",
+                "e -> fb:cell.1st",
+                "e -> fb:cell.1st_round",
+                "e -> fb:cell.1st_western",
+                "e -> fb:cell.2",
+                "e -> fb:cell.2001",
+                "e -> fb:cell.2002",
+                "e -> fb:cell.2003",
+                "e -> fb:cell.2004",
+                "e -> fb:cell.2005",
+                "e -> fb:cell.2006",
+                "e -> fb:cell.2007",
+                "e -> fb:cell.2008",
+                "e -> fb:cell.2009",
+                "e -> fb:cell.2010",
+                "e -> fb:cell.2nd",
+                "e -> fb:cell.2nd_pacific",
+                "e -> fb:cell.2nd_round",
+                "e -> fb:cell.3rd_pacific",
+                "e -> fb:cell.3rd_round",
+                "e -> fb:cell.3rd_usl_3rd",
+                "e -> fb:cell.4th_round",
+                "e -> fb:cell.4th_western",
+                "e -> fb:cell.5_575",
+                "e -> fb:cell.5_628",
+                "e -> fb:cell.5_871",
+                "e -> fb:cell.5th",
+                "e -> fb:cell.6_028",
+                "e -> fb:cell.6_260",
+                "e -> fb:cell.6_851",
+                "e -> fb:cell.7_169",
+                "e -> fb:cell.8_567",
+                "e -> fb:cell.9_734",
+                "e -> fb:cell.did_not_qualify",
+                "e -> fb:cell.quarterfinals",
+                "e -> fb:cell.semifinals",
+                "e -> fb:cell.usl_a_league",
+                "e -> fb:cell.usl_first_division",
+                "e -> fb:cell.ussf_d_2_pro_league",
+                "e -> x",
+
+                # We don't have any table-specific productions for PART_TYPE or ROW_TYPE, so these
+                # are just function applications, and one terminal production for rows.
+                "p -> [<#1,#1>, p]",
+                "p -> [<<d,p>,p>, <d,p>]",
+                "p -> [<d,p>, d]",
+                "p -> [<e,p>, e]",
+                "p -> [<p,p>, p]",
+                "p -> [<r,p>, r]",
+                "p -> x",
+                "r -> [<#1,#1>, r]",
+                "r -> [<<d,r>,r>, <d,r>]",
+                "r -> [<d,r>, d]",
+                "r -> [<e,r>, e]",
+                "r -> [<p,r>, p]",
+                "r -> [<r,r>, r]",
+                "r -> fb:type.row",
+                "r -> x",
+                ]
 
         action_sequence = instance.fields["target_action_sequences"].field_list[0]
-        actions = [l.label for l in action_sequence.field_list]
+        action_indices = [l.sequence_index for l in action_sequence.field_list]
+        actions = [actions[i] for i in action_indices]
         assert actions == ['@START@ -> d', 'd -> [<d,d>, d]', '<d,d> -> max', 'd -> [<e,d>, e]',
                            '<e,d> -> [<<#1,#2>,<#2,#1>>, <d,e>]', '<<#1,#2>,<#2,#1>> -> reverse',
                            '<d,e> -> fb:cell.cell.date', 'e -> [<r,e>, r]',

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-self-use
 from allennlp.data.dataset_readers import WikiTablesDatasetReader
+from allennlp.data.semparse.worlds import WikiTablesWorld
 from allennlp.common.testing import AllenNlpTestCase
 
 
@@ -11,17 +12,26 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
         dataset = reader.read("tests/fixtures/data/wikitables/sample_data.examples")
         assert len(dataset.instances) == 2
         instance = dataset.instances[0]
-        action_sequence = instance.fields["target_action_sequences"].field_list[0]
-        actions = [l.label for l in action_sequence.field_list]
         question_tokens = ["what", "was", "the", "last", "year", "where", "this", "team", "was",
                            "a", "part", "of", "the", "usl", "a", "-", "league", "?"]
         assert [t.text for t in instance.fields["question"].tokens] == question_tokens
-        assert actions == ['@@START@@', 'd', 'd -> [<d,d>, d]', '<d,d> -> max', 'd -> [<e,d>, e]',
+        entities = instance.fields['table'].knowledge_graph.get_all_entities()
+        assert len(entities) == 47
+        assert 'fb:row.row.year' in entities
+
+        # The content of this will be tested indirectly by checking the actions; we'll just make
+        # sure we get a WikiTablesWorld object in here.
+        assert isinstance(instance.fields['world'], WikiTablesWorld)
+
+        actions = [action_field.rule for action_field in instance.fields['actions'].field_list]
+        assert len(actions == 0)
+        assert actions == []
+
+        action_sequence = instance.fields["target_action_sequences"].field_list[0]
+        actions = [l.label for l in action_sequence.field_list]
+        assert actions == ['@START@ -> d', 'd -> [<d,d>, d]', '<d,d> -> max', 'd -> [<e,d>, e]',
                            '<e,d> -> [<<#1,#2>,<#2,#1>>, <d,e>]', '<<#1,#2>,<#2,#1>> -> reverse',
                            '<d,e> -> fb:cell.cell.date', 'e -> [<r,e>, r]',
                            '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]', '<<#1,#2>,<#2,#1>> -> reverse',
                            '<e,r> -> fb:row.row.year', 'r -> [<e,r>, e]', '<e,r> -> fb:row.row.league',
-                           'e -> fb:cell.usl_a_league', '@@END@@']
-        entities = instance.fields['table'].knowledge_graph.get_all_entities()
-        assert len(entities) == 47
-        assert 'fb:row.row.year' in entities
+                           'e -> fb:cell.usl_a_league']

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -24,7 +24,7 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
         assert isinstance(instance.fields['world'].as_tensor({}), WikiTablesWorld)
 
         actions = [action_field.rule for action_field in instance.fields['actions'].field_list]
-        assert len(actions) == 186
+        assert len(actions) == 171
 
         # This is going to be long, but I think it's worth it, to be sure that all of the actions
         # we're expecting are present, and there are no extras.
@@ -39,29 +39,18 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
                 "<<#1,#2>,<#2,#1>> -> reverse",
 
                 # These complex types are largely just here to build up a few specific functions:
-                # argmin and argmax.  The lambdas inside this are probably unnecessary, but are a
-                # side-effect of how we add lambdas wherever we can.
-                "<<d,d>,d> -> ['lambda x', d]",
+                # argmin and argmax.
                 "<<d,d>,d> -> [<d,<<d,d>,d>>, d]",
-                "<<d,e>,e> -> ['lambda x', e]",
                 "<<d,e>,e> -> [<e,<<d,e>,e>>, e]",
-                "<<d,p>,p> -> ['lambda x', p]",
                 "<<d,p>,p> -> [<p,<<d,p>,p>>, p]",
-                "<<d,r>,r> -> ['lambda x', r]",
                 "<<d,r>,r> -> [<r,<<d,r>,r>>, r]",
-                "<d,<<d,d>,d>> -> ['lambda x', <<d,d>,d>]",
                 "<d,<<d,d>,d>> -> [<d,<d,<<d,d>,d>>>, d]",
                 "<d,<d,<#1,<<d,#1>,#1>>>> -> argmax",
                 "<d,<d,<#1,<<d,#1>,#1>>>> -> argmin",
-                "<d,<d,<<d,d>,d>>> -> ['lambda x', <d,<<d,d>,d>>]",
                 "<d,<d,<<d,d>,d>>> -> [<d,<d,<#1,<<d,#1>,#1>>>>, d]",
                 "<d,<d,d>> -> -",
-                "<d,<d,d>> -> ['lambda x', <d,d>]",
-                "<d,<e,<<d,e>,e>>> -> ['lambda x', <e,<<d,e>,e>>]",
                 "<d,<e,<<d,e>,e>>> -> [<d,<d,<#1,<<d,#1>,#1>>>>, d]",
-                "<d,<p,<<d,p>,p>>> -> ['lambda x', <p,<<d,p>,p>>]",
                 "<d,<p,<<d,p>,p>>> -> [<d,<d,<#1,<<d,#1>,#1>>>>, d]",
-                "<d,<r,<<d,r>,r>>> -> ['lambda x', <r,<<d,r>,r>>]",
                 "<d,<r,<<d,r>,r>>> -> [<d,<d,<#1,<<d,#1>,#1>>>>, d]",
 
                 # Operations that manipulate numbers.
@@ -95,12 +84,9 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
                 "<d,r> -> fb:row.row.index",
 
                 # Now we get to the CELL_TYPE, which is represented by "e".
-                "<e,<<d,e>,e>> -> ['lambda x', <<d,e>,e>]",
                 "<e,<<d,e>,e>> -> [<d,<e,<<d,e>,e>>>, d]",
-                "<e,<e,<e,d>>> -> ['lambda x', <e,<e,d>>]",
                 # TODO(mattg): why is this so complicated?
                 "<e,<e,<e,d>>> -> date",
-                "<e,<e,d>> -> ['lambda x', <e,d>]",
                 "<e,<e,d>> -> [<e,<e,<e,d>>>, e]",
                 "<e,d> -> ['lambda x', d]",
                 "<e,d> -> [<<#1,#2>,<#2,#1>>, <d,e>]",
@@ -127,7 +113,6 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
 
                 # PART_TYPE rules.
                 # TODO(mattg): what is a cell part?
-                "<p,<<d,p>,p>> -> ['lambda x', <<d,p>,p>]",
                 "<p,<<d,p>,p>> -> [<d,<p,<<d,p>,p>>>, d]",
                 "<p,d> -> ['lambda x', d]",
                 "<p,d> -> [<<#1,#2>,<#2,#1>>, <d,p>]",
@@ -141,7 +126,6 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
                 "<p,r> -> [<<#1,#2>,<#2,#1>>, <r,p>]",
 
                 # Functions that operate on rows.
-                "<r,<<d,r>,r>> -> ['lambda x', <<d,r>,r>]",
                 "<r,<<d,r>,r>> -> [<d,<r,<<d,r>,r>>>, d]",
                 "<r,d> -> ['lambda x', d]",
                 "<r,d> -> [<<#1,#2>,<#2,#1>>, <d,r>]",

--- a/tests/data/semparse/type_declarations/grammar_state_test.py
+++ b/tests/data/semparse/type_declarations/grammar_state_test.py
@@ -1,0 +1,100 @@
+# pylint: disable=no-self-use,invalid-name
+import pytest
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.semparse.type_declarations import GrammarState
+
+
+class TestGrammarState(AllenNlpTestCase):
+    def test_is_finished_just_uses_nonterminal_stack(self):
+        state = GrammarState(['s'], {}, {}, {})
+        assert not state.is_finished()
+        state = GrammarState([], {}, {}, {})
+        assert state.is_finished()
+
+    def test_get_valid_actions_uses_top_of_stack(self):
+        state = GrammarState(['s'], {}, {'s': [1, 2], 't': [3, 4]}, {})
+        assert state.get_valid_actions() == [1,2]
+        state = GrammarState(['t'], {}, {'s': [1, 2], 't': [3, 4]}, {})
+        assert state.get_valid_actions() == [3,4]
+        state = GrammarState(['e'], {}, {'s': [1, 2], 't': [3, 4], 'e': []}, {})
+        assert state.get_valid_actions() == []
+
+    def test_get_valid_actions_adds_lambda_productions(self):
+        state = GrammarState(['s'], {('s', 'x'): ['s']}, {'s': [1, 2]}, {'s -> x': 5})
+        assert state.get_valid_actions() == [1,2,5]
+        # We're doing this assert twice to make sure we haven't accidentally modified the state.
+        assert state.get_valid_actions() == [1,2,5]
+
+    def test_get_valid_actions_adds_lambda_productions_only_for_correct_type(self):
+        state = GrammarState(['t'], {('s', 'x'): ['t']}, {'s': [1, 2], 't': [3, 4]}, {'s -> x': 5})
+        assert state.get_valid_actions() == [3,4]
+        # We're doing this assert twice to make sure we haven't accidentally modified the state.
+        assert state.get_valid_actions() == [3,4]
+
+    def test_take_action_gives_correct_next_states_with_non_lambda_productions(self):
+        # state.take_action() doesn't read or change these objects, it just passes them through, so
+        # we'll use some sentinels to be sure of that.
+        valid_actions = object()
+        action_indices = object()
+
+        state = GrammarState(['s'], {}, valid_actions, action_indices)
+        next_state = state.take_action('s', '[t, r]')
+        expected_next_state = GrammarState(['r', 't'], {}, valid_actions, action_indices)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+        state = GrammarState(['r', 't'], {}, valid_actions, action_indices)
+        next_state = state.take_action('t', 'identity')
+        expected_next_state = GrammarState(['r'], {}, valid_actions, action_indices)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+    def test_take_action_crashes_with_mismatched_types(self):
+        with pytest.raises(AssertionError):
+            state = GrammarState(['s'], {}, {}, {})
+            state.take_action('t', 'identity')
+
+    def test_take_action_gives_correct_next_states_with_lambda_productions(self):
+        # state.take_action() doesn't read or change these objects, it just passes them through, so
+        # we'll use some sentinels to be sure of that.
+        valid_actions = object()
+        action_indices = object()
+
+        state = GrammarState(['t', '<s,d>'], {}, valid_actions, action_indices)
+        next_state = state.take_action('<s,d>', '[lambda x, d]')
+        expected_next_state = GrammarState(['t', 'd'],
+                                           {('s', 'x'): ['d']},
+                                           valid_actions,
+                                           action_indices)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+        state = expected_next_state
+        next_state = state.take_action('d', '[<s,r>, d]')
+        expected_next_state = GrammarState(['t', 'd', '<s,r>'],
+                                           {('s', 'x'): ['d', '<s,r>']},
+                                           valid_actions,
+                                           action_indices)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+        state = expected_next_state
+        next_state = state.take_action('<s,r>', '[lambda y, r]')
+        expected_next_state = GrammarState(['t', 'd', 'r'],
+                                           {('s', 'x'): ['d', 'r'], ('s', 'y'): ['r']},
+                                           valid_actions,
+                                           action_indices)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+        state = expected_next_state
+        next_state = state.take_action('r', 'identity')
+        expected_next_state = GrammarState(['t', 'd'],
+                                           {('s', 'x'): ['d']},
+                                           valid_actions,
+                                           action_indices)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+        state = expected_next_state
+        next_state = state.take_action('d', 'x')
+        expected_next_state = GrammarState(['t'],
+                                           {},
+                                           valid_actions,
+                                           action_indices)
+        assert next_state.__dict__ == expected_next_state.__dict__

--- a/tests/data/semparse/type_declarations/type_declaration_test.py
+++ b/tests/data/semparse/type_declarations/type_declaration_test.py
@@ -21,11 +21,12 @@ class TestTypeResolution(AllenNlpTestCase):
         type_signatures = {'F': ComplexType(type_e, ComplexType(type_r, ComplexType(type_d, type_r)))}
         basic_types = {type_r, type_d, type_e}
         valid_actions = types.get_valid_actions(name_mapping, type_signatures, basic_types)
-        assert len(valid_actions) == 4
+        assert len(valid_actions) == 5
         assert valid_actions["<e,<r,<d,r>>>"] == {"<e,<r,<d,r>>> -> sample_function"}
         assert valid_actions["<r,<d,r>>"] == {"<r,<d,r>> -> [<e,<r,<d,r>>>, e]"}
         assert valid_actions["<d,r>"] == {"<d,r> -> [<r,<d,r>>, r]"}
         assert valid_actions["r"] == {"r -> [<d,r>, d]"}
+        assert valid_actions["@START@"] == {"@START@ -> d", "@START@ -> r", "@START@ -> e"}
 
     def test_get_valid_actions_with_placeholder_type(self):
         type_r = types.NamedBasicType("R")
@@ -36,11 +37,12 @@ class TestTypeResolution(AllenNlpTestCase):
         type_signatures = {'F': types.IdentityType(types.ANY_TYPE, types.ANY_TYPE)}
         basic_types = {type_r, type_d, type_e}
         valid_actions = types.get_valid_actions(name_mapping, type_signatures, basic_types)
-        assert len(valid_actions) == 4
+        assert len(valid_actions) == 5
         assert valid_actions["<#1,#1>"] == {"<#1,#1> -> sample_function"}
         assert valid_actions["e"] == {"e -> [<#1,#1>, e]"}
         assert valid_actions["r"] == {"r -> [<#1,#1>, r]"}
         assert valid_actions["d"] == {"d -> [<#1,#1>, d]"}
+        assert valid_actions["@START@"] == {"@START@ -> d", "@START@ -> r", "@START@ -> e"}
 
     def test_get_valid_actions_with_any_type(self):
         type_r = types.NamedBasicType("R")
@@ -55,11 +57,12 @@ class TestTypeResolution(AllenNlpTestCase):
         type_signatures = {'F': ComplexType(types.ANY_TYPE, type_r)}
         basic_types = {type_r, type_d, type_e}
         valid_actions = types.get_valid_actions(name_mapping, type_signatures, basic_types)
-        assert len(valid_actions) == 4
+        assert len(valid_actions) == 5
         assert valid_actions["<d,r>"] == {"<d,r> -> sample_function"}
         assert valid_actions["<e,r>"] == {"<e,r> -> sample_function"}
         assert valid_actions["<r,r>"] == {"<r,r> -> sample_function"}
         assert valid_actions["r"] == {"r -> [<e,r>, e]", "r -> [<d,r>, d]", "r -> [<r,r>, r]"}
+        assert valid_actions["@START@"] == {"@START@ -> d", "@START@ -> r", "@START@ -> e"}
 
     def test_get_valid_actions_with_reverse(self):
         valid_actions = types.get_valid_actions(wt_types.COMMON_NAME_MAPPING, wt_types.COMMON_TYPE_SIGNATURE,

--- a/tests/data/semparse/type_declarations/type_declaration_test.py
+++ b/tests/data/semparse/type_declarations/type_declaration_test.py
@@ -22,11 +22,11 @@ class TestTypeResolution(AllenNlpTestCase):
         basic_types = {type_r, type_d, type_e}
         valid_actions = types.get_valid_actions(name_mapping, type_signatures, basic_types)
         assert len(valid_actions) == 5
-        assert valid_actions["<e,<r,<d,r>>>"] == {"<e,<r,<d,r>>> -> sample_function"}
-        assert valid_actions["<r,<d,r>>"] == {"<r,<d,r>> -> [<e,<r,<d,r>>>, e]"}
-        assert valid_actions["<d,r>"] == {"<d,r> -> [<r,<d,r>>, r]"}
-        assert valid_actions["r"] == {"r -> [<d,r>, d]"}
-        assert valid_actions["@START@"] == {"@START@ -> d", "@START@ -> r", "@START@ -> e"}
+        assert valid_actions["<e,<r,<d,r>>>"] == ["<e,<r,<d,r>>> -> sample_function"]
+        assert valid_actions["<r,<d,r>>"] == ["<r,<d,r>> -> [<e,<r,<d,r>>>, e]"]
+        assert valid_actions["<d,r>"] == ["<d,r> -> [<r,<d,r>>, r]"]
+        assert valid_actions["r"] == ["r -> [<d,r>, d]"]
+        assert valid_actions["@START@"] == ["@START@ -> d", "@START@ -> e", "@START@ -> r"]
 
     def test_get_valid_actions_with_placeholder_type(self):
         type_r = types.NamedBasicType("R")
@@ -38,11 +38,11 @@ class TestTypeResolution(AllenNlpTestCase):
         basic_types = {type_r, type_d, type_e}
         valid_actions = types.get_valid_actions(name_mapping, type_signatures, basic_types)
         assert len(valid_actions) == 5
-        assert valid_actions["<#1,#1>"] == {"<#1,#1> -> sample_function"}
-        assert valid_actions["e"] == {"e -> [<#1,#1>, e]"}
-        assert valid_actions["r"] == {"r -> [<#1,#1>, r]"}
-        assert valid_actions["d"] == {"d -> [<#1,#1>, d]"}
-        assert valid_actions["@START@"] == {"@START@ -> d", "@START@ -> r", "@START@ -> e"}
+        assert valid_actions["<#1,#1>"] == ["<#1,#1> -> sample_function"]
+        assert valid_actions["e"] == ["e -> [<#1,#1>, e]"]
+        assert valid_actions["r"] == ["r -> [<#1,#1>, r]"]
+        assert valid_actions["d"] == ["d -> [<#1,#1>, d]"]
+        assert valid_actions["@START@"] == ["@START@ -> d", "@START@ -> e", "@START@ -> r"]
 
     def test_get_valid_actions_with_any_type(self):
         type_r = types.NamedBasicType("R")
@@ -58,17 +58,17 @@ class TestTypeResolution(AllenNlpTestCase):
         basic_types = {type_r, type_d, type_e}
         valid_actions = types.get_valid_actions(name_mapping, type_signatures, basic_types)
         assert len(valid_actions) == 5
-        assert valid_actions["<d,r>"] == {"<d,r> -> sample_function"}
-        assert valid_actions["<e,r>"] == {"<e,r> -> sample_function"}
-        assert valid_actions["<r,r>"] == {"<r,r> -> sample_function"}
-        assert valid_actions["r"] == {"r -> [<e,r>, e]", "r -> [<d,r>, d]", "r -> [<r,r>, r]"}
-        assert valid_actions["@START@"] == {"@START@ -> d", "@START@ -> r", "@START@ -> e"}
+        assert valid_actions["<d,r>"] == ["<d,r> -> sample_function"]
+        assert valid_actions["<e,r>"] == ["<e,r> -> sample_function"]
+        assert valid_actions["<r,r>"] == ["<r,r> -> sample_function"]
+        assert valid_actions["r"] == ["r -> [<d,r>, d]", "r -> [<e,r>, e]", "r -> [<r,r>, r]"]
+        assert valid_actions["@START@"] == ["@START@ -> d", "@START@ -> e", "@START@ -> r"]
 
     def test_get_valid_actions_with_reverse(self):
         valid_actions = types.get_valid_actions(wt_types.COMMON_NAME_MAPPING, wt_types.COMMON_TYPE_SIGNATURE,
                                                 wt_types.BASIC_TYPES)
-        assert valid_actions['<d,e>'] == {'<d,e> -> [<<#1,#2>,<#2,#1>>, <e,d>]',
+        assert valid_actions['<d,e>'] == ['<d,e> -> [<<#1,#2>,<#2,#1>>, <e,d>]',
                                           '<d,e> -> fb:cell.cell.date',
-                                          '<d,e> -> fb:cell.cell.number',
-                                          '<d,e> -> fb:cell.cell.num2'
-                                         }
+                                          '<d,e> -> fb:cell.cell.num2',
+                                          '<d,e> -> fb:cell.cell.number'
+                                         ]

--- a/tests/data/semparse/worlds/nlvr_world_test.py
+++ b/tests/data/semparse/worlds/nlvr_world_test.py
@@ -70,7 +70,7 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
         logical_form = "(assert_equals (color (circle (touch_wall (all_objects)))) color_black)"
         expression = nlvr_world.parse_logical_form(logical_form)
         action_sequence = nlvr_world.get_action_sequence(expression)
-        assert action_sequence == ['t', 't -> [<c,t>, c]', '<c,t> -> [<#1,<#1,t>>, c]',
+        assert action_sequence == ['@START@ -> t', 't -> [<c,t>, c]', '<c,t> -> [<#1,<#1,t>>, c]',
                                    '<#1,<#1,t>> -> assert_equals', 'c -> [<o,c>, o]', '<o,c> -> color',
                                    'o -> [<o,o>, o]', '<o,o> -> circle', 'o -> [<o,o>, o]',
                                    '<o,o> -> touch_wall', 'o -> all_objects', 'c -> color_black']
@@ -82,7 +82,7 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
                           1)")
         expression = nlvr_world.parse_logical_form(logical_form)
         action_sequence = nlvr_world.get_action_sequence(expression)
-        assert action_sequence == ['t', 't -> [<e,t>, e]', '<e,t> -> [<e,<e,t>>, e]',
+        assert action_sequence == ['@START@ -> t', 't -> [<e,t>, e]', '<e,t> -> [<e,<e,t>>, e]',
                                    '<e,<e,t>> -> assert_greater_equals', 'e -> [<#1,e>, b]', '<#1,e> -> count',
                                    'b -> [<e,b>, e]', '<e,b> -> [<<b,e>,<e,b>>, <b,e>]',
                                    '<<b,e>,<e,b>> -> [<b,<<b,#1>,<#1,b>>>, b]',

--- a/tests/data/semparse/worlds/wikitables_world_test.py
+++ b/tests/data/semparse/worlds/wikitables_world_test.py
@@ -1,19 +1,23 @@
 # pylint: disable=no-self-use,invalid-name
+from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data.semparse.knowledge_graphs.table_knowledge_graph import TableKnowledgeGraph
 from allennlp.data.semparse.worlds import WikiTablesWorld
-from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.tokenizers import Token
 
 
 class TestWikiTablesWorldRepresentation(AllenNlpTestCase):
     def setUp(self):
         super().setUp()
         table_kg = TableKnowledgeGraph.read_from_file("tests/fixtures/data/wikitables/sample_table.tsv")
-        self.world = WikiTablesWorld(table_kg)
+        question_tokens = [Token(x) for x in ['what', 'was', 'the', 'last', 'year', '?']]
+        self.world = WikiTablesWorld(table_kg, question_tokens)
 
     def test_world_processes_sempre_forms_correctly(self):
         sempre_form = "((reverse fb:row.row.year) (fb:row.row.league fb:cell.usl_a_league))"
         expression = self.world.parse_logical_form(sempre_form)
-        assert str(expression) == "R(C0,C1(cell:usl_a_league))"
+        # We add columns to the name mapping in sorted order, so "league" and "year" end up as C2
+        # and C6.
+        assert str(expression) == "R(C6,C2(cell:usl_a_league))"
 
     def test_world_returns_correct_actions_with_reverse(self):
         sempre_form = "((reverse fb:row.row.year) (fb:row.row.league fb:cell.usl_a_league))"

--- a/tests/data/semparse/worlds/wikitables_world_test.py
+++ b/tests/data/semparse/worlds/wikitables_world_test.py
@@ -19,7 +19,7 @@ class TestWikiTablesWorldRepresentation(AllenNlpTestCase):
         sempre_form = "((reverse fb:row.row.year) (fb:row.row.league fb:cell.usl_a_league))"
         expression = self.world.parse_logical_form(sempre_form)
         actions = self.world.get_action_sequence(expression)
-        target_action_sequence = ['e', 'e -> [<r,e>, r]', '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]',
+        target_action_sequence = ['@START@ -> e', 'e -> [<r,e>, r]', '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]',
                                   '<<#1,#2>,<#2,#1>> -> reverse', '<e,r> -> fb:row.row.year',
                                   'r -> [<e,r>, e]', '<e,r> -> fb:row.row.league', 'e -> fb:cell.usl_a_league']
         assert actions == target_action_sequence
@@ -29,7 +29,7 @@ class TestWikiTablesWorldRepresentation(AllenNlpTestCase):
                        "(fb:row.row.league fb:cell.usl_a_league))))")
         expression = self.world.parse_logical_form(sempre_form)
         actions = self.world.get_action_sequence(expression)
-        target_action_sequence = ['d', 'd -> [<d,d>, d]', '<d,d> -> max', 'd -> [<e,d>, e]',
+        target_action_sequence = ['@START@ -> d', 'd -> [<d,d>, d]', '<d,d> -> max', 'd -> [<e,d>, e]',
                                   '<e,d> -> [<<#1,#2>,<#2,#1>>, <d,e>]', '<<#1,#2>,<#2,#1>> -> reverse',
                                   '<d,e> -> fb:cell.cell.date', 'e -> [<r,e>, r]',
                                   '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]', '<<#1,#2>,<#2,#1>> -> reverse',

--- a/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment.json
+++ b/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment.json
@@ -18,6 +18,28 @@
         "trainable": true
       }
     },
+    "nonterminal_embedder": {
+      "tokens": {
+        "type": "embedding",
+        "vocab_namespace": "rule_labels",
+        "embedding_dim": 25,
+        "trainable": true
+      }
+    },
+    "terminal_embedder": {
+      "token_characters": {
+        "type": "character_encoding",
+        "embedding": {
+          "embedding_dim": 8
+        },
+        "encoder": {
+          "type": "cnn",
+          "embedding_dim": 8,
+          "num_filters": 8,
+          "ngram_filter_sizes": [3]
+        }
+      }
+    },
     "encoder": {
       "type": "lstm",
       "input_size": 25,
@@ -31,8 +53,6 @@
       "beam_size": 3
     },
     "max_decoding_steps": 20,
-    "action_namespace": "actions",
-    "action_embedding_dim": 10,
     "attention_function": {"type": "dot_product"}
   },
   "iterator": {

--- a/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment.json
+++ b/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment.json
@@ -35,7 +35,7 @@
         "encoder": {
           "type": "cnn",
           "embedding_dim": 8,
-          "num_filters": 8,
+          "num_filters": 25,
           "ngram_filter_sizes": [3]
         }
       }

--- a/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,no-self-use
 from allennlp.common.testing import ModelTestCase
 from allennlp.models import WikiTablesSemanticParser
 

--- a/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=invalid-name
 from allennlp.common.testing import ModelTestCase
+from allennlp.models import WikiTablesSemanticParser
 
 
 class WikiTablesSemanticParserTest(ModelTestCase):
@@ -10,3 +11,30 @@ class WikiTablesSemanticParserTest(ModelTestCase):
 
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)
+
+    def test_get_unique_elements(self):
+        # pylint: disable=protected-access
+        production_rules = [
+                # We won't bother with constructing the last element of the ProductionRuleArray
+                # here, the Dict[str, torch.Tensor].  It's not necessary for this test.  We'll just
+                # give each element a unique index that we can check in the resulting dictionaries.
+                # arrays.
+                [{"left": ('r', True, 1), "right": ('d', True, 2)},
+                 {"left": ('r', True, 1), "right": ('c', True, 3)},
+                 {"left": ('d', True, 2), "right": ('entity_1', False, 4)}],
+                [{"left": ('r', True, 1), "right": ('d', True, 2)},
+                 {"left": ('d', True, 2), "right": ('entity_2', False, 5)},
+                 {"left": ('d', True, 2), "right": ('entity_1', False, 4)},
+                 {"left": ('d', True, 2), "right": ('entity_3', False, 6)}]
+                ]
+        nonterminals, terminals = WikiTablesSemanticParser._get_unique_elements(production_rules)
+        assert nonterminals == {
+                'r': 1,
+                'd': 2,
+                'c': 3,
+                }
+        assert terminals == {
+                'entity_1': 4,
+                'entity_2': 5,
+                'entity_3': 6,
+                }

--- a/tests/nn/decoding/maximum_marginal_likelihood_test.py
+++ b/tests/nn/decoding/maximum_marginal_likelihood_test.py
@@ -23,11 +23,11 @@ class TestMaximumMarginalLikelihood(AllenNlpTestCase):
         assert len(result[0]) == 4
         assert result[0][()] == set([1])
         assert result[0][(1,)] == set([2, 4])
-        assert result[0][(1,2)] == set([3])  # note that 7 is not in here; it was masked
-        assert result[0][(1,4)] == set([5])
+        assert result[0][(1, 2)] == set([3])  # note that 7 is not in here; it was masked
+        assert result[0][(1, 4)] == set([5])
 
         # The second instance had two valid action sequence prefixes.
         assert len(result[1]) == 3
         assert result[1][()] == set([1])
         assert result[1][(1,)] == set([3])  # note that 9 is not in here; it was masked
-        assert result[1][(1,3)] == set([3, 5])
+        assert result[1][(1, 3)] == set([3, 5])

--- a/tests/nn/decoding/maximum_marginal_likelihood_test.py
+++ b/tests/nn/decoding/maximum_marginal_likelihood_test.py
@@ -19,13 +19,15 @@ class TestMaximumMarginalLikelihood(AllenNlpTestCase):
         # There were two instances in this batch.
         assert len(result) == 2
 
-        # The first instance had three valid action sequence prefixes.
-        assert len(result[0]) == 3
-        assert result[0][()] == set([2, 4])
-        assert result[0][(2,)] == set([3])  # note that 7 is not in here; it was masked
-        assert result[0][(4,)] == set([5])
+        # The first instance had four valid action sequence prefixes.
+        assert len(result[0]) == 4
+        assert result[0][()] == set([1])
+        assert result[0][(1,)] == set([2, 4])
+        assert result[0][(1,2)] == set([3])  # note that 7 is not in here; it was masked
+        assert result[0][(1,4)] == set([5])
 
         # The second instance had two valid action sequence prefixes.
-        assert len(result[1]) == 2
-        assert result[1][()] == set([3])  # note that 9 is not in here; it was masked
-        assert result[1][(3,)] == set([3, 5])
+        assert len(result[1]) == 3
+        assert result[1][()] == set([1])
+        assert result[1][(1,)] == set([3])  # note that 9 is not in here; it was masked
+        assert result[1][(1,3)] == set([3, 5])


### PR DESCRIPTION
This PR modifies the `WikiTablesDatasetReader` to use the new `ProductionRuleField`, and the `WikiTablesSemanticParser` to also take the new data format.  It's close, but not quite done.  I ran into a bit of a snag when trying to produce lambda expressions.

The gist of how this works is that we enumerate all possible actions up front, in the `DatasetReader`, so that we can get indexed representations of every possible action.  Then, in the model, we'll embed those representations before decoding, and just _reference_ the embedded vectors when we need them during decoding.  I had a few issues getting a representation for all of the possible actions, and I was able to resolve most of them, but the lambda expressions are giving me trouble.  I'll put a note in the code for the particular spot that's the issue; @pdasigi, if you have any ideas for how to fix this, that'd be great.

Fixes #499