### PR TITLE
Better KnowledgeGraphField

### DIFF
--- a/allennlp/data/fields/knowledge_graph_field.py
+++ b/allennlp/data/fields/knowledge_graph_field.py
@@ -7,12 +7,14 @@ import torch
 from torch.autograd import Variable
 from overrides import overrides
 
+from allennlp.common import util
 from allennlp.data.fields.field import Field
 from allennlp.data.semparse import KnowledgeGraph
 from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
 from allennlp.data.tokenizers.token import Token
+from allennlp.data.tokenizers.tokenizer import Tokenizer
 from allennlp.data.vocabulary import Vocabulary
-from allennlp.nn import util
+from allennlp.nn import util as nn_util
 
 TokenList = List[TokenType]  # pylint: disable=invalid-name
 
@@ -20,15 +22,33 @@ TokenList = List[TokenType]  # pylint: disable=invalid-name
 class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
     """
     A ``KnowledgeGraphField`` represents a ``KnowledgeGraph`` as a ``Field`` that can be used in a
-    ``Model``.  We take the (sorted) list of entities in the graph and output them as arrays using
-    ``TokenIndexers``, similar to how text tokens are treated by a ``TextField``.  We have
-    knowledge-graph-specific ``TokenIndexers``, however, that allow for more versatile treatment of
-    the knowledge graph entities than just treating them as text tokens.
+    ``Model``.  For each entity in the graph, we output two things: a text representation of the
+    entity, handled identically to a ``TextField``, and a list of linking features for each token
+    in some input utterance.
+
+    The output of this field is a dictionary::
+
+        {
+          "text": Dict[str, torch.Tensor],  # each tensor has shape (batch_size, num_entities, num_entity_tokens)
+          "linking": torch.Tensor  # shape (batch_size, num_entities, num_utterance_tokens)
+        }
+
+    The ``text`` component of this dictionary is suitable to be passed into a
+    ``TextFieldEmbedder`` (which handles the additional ``num_entities`` dimension without any
+    issues).  The ``linking`` component of the dictionary can be used however you want to decide
+    which tokens in the utterance correspond to which entities in the knowledge graph.
+
+    In order to create the ``text`` component, we use the same dictionary of ``TokenIndexers``
+    that's used in a ``TextField`` (as we're just representing the text corresponding to each
+    entity).  For the ``linking`` component, we use a set of hard-coded feature extractors that
+    operate between the text corresponding to each entity and each token in the utterance.
 
     Parameters
     ----------
     knowledge_graph : ``KnowledgeGraph``
         The knowledge graph that this field stores.
+    tokenizer : ``Tokenizer``
+        We'll use this ``Tokenizer`` to tokenize the text representation of each entity.
     token_indexers : ``Dict[str, TokenIndexer]``
         Token indexers that convert entities into arrays, similar to how text tokens are treated in
         a ``TextField``.  These might operate on the name of the entity itself, its type, its
@@ -36,46 +56,51 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
     """
     def __init__(self,
                  knowledge_graph: KnowledgeGraph,
+                 tokenizer: Tokenizer,
                  token_indexers: Dict[str, TokenIndexer]) -> None:
-        self.knowledge_graph: KnowledgeGraph = knowledge_graph
-        self.entities = [Token(entity) for entity in sorted(self.knowledge_graph.get_all_entities())]
+        self.knowledge_graph = knowledge_graph
+        self.entity_texts = [tokenizer.tokenize(knowledge_graph.entity_text[entity])
+                            for entity in knowledge_graph.entities]
+        self._tokenizer = tokenizer
         self._token_indexers: Dict[str, TokenIndexer] = token_indexers
-        self._indexed_entities: Dict[str, TokenList] = None
+        self._indexed_entity_texts: Dict[str, TokenList] = None
 
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
         for indexer in self._token_indexers.values():
-            for entity in self.entities:
-                indexer.count_vocab_items(entity, counter)
+            for entity_text in self.entity_texts:
+                for token in entity_text:
+                    indexer.count_vocab_items(token, counter)
 
     @overrides
     def index(self, vocab: Vocabulary):
-        entity_arrays = {}
+        self._indexed_entity_texts = {}
         for indexer_name, indexer in self._token_indexers.items():
-            arrays = [indexer.token_to_indices(entity, vocab) for entity in self.entities]
-            entity_arrays[indexer_name] = arrays
-        self._indexed_entities = entity_arrays
+            indexer_arrays = []
+            for entity_text in self.entity_texts:
+                indexer_arrays.append([indexer.token_to_indices(token, vocab) for token in entity_text])
+            self._indexed_entity_texts[indexer_name] = indexer_arrays
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:
+        padding_lengths = {'num_entities': len(self.entity_texts)}
+        padding_lengths['num_entity_tokens'] = max(len(entity_text) for entity_text in self.entity_texts)
         lengths = []
-        assert self._indexed_entities is not None, ("This field is not indexed yet. Call "
-                                                    ".index(vocabulary) before determining padding "
-                                                    "lengths.")
+        assert self._indexed_entity_texts is not None, ("This field is not indexed yet. Call "
+                                                       ".index(vocab) before determining padding "
+                                                       "lengths.")
         for indexer_name, indexer in self._token_indexers.items():
             indexer_lengths = {}
 
             # This is a list of dicts, one for each token in the field.
-            entity_lengths = [indexer.get_padding_lengths(entity)
-                              for entity in self._indexed_entities[indexer_name]]
+            entity_lengths = [indexer.get_padding_lengths(token)
+                              for entity_text in self._indexed_entity_texts[indexer_name]
+                              for token in entity_text]
             # Iterate over the keys in the first element of the list.  This is fine as for a given
             # indexer, all entities will return the same keys, so we can just use the first one.
             for key in entity_lengths[0].keys():
                 indexer_lengths[key] = max(x[key] if key in x else 0 for x in entity_lengths)
             lengths.append(indexer_lengths)
-
-        any_indexed_entity_key = list(self._indexed_entities.keys())[0]
-        padding_lengths = {'num_entities': len(self._indexed_entities[any_indexed_entity_key])}
 
         # Get all the keys which have been used for padding.
         padding_keys = {key for d in lengths for key in d.keys()}
@@ -90,20 +115,30 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
                   for_training: bool = True) -> Dict[str, torch.Tensor]:
         tensors = {}
         desired_num_entities = padding_lengths['num_entities']
+        desired_num_entity_tokens = padding_lengths['num_entity_tokens']
         for indexer_name, indexer in self._token_indexers.items():
-            padded_array = indexer.pad_token_sequence(self._indexed_entities[indexer_name],
-                                                      desired_num_entities, padding_lengths)
-            # Use the key of the indexer to recognise what the array corresponds to within the field
-            # (i.e. the result of word indexing, or the result of character indexing, for example).
-            tensor = Variable(torch.LongTensor(padded_array), volatile=not for_training)
+            padded_entities = util.pad_sequence_to_length(self._indexed_entity_texts[indexer_name],
+                                                          desired_num_entities,
+                                                          default_value=lambda x: [])
+            padded_arrays = []
+            for padded_entity in padded_entities:
+                padded_array = indexer.pad_token_sequence(padded_entity,
+                                                          desired_num_entity_tokens,
+                                                          padding_lengths)
+                print(padded_array)
+                padded_arrays.append(padded_array)
+            print(padded_arrays)
+            tensor = Variable(torch.LongTensor(padded_arrays), volatile=not for_training)
+            print(tensor)
             tensors[indexer_name] = tensor if cuda_device == -1 else tensor.cuda(cuda_device)
-        return tensors
+        return {'text': tensors}
 
     @overrides
     def empty_field(self) -> 'KnowledgeGraphField':
-        return KnowledgeGraphField(KnowledgeGraph({}), self._token_indexers)
+        return KnowledgeGraphField(KnowledgeGraph(set(), {}), self._tokenizer, self._token_indexers)
 
     @overrides
     def batch_tensors(self, tensor_list: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
         # pylint: disable=no-self-use
-        return util.batch_tensor_dicts(tensor_list)
+        batched_text = nn_util.batch_tensor_dicts(tensor['text'] for tensor in tensor_list)
+        return {'text': batched_text}

--- a/allennlp/data/fields/knowledge_graph_field.py
+++ b/allennlp/data/fields/knowledge_graph_field.py
@@ -1,13 +1,15 @@
 """
 ``KnowledgeGraphField`` is a ``Field`` which stores a knowledge graph representation.
 """
-from typing import Dict, List
+from typing import Callable, Dict, List, Set
 
+import editdistance
+from overrides import overrides
 import torch
 from torch.autograd import Variable
-from overrides import overrides
 
 from allennlp.common import util
+from allennlp.common.checks import ConfigurationError
 from allennlp.data.fields.field import Field
 from allennlp.data.semparse import KnowledgeGraph
 from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
@@ -30,7 +32,7 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
 
         {
           "text": Dict[str, torch.Tensor],  # each tensor has shape (batch_size, num_entities, num_entity_tokens)
-          "linking": torch.Tensor  # shape (batch_size, num_entities, num_utterance_tokens)
+          "linking": torch.Tensor  # shape (batch_size, num_entities, num_utterance_tokens, num_features)
         }
 
     The ``text`` component of this dictionary is suitable to be passed into a
@@ -47,23 +49,66 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
     ----------
     knowledge_graph : ``KnowledgeGraph``
         The knowledge graph that this field stores.
+    utterance_tokens : ``List[Token]``
+        The tokens in some utterance that is paired with the ``KnowledgeGraph``.  We compute a set
+        of features for linking tokens in the utterance to entities in the graph.
     tokenizer : ``Tokenizer``
         We'll use this ``Tokenizer`` to tokenize the text representation of each entity.
     token_indexers : ``Dict[str, TokenIndexer]``
         Token indexers that convert entities into arrays, similar to how text tokens are treated in
         a ``TextField``.  These might operate on the name of the entity itself, its type, its
         neighbors in the graph, etc.
+    feature_extractors : ``List[str]``, optional
+        Names of feature extractors to use for computing linking features.  These must be
+        attributes of this object, without the first underscore.  The feature extraction functions
+        are listed as the last methods in this class.  For example, to use
+        :func:`_exact_token_match`, you would pass the string ``exact_token_match``.  We will add
+        an underscore and look for a function matching that name.  If this list is omitted, we will
+        use all available feature functions.
     """
     def __init__(self,
                  knowledge_graph: KnowledgeGraph,
+                 utterance_tokens: List[Token],
                  tokenizer: Tokenizer,
-                 token_indexers: Dict[str, TokenIndexer]) -> None:
+                 token_indexers: Dict[str, TokenIndexer],
+                 feature_extractors: List[str] = None) -> None:
         self.knowledge_graph = knowledge_graph
         self.entity_texts = [tokenizer.tokenize(knowledge_graph.entity_text[entity])
-                            for entity in knowledge_graph.entities]
+                             for entity in knowledge_graph.entities]
+        self.utterance_tokens = utterance_tokens
         self._tokenizer = tokenizer
         self._token_indexers: Dict[str, TokenIndexer] = token_indexers
         self._indexed_entity_texts: Dict[str, TokenList] = None
+
+        feature_extractors = feature_extractors or [
+                'exact_token_match',
+                'contains_exact_token_match',
+                'lemma_match',
+                'contains_lemma_match',
+                'edit_distance',
+                'related_column',
+                'related_column_lemma',
+                ]
+        self._feature_extractors: List[Callable[[str, List[Token], Token], float]] = []
+        for feature_extractor_name in feature_extractors:
+            extractor = getattr(self, '_' + feature_extractor_name, None)
+            if not extractor:
+                raise ConfigurationError(f"Invalid feature extractor name: {feature_extractor_name}")
+            self._feature_extractors.append(extractor)
+
+        # For quicker lookups in our feature functions, we'll additionally store some dictionaries
+        # that map entity strings to useful information about the entity.
+        self._entity_text_map: Dict[str, List[Token]] = {}
+        for entity, entity_text in zip(knowledge_graph.entities, self.entity_texts):
+            self._entity_text_map[entity] = entity_text
+
+        self._entity_text_exact_text: Dict[str, Set[str]] = {}
+        for entity, entity_text in zip(knowledge_graph.entities, self.entity_texts):
+            self._entity_text_exact_text[entity] = set(e.text for e in entity_text)
+
+        self._entity_text_lemmas: Dict[str, Set[str]] = {}
+        for entity, entity_text in zip(knowledge_graph.entities, self.entity_texts):
+            self._entity_text_lemmas[entity] = set(e.lemma_ for e in entity_text)
 
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
@@ -83,12 +128,13 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:
-        padding_lengths = {'num_entities': len(self.entity_texts)}
+        padding_lengths = {'num_entities': len(self.entity_texts),
+                           'num_utterance_tokens': len(self.utterance_tokens)}
         padding_lengths['num_entity_tokens'] = max(len(entity_text) for entity_text in self.entity_texts)
         lengths = []
         assert self._indexed_entity_texts is not None, ("This field is not indexed yet. Call "
-                                                       ".index(vocab) before determining padding "
-                                                       "lengths.")
+                                                        ".index(vocab) before determining padding "
+                                                        "lengths.")
         for indexer_name, indexer in self._token_indexers.items():
             indexer_lengths = {}
 
@@ -116,29 +162,108 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
         tensors = {}
         desired_num_entities = padding_lengths['num_entities']
         desired_num_entity_tokens = padding_lengths['num_entity_tokens']
+        desired_num_utterance_tokens = padding_lengths['num_utterance_tokens']
         for indexer_name, indexer in self._token_indexers.items():
             padded_entities = util.pad_sequence_to_length(self._indexed_entity_texts[indexer_name],
                                                           desired_num_entities,
-                                                          default_value=lambda x: [])
+                                                          default_value=lambda: [])
             padded_arrays = []
             for padded_entity in padded_entities:
                 padded_array = indexer.pad_token_sequence(padded_entity,
                                                           desired_num_entity_tokens,
                                                           padding_lengths)
-                print(padded_array)
                 padded_arrays.append(padded_array)
-            print(padded_arrays)
             tensor = Variable(torch.LongTensor(padded_arrays), volatile=not for_training)
-            print(tensor)
             tensors[indexer_name] = tensor if cuda_device == -1 else tensor.cuda(cuda_device)
-        return {'text': tensors}
+        linking_features = self._compute_linking_features(desired_num_entities,
+                                                          desired_num_utterance_tokens,
+                                                          cuda_device,
+                                                          for_training)
+        return {'text': tensors, 'linking': linking_features}
+
+    def _compute_linking_features(self,
+                                  num_entities: int,
+                                  num_utterance_tokens: int,
+                                  cuda_device: int,
+                                  for_training: bool) -> torch.Tensor:
+        linking_features = []
+        for entity, entity_text in zip(self.knowledge_graph.entities, self.entity_texts):
+            entity_features = []
+            for token in self.utterance_tokens:
+                token_features = []
+                for feature_extractor in self._feature_extractors:
+                    token_features.append(feature_extractor(entity, entity_text, token))
+                entity_features.append(token_features)
+            for _ in range(num_utterance_tokens - len(entity_features)):
+                entity_features.append([0.0] * len(self._feature_extractors))
+            linking_features.append(entity_features)
+        for _ in range(num_entities - len(linking_features)):
+            padded_entity = []
+            for _ in range(num_utterance_tokens):
+                padded_entity.append([0.0] * len(self._feature_extractors))
+            linking_features.append(padded_entity)
+        tensor = Variable(torch.FloatTensor(linking_features), volatile=not for_training)
+        return tensor if cuda_device == -1 else tensor.cuda(cuda_device)
 
     @overrides
     def empty_field(self) -> 'KnowledgeGraphField':
-        return KnowledgeGraphField(KnowledgeGraph(set(), {}), self._tokenizer, self._token_indexers)
+        return KnowledgeGraphField(KnowledgeGraph(set(), {}), [], self._tokenizer, self._token_indexers)
 
     @overrides
     def batch_tensors(self, tensor_list: List[Dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
         # pylint: disable=no-self-use
-        batched_text = nn_util.batch_tensor_dicts(tensor['text'] for tensor in tensor_list)
-        return {'text': batched_text}
+        batched_text = nn_util.batch_tensor_dicts(tensor['text'] for tensor in tensor_list)  # type: ignore
+        batched_linking = torch.stack([tensor['linking'] for tensor in tensor_list])
+        return {'text': batched_text, 'linking': batched_linking}
+
+    # Below here we have feature extractor functions.  To keep a consistent API for easy logic
+    # above, some of these functions have unused arguments.
+    # For the feature functions used in the original parser written in PNP, see here:
+    # https://github.com/allenai/pnp/blob/wikitables2/src/main/scala/org/allenai/wikitables/SemanticParserFeatureGenerator.scala
+    # pylint: disable=unused-argument,no-self-use
+
+    def _exact_token_match(self, entity: str, entity_text: List[Token], token: Token) -> float:
+        if len(entity_text) != 1:
+            return 0.0
+        return self._contains_exact_token_match(entity, entity_text, token)
+
+    def _contains_exact_token_match(self, entity: str, entity_text: List[Token], token: Token) -> float:
+        if token.text in self._entity_text_exact_text[entity]:
+            return 1.0
+        return 0.0
+
+    def _lemma_match(self, entity: str, entity_text: List[Token], token: Token) -> float:
+        if len(entity_text) != 1:
+            return 0.0
+        return self._contains_lemma_match(entity, entity_text, token)
+
+    def _contains_lemma_match(self, entity: str, entity_text: List[Token], token: Token) -> float:
+        if token.text in self._entity_text_exact_text[entity]:
+            return 1.0
+        if token.lemma_ in self._entity_text_lemmas[entity]:
+            return 1.0
+        return 0.0
+
+    def _edit_distance(self, entity: str, entity_text: List[Token], token: Token) -> float:
+        edit_distance = float(editdistance.eval(' '.join(e.text for e in entity_text), token.text))
+        return 1.0 - edit_distance / len(token.text)
+
+    def _related_column(self, entity: str, entity_text: List[Token], token: Token) -> float:
+        if not entity.startswith('fb:row.row'):
+            return 0.0
+        for neighbor in self.knowledge_graph.neighbors[entity]:
+            if token.text in self._entity_text_exact_text[neighbor]:
+                return 1.0
+        return 0.0
+
+    def _related_column_lemma(self, entity: str, entity_text: List[Token], token: Token) -> float:
+        if not entity.startswith('fb:row.row'):
+            return 0.0
+        for neighbor in self.knowledge_graph.neighbors[entity]:
+            if token.text in self._entity_text_exact_text[neighbor]:
+                return 1.0
+            if token.lemma_ in self._entity_text_lemmas[neighbor]:
+                return 1.0
+        return 0.0
+
+    # pylint: enable=unused-argument,no-self-use

--- a/allennlp/data/semparse/knowledge_graphs/knowledge_graph.py
+++ b/allennlp/data/semparse/knowledge_graphs/knowledge_graph.py
@@ -3,45 +3,47 @@ A ``KnowledgeGraph`` is a graphical representation of some structured knowledge 
 table, figure or an explicit knowledge base.
 """
 
-from typing import Dict, List
+from typing import Dict, List, Set
 
 
 class KnowledgeGraph:
     """
-    ``KnowledgeGraph`` currently stores some basic neighborhood information, and provides  minimal
-    functionality for querying that information, for embedding this knowledge or linking the
-    entities in the knowledge base to some text.
+    A ``KnowledgeGraph`` represents a collection of entities and their relationships.
+
+    The ``KnowledgeGraph`` currently stores (untyped) neighborhood information and text
+    representations of each entity (if there is any).
 
     The knowledge base itself can be a table (like in WikitableQuestions), a figure (like in NLVR)
     or some other structured knowledge source. This abstract class needs to be inherited for
     implementing the functionality appropriate for a given KB.
 
+    All of the parameters listed below are stored as public attributes.
+
     Parameters
     ----------
-    neighbors : Dict[str, List[str]]
-        Entities (represented as strings) mapped to their neighbors.
+    entities : ``Set[str]``
+        The string identifiers of the entities in this knowledge graph.  We sort this set and store
+        it as a list.  The sorting is so that we get a guaranteed consistent ordering across
+        separate runs of the code.
+    neighbors : ``Dict[str, List[str]]``
+        A mapping from string identifiers to other string identifiers, denoting which entities are
+        neighbors in the graph.
+    entity_text : ``Dict[str, str]``
+        If you have additional text associated with each entity (other than its string identifier),
+        you can store that here.  This might be, e.g., the text in a table cell, or the description
+        of a wikipedia entity.
     """
-    def __init__(self, neighbors: Dict[str, List[str]]) -> None:
-        self._neighbors = neighbors
+    def __init__(self,
+                 entities: Set[str],
+                 neighbors: Dict[str, List[str]],
+                 entity_text: Dict[str, str] = None) -> None:
+        self.entities = sorted(entities)
+        self.neighbors = neighbors
+        self.entity_text = entity_text
 
     @classmethod
     def read_from_file(cls, filename: str):
         raise NotImplementedError
-
-    def get_neighbors(self, entity: str) -> List[str]:
-        """
-        Parameters
-        ----------
-        entity : str
-            String representation of the entity whose neighbors will be returned.
-        """
-        return self._neighbors[entity]
-
-    def get_all_entities(self) -> List[str]:
-        # We return a sorted list here so we get guaranteed consistent ordering, for
-        # reproducibility's sake.  The ordering will affect the name mapping that we do, which
-        # affects the intermediate nltk logical forms.
-        return sorted(self._neighbors.keys())
 
     def __eq__(self, other):
         if isinstance(self, other.__class__):

--- a/allennlp/data/semparse/knowledge_graphs/table_knowledge_graph.py
+++ b/allennlp/data/semparse/knowledge_graphs/table_knowledge_graph.py
@@ -4,7 +4,7 @@ Classes related to representing a table in WikitableQuestions. At this point we 
 """
 import re
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, List, Set
+from typing import Any, DefaultDict, Dict, List
 
 from unidecode import unidecode
 

--- a/allennlp/data/semparse/worlds/wikitables_world.py
+++ b/allennlp/data/semparse/worlds/wikitables_world.py
@@ -45,7 +45,7 @@ class WikiTablesWorld(World):
         # cells and columns, so we can get them as valid actions in the parser.  The null cell and
         # column are used to check against empty sets, e.g., for questions like "Is there a team
         # that won three times in a row?".
-        for entity in table_graph.get_all_entities() + ['fb:cell.null', 'fb:row.row.null']:
+        for entity in table_graph.entities + ['fb:cell.null', 'fb:row.row.null']:
             self._map_name(entity, keep_mapping=True)
 
         numbers = self._get_numbers_from_tokens(question_tokens) + list(str(i) for i in range(-1, 10))

--- a/allennlp/data/tokenizers/token.py
+++ b/allennlp/data/tokenizers/token.py
@@ -1,8 +1,8 @@
 class Token:
     """
     A simple token representation, keeping track of the token's text, offset in the passage it was
-    taken from, POS tag, and dependency relation.  These fields match spacy's exactly, so we can
-    just use a spacy token for this.
+    taken from, POS tag, dependency relation, and similar information.  These fields match spacy's
+    exactly, so we can just use a spacy token for this.
 
     Parameters
     ----------
@@ -10,6 +10,8 @@ class Token:
         The original text represented by this token.
     idx : ``int``, optional
         The character offset of this token into the tokenized passage.
+    lemma : ``str``, optional
+        The lemma of this token.
     pos : ``str``, optional
         The coarse-grained part of speech of this token.
     tag : ``str``, optional
@@ -31,6 +33,7 @@ class Token:
     def __init__(self,
                  text: str = None,
                  idx: int = None,
+                 lemma: str = None,
                  pos: str = None,
                  tag: str = None,
                  dep: str = None,
@@ -38,6 +41,7 @@ class Token:
                  text_id: int = None) -> None:
         self.text = text
         self.idx = idx
+        self.lemma_ = lemma
         self.pos_ = pos
         self.tag_ = tag
         self.dep_ = dep

--- a/allennlp/data/tokenizers/word_stemmer.py
+++ b/allennlp/data/tokenizers/word_stemmer.py
@@ -51,4 +51,11 @@ class PorterStemmer(WordStemmer):
     @overrides
     def stem_word(self, word: Token) -> Token:
         new_text = self.stemmer.stem(word.text)
-        return Token(new_text, word.idx, word.pos_, word.tag_, word.dep_, getattr(word, 'text_id', None))
+        return Token(text=new_text,
+                     idx=word.idx,
+                     lemma=word.lemma_,
+                     pos=word.pos_,
+                     tag=word.tag_,
+                     dep=word.dep_,
+                     ent_type=word.ent_type_,
+                     text_id=getattr(word, 'text_id', None))

--- a/allennlp/data/tokenizers/word_tokenizer.py
+++ b/allennlp/data/tokenizers/word_tokenizer.py
@@ -35,19 +35,6 @@ class WordTokenizer(Tokenizer):
         If given, these tokens will be added to the beginning of every string we tokenize.
     end_tokens : ``List[str]``, optional
         If given, these tokens will be added to the end of every string we tokenize.
-    language : ``str``, optional
-        We use spacy to tokenize strings; this option specifies which language to use.  By default
-        we use English.
-    pos_tags : ``bool``, optional
-        By default we do not load spacy's tagging model, to save loading time and memory.  Set this
-        to ``True`` if you want to have access to spacy's POS tags in the returned tokens.
-    parse : ``bool``, optional
-        By default we do not load spacy's parsing model, to save loading time and memory.  Set this
-        to ``True`` if you want to have access to spacy's dependency parse tags in the returned
-        tokens.
-    ner : ``bool``, optional
-        By default we do not load spacy's parsing model, to save loading time and memory.  Set this
-        to ``True`` if you want to have access to spacy's NER tags in the returned tokens.
     """
     def __init__(self,
                  word_splitter: WordSplitter = None,

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -87,6 +87,8 @@ class WikiTablesSemanticParser(Model):
         check_dimensions_match(nonterminal_embedder.get_output_dim(), terminal_embedder.get_output_dim(),
                                "nonterminal embedding dim", "terminal embedding dim")
 
+        # TODO(mattg): instantiate a parameter vector for the linking features.
+
         self._action_padding_index = -1  # the padding value used by IndexField
         action_embedding_dim = nonterminal_embedder.get_output_dim() * 2
         self._decoder_step = WikiTablesDecoderStep(vocab=vocab,
@@ -133,6 +135,25 @@ class WikiTablesSemanticParser(Model):
         embedded_input = self._question_embedder(question)
         question_mask = util.get_text_field_mask(question).float()
         batch_size = embedded_input.size(0)
+
+        # Actually a Dict[str, torch.LongTensor], but there is probably a single entry, with a
+        # tensor of shape (batch_size, num_entities, num_entity_tokens).
+        table_text = table['text']
+        # TODO(mattg): embed the table, similar to how the question is embedded (probably just
+        # using the question embedder), giving a tensor of shape (batch_size, num_entities,
+        # num_entity_tokens, embedding_dim).  Then encode that into shape (batch_size,
+        # num_entities, embedding_dim).
+
+        # (batch_size, num_entities, num_question_tokens, num_features)
+        linking_features = table['linking']
+        # TODO(mattg): multiply this by the feature weights, use this and the text embedding above
+        # to compute a linking scores.
+
+        # TODO(mattg): we need to actually compute this with the stuff mentioned above.  This
+        # represents how well each question token matches table entities.  I'm stubbing this out
+        # for now, so that I have a variable to pass to the decoder, because we need this there.
+        # (batch_size, num_entities, num_question_tokens)
+        linking_scores: torch.FloatTensor = None
 
         # (batch_size, question_length, encoder_output_dim)
         encoder_outputs = self._encoder(embedded_input, question_mask)

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -15,7 +15,7 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
         question_tokens = ["what", "was", "the", "last", "year", "where", "this", "team", "was",
                            "a", "part", "of", "the", "usl", "a", "-", "league", "?"]
         assert [t.text for t in instance.fields["question"].tokens] == question_tokens
-        entities = instance.fields['table'].knowledge_graph.get_all_entities()
+        entities = instance.fields['table'].knowledge_graph.entities
         assert len(entities) == 47
         assert sorted(entities) == [
                 # The table cell entity names.  Duplicates have trailing _2, _3, etc.

--- a/tests/data/fields/knowledge_graph_field_test.py
+++ b/tests/data/fields/knowledge_graph_field_test.py
@@ -1,0 +1,113 @@
+# pylint: disable=no-self-use,invalid-name
+from collections import defaultdict
+
+import pytest
+import numpy
+from numpy.testing import assert_almost_equal
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Vocabulary
+from allennlp.data.fields import KnowledgeGraphField
+from allennlp.data.semparse.knowledge_graphs import TableKnowledgeGraph
+from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenCharactersIndexer
+from allennlp.data.tokenizers import WordTokenizer
+
+
+class KnowledgeGraphFieldTest(AllenNlpTestCase):
+    def setUp(self):
+        json = {
+                'columns': ['Name in English', 'Location in English'],
+                'cells': [['Paradeniz', 'Mersin'],
+                          ['Lake Gala', 'Edirne']]
+                }
+        self.graph = TableKnowledgeGraph.read_from_json(json)
+        self.vocab = Vocabulary()
+        self.name_index = self.vocab.add_token_to_namespace("Name", namespace='tokens')
+        self.in_index = self.vocab.add_token_to_namespace("in", namespace='tokens')
+        self.english_index = self.vocab.add_token_to_namespace("English", namespace='tokens')
+        self.location_index = self.vocab.add_token_to_namespace("Location", namespace='tokens')
+        self.paradeniz_index = self.vocab.add_token_to_namespace("Paradeniz", namespace='tokens')
+        self.mersin_index = self.vocab.add_token_to_namespace("Mersin", namespace='tokens')
+        self.lake_index = self.vocab.add_token_to_namespace("Lake", namespace='tokens')
+        self.gala_index = self.vocab.add_token_to_namespace("Gala", namespace='tokens')
+
+        self.oov_index = self.vocab.get_token_index('random OOV string', namespace='tokens')
+        self.edirne_index = self.oov_index
+
+        self.tokenizer = WordTokenizer()
+        self.token_indexers = {"tokens": SingleIdTokenIndexer("tokens")}
+        self.field = KnowledgeGraphField(self.graph, self.tokenizer, self.token_indexers)
+
+        super(KnowledgeGraphFieldTest, self).setUp()
+
+    def test_count_vocab_items(self):
+        namespace_token_counts = defaultdict(lambda: defaultdict(int))
+        self.field.count_vocab_items(namespace_token_counts)
+
+        assert namespace_token_counts["tokens"] == {
+                'Name': 1,
+                'in': 2,
+                'English': 2,
+                'Location': 1,
+                'Paradeniz': 1,
+                'Mersin': 1,
+                'Lake': 1,
+                'Gala': 1,
+                'Edirne': 1,
+                }
+
+    def test_index_converts_field_correctly(self):
+        # pylint: disable=protected-access
+        self.field.index(self.vocab)
+        assert self.field._indexed_entity_texts.keys() == {'tokens'}
+        # Note that these are sorted by their _identifiers_, not their cell text, so the
+        # `fb:row.rows` show up after the `fb:cells`.
+        expected_array = [[self.edirne_index],
+                          [self.lake_index, self.gala_index],
+                          [self.mersin_index],
+                          [self.paradeniz_index],
+                          [self.location_index, self.in_index, self.english_index],
+                          [self.name_index, self.in_index, self.english_index]]
+        assert self.field._indexed_entity_texts['tokens'] == expected_array
+
+    def test_get_padding_lengths_raises_if_not_indexed(self):
+        with pytest.raises(AssertionError):
+            self.field.get_padding_lengths()
+
+    def test_padding_lengths_are_computed_correctly(self):
+        self.field.index(self.vocab)
+        assert self.field.get_padding_lengths() == {'num_entities': 6, 'num_entity_tokens': 3}
+        self.field._token_indexers['token_characters'] = TokenCharactersIndexer()
+        self.field.index(self.vocab)
+        assert self.field.get_padding_lengths() == {'num_entities': 6, 'num_entity_tokens': 3,
+                                                    'num_token_characters': 9}
+
+    def test_as_tensor_produces_correct_output(self):
+        self.field.index(self.vocab)
+        padding_lengths = self.field.get_padding_lengths()
+        tensor_dict = self.field.as_tensor(padding_lengths)
+        assert tensor_dict.keys() == {'text'}
+        expected_text_tensor = [[self.edirne_index, 0, 0],
+                                [self.lake_index, self.gala_index, 0],
+                                [self.mersin_index, 0, 0],
+                                [self.paradeniz_index, 0, 0],
+                                [self.location_index, self.in_index, self.english_index],
+                                [self.name_index, self.in_index, self.english_index]]
+        assert_almost_equal(tensor_dict['text']['tokens'].data.cpu().numpy(), expected_text_tensor)
+
+    def test_batch_tensors(self):
+        self.field.index(self.vocab)
+        padding_lengths = self.field.get_padding_lengths()
+        tensor_dict1 = self.field.as_tensor(padding_lengths)
+        tensor_dict2 = self.field.as_tensor(padding_lengths)
+        batched_tensor_dict = self.field.batch_tensors([tensor_dict1, tensor_dict2])
+        assert batched_tensor_dict.keys() == {'text'}
+        expected_single_tensor = [[self.edirne_index, 0, 0],
+                                  [self.lake_index, self.gala_index, 0],
+                                  [self.mersin_index, 0, 0],
+                                  [self.paradeniz_index, 0, 0],
+                                  [self.location_index, self.in_index, self.english_index],
+                                  [self.name_index, self.in_index, self.english_index]]
+        expected_batched_tensor = [expected_single_tensor, expected_single_tensor]
+        assert_almost_equal(batched_tensor_dict['text']['tokens'].data.cpu().numpy(),
+                            expected_batched_tensor)

--- a/tests/data/semparse/knowledge_graphs/table_knowledge_graph_test.py
+++ b/tests/data/semparse/knowledge_graphs/table_knowledge_graph_test.py
@@ -10,11 +10,20 @@ class TestTableKnowledgeGraph(AllenNlpTestCase):
                 'cells': [['Paradeniz', 'Mersin'],
                           ['Lake Gala', 'Edirne']]
                 }
-        knowledge_graph = TableKnowledgeGraph.read_from_json(json)
-        neighbors = set(knowledge_graph.get_cell_neighbors('fb:cell.mersin'))
+        graph = TableKnowledgeGraph.read_from_json(json)
+        neighbors = set(graph.neighbors['fb:cell.mersin'])
+        assert graph.entities == ['fb:cell.edirne', 'fb:cell.lake_gala', 'fb:cell.mersin',
+                                  'fb:cell.paradeniz', 'fb:row.row.location',
+                                  'fb:row.row.name_in_english']
         assert neighbors == {'fb:row.row.location'}
-        neighbors = set(knowledge_graph.get_column_neighbors('fb:row.row.name_in_english'))
+        neighbors = set(graph.neighbors['fb:row.row.name_in_english'])
         assert neighbors == {'fb:cell.paradeniz', 'fb:cell.lake_gala'}
+        assert graph.entity_text['fb:cell.edirne'] == 'Edirne'
+        assert graph.entity_text['fb:cell.lake_gala'] == 'Lake Gala'
+        assert graph.entity_text['fb:cell.mersin'] == 'Mersin'
+        assert graph.entity_text['fb:cell.paradeniz'] == 'Paradeniz'
+        assert graph.entity_text['fb:row.row.location'] == 'Location'
+        assert graph.entity_text['fb:row.row.name_in_english'] == 'Name in English'
 
     def test_read_from_json_handles_diacritics(self):
         json = {
@@ -22,8 +31,8 @@ class TestTableKnowledgeGraph(AllenNlpTestCase):
                 'cells': [['Lake Van', 'Van Gölü', 'Mersin'],
                           ['Lake Gala', 'Gala Gölü', 'Edirne']]
                 }
-        knowledge_graph = TableKnowledgeGraph.read_from_json(json)
-        neighbors = set(knowledge_graph.get_column_neighbors('fb:row.row.name_in_turkish'))
+        graph = TableKnowledgeGraph.read_from_json(json)
+        neighbors = set(graph.neighbors['fb:row.row.name_in_turkish'])
         assert neighbors == {'fb:cell.van_golu', 'fb:cell.gala_golu'}
 
     def test_read_from_json_handles_newlines_in_columns(self):
@@ -34,20 +43,20 @@ class TestTableKnowledgeGraph(AllenNlpTestCase):
                 'cells': [['1', '2'],
                           ['3', '4']]
                 }
-        knowledge_graph = TableKnowledgeGraph.read_from_json(json)
-        neighbors = set(knowledge_graph.get_column_neighbors('fb:row.row.peak_aus'))
+        graph = TableKnowledgeGraph.read_from_json(json)
+        neighbors = set(graph.neighbors['fb:row.row.peak_aus'])
         assert neighbors == {'fb:cell.1', 'fb:cell.3'}
-        neighbors = set(knowledge_graph.get_column_neighbors('fb:row.row.peak_nz'))
+        neighbors = set(graph.neighbors['fb:row.row.peak_nz'])
         assert neighbors == {'fb:cell.2', 'fb:cell.4'}
-        neighbors = set(knowledge_graph.get_cell_neighbors('fb:cell.1'))
+        neighbors = set(graph.neighbors['fb:cell.1'])
         assert neighbors == {'fb:row.row.peak_aus'}
 
         json = {
                 'columns': ['Title'],
                 'cells': [['Dance of the\\nSeven Veils']]
                 }
-        knowledge_graph = TableKnowledgeGraph.read_from_json(json)
-        neighbors = set(knowledge_graph.get_column_neighbors('fb:row.row.title'))
+        graph = TableKnowledgeGraph.read_from_json(json)
+        neighbors = set(graph.neighbors['fb:row.row.title'])
         assert neighbors == {'fb:cell.dance_of_the_seven_veils'}
 
     def test_read_from_json_handles_diacritics_and_newlines(self):
@@ -55,8 +64,8 @@ class TestTableKnowledgeGraph(AllenNlpTestCase):
                 'columns': ['Notes'],
                 'cells': [['8 districts\nFormed from Orūzgān Province in 2004']]
                 }
-        knowledge_graph = TableKnowledgeGraph.read_from_json(json)
-        neighbors = set(knowledge_graph.get_column_neighbors('fb:row.row.notes'))
+        graph = TableKnowledgeGraph.read_from_json(json)
+        neighbors = set(graph.neighbors['fb:row.row.notes'])
         assert neighbors == {'fb:cell.8_districts_formed_from_oruzgan_province_in_2004'}
 
     def test_read_from_json_handles_crazy_unicode(self):
@@ -65,8 +74,8 @@ class TestTableKnowledgeGraph(AllenNlpTestCase):
                 'cells': [['Viðareiði'],
                           ['Funningsfjørður']]
                 }
-        knowledge_graph = TableKnowledgeGraph.read_from_json(json)
-        neighbors = set(knowledge_graph.get_column_neighbors('fb:row.row.town'))
+        graph = TableKnowledgeGraph.read_from_json(json)
+        neighbors = set(graph.neighbors['fb:row.row.town'])
         assert neighbors == {'fb:cell.funningsfj_r_ur',
                              'fb:cell.vi_arei_i',
                              }
@@ -78,8 +87,8 @@ class TestTableKnowledgeGraph(AllenNlpTestCase):
                           ['South Korea (KOR)'],
                           ['Area (km²)']]
                 }
-        knowledge_graph = TableKnowledgeGraph.read_from_json(json)
-        neighbors = set(knowledge_graph.get_column_neighbors('fb:row.row.urban_settlements'))
+        graph = TableKnowledgeGraph.read_from_json(json)
+        neighbors = set(graph.neighbors['fb:row.row.urban_settlements'])
         assert neighbors == {'fb:cell.dzhebariki_khaya',
                              'fb:cell.south_korea_kor',
                              'fb:cell.area_km'}
@@ -90,10 +99,10 @@ class TestTableKnowledgeGraph(AllenNlpTestCase):
                 'cells': [['1', '2'],
                           ['3', '4']]
                 }
-        knowledge_graph = TableKnowledgeGraph.read_from_json(json)
-        neighbors = set(knowledge_graph.get_column_neighbors('fb:row.row._of_votes'))
+        graph = TableKnowledgeGraph.read_from_json(json)
+        neighbors = set(graph.neighbors['fb:row.row._of_votes'])
         assert neighbors == {'fb:cell.1', 'fb:cell.3'}
-        neighbors = set(knowledge_graph.get_column_neighbors('fb:row.row._of_votes_2'))
+        neighbors = set(graph.neighbors['fb:row.row._of_votes_2'])
         assert neighbors == {'fb:cell.2', 'fb:cell.4'}
-        neighbors = set(knowledge_graph.get_cell_neighbors('fb:cell.1'))
+        neighbors = set(graph.neighbors['fb:cell.1'])
         assert neighbors == {'fb:row.row._of_votes'}


### PR DESCRIPTION
This builds on #639 (which in turn builds on #606).  I'll rebase this once that one is merged.  It's only the most recent two commits shown in the list.

This PR makes the `KnowledgeGraphField` actually work the way that the original parser did.  We have two separate representations for each KG entity: an embedded representation of the text in the corresponding cell, and a set of linking features for each token in the question.  I haven't updated the model code to _use_ this at all - that will come next.

I've implemented most of the entity linking features from the original parser, except for the span matching ones.  Shouldn't be _too_ hard to add those, but it will be a little annoying.
  