### PR TITLE
Use linking for action scoring

### DIFF
--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -203,7 +203,7 @@ class WikiTablesDatasetReader(DatasetReader):
             field = ProductionRuleField(production_rule,
                                         terminal_indexers=self._terminal_indexers,
                                         nonterminal_indexers=self._nonterminal_indexers,
-                                        nonterminal_types=self._basic_types,
+                                        is_nonterminal=world.is_table_entity,
                                         context=tokenized_question)
             production_rule_fields.append(field)
         action_field = ListField(production_rule_fields)

--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -203,7 +203,7 @@ class WikiTablesDatasetReader(DatasetReader):
             field = ProductionRuleField(production_rule,
                                         terminal_indexers=self._terminal_indexers,
                                         nonterminal_indexers=self._nonterminal_indexers,
-                                        is_nonterminal=world.is_table_entity,
+                                        is_nonterminal=lambda x: not world.is_table_entity(x),
                                         context=tokenized_question)
             production_rule_fields.append(field)
         action_field = ListField(production_rule_fields)

--- a/allennlp/data/fields/production_rule_field.py
+++ b/allennlp/data/fields/production_rule_field.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Set, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import torch
 from torch.autograd import Variable

--- a/allennlp/data/fields/production_rule_field.py
+++ b/allennlp/data/fields/production_rule_field.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Callable, Dict, List, Set, Tuple
 
 import torch
 from torch.autograd import Variable
@@ -46,9 +46,9 @@ class ProductionRuleField(Field[ProductionRuleArray]):  # type: ignore
     split the indexing decision is on "built-in" vs. instance-specific.  That is, if you have a
     terminal production that is part of your grammar, like "<#1,#1> -> identity", you might want to
     just learn an embedding for the terminal "identity", instead of treating it like you might
-    treat a terminal like "my_instance_specific_function".  You can accomplish this by just adding
-    all built-in terminals to the set of ``nonterminal_types`` passed in to this ``Field`` 's
-    constructor, and they will get indexed with the ``nonterminal_indexers``.
+    treat a terminal like "my_instance_specific_function".  You can accomplish this by just
+    defining ``is_nonterminal`` to return ``True`` for any globally-valid terminal productions, and
+    they will get indexed with the ``nonterminal_indexers``.
 
     We currently treat non-terminal sequences as a single non-terminal token from the
     ``TokenIndexers`` point of view.  The alternative here would be to represent each non-terminal
@@ -74,10 +74,10 @@ class ProductionRuleField(Field[ProductionRuleArray]):  # type: ignore
         The ``TokenIndexers`` that we will use to convert terminal strings into arrays.
     nonterminal_indexers : ``Dict[str, TokenIndexer]``
         The ``TokenIndexers`` that we will use to convert non-terminal strings into arrays.
-    nonterminal_types : ``Set[str]``
-        A set of basic types used in the grammar.  This is for things like NP, VP, S, N, a, b, and
-        c in the examples above.  We use this set to determine whether to use the terminal or the
-        non-terminal token indexers when we are representing the RHS of a production rule.
+    is_nonterminal : ``Callable[[str], bool]``
+        A function that maps right-hand sides of production rules to whether they represent
+        non-terminals.  We use this to determine whether to use the terminal or the non-terminal
+        token indexers when we are representing the RHS of a production rule.
     context : Any, optional
         Additional context that can be used by the token indexers when constructing their
         representations.  This could be an utterance we're trying to produce a semantic parse for,
@@ -88,12 +88,12 @@ class ProductionRuleField(Field[ProductionRuleArray]):  # type: ignore
                  rule: str,
                  terminal_indexers: Dict[str, TokenIndexer],
                  nonterminal_indexers: Dict[str, TokenIndexer],
-                 nonterminal_types: Set[str],
+                 is_nonterminal: Callable[[str], bool],
                  context: Any = None) -> None:
         self.rule = rule
         self._terminal_indexers = terminal_indexers
         self._nonterminal_indexers = nonterminal_indexers
-        self._nonterminal_types = nonterminal_types
+        self._is_nonterminal = is_nonterminal
         self._context = context
 
         if rule:
@@ -114,11 +114,6 @@ class ProductionRuleField(Field[ProductionRuleArray]):  # type: ignore
         # annotations like this?
         self._indexed_left_side: Dict = None
         self._indexed_right_side: Dict = None
-
-    def _is_nonterminal(self, right_side: str) -> bool:
-        if right_side[0] == '[' or right_side[0] == '<':
-            return True
-        return right_side in self._nonterminal_types
 
     @overrides
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
@@ -201,7 +196,7 @@ class ProductionRuleField(Field[ProductionRuleArray]):  # type: ignore
         return ProductionRuleField(rule='',
                                    terminal_indexers={},
                                    nonterminal_indexers={},
-                                   nonterminal_types=set(),
+                                   is_nonterminal=self._is_nonterminal,
                                    context=None)
 
     @overrides

--- a/allennlp/data/semparse/worlds/wikitables_world.py
+++ b/allennlp/data/semparse/worlds/wikitables_world.py
@@ -52,6 +52,14 @@ class WikiTablesWorld(World):
         for number in numbers:
             self._map_name(number, keep_mapping=True)
 
+        self._entity_set = set(table_graph.entities)
+
+    def is_table_entity(self, entity_name: str) -> bool:
+        """
+        Returns ``True`` if the given entity is one of the entities in the table.
+        """
+        return entity_name in self._entity_set
+
     def _get_numbers_from_tokens(self, tokens: List[Token]) -> List[str]:
         """
         Finds numbers in the input tokens and returns them as strings.

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -798,6 +798,8 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
 
         num_embedded_actions = max(len(actions) for actions in embedded_actions)
         num_linked_actions = max(len(actions) for actions in linked_actions)
+        if num_linked_actions == 0:
+            linked_actions = None
         considered_actions = []
         for global_action_list in global_valid_actions:
             # The global_valid_action list is already sorted from above.

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -166,7 +166,7 @@ class WikiTablesSemanticParser(Model):
         # (batch_size, num_entities, num_question_tokens)
         num_entities = embedded_table_text.size(1)
         num_question_tokens = embedded_input.size(1)
-        linking_scores: torch.FloatTensor = torch.rand(batch_size, num_entities, num_question_tokens)
+        linking_scores: torch.FloatTensor = Variable(torch.rand(batch_size, num_entities, num_question_tokens))
 
         # (batch_size, question_length, encoder_output_dim)
         encoder_outputs = self._encoder(embedded_input, question_mask)
@@ -1014,7 +1014,6 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
         for batch_index, action_list in zip(state.batch_indices, actions_to_link):
             action_entities.append([])
             for action_index in action_list:
-                print(state.possible_actions[batch_index][action_index]['right'][0])
                 action_entities[-1].append(state.actions_to_entities[(batch_index, action_index)])
 
         # Then we create a padded tensor suitable for use with

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -777,7 +777,6 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
             `None` here.
         """
         num_global_actions = state.action_embeddings.size(0)
-        print(num_global_actions)
         valid_actions = state.get_valid_actions()
         global_valid_actions = []
         for batch_index, valid_action_list in zip(state.batch_indices, valid_actions):
@@ -787,7 +786,7 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
                 global_valid_actions[-1].append((global_action_index, action_index))
         embedded_actions = []
         linked_actions = []
-        for batch_index, global_action_list in zip(state.batch_indices, global_valid_actions):
+        for global_action_list in global_valid_actions:
             global_action_list.sort()
             embedded_actions.append([])
             linked_actions.append([])
@@ -800,21 +799,20 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
         num_embedded_actions = max(len(actions) for actions in embedded_actions)
         num_linked_actions = max(len(actions) for actions in linked_actions)
         considered_actions = []
-        # TODO(mattg): this block isn't working right...
-        for batch_index, global_valid_actions in zip(state.batch_indices, global_valid_actions):
+        for global_action_list in global_valid_actions:
             # The global_valid_action list is already sorted from above.
             considered_actions.append([])
             # First we add the embedded actions to the list.
             for global_action_index, action_index in global_action_list:
                 if global_action_index < num_global_actions:
-                    considered_actions[-1].append((action_index))
+                    considered_actions[-1].append(action_index)
             # Then we pad that portion.
             while len(considered_actions[-1]) < num_embedded_actions:
                 considered_actions[-1].append(-1)
             # Then we add the linked actions to the list.
             for global_action_index, action_index in global_action_list:
                 if global_action_index >= num_global_actions:
-                    considered_actions[-1].append((action_index))
+                    considered_actions[-1].append(action_index)
             # Finally, we pad the linked portion.
             while len(considered_actions[-1]) < num_embedded_actions + num_linked_actions:
                 considered_actions[-1].append(-1)

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -6,6 +6,9 @@ from allennlp.common.testing import AllenNlpTestCase
 
 class TestWikiTablesDatasetReader(AllenNlpTestCase):
     def test_reader_reads(self):
+        # pylint is having trouble applying the disable command above to this method; maybe because
+        # it is so long?
+        # pylint: disable=no-self-use,protected-access
         tables_directory = "tests/fixtures/data/wikitables"
         dpd_output_directory = "tests/fixtures/data/wikitables/dpd_output"
         reader = WikiTablesDatasetReader(tables_directory, dpd_output_directory)

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -23,7 +23,7 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
         entities = instance.fields['table'].knowledge_graph.entities
         assert len(entities) == 47
         assert sorted(entities) == [
-                # The table cell entity names.  Duplicates have trailing _2, _3, etc.
+                # The table cell entity names.
                 'fb:cell.10_727',
                 'fb:cell.11th',
                 'fb:cell.1st',
@@ -105,15 +105,15 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
         for i in range(63, 117):
             assert action_fields[i]._right_is_nonterminal is True, f"{i}, {action_fields[i].rule}"
         # Start of the "e -> fb:cell.[column]" block.
-        for i in range(117, 171):
+        for i in range(117, 152):
             assert action_fields[i]._right_is_nonterminal is False, f"{i}, {action_fields[i].rule}"
         # This is the null cell, right in the middle of the other cells.
-        assert action_fields[171]._right_is_nonterminal is True, f"{i}, {action_fields[i].rule}"
+        assert action_fields[152]._right_is_nonterminal is True, f"{i}, {action_fields[i].rule}"
         # End of the "e -> fb:cell.[column]" block.
-        for i in range(172, 188):
+        for i in range(153, 158):
             assert action_fields[i]._right_is_nonterminal is False, f"{i}, {action_fields[i].rule}"
         # After the "e -> fb:cell.[column]" block.
-        for i in range(188, 204):
+        for i in range(158, 174):
             assert action_fields[i]._right_is_nonterminal is True, f"{i}, {action_fields[i].rule}"
 
         # This is going to be long, but I think it's worth it, to be sure that all of the actions

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-self-use
+# pylint: disable=invalid-name,no-self-use,protected-access
 from allennlp.data.dataset_readers import WikiTablesDatasetReader
 from allennlp.data.semparse.worlds import WikiTablesWorld
 from allennlp.common.testing import AllenNlpTestCase

--- a/tests/data/fields/production_rule_field_test.py
+++ b/tests/data/fields/production_rule_field_test.py
@@ -30,7 +30,11 @@ class TestProductionRuleField(AllenNlpTestCase):
         self.terminal_indexers = {"entities": SingleIdTokenIndexer("entities")}
         self.nonterminal_indexers = {"rules": SingleIdTokenIndexer("rule_labels")}
         self.character_indexer = {'characters': TokenCharactersIndexer('characters')}
-        self.nonterminal_types = {'S', 'NP', 'VP'}
+        def is_nonterminal(name: str) -> bool:
+            if name[0] in {'<', '['}:
+                return True
+            return name in {'S', 'NP', 'VP'}
+        self.is_nonterminal = is_nonterminal
 
         super(TestProductionRuleField, self).setUp()
 
@@ -43,7 +47,7 @@ class TestProductionRuleField(AllenNlpTestCase):
         return ProductionRuleField(rule_string,
                                    terminal_indexers=terminal_indexers,
                                    nonterminal_indexers=nonterminal_indexers,
-                                   nonterminal_types=self.nonterminal_types)
+                                   is_nonterminal=self.is_nonterminal)
 
     def test_field_counts_vocab_items_correctly(self):
         field = self._make_field('S -> [NP, VP]')

--- a/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
@@ -234,7 +234,7 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         # pylint: disable=protected-access
         valid_actions_1 = {'e': [0, 1, 2, 4]}
         valid_actions_2 = {'e': [0, 1, 3]}
-        valid_actions_3 = {'e': [3, 4]}
+        valid_actions_3 = {'e': [2, 3, 4]}
         self.state.grammar_state[0] = GrammarState(['e'], {}, valid_actions_1, {})
         self.state.grammar_state[1] = GrammarState(['e'], {}, valid_actions_2, {})
         self.state.grammar_state[2] = GrammarState(['e'], {}, valid_actions_3, {})
@@ -246,11 +246,11 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         # These are _batch_ action indices with a _global_ action index above num_global_actions,
         # sorted by their _global_ action index.
         # They come from actions [[(0, 2), (0, 4)], [(1, 3), (1, 0)], [(0, 3), (0, 4)]].
-        expected_to_link = [[2, 4], [3, 0], [3, 4]]
+        expected_to_link = [[2, 4], [3, 0], [2, 3, 4]]
         assert to_link == expected_to_link
         # These are _batch_ action indices, sorted by _global_ action index, with padding in
         # between the embedded actions and the linked actions.
-        expected_considered = [[1, 0, 2, 4], [1, -1, 3, 0], [-1, -1, 3, 4]]
+        expected_considered = [[1, 0, 2, 4, -1], [1, -1, 3, 0, -1], [-1, -1, 2, 3, 4]]
         assert considered == expected_considered
 
     def test_compute_new_states(self):

--- a/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
@@ -10,6 +10,7 @@ from allennlp.data.semparse.type_declarations.type_declaration import START_SYMB
 from allennlp.models import WikiTablesSemanticParser
 from allennlp.models.encoder_decoders.wikitables_semantic_parser import WikiTablesDecoderState
 from allennlp.models.encoder_decoders.wikitables_semantic_parser import WikiTablesDecoderStep
+from allennlp.models.encoder_decoders import wikitables_semantic_parser
 
 
 class WikiTablesSemanticParserTest(ModelTestCase):
@@ -49,6 +50,8 @@ class WikiTablesSemanticParserTest(ModelTestCase):
                 }
 
     def test_embed_actions_works_with_batched_and_padded_input(self):
+        old_terminal_embedding_value = wikitables_semantic_parser.USE_TERMINAL_EMBEDDING
+        wikitables_semantic_parser.USE_TERMINAL_EMBEDDING = True
         # pylint: disable=protected-access
         model = self.model
         nonterminal_embedding = model._nonterminal_embedder._token_embedders['tokens']
@@ -124,12 +127,63 @@ class WikiTablesSemanticParserTest(ModelTestCase):
         expected_action_embedding = torch.cat([zeros, start_embedding], dim=-1)
         assert_almost_equal(initial_action_embedding.cpu().data.numpy(),
                             expected_action_embedding.cpu().data.numpy())
+        wikitables_semantic_parser.USE_TERMINAL_EMBEDDING = old_terminal_embedding_value
 
+    def test_embed_actions_does_not_embed_terminals_when_set(self):
+        old_terminal_embedding_value = wikitables_semantic_parser.USE_TERMINAL_EMBEDDING
+        wikitables_semantic_parser.USE_TERMINAL_EMBEDDING = False
+        # pylint: disable=protected-access
+        model = self.model
+        nonterminal_embedding = model._nonterminal_embedder._token_embedders['tokens']
+        terminal_encoder = model._terminal_embedder._token_embedders['token_characters']
+        start_id = model.vocab.get_token_index(START_SYMBOL, 'rule_labels')
+        start_tensor = Variable(torch.LongTensor([start_id]))
+        rule2 = model.vocab.get_token_from_index(2, 'rule_labels')
+        rule2_tensor = Variable(torch.LongTensor([2]))
+        rule3 = model.vocab.get_token_from_index(3, 'rule_labels')
+        rule3_tensor = Variable(torch.LongTensor([3]))
+        rule4 = model.vocab.get_token_from_index(4, 'rule_labels')
+        rule4_tensor = Variable(torch.LongTensor([4]))
+        char2 = model.vocab.get_token_from_index(2, 'token_characters')
+        char2_tensor = Variable(torch.LongTensor([2, 2, 2]))
+        char3 = model.vocab.get_token_from_index(3, 'token_characters')
+        char3_tensor = Variable(torch.LongTensor([3, 3, 3]))
+        char4 = model.vocab.get_token_from_index(4, 'token_characters')
+        char4_tensor = Variable(torch.LongTensor([4, 4, 4]))
+        actions = [[{'left': (rule2, True, {'tokens': rule2_tensor}),
+                     'right': (char2 * 3, False, {'token_characters': char2_tensor})},
+                    {'left': (rule3, True, {'tokens': rule3_tensor}),
+                     'right': (char3 * 3, False, {'token_characters': char3_tensor})},
+                    # This one is padding; the tensors shouldn't matter here.
+                    {'left': ('', True, {'tokens': rule3_tensor}),
+                     'right': ('', False, {'token_characters': char3_tensor})}],
+                   [{'left': (rule2, True, {'tokens': rule2_tensor}),
+                     'right': (char2 * 3, False, {'token_characters': char2_tensor})},
+                    {'left': (rule4, True, {'tokens': rule4_tensor}),
+                     'right': (char4 * 3, False, {'token_characters': char4_tensor})},
+                    {'left': (START_SYMBOL, True, {'tokens': start_tensor}),
+                     'right': (rule2, True, {'tokens': rule2_tensor})}]]
+        embedded_actions, action_indices, initial_action_embedding = model._embed_actions(actions)
+        assert embedded_actions.size(0) == 1
+        assert action_indices[(1, 2)] == 0  # non-terminals should have lower indices than terminals
+        assert action_indices[(0, 0)] == action_indices[(1, 0)]
+        assert len(set(action_indices.values())) == 4
+
+        # Now we'll go through all four unique actions and make sure the embedding is as we expect.
+        action_embedding = embedded_actions[action_indices[(1, 2)]]
+        left_side_embedding = nonterminal_embedding(start_tensor)
+        right_side_embedding = nonterminal_embedding(rule2_tensor)
+        expected_action_embedding = torch.cat([left_side_embedding, right_side_embedding],
+                                              dim=-1).squeeze(0)
+        assert_almost_equal(action_embedding.cpu().data.numpy(),
+                            expected_action_embedding.cpu().data.numpy())
+        wikitables_semantic_parser.USE_TERMINAL_EMBEDDING = old_terminal_embedding_value
 
 
 class WikiTablesDecoderStepTest(AllenNlpTestCase):
-    def test_compute_new_states(self):
-        # pylint: disable=protected-access
+    def setUp(self):
+        super(WikiTablesDecoderStepTest, self).setUp()
+
         batch_indices = [0, 1, 0]
         action_history = [[1], [3, 4], []]
         score = [Variable(torch.FloatTensor([x])) for x in [.1, 1.1, 2.2]]
@@ -138,10 +192,10 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         previous_action_embedding = [torch.FloatTensor([i, i]) for i in range(len(batch_indices))]
         attended_question = [torch.FloatTensor([i, i]) for i in range(len(batch_indices))]
         grammar_state = [GrammarState(['e'], {}, {}, {}) for _ in batch_indices]
-        encoder_outputs = torch.FloatTensor([[1, 2], [3, 4], [5, 6]])
-        encoder_output_mask = torch.FloatTensor([[1, 1], [1, 0], [1, 1]])
-        action_embeddings = torch.FloatTensor([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5]])
-        action_indices = {
+        self.encoder_outputs = torch.FloatTensor([[1, 2], [3, 4], [5, 6]])
+        self.encoder_output_mask = torch.FloatTensor([[1, 1], [1, 0], [1, 1]])
+        self.action_embeddings = torch.FloatTensor([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5]])
+        self.action_indices = {
                 (0, 0): 1,
                 (0, 1): 0,
                 (0, 2): 2,
@@ -152,7 +206,7 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
                 (1, 2): 2,
                 (1, 3): 3,
                 }
-        possible_actions = [
+        self.possible_actions = [
                 [{'left': ('e', True, None), 'right': ('f', False, None)},
                  {'left': ('e', True, None), 'right': ('g', True, None)},
                  {'left': ('e', True, None), 'right': ('h', True, None)},
@@ -162,19 +216,45 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
                  {'left': ('e', True, None), 'right': ('g', True, None)},
                  {'left': ('e', True, None), 'right': ('h', True, None)},
                  {'left': ('e', True, None), 'right': ('i', True, None)}]]
-        state = WikiTablesDecoderState(batch_indices=batch_indices,
-                                       action_history=action_history,
-                                       score=score,
-                                       hidden_state=hidden_state,
-                                       memory_cell=memory_cell,
-                                       previous_action_embedding=previous_action_embedding,
-                                       attended_question=attended_question,
-                                       grammar_state=grammar_state,
-                                       encoder_outputs=encoder_outputs,
-                                       encoder_output_mask=encoder_output_mask,
-                                       action_embeddings=action_embeddings,
-                                       action_indices=action_indices,
-                                       possible_actions=possible_actions)
+        self.state = WikiTablesDecoderState(batch_indices=batch_indices,
+                                            action_history=action_history,
+                                            score=score,
+                                            hidden_state=hidden_state,
+                                            memory_cell=memory_cell,
+                                            previous_action_embedding=previous_action_embedding,
+                                            attended_question=attended_question,
+                                            grammar_state=grammar_state,
+                                            encoder_outputs=self.encoder_outputs,
+                                            encoder_output_mask=self.encoder_output_mask,
+                                            action_embeddings=self.action_embeddings,
+                                            action_indices=self.action_indices,
+                                            possible_actions=self.possible_actions)
+
+    def test_get_actions_to_consider(self):
+        # pylint: disable=protected-access
+        valid_actions_1 = {'e': [0, 1, 2, 4]}
+        valid_actions_2 = {'e': [0, 1, 3]}
+        valid_actions_3 = {'e': [3, 4]}
+        self.state.grammar_state[0] = GrammarState(['e'], {}, valid_actions_1, {})
+        self.state.grammar_state[1] = GrammarState(['e'], {}, valid_actions_2, {})
+        self.state.grammar_state[2] = GrammarState(['e'], {}, valid_actions_3, {})
+        self.state.action_embeddings = self.state.action_embeddings[:2]
+        considered, to_embed, to_link = WikiTablesDecoderStep._get_actions_to_consider(self.state)
+        # These are _global_ action indices.  They come from actions [[(0, 1), (0, 0)], [(1, 1)], []].
+        expected_to_embed = [[0, 1], [0], []]
+        assert to_embed == expected_to_embed
+        # These are _batch_ action indices with a _global_ action index above num_global_actions,
+        # sorted by their _global_ action index.
+        # They come from actions [[(0, 2), (0, 4)], [(1, 3), (1, 0)], [(0, 3), (0, 4)]].
+        expected_to_link = [[2, 4], [3, 0], [3, 4]]
+        assert to_link == expected_to_link
+        # These are _batch_ action indices, sorted by _global_ action index, with padding in
+        # between the embedded actions and the linked actions.
+        expected_considered = [[1, 0, 2, 4], [1, -1, 3, 0], [-1, -1, 3, 4]]
+        assert considered == expected_considered
+
+    def test_compute_new_states(self):
+        # pylint: disable=protected-access
         log_probs = Variable(torch.FloatTensor([[.1, .9, -.1, .2],
                                                 [.3, .1, 0, .8],
                                                 [.1, .25, .3, .4]]))
@@ -184,10 +264,10 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         step_action_embeddings = torch.FloatTensor([[[1, 1], [0, 0], [2, 2], [3, 3]],
                                                     [[4, 4], [3, 3], [0, 0], [0, 0]],
                                                     [[1, 1], [2, 2], [5, 5], [0, 0]]])
-        new_hidden_state = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(batch_indices))]
-        new_memory_cell = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(batch_indices))]
-        new_attended_question = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(batch_indices))]
-        new_states = WikiTablesDecoderStep._compute_new_states(state,
+        new_hidden_state = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(allowed_actions))]
+        new_memory_cell = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(allowed_actions))]
+        new_attended_question = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(allowed_actions))]
+        new_states = WikiTablesDecoderStep._compute_new_states(self.state,
                                                                log_probs,
                                                                new_hidden_state,
                                                                new_memory_cell,
@@ -211,13 +291,13 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         assert_almost_equal(new_state.attended_question[0].cpu().numpy().tolist(), [3, 3])
         assert new_state.grammar_state[0]._nonterminal_stack == ['j']
         assert_almost_equal(new_state.encoder_outputs.cpu().numpy(),
-                            encoder_outputs.cpu().numpy())
+                            self.encoder_outputs.cpu().numpy())
         assert_almost_equal(new_state.encoder_output_mask.cpu().numpy(),
-                            encoder_output_mask.cpu().numpy())
+                            self.encoder_output_mask.cpu().numpy())
         assert_almost_equal(new_state.action_embeddings.cpu().numpy(),
-                            action_embeddings.cpu().numpy())
-        assert new_state.action_indices == action_indices
-        assert new_state.possible_actions == possible_actions
+                            self.action_embeddings.cpu().numpy())
+        assert new_state.action_indices == self.action_indices
+        assert new_state.possible_actions == self.possible_actions
 
         new_state = new_states[1]
         assert new_state.batch_indices == [1]
@@ -231,10 +311,10 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         assert_almost_equal(new_state.attended_question[0].cpu().numpy().tolist(), [2, 2])
         assert new_state.grammar_state[0]._nonterminal_stack == ['q']
         assert_almost_equal(new_state.encoder_outputs.cpu().numpy(),
-                            encoder_outputs.cpu().numpy())
+                            self.encoder_outputs.cpu().numpy())
         assert_almost_equal(new_state.encoder_output_mask.cpu().numpy(),
-                            encoder_output_mask.cpu().numpy())
+                            self.encoder_output_mask.cpu().numpy())
         assert_almost_equal(new_state.action_embeddings.cpu().numpy(),
-                            action_embeddings.cpu().numpy())
-        assert new_state.action_indices == action_indices
-        assert new_state.possible_actions == possible_actions
+                            self.action_embeddings.cpu().numpy())
+        assert new_state.action_indices == self.action_indices
+        assert new_state.possible_actions == self.possible_actions


### PR DESCRIPTION
This implements action scores based on entity linking, for terminal entity productions.  We had previously assumed that every action had an embedding, and we used that for scoring actions. 
 This ignores the linking scores between the table and the question, and the current question attention at the given timestep.  This now implements equations 5 and 6 in the paper correctly, though it uses fake linking scores, as @rajasagashe is still implementing that piece.  Once Rajas is done, the model should be finished, and we can try to reproduce the original numbers.

This PR depends on #663 (which depends on #639).  I'll rebase this once those two PRs are merged.