### PR TITLE
Add end and optional start tokens to source sentence in seq2seq DatasetReader (fixes #611)

### DIFF
--- a/allennlp/data/dataset_readers/seq2seq.py
+++ b/allennlp/data/dataset_readers/seq2seq.py
@@ -31,7 +31,7 @@ class Seq2SeqDatasetReader(DatasetReader):
         source_tokens: ``TextField`` and
         target_tokens: ``TextField``
 
-    `START_SYMBOL` and `END_SYMBOL` tokens are added to the source and target sequences 
+    `START_SYMBOL` and `END_SYMBOL` tokens are added to the source and target sequences. 
 
     Parameters
     ----------
@@ -49,7 +49,6 @@ class Seq2SeqDatasetReader(DatasetReader):
         ``source_token_indexers``.
     source_add_start_token : bool, (optional, default=True)
         Whether or not to add `START_SYMBOL` to the beginning of the source sequence.
-
     """
     def __init__(self,
                  source_tokenizer: Tokenizer = None,

--- a/allennlp/data/dataset_readers/seq2seq.py
+++ b/allennlp/data/dataset_readers/seq2seq.py
@@ -31,7 +31,7 @@ class Seq2SeqDatasetReader(DatasetReader):
         source_tokens: ``TextField`` and
         target_tokens: ``TextField``
 
-    `START_SYMBOL` and `END_SYMBOL` tokens are added to the source and target sequences. 
+    `START_SYMBOL` and `END_SYMBOL` tokens are added to the source and target sequences.
 
     Parameters
     ----------
@@ -88,7 +88,7 @@ class Seq2SeqDatasetReader(DatasetReader):
         tokenized_source = self._source_tokenizer.tokenize(source_string)
         if self._source_add_start_token:
             tokenized_source.insert(0, Token(START_SYMBOL))
-        tokenized_source.append(Token(END_SYMBOL))        
+        tokenized_source.append(Token(END_SYMBOL))
         source_field = TextField(tokenized_source, self._source_token_indexers)
         if target_string is not None:
             tokenized_target = self._target_tokenizer.tokenize(target_string)

--- a/tests/data/dataset_readers/seq2seq_test.py
+++ b/tests/data/dataset_readers/seq2seq_test.py
@@ -10,21 +10,23 @@ class TestSeq2SeqDatasetReader(AllenNlpTestCase):
 
         assert len(dataset.instances) == 3
         fields = dataset.instances[0].fields
-        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is", "a", "sentence", "@@END@@"]
+        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is", 
+                                                                    "a", "sentence", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "a", "sentence", "@@END@@"]
         fields = dataset.instances[1].fields
-        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is", "another", "@@END@@"]
+        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is", 
+                                                                    "another", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "another", "@@END@@"]
         fields = dataset.instances[2].fields
-        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "all", "these", "sentences", "should", "get",
-                                                                    "copied", "@@END@@"]
+        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "all", "these", "sentences",
+                                                                    "should", "get", "copied", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "all", "these", "sentences",
                                                                     "should", "get", "copied", "@@END@@"]
 
     def test_source_add_start_token(self):
-        reader = Seq2SeqDatasetReader(source_add_start_token = False)
+        reader = Seq2SeqDatasetReader(source_add_start_token=False)
         dataset = reader.read('tests/fixtures/data/seq2seq_copy.tsv')
         
         assert len(dataset.instances) == 3

--- a/tests/data/dataset_readers/seq2seq_test.py
+++ b/tests/data/dataset_readers/seq2seq_test.py
@@ -10,15 +10,26 @@ class TestSeq2SeqDatasetReader(AllenNlpTestCase):
 
         assert len(dataset.instances) == 3
         fields = dataset.instances[0].fields
-        assert [t.text for t in fields["source_tokens"].tokens] == ["this", "is", "a", "sentence"]
+        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is", "a", "sentence", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "a", "sentence", "@@END@@"]
         fields = dataset.instances[1].fields
-        assert [t.text for t in fields["source_tokens"].tokens] == ["this", "is", "another"]
+        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is", "another", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "another", "@@END@@"]
         fields = dataset.instances[2].fields
-        assert [t.text for t in fields["source_tokens"].tokens] == ["all", "these", "sentences", "should", "get",
-                                                                    "copied"]
+        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "all", "these", "sentences", "should", "get",
+                                                                    "copied", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "all", "these", "sentences",
                                                                     "should", "get", "copied", "@@END@@"]
+
+    def test_source_add_start_token(self):
+        reader = Seq2SeqDatasetReader(source_add_start_token = False)
+        dataset = reader.read('tests/fixtures/data/seq2seq_copy.tsv')
+        
+        assert len(dataset.instances) == 3
+        fields = dataset.instances[0].fields
+        assert [t.text for t in fields["source_tokens"].tokens] == ["this", "is", "a", "sentence", "@@END@@"]
+        assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
+                                                                    "a", "sentence", "@@END@@"]
+        

--- a/tests/data/dataset_readers/seq2seq_test.py
+++ b/tests/data/dataset_readers/seq2seq_test.py
@@ -10,12 +10,12 @@ class TestSeq2SeqDatasetReader(AllenNlpTestCase):
 
         assert len(dataset.instances) == 3
         fields = dataset.instances[0].fields
-        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is", 
+        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "a", "sentence", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "a", "sentence", "@@END@@"]
         fields = dataset.instances[1].fields
-        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is", 
+        assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "another", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "another", "@@END@@"]
@@ -28,7 +28,7 @@ class TestSeq2SeqDatasetReader(AllenNlpTestCase):
     def test_source_add_start_token(self):
         reader = Seq2SeqDatasetReader(source_add_start_token=False)
         dataset = reader.read('tests/fixtures/data/seq2seq_copy.tsv')
-        
+
         assert len(dataset.instances) == 3
         fields = dataset.instances[0].fields
         assert [t.text for t in fields["source_tokens"].tokens] == ["this", "is", "a", "sentence", "@@END@@"]

--- a/tests/data/dataset_readers/seq2seq_test.py
+++ b/tests/data/dataset_readers/seq2seq_test.py
@@ -32,4 +32,3 @@ class TestSeq2SeqDatasetReader(AllenNlpTestCase):
         assert [t.text for t in fields["source_tokens"].tokens] == ["this", "is", "a", "sentence", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "a", "sentence", "@@END@@"]
-        


### PR DESCRIPTION
End token is always added to the source while adding the start token is optional. 
Fixes #611.