### PR TITLE
[WIP / for discussion] Lazy datasets

### DIFF
--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -158,10 +158,13 @@ def train_model(params: Params, serialization_dir: str) -> Model:
     # with the combined instances.
     def combined_generator():
         yield from (instance for key, dataset in all_datasets.items()
-                    for instance in dataset.iterinstances()
+                    for instance in dataset
                     if key in datasets_for_vocab_creation)
 
-    lazy_combined_dataset = LazyDataset(combined_generator)
+    total_instances = sum(dataset.num_instances
+                          for key, dataset in all_datasets.items()
+                          if key in datasets_for_vocab_creation)
+    lazy_combined_dataset = LazyDataset(combined_generator, total_instances)
     vocab = Vocabulary.from_params(params.pop("vocabulary", {}), lazy_combined_dataset)
 
     vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -161,10 +161,7 @@ def train_model(params: Params, serialization_dir: str) -> Model:
                     for instance in dataset
                     if key in datasets_for_vocab_creation)
 
-    total_instances = sum(dataset.num_instances
-                          for key, dataset in all_datasets.items()
-                          if key in datasets_for_vocab_creation)
-    lazy_combined_dataset = LazyDataset(combined_generator, total_instances)
+    lazy_combined_dataset = LazyDataset(combined_generator)
     vocab = Vocabulary.from_params(params.pop("vocabulary", {}), lazy_combined_dataset)
 
     vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -133,7 +133,7 @@ class ModelTestCase(AllenNlpTestCase):
     def ensure_batch_predictions_are_consistent(self):
         self.model.eval()
         single_predictions = []
-        for i, instance in enumerate(self.dataset.instances):
+        for i, instance in enumerate(self.dataset.iterinstances()):
             dataset = Dataset([instance])
             tensors = dataset.as_tensor_dict(dataset.get_padding_lengths(), for_training=False)
             result = self.model(**tensors)

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -7,6 +7,7 @@ from allennlp.commands.train import train_model_from_file
 from allennlp.common import Params
 from allennlp.common.testing.test_case import AllenNlpTestCase
 from allennlp.data import DataIterator, Dataset, DatasetReader, Vocabulary
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.models import Model, load_archive
 
 
@@ -134,7 +135,7 @@ class ModelTestCase(AllenNlpTestCase):
         self.model.eval()
         single_predictions = []
         for i, instance in enumerate(self.dataset):
-            dataset = Dataset([instance])
+            dataset = InMemoryDataset([instance])
             tensors = dataset.as_tensor_dict(dataset.get_padding_lengths(), for_training=False)
             result = self.model(**tensors)
             single_predictions.append(result)

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -133,7 +133,7 @@ class ModelTestCase(AllenNlpTestCase):
     def ensure_batch_predictions_are_consistent(self):
         self.model.eval()
         single_predictions = []
-        for i, instance in enumerate(self.dataset.iterinstances()):
+        for i, instance in enumerate(self.dataset):
             dataset = Dataset([instance])
             tensors = dataset.as_tensor_dict(dataset.get_padding_lengths(), for_training=False)
             result = self.model(**tensors)

--- a/allennlp/data/__init__.py
+++ b/allennlp/data/__init__.py
@@ -3,6 +3,7 @@ from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields.field import DataArray, Field
 from allennlp.data.instance import Instance
 from allennlp.data.iterators.data_iterator import DataIterator
+from allennlp.data.lazy_dataset import LazyDataset
 from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
 from allennlp.data.tokenizers.token import Token
 from allennlp.data.tokenizers.tokenizer import Tokenizer

--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -66,7 +66,7 @@ class Dataset:
         """
         A ``Dataset`` is its own iterator.
         """
-        yield from self._instances
+        return (instance for instance in self._instances)
 
     def get_padding_lengths(self) -> Dict[str, Dict[str, int]]:
         """

--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -4,179 +4,25 @@ For example, when you train a model, you will likely have a *training* dataset a
 """
 
 import logging
-from collections import defaultdict
-from typing import Dict, List, Union, Iterator
-
-import torch
-import tqdm
+from typing import Iterator, Iterable
 
 from allennlp.data.instance import Instance
 from allennlp.data.vocabulary import Vocabulary
-from allennlp.common.checks import ConfigurationError
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-class Dataset:
-    """
-    A collection of :class:`~allennlp.data.instance.Instance` objects.
-    The ``Instances`` have ``Fields``, and the fields
-    could be in an indexed or unindexed state - the ``Dataset`` has methods around indexing the
-    data and converting the data into arrays.
-    """
-    def __init__(self, instances: List[Instance]) -> None:
-        """
-        A Dataset just takes a list of instances in its constructor.  It's important that all
-        subclasses have an identical constructor to this (though possibly with different Instance
-        types).  If you change the constructor, you also have to override all methods in this base
-        class that call the constructor, such as `truncate()`.
-        """
-        all_instance_fields_and_types: List[Dict[str, str]] = [{k: v.__class__.__name__
-                                                                for k, v in x.fields.items()}
-                                                               for x in instances]
-        # Check all the field names and Field types are the same for every instance.
-        if not all([all_instance_fields_and_types[0] == x for x in all_instance_fields_and_types]):
-            raise ConfigurationError("You cannot construct a Dataset with non-homogeneous Instances.")
+class Dataset(Iterable):
+    def __init__(self, num_instances: int = None):
+        self.num_instances = num_instances
 
-        self._instances = instances
-        self.num_instances = len(instances)
-
-        # A Dataset is an ``Iterator[Instance]``, this index ranges over
-        # the instances in each iteration.
-        self.idx = 0
-
-    def truncate(self, max_instances: int):
-        """
-        If there are more instances than ``max_instances`` in this dataset, we truncate the
-        instances to the first ``max_instances``.  This `modifies` the current object, and returns
-        nothing.
-        """
-        if len(self._instances) > max_instances:
-            self._instances = self._instances[:max_instances]
+    def __iter__(self) -> Iterator[Instance]:
+        raise NotImplementedError
 
     def index_instances(self, vocab: Vocabulary):
         """
         Converts all ``UnindexedFields`` in all ``Instances`` in this ``Dataset`` into
         ``IndexedFields``.  This modifies the current object, it does not return a new object.
+        Depending on the subclass implementation, this indexing may occur immediately, or it
+        may not occur until iteration time.
         """
-        logger.info("Indexing dataset")
-        for instance in tqdm.tqdm(self._instances):
-            instance.index_fields(vocab)
-
-    def __iter__(self) -> Iterator[Instance]:
-        """
-        A ``Dataset`` is its own iterator.
-        """
-        return (instance for instance in self._instances)
-
-    def get_padding_lengths(self) -> Dict[str, Dict[str, int]]:
-        """
-        Gets the maximum padding lengths from all ``Instances`` in this dataset.  Each ``Instance``
-        has multiple ``Fields``, and each ``Field`` could have multiple things that need padding.
-        We look at all fields in all instances, and find the max values for each (field_name,
-        padding_key) pair, returning them in a dictionary.
-
-        This can then be used to convert this dataset into arrays of consistent length, or to set
-        model parameters, etc.
-        """
-        padding_lengths: Dict[str, Dict[str, int]] = defaultdict(dict)
-        all_instance_lengths: List[Dict[str, Dict[str, int]]] = [instance.get_padding_lengths()
-                                                                 for instance in self._instances]
-        if not all_instance_lengths:
-            return {**padding_lengths}
-        all_field_lengths: Dict[str, List[Dict[str, int]]] = defaultdict(list)
-        for instance_lengths in all_instance_lengths:
-            for field_name, instance_field_lengths in instance_lengths.items():
-                all_field_lengths[field_name].append(instance_field_lengths)
-        for field_name, field_lengths in all_field_lengths.items():
-            for padding_key in field_lengths[0].keys():
-                max_value = max(x[padding_key] if padding_key in x else 0 for x in field_lengths)
-                padding_lengths[field_name][padding_key] = max_value
-        return {**padding_lengths}
-
-    def as_tensor_dict(self,
-                       padding_lengths: Dict[str, Dict[str, int]] = None,
-                       cuda_device: int = -1,
-                       for_training: bool = True,
-                       verbose: bool = False) -> Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]:
-        # This complex return type is actually predefined elsewhere as a DataArray,
-        # but we can't use it because mypy doesn't like it.
-        """
-        This method converts this ``Dataset`` into a set of pytorch Tensors that can be passed
-        through a model.  In order for the tensors to be valid tensors, all ``Instances`` in this
-        dataset need to be padded to the same lengths wherever padding is necessary, so we do that
-        first, then we combine all of the tensors for each field in each instance into a set of
-        batched tensors for each field.
-
-        Parameters
-        ----------
-        padding_lengths : ``Dict[str, Dict[str, int]]``
-            If a key is present in this dictionary with a non-``None`` value, we will pad to that
-            length instead of the length calculated from the data.  This lets you, e.g., set a
-            maximum value for sentence length if you want to throw out long sequences.
-
-            Entries in this dictionary are keyed first by field name (e.g., "question"), then by
-            padding key (e.g., "num_tokens").
-        cuda_device : ``int``
-            If cuda_device >= 0, GPUs are available and Pytorch was compiled with CUDA support, the
-            tensor will be copied to the cuda_device specified.
-        for_training : ``bool``, optional (default=``True``)
-            If ``False``, we will pass the ``volatile=True`` flag when constructing variables,
-            which disables gradient computations in the graph.  This makes inference more efficient
-            (particularly in memory usage), but is incompatible with training models.
-        verbose : ``bool``, optional (default=``False``)
-            Should we output logging information when we're doing this padding?  If the dataset is
-            large, this is nice to have, because padding a large dataset could take a long time.
-            But if you're doing this inside of a data generator, having all of this output per
-            batch is a bit obnoxious (and really slow).
-
-        Returns
-        -------
-        tensors : ``Dict[str, DataArray]``
-            A dictionary of tensors, keyed by field name, suitable for passing as input to a model.
-            This is a `batch` of instances, so, e.g., if the instances have a "question" field and
-            an "answer" field, the "question" fields for all of the instances will be grouped
-            together into a single tensor, and the "answer" fields for all instances will be
-            similarly grouped in a parallel set of tensors, for batched computation. Additionally,
-            for complex ``Fields``, the value of the dictionary key is not necessarily a single
-            tensor.  For example, with the ``TextField``, the output is a dictionary mapping
-            ``TokenIndexer`` keys to tensors. The number of elements in this sub-dictionary
-            therefore corresponds to the number of ``TokenIndexers`` used to index the
-            ``TextField``.  Each ``Field`` class is responsible for batching its own output.
-        """
-        if padding_lengths is None:
-            padding_lengths = defaultdict(dict)
-        # First we need to decide _how much_ to pad.  To do that, we find the max length for all
-        # relevant padding decisions from the instances themselves.  Then we check whether we were
-        # given a max length for a particular field and padding key.  If we were, we use that
-        # instead of the instance-based one.
-        if verbose:
-            logger.info("Padding dataset of size %d to lengths %s", self.num_instances, str(padding_lengths))
-            logger.info("Getting max lengths from instances")
-        instance_padding_lengths = self.get_padding_lengths()
-        if verbose:
-            logger.info("Instance max lengths: %s", str(instance_padding_lengths))
-        lengths_to_use: Dict[str, Dict[str, int]] = defaultdict(dict)
-        for field_name, instance_field_lengths in instance_padding_lengths.items():
-            for padding_key in instance_field_lengths.keys():
-                if padding_lengths[field_name].get(padding_key) is not None:
-                    lengths_to_use[field_name][padding_key] = padding_lengths[field_name][padding_key]
-                else:
-                    lengths_to_use[field_name][padding_key] = instance_field_lengths[padding_key]
-
-        # Now we actually pad the instances to tensors.
-        field_tensors: Dict[str, list] = defaultdict(list)
-        if verbose:
-            logger.info("Now actually padding instances to length: %s", str(lengths_to_use))
-        for instance in self._instances:
-            for field, tensors in instance.as_tensor_dict(lengths_to_use, cuda_device, for_training).items():
-                field_tensors[field].append(tensors)
-
-        # Finally, we combine the tensors that we got for each instance into one big tensor (or set
-        # of tensors) per field.  The `Field` classes themselves have the logic for batching the
-        # tensors together, so we grab a dictionary of field_name -> field class from the first
-        # instance in the dataset.
-        field_classes = self._instances[0].fields
-        final_fields = {}
-        for field_name, field_tensor_list in field_tensors.items():
-            final_fields[field_name] = field_classes[field_name].batch_tensors(field_tensor_list)
-        return final_fields
+        raise NotImplementedError

--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -16,7 +16,6 @@ from allennlp.common.checks import ConfigurationError
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-
 class Dataset:
     """
     A collection of :class:`~allennlp.data.instance.Instance` objects.
@@ -41,6 +40,10 @@ class Dataset:
         self._instances = instances
         self.num_instances = len(instances)
 
+        # A Dataset is an ``Iterator[Instance]``, this index ranges over
+        # the instances in each iteration.
+        self.idx = 0
+
     def truncate(self, max_instances: int):
         """
         If there are more instances than ``max_instances`` in this dataset, we truncate the
@@ -59,9 +62,9 @@ class Dataset:
         for instance in tqdm.tqdm(self._instances):
             instance.index_fields(vocab)
 
-    def iterinstances(self) -> Iterator[Instance]:
+    def __iter__(self) -> Iterator[Instance]:
         """
-        An iterator over instances.
+        A ``Dataset`` is its own iterator.
         """
         yield from self._instances
 
@@ -164,7 +167,7 @@ class Dataset:
         field_tensors: Dict[str, list] = defaultdict(list)
         if verbose:
             logger.info("Now actually padding instances to length: %s", str(lengths_to_use))
-        for instance in self.iterinstances():
+        for instance in self._instances:
             for field, tensors in instance.as_tensor_dict(lengths_to_use, cuda_device, for_training).items():
                 field_tensors[field].append(tensors)
 

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -9,6 +9,7 @@ from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import TextField, SequenceLabelField
 from allennlp.data.instance import Instance
@@ -118,7 +119,7 @@ class Conll2003DatasetReader(DatasetReader):
         if not instances:
             raise ConfigurationError("reading {} resulted in an empty Dataset".format(file_path))
 
-        return Dataset(instances)
+        return InMemoryDataset(instances)
 
     def text_to_instance(self, tokens: List[Token]) -> Instance:  # type: ignore
         """

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -9,6 +9,7 @@ from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import Field, ListField, TextField, IndexField, MetadataField, SequenceLabelField
 from allennlp.data.instance import Instance
@@ -157,7 +158,7 @@ class ConllCorefReader(DatasetReader):
         if not instances:
             raise ConfigurationError("No instances were read from the given filepath {}. "
                                      "Is the path correct?".format(file_path))
-        return Dataset(instances)
+        return InMemoryDataset(instances)
 
     @overrides
     def text_to_instance(self,  # type: ignore

--- a/allennlp/data/dataset_readers/language_modeling.py
+++ b/allennlp/data/dataset_readers/language_modeling.py
@@ -8,6 +8,7 @@ from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.instance import Instance
 from allennlp.data.tokenizers.tokenizer import Tokenizer
 from allennlp.data.tokenizers import WordTokenizer
@@ -93,7 +94,7 @@ class LanguageModelingReader(DatasetReader):
         if not instances:
             raise ConfigurationError("No instances were read from the given filepath {}. "
                                      "Is the path correct?".format(file_path))
-        return Dataset(instances)
+        return InMemoryDataset(instances)
 
     @overrides
     def text_to_instance(self, sentence: str) -> Instance:  # type: ignore

--- a/allennlp/data/dataset_readers/reading_comprehension/squad.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/squad.py
@@ -9,6 +9,7 @@ from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.instance import Instance
 from allennlp.data.dataset_readers.reading_comprehension import util
@@ -75,7 +76,7 @@ class SquadReader(DatasetReader):
         if not instances:
             raise ConfigurationError("No instances were read from the given filepath {}. "
                                      "Is the path correct?".format(file_path))
-        return Dataset(instances)
+        return InMemoryDataset(instances)
 
     @overrides
     def text_to_instance(self,  # type: ignore

--- a/allennlp/data/dataset_readers/reading_comprehension/triviaqa.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/triviaqa.py
@@ -11,6 +11,7 @@ from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.instance import Instance
 from allennlp.data.dataset_readers.reading_comprehension import util
@@ -115,7 +116,7 @@ class TriviaQaReader(DatasetReader):
         if not instances:
             raise ConfigurationError("No instances were read from the given filepath {}. "
                                      "Is the path correct?".format(file_path))
-        return Dataset(instances)
+        return InMemoryDataset(instances)
 
     def pick_paragraphs(self,
                         evidence_files: List[List[str]],

--- a/allennlp/data/dataset_readers/semantic_role_labeling.py
+++ b/allennlp/data/dataset_readers/semantic_role_labeling.py
@@ -10,6 +10,7 @@ from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import Field, TextField, SequenceLabelField
 from allennlp.data.instance import Instance
@@ -259,7 +260,7 @@ class SrlReader(DatasetReader):
         if not instances:
             raise ConfigurationError("No instances were read from the given filepath {}. "
                                      "Is the path correct?".format(file_path))
-        return Dataset(instances)
+        return InMemoryDataset(instances)
 
     def text_to_instance(self,  # type: ignore
                          tokens: List[Token],

--- a/allennlp/data/dataset_readers/seq2seq.py
+++ b/allennlp/data/dataset_readers/seq2seq.py
@@ -8,6 +8,7 @@ import tqdm
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.data.dataset import Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import TextField
 from allennlp.data.instance import Instance
@@ -80,7 +81,7 @@ class Seq2SeqDatasetReader(DatasetReader):
                 instances.append(self.text_to_instance(source_sequence, target_sequence))
         if not instances:
             raise ConfigurationError("No instances read!")
-        return Dataset(instances)
+        return InMemoryDataset(instances)
 
     @overrides
     def text_to_instance(self, source_string: str, target_string: str = None) -> Instance:  # type: ignore

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -8,6 +8,7 @@ from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import TextField, SequenceLabelField
 from allennlp.data.instance import Instance
@@ -76,7 +77,7 @@ class SequenceTaggingDatasetReader(DatasetReader):
         if not instances:
             raise ConfigurationError("No instances were read from the given filepath {}. "
                                      "Is the path correct?".format(file_path))
-        return Dataset(instances)
+        return InMemoryDataset(instances)
 
     def text_to_instance(self, tokens: List[Token]) -> Instance:  # type: ignore
         """

--- a/allennlp/data/dataset_readers/snli.py
+++ b/allennlp/data/dataset_readers/snli.py
@@ -9,6 +9,7 @@ from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 from allennlp.data.dataset import Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import Field, TextField, LabelField
 from allennlp.data.instance import Instance
@@ -63,7 +64,7 @@ class SnliReader(DatasetReader):
         if not instances:
             raise ConfigurationError("No instances were read from the given filepath {}. "
                                      "Is the path correct?".format(file_path))
-        return Dataset(instances)
+        return InMemoryDataset(instances)
 
     @overrides
     def text_to_instance(self,  # type: ignore

--- a/allennlp/data/in_memory_dataset.py
+++ b/allennlp/data/in_memory_dataset.py
@@ -1,0 +1,183 @@
+"""
+A :class:`~Dataset` represents a collection of data suitable for feeding into a model.
+For example, when you train a model, you will likely have a *training* dataset and a *validation* dataset.
+"""
+
+import logging
+from collections import defaultdict
+from typing import Dict, List, Union, Iterator
+
+import torch
+import tqdm
+from overrides import overrides
+
+from allennlp.data.dataset import Dataset
+from allennlp.data.instance import Instance
+from allennlp.data.vocabulary import Vocabulary
+from allennlp.common.checks import ConfigurationError
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class InMemoryDataset(Dataset):
+    """
+    A collection of :class:`~allennlp.data.instance.Instance` objects.
+    The ``Instances`` have ``Fields``, and the fields
+    could be in an indexed or unindexed state - the ``Dataset`` has methods around indexing the
+    data and converting the data into arrays.
+    """
+    def __init__(self, instances: List[Instance]) -> None:
+        """
+        A Dataset just takes a list of instances in its constructor.  It's important that all
+        subclasses have an identical constructor to this (though possibly with different Instance
+        types).  If you change the constructor, you also have to override all methods in this base
+        class that call the constructor, such as `truncate()`.
+        """
+        super().__init__(len(instances))
+        self._instances = instances
+
+        all_instance_fields_and_types: List[Dict[str, str]] = [{k: v.__class__.__name__
+                                                                for k, v in x.fields.items()}
+                                                            for x in instances]
+
+        # Check all the field names and Field types are the same for every instance.
+        if not all([all_instance_fields_and_types[0] == x for x in all_instance_fields_and_types]):
+            raise ConfigurationError("You cannot construct a Dataset with non-homogeneous Instances.")
+
+    def truncate(self, max_instances: int):
+        """
+        If there are more instances than ``max_instances`` in this dataset, we truncate the
+        instances to the first ``max_instances``.  This `modifies` the current object, and returns
+        nothing.
+        """
+        if len(self._instances) > max_instances:
+            self._instances = self._instances[:max_instances]
+
+    def index_instances(self, vocab: Vocabulary):
+        """
+        Converts all ``UnindexedFields`` in all ``Instances`` in this ``Dataset`` into
+        ``IndexedFields``.  This modifies the current object, it does not return a new object.
+        """
+        logger.info("Indexing dataset")
+        for instance in tqdm.tqdm(self._instances):
+            instance.index_fields(vocab)
+
+    @overrides
+    def __iter__(self) -> Iterator[Instance]:
+        """
+        A ``Dataset`` is its own iterator.
+        """
+        return (instance for instance in self._instances)
+
+    def get_padding_lengths(self) -> Dict[str, Dict[str, int]]:
+        """
+        Gets the maximum padding lengths from all ``Instances`` in this dataset.  Each ``Instance``
+        has multiple ``Fields``, and each ``Field`` could have multiple things that need padding.
+        We look at all fields in all instances, and find the max values for each (field_name,
+        padding_key) pair, returning them in a dictionary.
+
+        This can then be used to convert this dataset into arrays of consistent length, or to set
+        model parameters, etc.
+        """
+        padding_lengths: Dict[str, Dict[str, int]] = defaultdict(dict)
+        all_instance_lengths: List[Dict[str, Dict[str, int]]] = [instance.get_padding_lengths()
+                                                                 for instance in self._instances]
+        if not all_instance_lengths:
+            return {**padding_lengths}
+        all_field_lengths: Dict[str, List[Dict[str, int]]] = defaultdict(list)
+        for instance_lengths in all_instance_lengths:
+            for field_name, instance_field_lengths in instance_lengths.items():
+                all_field_lengths[field_name].append(instance_field_lengths)
+        for field_name, field_lengths in all_field_lengths.items():
+            for padding_key in field_lengths[0].keys():
+                max_value = max(x[padding_key] if padding_key in x else 0 for x in field_lengths)
+                padding_lengths[field_name][padding_key] = max_value
+        return {**padding_lengths}
+
+    def as_tensor_dict(self,
+                       padding_lengths: Dict[str, Dict[str, int]] = None,
+                       cuda_device: int = -1,
+                       for_training: bool = True,
+                       verbose: bool = False) -> Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]:
+        # This complex return type is actually predefined elsewhere as a DataArray,
+        # but we can't use it because mypy doesn't like it.
+        """
+        This method converts this ``Dataset`` into a set of pytorch Tensors that can be passed
+        through a model.  In order for the tensors to be valid tensors, all ``Instances`` in this
+        dataset need to be padded to the same lengths wherever padding is necessary, so we do that
+        first, then we combine all of the tensors for each field in each instance into a set of
+        batched tensors for each field.
+
+        Parameters
+        ----------
+        padding_lengths : ``Dict[str, Dict[str, int]]``
+            If a key is present in this dictionary with a non-``None`` value, we will pad to that
+            length instead of the length calculated from the data.  This lets you, e.g., set a
+            maximum value for sentence length if you want to throw out long sequences.
+
+            Entries in this dictionary are keyed first by field name (e.g., "question"), then by
+            padding key (e.g., "num_tokens").
+        cuda_device : ``int``
+            If cuda_device >= 0, GPUs are available and Pytorch was compiled with CUDA support, the
+            tensor will be copied to the cuda_device specified.
+        for_training : ``bool``, optional (default=``True``)
+            If ``False``, we will pass the ``volatile=True`` flag when constructing variables,
+            which disables gradient computations in the graph.  This makes inference more efficient
+            (particularly in memory usage), but is incompatible with training models.
+        verbose : ``bool``, optional (default=``False``)
+            Should we output logging information when we're doing this padding?  If the dataset is
+            large, this is nice to have, because padding a large dataset could take a long time.
+            But if you're doing this inside of a data generator, having all of this output per
+            batch is a bit obnoxious (and really slow).
+
+        Returns
+        -------
+        tensors : ``Dict[str, DataArray]``
+            A dictionary of tensors, keyed by field name, suitable for passing as input to a model.
+            This is a `batch` of instances, so, e.g., if the instances have a "question" field and
+            an "answer" field, the "question" fields for all of the instances will be grouped
+            together into a single tensor, and the "answer" fields for all instances will be
+            similarly grouped in a parallel set of tensors, for batched computation. Additionally,
+            for complex ``Fields``, the value of the dictionary key is not necessarily a single
+            tensor.  For example, with the ``TextField``, the output is a dictionary mapping
+            ``TokenIndexer`` keys to tensors. The number of elements in this sub-dictionary
+            therefore corresponds to the number of ``TokenIndexers`` used to index the
+            ``TextField``.  Each ``Field`` class is responsible for batching its own output.
+        """
+        if padding_lengths is None:
+            padding_lengths = defaultdict(dict)
+        # First we need to decide _how much_ to pad.  To do that, we find the max length for all
+        # relevant padding decisions from the instances themselves.  Then we check whether we were
+        # given a max length for a particular field and padding key.  If we were, we use that
+        # instead of the instance-based one.
+        if verbose:
+            logger.info("Padding dataset of size %d to lengths %s", self.num_instances, str(padding_lengths))
+            logger.info("Getting max lengths from instances")
+        instance_padding_lengths = self.get_padding_lengths()
+        if verbose:
+            logger.info("Instance max lengths: %s", str(instance_padding_lengths))
+        lengths_to_use: Dict[str, Dict[str, int]] = defaultdict(dict)
+        for field_name, instance_field_lengths in instance_padding_lengths.items():
+            for padding_key in instance_field_lengths.keys():
+                if padding_lengths[field_name].get(padding_key) is not None:
+                    lengths_to_use[field_name][padding_key] = padding_lengths[field_name][padding_key]
+                else:
+                    lengths_to_use[field_name][padding_key] = instance_field_lengths[padding_key]
+
+        # Now we actually pad the instances to tensors.
+        field_tensors: Dict[str, list] = defaultdict(list)
+        if verbose:
+            logger.info("Now actually padding instances to length: %s", str(lengths_to_use))
+        for instance in self._instances:
+            for field, tensors in instance.as_tensor_dict(lengths_to_use, cuda_device, for_training).items():
+                field_tensors[field].append(tensors)
+
+        # Finally, we combine the tensors that we got for each instance into one big tensor (or set
+        # of tensors) per field.  The `Field` classes themselves have the logic for batching the
+        # tensors together, so we grab a dictionary of field_name -> field class from the first
+        # instance in the dataset.
+        field_classes = self._instances[0].fields
+        final_fields = {}
+        for field_name, field_tensor_list in field_tensors.items():
+            final_fields[field_name] = field_classes[field_name].batch_tensors(field_tensor_list)
+        return final_fields

--- a/allennlp/data/iterators/__init__.py
+++ b/allennlp/data/iterators/__init__.py
@@ -7,3 +7,4 @@ from allennlp.data.iterators.data_iterator import DataIterator
 from allennlp.data.iterators.basic_iterator import BasicIterator
 from allennlp.data.iterators.bucket_iterator import BucketIterator
 from allennlp.data.iterators.adaptive_iterator import AdaptiveIterator
+from allennlp.data.iterators.lazy_iterator import LazyIterator

--- a/allennlp/data/iterators/adaptive_iterator.py
+++ b/allennlp/data/iterators/adaptive_iterator.py
@@ -123,7 +123,7 @@ class AdaptiveIterator(BucketIterator):
         current_batch = []
         current_lengths: Dict[str, Dict[str, int]] = defaultdict(dict)
         logger.debug("Creating adaptive groups")
-        for instance in dataset.instances:
+        for instance in dataset.iterinstances():
             current_batch.append(instance)
             instance_lengths = instance.get_padding_lengths()
             for field_name in instance_lengths:

--- a/allennlp/data/iterators/adaptive_iterator.py
+++ b/allennlp/data/iterators/adaptive_iterator.py
@@ -123,7 +123,7 @@ class AdaptiveIterator(BucketIterator):
         current_batch = []
         current_lengths: Dict[str, Dict[str, int]] = defaultdict(dict)
         logger.debug("Creating adaptive groups")
-        for instance in dataset.iterinstances():
+        for instance in dataset:
             current_batch.append(instance)
             instance_lengths = instance.get_padding_lengths()
             for field_name in instance_lengths:

--- a/allennlp/data/iterators/basic_iterator.py
+++ b/allennlp/data/iterators/basic_iterator.py
@@ -27,11 +27,11 @@ class BasicIterator(DataIterator):
 
     @overrides
     def get_num_batches(self, dataset: Dataset) -> int:
-        return math.ceil(len(dataset.instances) / self._batch_size)
+        return math.ceil(dataset.num_instances / self._batch_size)
 
     @overrides
     def _create_batches(self, dataset: Dataset, shuffle: bool) -> List[List[Instance]]:
-        instances = dataset.instances
+        instances = [instance for instance in dataset.iterinstances()]
         if shuffle:
             random.shuffle(instances)
         grouped_instances = group_by_count(instances, self._batch_size, None)

--- a/allennlp/data/iterators/basic_iterator.py
+++ b/allennlp/data/iterators/basic_iterator.py
@@ -31,7 +31,7 @@ class BasicIterator(DataIterator):
 
     @overrides
     def _create_batches(self, dataset: Dataset, shuffle: bool) -> List[List[Instance]]:
-        instances = [instance for instance in dataset.iterinstances()]
+        instances = [instance for instance in dataset]
         if shuffle:
             random.shuffle(instances)
         grouped_instances = group_by_count(instances, self._batch_size, None)

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -7,6 +7,7 @@ from overrides import overrides
 from allennlp.common import Params
 from allennlp.common.util import add_noise_to_dict_values
 from allennlp.data import Dataset, Instance
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.iterators.basic_iterator import BasicIterator
 from allennlp.data.iterators.data_iterator import DataIterator
 
@@ -104,7 +105,7 @@ class BucketIterator(BasicIterator):
                                      instance)
             instances_with_lengths.append(instance_with_lengths)
         instances_with_lengths.sort(key=lambda x: x[0])
-        return Dataset([instance_with_lengths[-1] for instance_with_lengths in instances_with_lengths])
+        return InMemoryDataset([instance_with_lengths[-1] for instance_with_lengths in instances_with_lengths])
 
     @classmethod
     def from_params(cls, params: Params) -> 'BucketIterator':

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -92,7 +92,7 @@ class BucketIterator(BasicIterator):
         ``(field_name, padding_key)`` tuples.
         """
         instances_with_lengths = []
-        for instance in dataset.iterinstances():
+        for instance in dataset:
             padding_lengths = cast(Dict[str, Dict[str, float]], instance.get_padding_lengths())
             if padding_noise > 0.0:
                 noisy_lengths = {}

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -92,7 +92,7 @@ class BucketIterator(BasicIterator):
         ``(field_name, padding_key)`` tuples.
         """
         instances_with_lengths = []
-        for instance in dataset.instances:
+        for instance in dataset.iterinstances():
             padding_lengths = cast(Dict[str, Dict[str, float]], instance.get_padding_lengths())
             if padding_noise > 0.0:
                 noisy_lengths = {}

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Generator, Union
 import numpy
 
 from allennlp.data.dataset import Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.instance import Instance
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.common import Params
@@ -68,7 +69,7 @@ class DataIterator(Registrable):
     def _yield_one_epoch(self, dataset: Dataset, shuffle: bool, cuda_device: int, for_training: bool):
         grouped_instances = self._create_batches(dataset, shuffle)
         for group in grouped_instances:
-            batch = Dataset(group)
+            batch = InMemoryDataset(group)
             padding_lengths = batch.get_padding_lengths()
             logger.debug("Batch padding lengths: %s", str(padding_lengths))
             logger.debug("Batch size: %d", batch.num_instances)

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -67,7 +67,7 @@ class DataIterator(Registrable):
             batch = Dataset(group)
             padding_lengths = batch.get_padding_lengths()
             logger.debug("Batch padding lengths: %s", str(padding_lengths))
-            logger.debug("Batch size: %d", len(batch.instances))
+            logger.debug("Batch size: %d", batch.num_instances)
             yield batch.as_tensor_dict(padding_lengths,
                                        cuda_device=cuda_device,
                                        for_training=for_training)

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -5,6 +5,7 @@ import numpy
 
 from allennlp.data.dataset import Dataset
 from allennlp.data.instance import Instance
+from allennlp.data.vocabulary import Vocabulary
 from allennlp.common import Params
 from allennlp.common.registrable import Registrable
 
@@ -20,6 +21,7 @@ class DataIterator(Registrable):
 
     def __call__(self,
                  dataset: Dataset,
+                 vocab: Vocabulary = None,
                  num_epochs: int = None,
                  shuffle: bool = True,
                  cuda_device: int = -1,
@@ -46,6 +48,8 @@ class DataIterator(Registrable):
             which disables gradient computations in the graph.  This makes inference more efficient
             (particularly in memory usage), but is incompatible with training models.
         """
+        self.vocab = vocab
+
         if num_epochs is None:
             while True:
                 yield from self._yield_one_epoch(dataset, shuffle, cuda_device, for_training)

--- a/allennlp/data/iterators/lazy_iterator.py
+++ b/allennlp/data/iterators/lazy_iterator.py
@@ -1,0 +1,54 @@
+import itertools
+import logging
+import math
+from typing import List
+
+from overrides import overrides
+
+from allennlp.common import Params
+from allennlp.data.iterators.data_iterator import DataIterator
+from allennlp.data.dataset import Dataset
+from allennlp.data.instance import Instance
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+@DataIterator.register("lazy")
+class LazyIterator(DataIterator):
+    """
+    An iterator for iterating lazily across a dataset, yielding fixed size batches.
+
+    Parameters
+    ----------
+    batch_size : int, optional, (default = 32)
+        The size of each batch of instances yielded when calling the iterator.
+    """
+    def __init__(self, batch_size: int = 32) -> None:
+        self._batch_size = batch_size
+
+    def _yield_one_epoch(self, dataset: Dataset, shuffle: bool, cuda_device: int, for_training: bool):
+        if shuffle:
+            logger.warning("shuffle is not implemented for LazyIterator")
+
+        indexed_instances = enumerate(dataset.iterinstances())
+        for _, group in itertools.groupby(indexed_instances, lambda pair: pair[0] // self._batch_size):
+            batch = Dataset([instance for _, instance in group])
+            padding_lengths = batch.get_padding_lengths()
+            logger.debug("Batch padding lengths: %s", str(padding_lengths))
+            logger.debug("Batch size: %d", batch.num_instances)
+            yield batch.as_tensor_dict(padding_lengths,
+                                       cuda_device=cuda_device,
+                                       for_training=for_training)
+
+    def _create_batches(self, dataset: Dataset, shuffle: bool) -> List[List[Instance]]:
+        raise RuntimeError("should never be called")
+
+    @overrides
+    def get_num_batches(self, dataset: Dataset) -> int:
+        return math.ceil(dataset.num_instances / self._batch_size)
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'LazyIterator':
+        batch_size = params.pop('batch_size', 32)
+        params.assert_empty(cls.__name__)
+        return cls(batch_size=batch_size)

--- a/allennlp/data/iterators/lazy_iterator.py
+++ b/allennlp/data/iterators/lazy_iterator.py
@@ -25,21 +25,16 @@ class LazyIterator(DataIterator):
     """
     def __init__(self, batch_size: int = 32) -> None:
         self._batch_size = batch_size
-        self.vocab = None
 
     def _yield_one_epoch(self, dataset: Dataset, shuffle: bool, cuda_device: int, for_training: bool):
-        if self.vocab is None:
-            raise RuntimeError("LazyIterator must be called with vocab parameter")
-
         # TODO(joelgrus): this should probably throw a ConfigurationError
         # but right now `shuffle` is not even part of the configuration
         if shuffle:
             logger.warning("shuffle is not implemented for LazyIterator")
 
-        indexed_instances = enumerate(dataset)
+        indexed_instances = enumerate(instance for instance in dataset)
         for _, group in itertools.groupby(indexed_instances, lambda pair: pair[0] // self._batch_size):
             batch = Dataset([instance for _, instance in group])
-            batch.index_instances(self.vocab)
             padding_lengths = batch.get_padding_lengths()
             logger.debug("Batch padding lengths: %s", str(padding_lengths))
             logger.debug("Batch size: %d", batch.num_instances)

--- a/allennlp/data/lazy_dataset.py
+++ b/allennlp/data/lazy_dataset.py
@@ -1,7 +1,9 @@
 """
-A :class:`~LazyDataset` is essentially a :class:`~Dataset` that lives on disk
-instead of in-memory. It's not a subclass of ``Dataset`` because it doesn't
-behave quite the same.
+A :class:`~LazyDataset` is a subclass of :class:`~Dataset` that
+instead of storing a ``List`` of ``Instance`` s, stores a method
+for generating instances. The main intended use case is for datasets
+that are too large to load into memory, in which case the generator
+would just read the file from disk for each call to ``iterinstances``.
 """
 import logging
 from collections import defaultdict

--- a/allennlp/data/lazy_dataset.py
+++ b/allennlp/data/lazy_dataset.py
@@ -1,0 +1,106 @@
+"""
+A :class:`~LazyDataset` is essentially a :class:`~Dataset` that lives on disk
+instead of in-memory. It's not a subclass of ``Dataset`` because it doesn't
+behave quite the same.
+"""
+import logging
+from collections import defaultdict
+from typing import Dict, Union, Callable, Iterator
+
+import torch
+import tqdm
+
+from allennlp.data.dataset import Dataset
+from allennlp.data.instance import Instance
+from allennlp.data.vocabulary import Vocabulary
+from allennlp.common.checks import ConfigurationError
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class LazyDataset(Dataset):
+    """
+    A collection of :class:`~allennlp.data.instance.Instance` objects.
+    The ``Instances`` have ``Fields``, and the fields
+    could be in an indexed or unindexed state - the ``Dataset`` has methods around indexing the
+    data and converting the data into arrays.
+    """
+    def __init__(self, generator: Callable[[], Iterator[Instance]]) -> None:
+        """
+        A LazyDataset just takes a way of generating instances.
+        """
+        # Call superclass constructor with no instances, we'll override the methods that use them.
+        super().__init__([])
+
+        self.generator = generator
+        self.max_instances: int = None
+        self.vocab: Vocabulary = None
+        self.padding_lengths: Dict[str, Dict[str, int]] = None
+        self.num_instances = 0
+
+        logger.info("initial pass through the dataset")
+        fields_and_types: Dict[str, str] = None
+
+        for instance in tqdm.tqdm(generator()):
+            self.num_instances += 1
+
+            # Check that all instances have the same "shape"
+            instance_fields_and_types = {k: v.__class__.__name__ for k, v in instance.fields.items()}
+            if fields_and_types is None:
+                fields_and_types = instance_fields_and_types
+            elif instance_fields_and_types != fields_and_types:
+                raise ConfigurationError("You cannot construct a LazyDataset with non-homogeneous Instances.")
+
+
+    def truncate(self, max_instances: int):
+        """
+        If there are more instances than ``max_instances`` in this dataset, we truncate the
+        instances to the first ``max_instances``.  This `modifies` the current object, and returns
+        nothing.
+        """
+        self.max_instances = max_instances
+
+    def index_instances(self, vocab: Vocabulary):
+        """
+        This is a little bit misleading, as we have to index the instances as they're generated.
+        However, code will still call this and it's a good place to grab a reference to the
+        ``Vocabulary``.
+        """
+        self.vocab = vocab
+
+        padding_lengths: Dict[str, Dict[str, int]] = defaultdict(dict)
+        for instance in tqdm.tqdm(self.iterinstances()):
+            instance.index_fields(vocab)
+            instance_lengths = instance.get_padding_lengths()
+            for field_name, instance_field_lengths in instance_lengths.items():
+                for padding_key, length in instance_field_lengths.items():
+                    prev_max_length = padding_lengths[field_name].get(padding_key, 0)
+                    padding_lengths[field_name][padding_key] = max(length, prev_max_length)
+
+        self.padding_lengths = {**padding_lengths}
+
+    def iterinstances(self) -> Iterator[Instance]:
+        for i, instance in tqdm.tqdm(enumerate(self.generator())):
+            if self.max_instances is not None and i >= self.max_instances:
+                return
+            instance.index_fields(self.vocab)
+            yield instance
+
+    def get_padding_lengths(self) -> Dict[str, Dict[str, int]]:
+        """
+        Gets the maximum padding lengths from all ``Instances`` in this dataset.  Each ``Instance``
+        has multiple ``Fields``, and each ``Field`` could have multiple things that need padding.
+        We look at all fields in all instances, and find the max values for each (field_name,
+        padding_key) pair, returning them in a dictionary.
+
+        This can then be used to convert this dataset into arrays of consistent length, or to set
+        model parameters, etc.
+        """
+        return self.padding_lengths
+
+    def as_tensor_dict(self,
+                       padding_lengths: Dict[str, Dict[str, int]] = None,
+                       cuda_device: int = -1,
+                       for_training: bool = True,
+                       verbose: bool = False) -> Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]:
+        raise NotImplementedError("cannot call as_tensor_dict on a LazyDataset")

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -323,7 +323,7 @@ class Vocabulary:
         """
         logger.info("Fitting token dictionary from dataset.")
         namespace_token_counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
-        for instance in tqdm.tqdm(dataset.instances):
+        for instance in tqdm.tqdm(dataset.iterinstances()):
             instance.count_vocab_items(namespace_token_counts)
 
         return Vocabulary(counter=namespace_token_counts,

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -323,7 +323,7 @@ class Vocabulary:
         """
         logger.info("Fitting token dictionary from dataset.")
         namespace_token_counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
-        for instance in tqdm.tqdm(dataset.iterinstances()):
+        for instance in tqdm.tqdm(dataset):
             instance.count_vocab_items(namespace_token_counts)
 
         return Vocabulary(counter=namespace_token_counts,

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -13,6 +13,7 @@ import torch
 from allennlp.common.params import Params
 from allennlp.common.registrable import Registrable
 from allennlp.data import Instance, Vocabulary, Dataset
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.nn import util
 from allennlp.nn.regularizers import RegularizerApplicator
 
@@ -125,7 +126,7 @@ class Model(torch.nn.Module, Registrable):
         :func:`forward_on_instance`.
         """
 
-        dataset = Dataset(instances)
+        dataset = InMemoryDataset(instances)
         dataset.index_instances(self.vocab)
         model_input = dataset.as_tensor_dict(cuda_device=cuda_device, for_training=False)
         outputs = self.decode(self(**model_input))

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -130,7 +130,7 @@ class Model(torch.nn.Module, Registrable):
         model_input = dataset.as_tensor_dict(cuda_device=cuda_device, for_training=False)
         outputs = self.decode(self(**model_input))
 
-        instance_separated_output: List[Dict[str, numpy.ndarray]] = [{} for _ in dataset.iterinstances()]
+        instance_separated_output: List[Dict[str, numpy.ndarray]] = [{} for _ in dataset]
         for name, output in list(outputs.items()):
             if isinstance(output, torch.autograd.Variable):
                 output = output.data.cpu().numpy()

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -130,7 +130,7 @@ class Model(torch.nn.Module, Registrable):
         model_input = dataset.as_tensor_dict(cuda_device=cuda_device, for_training=False)
         outputs = self.decode(self(**model_input))
 
-        instance_separated_output: List[Dict[str, numpy.ndarray]] = [{} for _ in dataset.instances]
+        instance_separated_output: List[Dict[str, numpy.ndarray]] = [{} for _ in dataset.iterinstances()]
         for name, output in list(outputs.items()):
             if isinstance(output, torch.autograd.Variable):
                 output = output.data.cpu().numpy()

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -207,7 +207,8 @@ class Trainer:
         # Get tqdm for the training batches
         train_generator = self._iterator(self._train_dataset,
                                          num_epochs=1,
-                                         cuda_device=self._cuda_device)
+                                         cuda_device=self._cuda_device,
+                                         vocab=self._model.vocab)
         num_training_batches = self._iterator.get_num_batches(self._train_dataset)
         train_generator_tqdm = tqdm.tqdm(train_generator,
                                          disable=self._no_tqdm,
@@ -334,7 +335,8 @@ class Trainer:
         val_generator = self._iterator(self._validation_dataset,
                                        num_epochs=1,
                                        cuda_device=self._cuda_device,
-                                       for_training=False)
+                                       for_training=False,
+                                       vocab=self._model.vocab)
         num_validation_batches = self._iterator.get_num_batches(self._validation_dataset)
         val_generator_tqdm = tqdm.tqdm(val_generator,
                                        disable=self._no_tqdm,

--- a/scripts/evaluate_squad_model.py
+++ b/scripts/evaluate_squad_model.py
@@ -58,7 +58,7 @@ def main(config_file):
         best_span_tensor = result['best_span']
         for i in range(best_span_tensor.size(0)):
             best_spans.append(best_span_tensor[i].data.cpu().tolist())
-    for best_span, instance in zip(best_spans, dataset.iterinstances()):
+    for best_span, instance in zip(best_spans, dataset):
         span_tokens = instance.fields['passage'].tokens[best_span[0]:best_span[1]]
         # We have to do some hacks to get from our tokens back to the original passage text, so
         # that our answers get scored correctly.  This could be made much easier if we kept around

--- a/scripts/evaluate_squad_model.py
+++ b/scripts/evaluate_squad_model.py
@@ -58,7 +58,7 @@ def main(config_file):
         best_span_tensor = result['best_span']
         for i in range(best_span_tensor.size(0)):
             best_spans.append(best_span_tensor[i].data.cpu().tolist())
-    for best_span, instance in zip(best_spans, dataset.instances):
+    for best_span, instance in zip(best_spans, dataset.iterinstances()):
         span_tokens = instance.fields['passage'].tokens[best_span[0]:best_span[1]]
         # We have to do some hacks to get from our tokens back to the original passage text, so
         # that our answers get scored correctly.  This could be made much easier if we kept around

--- a/scripts/write_srl_predictions_to_conll_format.py
+++ b/scripts/write_srl_predictions_to_conll_format.py
@@ -44,7 +44,7 @@ def main(serialization_directory, device):
         predictions = model.decode(result)
         model_predictions.extend(predictions["tags"])
 
-    for instance, prediction in zip(dataset.iterinstances(), model_predictions):
+    for instance, prediction in zip(dataset, model_predictions):
         fields = instance.fields
         predicted_tags = [model._vocab.get_token_from_index(x, namespace="labels") for x in prediction]
         try:

--- a/scripts/write_srl_predictions_to_conll_format.py
+++ b/scripts/write_srl_predictions_to_conll_format.py
@@ -44,7 +44,7 @@ def main(serialization_directory, device):
         predictions = model.decode(result)
         model_predictions.extend(predictions["tags"])
 
-    for instance, prediction in zip(dataset.instances, model_predictions):
+    for instance, prediction in zip(dataset.iterinstances(), model_predictions):
         fields = instance.fields
         predicted_tags = [model._vocab.get_token_from_index(x, namespace="labels") for x in prediction]
         try:

--- a/tests/commands/train_lazy_test.py
+++ b/tests/commands/train_lazy_test.py
@@ -1,0 +1,92 @@
+# pylint: disable=invalid-name,no-self-use,abstract-method
+from typing import Iterator
+
+from allennlp.common import Params
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.commands.train import train_model
+from allennlp.data import LazyDataset, Instance
+from allennlp.data.dataset_readers import DatasetReader
+from allennlp.data.dataset_readers.sequence_tagging import SequenceTaggingDatasetReader
+
+@DatasetReader.register('lazy-sequence-tagger')
+class LazySequenceTaggerDatasetReader(DatasetReader):
+    """
+    This is a dumb hack to get a LazyDataset
+    """
+    def __init__(self) -> None:
+        self.reader = SequenceTaggingDatasetReader()
+
+    def read(self, file_path: str):
+        def generator() -> Iterator[Instance]:
+            """
+            Read from the file every time generator is called
+            """
+            yield from self.reader.read(file_path).iterinstances()
+
+        return LazyDataset(generator)
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'LazySequenceTaggingDatasetReader':
+        return cls()
+
+
+class TestLazyTrain(AllenNlpTestCase):
+    def test_train_model(self):
+        params = Params({
+                "model": {
+                        "type": "simple_tagger",
+                        "text_field_embedder": {
+                                "tokens": {
+                                        "type": "embedding",
+                                        "embedding_dim": 5
+                                }
+                        },
+                        "stacked_encoder": {
+                                "type": "lstm",
+                                "input_size": 5,
+                                "hidden_size": 7,
+                                "num_layers": 2
+                        }
+                },
+                "dataset_reader": {"type": "lazy-sequence-tagger"},
+                "train_data_path": 'tests/fixtures/data/sequence_tagging.tsv',
+                "validation_data_path": 'tests/fixtures/data/sequence_tagging.tsv',
+                "iterator": {"type": "basic", "batch_size": 2},
+                "trainer": {
+                        "num_epochs": 2,
+                        "optimizer": "adam"
+                }
+        })
+
+        train_model(params, serialization_dir=self.TEST_DIR)
+
+    def test_train_with_test_set(self):
+        params = Params({
+                "model": {
+                        "type": "simple_tagger",
+                        "text_field_embedder": {
+                                "tokens": {
+                                        "type": "embedding",
+                                        "embedding_dim": 5
+                                }
+                        },
+                        "stacked_encoder": {
+                                "type": "lstm",
+                                "input_size": 5,
+                                "hidden_size": 7,
+                                "num_layers": 2
+                        }
+                },
+                "dataset_reader": {"type": "lazy-sequence-tagger"},
+                "train_data_path": 'tests/fixtures/data/sequence_tagging.tsv',
+                "test_data_path": 'tests/fixtures/data/sequence_tagging.tsv',
+                "validation_data_path": 'tests/fixtures/data/sequence_tagging.tsv',
+                "evaluate_on_test": True,
+                "iterator": {"type": "basic", "batch_size": 2},
+                "trainer": {
+                        "num_epochs": 2,
+                        "optimizer": "adam"
+                }
+        })
+
+        train_model(params, serialization_dir=self.TEST_DIR)

--- a/tests/data/dataset_readers/coref_reader_test.py
+++ b/tests/data/dataset_readers/coref_reader_test.py
@@ -16,7 +16,7 @@ class TestCorefReader(AllenNlpTestCase):
         conll_reader = ConllCorefReader(max_span_width=self.span_width)
         dataset = conll_reader.read('tests/fixtures/data/coref/sample.gold_conll')
 
-        instances = list(dataset.iterinstances())
+        instances = list(dataset)
         assert len(instances) == 2
 
         fields = instances[0].fields

--- a/tests/data/dataset_readers/coref_reader_test.py
+++ b/tests/data/dataset_readers/coref_reader_test.py
@@ -16,9 +16,9 @@ class TestCorefReader(AllenNlpTestCase):
         conll_reader = ConllCorefReader(max_span_width=self.span_width)
         dataset = conll_reader.read('tests/fixtures/data/coref/sample.gold_conll')
 
-        assert len(dataset.instances) == 2
+        instances = list(dataset.iterinstances())
+        assert len(instances) == 2
 
-        instances = dataset.instances
         fields = instances[0].fields
         text = [x.text for x in fields["text"].tokens]
         assert text == ['In', 'the', 'summer', 'of', '2005', ',', 'a', 'picture', 'that',

--- a/tests/data/dataset_readers/language_modeling_dataset_test.py
+++ b/tests/data/dataset_readers/language_modeling_dataset_test.py
@@ -8,7 +8,7 @@ class TestLanguageModelingDatasetReader(AllenNlpTestCase):
         reader = LanguageModelingReader(tokens_per_instance=3)
 
         dataset = reader.read('tests/fixtures/data/language_modeling.txt')
-        instances = list(dataset.iterinstances())
+        instances = list(dataset)
         # The last potential instance is left out, which is ok, because we don't have an end token
         # in here, anyway.
         assert len(instances) == 5

--- a/tests/data/dataset_readers/language_modeling_dataset_test.py
+++ b/tests/data/dataset_readers/language_modeling_dataset_test.py
@@ -8,7 +8,7 @@ class TestLanguageModelingDatasetReader(AllenNlpTestCase):
         reader = LanguageModelingReader(tokens_per_instance=3)
 
         dataset = reader.read('tests/fixtures/data/language_modeling.txt')
-        instances = dataset.instances
+        instances = list(dataset.iterinstances())
         # The last potential instance is left out, which is ok, because we don't have an end token
         # in here, anyway.
         assert len(instances) == 5

--- a/tests/data/dataset_readers/reading_comprehension/squad_test.py
+++ b/tests/data/dataset_readers/reading_comprehension/squad_test.py
@@ -7,7 +7,7 @@ from allennlp.data.dataset_readers import SquadReader
 class TestSquadReader(AllenNlpTestCase):
     def test_read_from_file(self):
         reader = SquadReader()
-        instances = reader.read('tests/fixtures/data/squad.json').instances
+        instances = list(reader.read('tests/fixtures/data/squad.json').iterinstances())
         assert len(instances) == 5
 
         assert [t.text for t in instances[0].fields["question"].tokens[:3]] == ["To", "whom", "did"]

--- a/tests/data/dataset_readers/reading_comprehension/squad_test.py
+++ b/tests/data/dataset_readers/reading_comprehension/squad_test.py
@@ -7,7 +7,7 @@ from allennlp.data.dataset_readers import SquadReader
 class TestSquadReader(AllenNlpTestCase):
     def test_read_from_file(self):
         reader = SquadReader()
-        instances = list(reader.read('tests/fixtures/data/squad.json').iterinstances())
+        instances = list(reader.read('tests/fixtures/data/squad.json'))
         assert len(instances) == 5
 
         assert [t.text for t in instances[0].fields["question"].tokens[:3]] == ["To", "whom", "did"]

--- a/tests/data/dataset_readers/reading_comprehension/triviaqa_test.py
+++ b/tests/data/dataset_readers/reading_comprehension/triviaqa_test.py
@@ -10,7 +10,7 @@ class TestTriviaQaReader(AllenNlpTestCase):
                 'base_tarball_path': 'tests/fixtures/data/triviaqa-sample.tgz',
                 })
         reader = TriviaQaReader.from_params(params)
-        instances = reader.read('web-train.json').instances
+        instances = list(reader.read('web-train.json').iterinstances())
         assert len(instances) == 3
 
         assert [t.text for t in instances[0].fields["question"].tokens[:3]] == ["Which", "American", "-"]

--- a/tests/data/dataset_readers/reading_comprehension/triviaqa_test.py
+++ b/tests/data/dataset_readers/reading_comprehension/triviaqa_test.py
@@ -10,7 +10,7 @@ class TestTriviaQaReader(AllenNlpTestCase):
                 'base_tarball_path': 'tests/fixtures/data/triviaqa-sample.tgz',
                 })
         reader = TriviaQaReader.from_params(params)
-        instances = list(reader.read('web-train.json').iterinstances())
+        instances = list(reader.read('web-train.json'))
         assert len(instances) == 3
 
         assert [t.text for t in instances[0].fields["question"].tokens[:3]] == ["Which", "American", "-"]

--- a/tests/data/dataset_readers/seq2seq_test.py
+++ b/tests/data/dataset_readers/seq2seq_test.py
@@ -8,7 +8,7 @@ class TestSeq2SeqDatasetReader(AllenNlpTestCase):
         reader = Seq2SeqDatasetReader()
         dataset = reader.read('tests/fixtures/data/seq2seq_copy.tsv')
 
-        instances = list(dataset.iterinstances())
+        instances = list(dataset)
         assert len(instances) == 3
         fields = instances[0].fields
         assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is",
@@ -30,7 +30,7 @@ class TestSeq2SeqDatasetReader(AllenNlpTestCase):
         reader = Seq2SeqDatasetReader(source_add_start_token=False)
         dataset = reader.read('tests/fixtures/data/seq2seq_copy.tsv')
 
-        instances = list(dataset.iterinstances())
+        instances = list(dataset)
         assert len(instances) == 3
         fields = instances[0].fields
         assert [t.text for t in fields["source_tokens"].tokens] == ["this", "is", "a", "sentence", "@@END@@"]

--- a/tests/data/dataset_readers/seq2seq_test.py
+++ b/tests/data/dataset_readers/seq2seq_test.py
@@ -8,18 +8,19 @@ class TestSeq2SeqDatasetReader(AllenNlpTestCase):
         reader = Seq2SeqDatasetReader()
         dataset = reader.read('tests/fixtures/data/seq2seq_copy.tsv')
 
-        assert len(dataset.instances) == 3
-        fields = dataset.instances[0].fields
+        instances = list(dataset.iterinstances())
+        assert len(instances) == 3
+        fields = instances[0].fields
         assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "a", "sentence", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "a", "sentence", "@@END@@"]
-        fields = dataset.instances[1].fields
+        fields = instances[1].fields
         assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "another", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "another", "@@END@@"]
-        fields = dataset.instances[2].fields
+        fields = instances[2].fields
         assert [t.text for t in fields["source_tokens"].tokens] == ["@@START@@", "all", "these", "sentences",
                                                                     "should", "get", "copied", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "all", "these", "sentences",
@@ -29,8 +30,9 @@ class TestSeq2SeqDatasetReader(AllenNlpTestCase):
         reader = Seq2SeqDatasetReader(source_add_start_token=False)
         dataset = reader.read('tests/fixtures/data/seq2seq_copy.tsv')
 
-        assert len(dataset.instances) == 3
-        fields = dataset.instances[0].fields
+        instances = list(dataset.iterinstances())
+        assert len(instances) == 3
+        fields = instances[0].fields
         assert [t.text for t in fields["source_tokens"].tokens] == ["this", "is", "a", "sentence", "@@END@@"]
         assert [t.text for t in fields["target_tokens"].tokens] == ["@@START@@", "this", "is",
                                                                     "a", "sentence", "@@END@@"]

--- a/tests/data/dataset_readers/sequence_tagging_test.py
+++ b/tests/data/dataset_readers/sequence_tagging_test.py
@@ -8,17 +8,18 @@ class TestSequenceTaggingDatasetReader(AllenNlpTestCase):
         reader = SequenceTaggingDatasetReader()
         dataset = reader.read('tests/fixtures/data/sequence_tagging.tsv')
 
-        assert len(dataset.instances) == 4
-        fields = dataset.instances[0].fields
+        instances = list(dataset.iterinstances())
+        assert len(instances) == 4
+        fields = instances[0].fields
         assert [t.text for t in fields["tokens"].tokens] == ["cats", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
-        fields = dataset.instances[1].fields
+        fields = instances[1].fields
         assert [t.text for t in fields["tokens"].tokens] == ["dogs", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
-        fields = dataset.instances[2].fields
+        fields = instances[2].fields
         assert [t.text for t in fields["tokens"].tokens] == ["snakes", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
-        fields = dataset.instances[3].fields
+        fields = instances[3].fields
         assert [t.text for t in fields["tokens"].tokens] == ["birds", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
 
@@ -26,16 +27,17 @@ class TestSequenceTaggingDatasetReader(AllenNlpTestCase):
         reader = SequenceTaggingDatasetReader(word_tag_delimiter='/')
         dataset = reader.read('tests/fixtures/data/brown_corpus.txt')
 
-        assert len(dataset.instances) == 4
-        fields = dataset.instances[0].fields
+        instances = list(dataset.iterinstances())
+        assert len(instances) == 4
+        fields = instances[0].fields
         assert [t.text for t in fields["tokens"].tokens] == ["cats", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
-        fields = dataset.instances[1].fields
+        fields = instances[1].fields
         assert [t.text for t in fields["tokens"].tokens] == ["dogs", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
-        fields = dataset.instances[2].fields
+        fields = instances[2].fields
         assert [t.text for t in fields["tokens"].tokens] == ["snakes", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]
-        fields = dataset.instances[3].fields
+        fields = instances[3].fields
         assert [t.text for t in fields["tokens"].tokens] == ["birds", "are", "animals", "."]
         assert fields["tags"].labels == ["N", "V", "N", "N"]

--- a/tests/data/dataset_readers/sequence_tagging_test.py
+++ b/tests/data/dataset_readers/sequence_tagging_test.py
@@ -8,7 +8,7 @@ class TestSequenceTaggingDatasetReader(AllenNlpTestCase):
         reader = SequenceTaggingDatasetReader()
         dataset = reader.read('tests/fixtures/data/sequence_tagging.tsv')
 
-        instances = list(dataset.iterinstances())
+        instances = list(dataset)
         assert len(instances) == 4
         fields = instances[0].fields
         assert [t.text for t in fields["tokens"].tokens] == ["cats", "are", "animals", "."]
@@ -27,7 +27,7 @@ class TestSequenceTaggingDatasetReader(AllenNlpTestCase):
         reader = SequenceTaggingDatasetReader(word_tag_delimiter='/')
         dataset = reader.read('tests/fixtures/data/brown_corpus.txt')
 
-        instances = list(dataset.iterinstances())
+        instances = list(dataset)
         assert len(instances) == 4
         fields = instances[0].fields
         assert [t.text for t in fields["tokens"].tokens] == ["cats", "are", "animals", "."]

--- a/tests/data/dataset_readers/snli_reader_test.py
+++ b/tests/data/dataset_readers/snli_reader_test.py
@@ -25,16 +25,17 @@ class TestSnliReader(AllenNlpTestCase):
                      "hypothesis": ["A", "person", "is", "outdoors", ",", "on", "a", "horse", "."],
                      "label": "entailment"}
 
-        assert len(dataset.instances) == 3
-        fields = dataset.instances[0].fields
+        instances = list(dataset.iterinstances())
+        assert len(instances) == 3
+        fields = instances[0].fields
         assert [t.text for t in fields["premise"].tokens] == instance1["premise"]
         assert [t.text for t in fields["hypothesis"].tokens] == instance1["hypothesis"]
         assert fields["label"].label == instance1["label"]
-        fields = dataset.instances[1].fields
+        fields = instances[1].fields
         assert [t.text for t in fields["premise"].tokens] == instance2["premise"]
         assert [t.text for t in fields["hypothesis"].tokens] == instance2["hypothesis"]
         assert fields["label"].label == instance2["label"]
-        fields = dataset.instances[2].fields
+        fields = instances[2].fields
         assert [t.text for t in fields["premise"].tokens] == instance3["premise"]
         assert [t.text for t in fields["hypothesis"].tokens] == instance3["hypothesis"]
         assert fields["label"].label == instance3["label"]

--- a/tests/data/dataset_readers/snli_reader_test.py
+++ b/tests/data/dataset_readers/snli_reader_test.py
@@ -25,7 +25,7 @@ class TestSnliReader(AllenNlpTestCase):
                      "hypothesis": ["A", "person", "is", "outdoors", ",", "on", "a", "horse", "."],
                      "label": "entailment"}
 
-        instances = list(dataset.iterinstances())
+        instances = list(dataset)
         assert len(instances) == 3
         fields = instances[0].fields
         assert [t.text for t in fields["premise"].tokens] == instance1["premise"]

--- a/tests/data/dataset_readers/srl_dataset_reader_test.py
+++ b/tests/data/dataset_readers/srl_dataset_reader_test.py
@@ -8,7 +8,7 @@ class TestSrlReader(AllenNlpTestCase):
     def test_read_from_file(self):
         conll_reader = SrlReader()
         dataset = conll_reader.read('tests/fixtures/conll_2012/')
-        instances = list(dataset.iterinstances())
+        instances = list(dataset)
 
         fields = instances[0].fields
         tokens = [t.text for t in fields['tokens'].tokens]

--- a/tests/data/dataset_readers/srl_dataset_reader_test.py
+++ b/tests/data/dataset_readers/srl_dataset_reader_test.py
@@ -8,7 +8,7 @@ class TestSrlReader(AllenNlpTestCase):
     def test_read_from_file(self):
         conll_reader = SrlReader()
         dataset = conll_reader.read('tests/fixtures/conll_2012/')
-        instances = dataset.instances
+        instances = list(dataset.iterinstances())
 
         fields = instances[0].fields
         tokens = [t.text for t in fields['tokens'].tokens]

--- a/tests/data/dataset_test.py
+++ b/tests/data/dataset_test.py
@@ -49,7 +49,7 @@ class TestDataset(AllenNlpTestCase):
         dataset = self.get_dataset()
         dataset.index_instances(self.vocab)
         padding_lengths = dataset.get_padding_lengths()
-        iterator = dataset.iterinstances()
+        iterator = iter(dataset)
 
         instance1 = next(iterator)
         instance2 = next(iterator)

--- a/tests/data/dataset_test.py
+++ b/tests/data/dataset_test.py
@@ -5,6 +5,7 @@ import numpy
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Dataset, Instance, Token, Vocabulary
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.fields import TextField, LabelField
 from allennlp.data.token_indexers import SingleIdTokenIndexer
 
@@ -24,7 +25,7 @@ class TestDataset(AllenNlpTestCase):
         instance1 = Instance({"tag": (LabelField(1, skip_indexing=True))})
         instance2 = Instance({"words": TextField([Token("hello")], {})})
         with pytest.raises(ConfigurationError):
-            _ = Dataset([instance1, instance2])
+            _ = InMemoryDataset([instance1, instance2])
 
     def test_padding_lengths_uses_max_instance_lengths(self):
         dataset = self.get_dataset()
@@ -81,4 +82,4 @@ class TestDataset(AllenNlpTestCase):
                            self.token_indexer)
         instances = [Instance({"text1": field1, "text2": field2}),
                      Instance({"text1": field3, "text2": field4})]
-        return Dataset(instances)
+        return InMemoryDataset(instances)

--- a/tests/data/iterators/basic_iterator_test.py
+++ b/tests/data/iterators/basic_iterator_test.py
@@ -4,6 +4,7 @@ from typing import List
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Dataset, Instance, Token, Vocabulary
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.fields import TextField
 from allennlp.data.iterators import BasicIterator
 from allennlp.data.token_indexers import SingleIdTokenIndexer
@@ -28,7 +29,7 @@ class IteratorTest(AllenNlpTestCase):
                 self.create_instance(["this", "is", "a", "very", "very", "very", "very", "long", "sentence"]),
                 self.create_instance(["sentence"]),
                 ]
-        self.dataset = Dataset(self.instances)
+        self.dataset = InMemoryDataset(self.instances)
 
     def create_instance(self, str_tokens: List[str]):
         tokens = [Token(t) for t in str_tokens]

--- a/tests/data/iterators/lazy_iterator_test.py
+++ b/tests/data/iterators/lazy_iterator_test.py
@@ -50,7 +50,7 @@ class TestLazyIterator(LazyIteratorTestCase):
     # We also test some of the stuff in `DataIterator` here.
     def test_yield_one_epoch_iterates_over_the_data_once(self):
         iterator = LazyIterator(batch_size=2)
-        batches = list(iterator(self.dataset, num_epochs=1))
+        batches = list(iterator(self.dataset, num_epochs=1, shuffle=False))
         # We just want to get the single-token array for the text field in the instance.
         instances = [tuple(instance.data.cpu().numpy())
                      for batch in batches
@@ -59,7 +59,7 @@ class TestLazyIterator(LazyIteratorTestCase):
         self.assert_instances_are_correct(instances)
 
     def test_call_iterates_over_data_forever(self):
-        generator = LazyIterator(batch_size=2)(self.dataset)
+        generator = LazyIterator(batch_size=2)(self.dataset, shuffle=False)
         batches = [next(generator) for _ in range(18)]  # going over the data 6 times
         # We just want to get the single-token array for the text field in the instance.
         instances = [tuple(instance.data.cpu().numpy())

--- a/tests/data/iterators/lazy_iterator_test.py
+++ b/tests/data/iterators/lazy_iterator_test.py
@@ -1,0 +1,79 @@
+# pylint: disable=no-self-use,invalid-name
+from typing import List
+
+from allennlp.common import Params
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import LazyDataset, Instance, Token, Vocabulary
+from allennlp.data.fields import TextField
+from allennlp.data.iterators import LazyIterator
+from allennlp.data.token_indexers import SingleIdTokenIndexer
+
+class LazyIteratorTestCase(AllenNlpTestCase):
+    def setUp(self):
+        super(LazyIteratorTestCase, self).setUp()
+        self.token_indexers = {"tokens": SingleIdTokenIndexer()}
+        self.vocab = Vocabulary()
+        self.this_index = self.vocab.add_token_to_namespace('this')
+        self.is_index = self.vocab.add_token_to_namespace('is')
+        self.a_index = self.vocab.add_token_to_namespace('a')
+        self.sentence_index = self.vocab.add_token_to_namespace('sentence')
+        self.another_index = self.vocab.add_token_to_namespace('another')
+        self.yet_index = self.vocab.add_token_to_namespace('yet')
+        self.very_index = self.vocab.add_token_to_namespace('very')
+        self.long_index = self.vocab.add_token_to_namespace('long')
+        self.instances = [
+                self.create_instance(["this", "is", "a", "sentence"]),
+                self.create_instance(["this", "is", "another", "sentence"]),
+                self.create_instance(["yet", "another", "sentence"]),
+                self.create_instance(["this", "is", "a", "very", "very", "very", "very", "long", "sentence"]),
+                self.create_instance(["sentence"]),
+                ]
+        self.dataset = LazyDataset(lambda: (i for i in self.instances))
+        self.dataset.index_instances(self.vocab)
+
+    def create_instance(self, str_tokens: List[str]):
+        tokens = [Token(t) for t in str_tokens]
+        instance = Instance({'text': TextField(tokens, self.token_indexers)})
+        instance.index_fields(self.vocab)
+        return instance
+
+    def assert_instances_are_correct(self, candidate_instances):
+        # First we need to remove padding tokens from the candidates.
+        # pylint: disable=protected-access
+        candidate_instances = [tuple(w for w in instance if w != 0) for instance in candidate_instances]
+        expected_instances = [tuple(instance.fields["text"]._indexed_tokens["tokens"])
+                              for instance in self.instances]
+        assert set(candidate_instances) == set(expected_instances)
+
+
+class TestLazyIterator(LazyIteratorTestCase):
+    # We also test some of the stuff in `DataIterator` here.
+    def test_yield_one_epoch_iterates_over_the_data_once(self):
+        iterator = LazyIterator(batch_size=2)
+        batches = list(iterator(self.dataset, num_epochs=1))
+        # We just want to get the single-token array for the text field in the instance.
+        instances = [tuple(instance.data.cpu().numpy())
+                     for batch in batches
+                     for instance in batch['text']["tokens"]]
+        assert len(instances) == 5
+        self.assert_instances_are_correct(instances)
+
+    def test_call_iterates_over_data_forever(self):
+        generator = LazyIterator(batch_size=2)(self.dataset)
+        batches = [next(generator) for _ in range(18)]  # going over the data 6 times
+        # We just want to get the single-token array for the text field in the instance.
+        instances = [tuple(instance.data.cpu().numpy())
+                     for batch in batches
+                     for instance in batch['text']["tokens"]]
+        assert len(instances) == 5 * 6
+        self.assert_instances_are_correct(instances)
+
+    def test_from_params(self):
+        # pylint: disable=protected-access
+        params = Params({})
+        iterator = LazyIterator.from_params(params)
+        assert iterator._batch_size == 32  # default value
+
+        params = Params({"batch_size": 10})
+        iterator = LazyIterator.from_params(params)
+        assert iterator._batch_size == 10

--- a/tests/data/lazy_dataset_test.py
+++ b/tests/data/lazy_dataset_test.py
@@ -4,12 +4,12 @@ import numpy
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.data import Dataset, Instance, Token, Vocabulary
+from allennlp.data import LazyDataset, Instance, Token, Vocabulary
 from allennlp.data.fields import TextField, LabelField
 from allennlp.data.token_indexers import SingleIdTokenIndexer
 
 
-class TestDataset(AllenNlpTestCase):
+class TestLazyDataset(AllenNlpTestCase):
     def setUp(self):
         self.vocab = Vocabulary()
         self.vocab.add_token_to_namespace("this")
@@ -18,35 +18,29 @@ class TestDataset(AllenNlpTestCase):
         self.vocab.add_token_to_namespace("sentence")
         self.vocab.add_token_to_namespace(".")
         self.token_indexer = {"tokens": SingleIdTokenIndexer()}
-        super(TestDataset, self).setUp()
+        super(TestLazyDataset, self).setUp()
 
     def test_instances_must_have_homogeneous_fields(self):
         instance1 = Instance({"tag": (LabelField(1, skip_indexing=True))})
         instance2 = Instance({"words": TextField([Token("hello")], {})})
         with pytest.raises(ConfigurationError):
-            _ = Dataset([instance1, instance2])
+            _ = LazyDataset(lambda: (instance for instance in [instance1, instance2]))
 
     def test_padding_lengths_uses_max_instance_lengths(self):
-        dataset = self.get_dataset()
+        dataset = self.get_lazy_dataset()
         dataset.index_instances(self.vocab)
         padding_lengths = dataset.get_padding_lengths()
         assert padding_lengths == {"text1": {"num_tokens": 5}, "text2": {"num_tokens": 6}}
 
     def test_as_tensor_dict(self):
-        dataset = self.get_dataset()
+        dataset = self.get_lazy_dataset()
         dataset.index_instances(self.vocab)
         padding_lengths = dataset.get_padding_lengths()
-        tensors = dataset.as_tensor_dict(padding_lengths)
-        text1 = tensors["text1"]["tokens"].data.cpu().numpy()
-        text2 = tensors["text2"]["tokens"].data.cpu().numpy()
-
-        numpy.testing.assert_array_almost_equal(text1, numpy.array([[2, 3, 4, 5, 6],
-                                                                    [1, 3, 4, 5, 6]]))
-        numpy.testing.assert_array_almost_equal(text2, numpy.array([[2, 3, 4, 1, 5, 6],
-                                                                    [2, 3, 1, 0, 0, 0]]))
+        with pytest.raises(NotImplementedError):
+            _ = dataset.as_tensor_dict(padding_lengths)
 
     def test_iterinstances(self):
-        dataset = self.get_dataset()
+        dataset = self.get_lazy_dataset()
         dataset.index_instances(self.vocab)
         padding_lengths = dataset.get_padding_lengths()
         iterator = dataset.iterinstances()
@@ -69,8 +63,7 @@ class TestDataset(AllenNlpTestCase):
         numpy.testing.assert_array_almost_equal(text_2_1, numpy.array([1, 3, 4, 5, 6]))
         numpy.testing.assert_array_almost_equal(text_2_2, numpy.array([2, 3, 1, 0, 0, 0]))
 
-
-    def get_dataset(self):
+    def get_lazy_dataset(self):
         field1 = TextField([Token(t) for t in ["this", "is", "a", "sentence", "."]],
                            self.token_indexer)
         field2 = TextField([Token(t) for t in ["this", "is", "a", "different", "sentence", "."]],
@@ -81,4 +74,4 @@ class TestDataset(AllenNlpTestCase):
                            self.token_indexer)
         instances = [Instance({"text1": field1, "text2": field2}),
                      Instance({"text1": field3, "text2": field4})]
-        return Dataset(instances)
+        return LazyDataset(lambda: (instance for instance in instances))

--- a/tests/data/lazy_dataset_test.py
+++ b/tests/data/lazy_dataset_test.py
@@ -43,7 +43,7 @@ class TestLazyDataset(AllenNlpTestCase):
         text_2_1 = tensors2['text1']['tokens'].data.cpu().numpy()
         text_2_2 = tensors2['text2']['tokens'].data.cpu().numpy()
         numpy.testing.assert_array_almost_equal(text_2_1, numpy.array([1, 3, 4, 5, 6]))
-        numpy.testing.assert_array_almost_equal(text_2_2, numpy.array([2, 3, 1, 0, 0, 0]))
+        numpy.testing.assert_array_almost_equal(text_2_2, numpy.array([2, 3, 1]))
 
     def get_lazy_dataset(self):
         field1 = TextField([Token(t) for t in ["this", "is", "a", "sentence", "."]],

--- a/tests/data/vocabulary_test.py
+++ b/tests/data/vocabulary_test.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 import pytest
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Dataset, Instance, Token
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.fields import TextField
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenCharactersIndexer
 from allennlp.data.tokenizers import CharacterTokenizer
@@ -21,7 +22,7 @@ class TestVocabulary(AllenNlpTestCase):
         text_field = TextField([Token(t) for t in ["a", "a", "a", "a", "b", "b", "c", "c", "c"]],
                                {"tokens": token_indexer})
         self.instance = Instance({"text": text_field})
-        self.dataset = Dataset([self.instance])
+        self.dataset = InMemoryDataset([self.instance])
         super(TestVocabulary, self).setUp()
 
     def test_from_dataset_respects_min_count(self):
@@ -250,7 +251,7 @@ class TestVocabulary(AllenNlpTestCase):
         token_indexer = TokenCharactersIndexer(character_tokenizer=tokenizer)
         tokens = [Token(t) for t in ["Øyvind", "für", "汉字"]]
         text_field = TextField(tokens, {"characters": token_indexer})
-        dataset = Dataset([Instance({"sentence": text_field})])
+        dataset = InMemoryDataset([Instance({"sentence": text_field})])
         vocab = Vocabulary.from_dataset(dataset)
         text_field.index(vocab)
         indexed_tokens = deepcopy(text_field._indexed_tokens)  # pylint: disable=protected-access

--- a/tests/models/reading_comprehension/bidaf_test.py
+++ b/tests/models/reading_comprehension/bidaf_test.py
@@ -36,9 +36,11 @@ class BidirectionalAttentionFlowTest(ModelTestCase):
         assert_almost_equal(numpy.sum(span_start_probs, -1), 1, decimal=6)
         assert_almost_equal(numpy.sum(span_end_probs, -1), 1, decimal=6)
         span_start, span_end = tuple(output_dict['best_span'][0].data.numpy())
+
+        instance = next(self.dataset.iterinstances())
         assert span_start >= 0
         assert span_start <= span_end
-        assert span_end < self.dataset.instances[0].fields['passage'].sequence_length()
+        assert span_end < instance.fields['passage'].sequence_length()
         assert isinstance(output_dict['best_span_str'][0], str)
 
     # Some recent efficiency changes (using bmm for `weighted_sum`, the more efficient

--- a/tests/models/reading_comprehension/bidaf_test.py
+++ b/tests/models/reading_comprehension/bidaf_test.py
@@ -37,7 +37,7 @@ class BidirectionalAttentionFlowTest(ModelTestCase):
         assert_almost_equal(numpy.sum(span_end_probs, -1), 1, decimal=6)
         span_start, span_end = tuple(output_dict['best_span'][0].data.numpy())
 
-        instance = next(self.dataset.iterinstances())
+        instance = next(iter(self.dataset))
         assert span_start >= 0
         assert span_start <= span_end
         assert span_end < instance.fields['passage'].sequence_length()

--- a/tests/modules/elmo_test.py
+++ b/tests/modules/elmo_test.py
@@ -10,6 +10,7 @@ from torch.autograd import Variable
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data.token_indexers.elmo_indexer import ELMoTokenCharactersIndexer
 from allennlp.data import Token, Vocabulary, Dataset, Instance
+from allennlp.data.in_memory_dataset import InMemoryDataset
 from allennlp.data.iterators import BasicIterator
 from allennlp.modules.elmo import _ElmoBiLm, Elmo, _ElmoCharacterEncoder
 from allennlp.data.fields import TextField
@@ -40,7 +41,7 @@ class TestElmoBiLm(AllenNlpTestCase):
                 instance = Instance({"elmo": field})
                 instances.append(instance)
 
-        dataset = Dataset(instances)
+        dataset = InMemoryDataset(instances)
         vocab = Vocabulary()
         dataset.index_instances(vocab)
 
@@ -115,7 +116,7 @@ class TestElmo(AllenNlpTestCase):
             instance = Instance({'elmo': field})
             instances.append(instance)
 
-        dataset = Dataset(instances)
+        dataset = InMemoryDataset(instances)
         vocab = Vocabulary()
         dataset.index_instances(vocab)
         return dataset.as_tensor_dict()['elmo']['character_ids']

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -83,8 +83,10 @@ class TestTrainer(AllenNlpTestCase):
     def test_train_driver_raises_on_model_with_no_loss_key(self):
 
         class FakeModel(torch.nn.Module):
+            vocab = Vocabulary()
             def forward(self, **kwargs):  # pylint: disable=arguments-differ,unused-argument
                 return {}
+
         with pytest.raises(ConfigurationError):
             trainer = Trainer(FakeModel(), self.optimizer,
                               self.iterator, self.dataset,


### PR DESCRIPTION
here's a proposal for how to handle lazy datasets

at a high level, here are the changes

* make `Dataset.instances` private (and eliminate all external access to it)
* replace it with `Dataset.iterinstances() -> Iterator[Instance]` and change all calling code to use that
* introduce `Dataset.num_instances` property to replace calls to `len(dataset.instances)`
* create `LazyDataset` subclass that takes an "instance generator" instead of a list of instances
* create lazy `DataIterator` subclass that doesn't rely on having all instances in-memory
* modify `commands/train` to build the vocabulary from a `LazyDataset` instead of a `Dataset`
* add some tests

I'm not certain this is the right approach. It's a breaking change for anyone who's using `Dataset.instances` directly, although I'm not sure if that's anyone or not. A non-breaking alternative would have `LazyDataset` not be a subclass of `Dataset` and then try to flow those changes through, but that felt worse.

Some of the steps around how the LazyDataset handles indexing and padding are a little bit clunky, but I think they're right.

I don't *think* this should have any performance impacts (I think now during training we'll make a shallow copy of the list of instances each epoch, but that should be really fast).

Let me know what you think about this approach / the naming.