### PR TITLE
Add __str__ and __repr__ to Token class

### DIFF
--- a/allennlp/data/tokenizers/token.py
+++ b/allennlp/data/tokenizers/token.py
@@ -43,3 +43,9 @@ class Token:
         self.dep_ = dep
         self.ent_type_ = ent_type
         self.text_id = text_id
+
+    def __str__(self):
+        return self.text
+
+    def __repr__(self):
+        return self.__str__()


### PR DESCRIPTION
Fixes #624 by adding `__str__` and `__repr__` magic methods to the `Token` class, enabling them to be printed / logged.

Does this need a test? If so, where do you think is a good place?