### PR TITLE
Update install tutorial for PyTorch 0.3, mention python setup.py install

### DIFF
--- a/tutorials/getting_started/installation.md
+++ b/tutorials/getting_started/installation.md
@@ -30,7 +30,7 @@ You can install `allennlp` using pip in three easy steps.
     $ pip install allennlp
     ```
 
-2.  You'll also need to install PyTorch 0.2, following the appropriate instructions
+2.  You'll also need to install PyTorch 0.3, following the appropriate instructions
     for your platform from [their website](http://pytorch.org/).
 
 3.  Finally, you'll need to download spaCy's English models:
@@ -57,7 +57,7 @@ $ INSTALL_TEST_REQUIREMENTS=true scripts/install_requirements.sh
 changing the flag to `false` if you don't want to be able to run tests.
 (Narrator: You want to be able to run tests.)
 
-You'll also need to install PyTorch 0.2, following the appropriate instructions
+You'll also need to install PyTorch 0.3, following the appropriate instructions
 for your platform from [their website](http://pytorch.org/).
 
 Finally, install the package from source:

--- a/tutorials/getting_started/installation.md
+++ b/tutorials/getting_started/installation.md
@@ -47,7 +47,8 @@ A third alternative is to clone from our git repository:
 $ git clone https://github.com/allenai/allennlp.git
 ```
 
-Create a Python 3.6 virtual environment, and run
+Create a Python 3.6 virtual environment, and install the necessary requirements
+by running:
 
 ```bash
 $ INSTALL_TEST_REQUIREMENTS=true scripts/install_requirements.sh
@@ -58,6 +59,12 @@ changing the flag to `false` if you don't want to be able to run tests.
 
 You'll also need to install PyTorch 0.2, following the appropriate instructions
 for your platform from [their website](http://pytorch.org/).
+
+Finally, install the package from source:
+
+```bash
+$ python setup.py install
+```
 
 ## Once You've Installed
 

--- a/tutorials/getting_started/installation.md
+++ b/tutorials/getting_started/installation.md
@@ -60,12 +60,6 @@ changing the flag to `false` if you don't want to be able to run tests.
 You'll also need to install PyTorch 0.3, following the appropriate instructions
 for your platform from [their website](http://pytorch.org/).
 
-Finally, install the package from source:
-
-```bash
-$ python setup.py install
-```
-
 ## Once You've Installed
 
 If you just want to use the models and helper classes that are included with AllenNLP,


### PR DESCRIPTION
I was reading the installation tutorial to figure out how to build from source to contribute, and I noticed that there was no mention of actually running `python setup.py install` to install the cloned version of allennlp. This PR fixes that.

In addition, there are still some mentions of PyTorch 0.2 when it looks like you've moved on to 0.3 --- changed those as well.