### PR TITLE
Disable running coverage in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   - /home/travis/.allennlp/datasets
 env:
   matrix:
-    - COVERAGE="true" RUN_TESTS="true"
+    - RUN_TESTS="true"
     - RUN_PYLINT="true"
     - RUN_MYPY="true"
     - BUILD_DOCS="true" CHECK_DOCS="true"


### PR DESCRIPTION
This is configured in TeamCity now and we don't want it running in both places.

On Thursday I'll make a PR that removes Travis entirely from our repo.