### PR TITLE
add static `load_line` and `dump_line` methods to predictor to allow non-JSONL formats

### DIFF
--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -23,7 +23,6 @@ predictions using a trained model and its :class:`~allennlp.service.predictors.p
 
 import argparse
 from contextlib import ExitStack
-import json
 import sys
 from typing import Optional, IO, Dict
 
@@ -103,18 +102,18 @@ def _run(predictor: Predictor,
             results = predictor.predict_batch_json(batch_data, cuda_device)
 
         for model_input, output in zip(batch_data, results):
-            string_output = json.dumps(output)
+            string_output = predictor.dump_line(output)
             if print_to_console:
                 print("input: ", model_input)
                 print("prediction: ", string_output)
             if output_file:
-                output_file.write(string_output + "\n")
+                output_file.write(string_output)
 
     batch_json_data = []
     for line in input_file:
         if not line.isspace():
             # Collect batch size amount of data.
-            json_data = json.loads(line)
+            json_data = predictor.load_line(line)
             batch_json_data.append(json_data)
             if len(batch_json_data) == batch_size:
                 _run_predictor(batch_json_data)

--- a/allennlp/service/predictors/bidaf.py
+++ b/allennlp/service/predictors/bidaf.py
@@ -11,10 +11,10 @@ class BidafPredictor(Predictor):
     Wrapper for the :class:`~allennlp.models.bidaf.BidirectionalAttentionFlow` model.
     """
     @overrides
-    def _json_to_instance(self, json: JsonDict) -> Instance:
+    def _json_to_instance(self, obj: JsonDict) -> Instance:
         """
         Expects JSON that looks like ``{"question": "...", "passage": "..."}``.
         """
-        question_text = json["question"]
-        passage_text = json["passage"]
+        question_text = obj["question"]
+        passage_text = obj["passage"]
         return self._dataset_reader.text_to_instance(question_text, passage_text)

--- a/allennlp/service/predictors/coref.py
+++ b/allennlp/service/predictors/coref.py
@@ -19,7 +19,7 @@ class CorefPredictor(Predictor):
         # to also know sentence boundaries to propose valid mentions.
         self._spacy = get_spacy_model("en_core_web_sm", pos_tags=True, parse=True, ner=False)
 
-    def _json_to_instance(self, json: JsonDict) -> Instance:
+    def _json_to_instance(self, obj: JsonDict) -> Instance:
         # We're overriding `predict_json` directly, so we don't need this.  But I'd rather have a
         # useless stub here then make the base class throw a RuntimeError instead of a
         # NotImplementedError - the checking on the base class is worth it.

--- a/allennlp/service/predictors/decomposable_attention.py
+++ b/allennlp/service/predictors/decomposable_attention.py
@@ -11,10 +11,10 @@ class DecomposableAttentionPredictor(Predictor):
     Wrapper for the :class:`~allennlp.models.bidaf.DecomposableAttention` model.
     """
     @overrides
-    def _json_to_instance(self, json: JsonDict) -> Instance:
+    def _json_to_instance(self, obj: JsonDict) -> Instance:
         """
         Expects JSON that looks like ``{"premise": "...", "hypothesis": "..."}``.
         """
-        premise_text = json["premise"]
-        hypothesis_text = json["hypothesis"]
+        premise_text = obj["premise"]
+        hypothesis_text = obj["hypothesis"]
         return self._dataset_reader.text_to_instance(premise_text, hypothesis_text)

--- a/allennlp/service/predictors/semantic_role_labeler.py
+++ b/allennlp/service/predictors/semantic_role_labeler.py
@@ -41,14 +41,14 @@ class SemanticRoleLabelerPredictor(Predictor):
 
         return " ".join(frame)
 
-    def _json_to_instance(self, json: JsonDict) -> Instance:
+    def _json_to_instance(self, obj: JsonDict) -> Instance:
         # We're overriding `predict_json` directly, so we don't need this.  But I'd rather have a
         # useless stub here then make the base class throw a RuntimeError instead of a
         # NotImplementedError - the checking on the base class is worth it.
         raise RuntimeError("this should never be called")
 
     @overrides
-    def _batch_json_to_instances(self, json: List[JsonDict]) -> List[Instance]:
+    def _batch_json_to_instances(self, objs: List[JsonDict]) -> List[Instance]:
         raise NotImplementedError("The SRL Predictor does not currently support batch prediction.")
 
     @overrides

--- a/allennlp/service/predictors/sentence_tagger.py
+++ b/allennlp/service/predictors/sentence_tagger.py
@@ -21,7 +21,7 @@ class SentenceTaggerPredictor(Predictor):
         self._tokenizer = SpacyWordSplitter(language='en_core_web_sm', pos_tags=True)
 
     @overrides
-    def _json_to_instance(self, json: JsonDict) -> Instance:
+    def _json_to_instance(self, obj: JsonDict) -> Instance:
         # We're overriding `predict_json` directly, so we don't need this.  But I'd rather have a
         # useless stub here then make the base class throw a RuntimeError instead of a
         # NotImplementedError - the checking on the base class is worth it.

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -211,7 +211,6 @@ class TestPredict(TestCase):
 
         assert len(results) == 2
         for row in results:
-            print(row)
             assert len(row) == 5
             start_prob, end_prob, span_start, span_end, span = row
             for prob in (start_prob, end_prob):


### PR DESCRIPTION
and then once I imported the `json` library into the base `predictor.py`, I had to rename the `json` variables there, and then in the subclasses.

