### PR TITLE
Speed up WikiTablesDatasetReader

### DIFF
--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -25,7 +25,7 @@ from allennlp.data.semparse.knowledge_graphs import TableKnowledgeGraph
 from allennlp.data.semparse.type_declarations import wikitables_type_declaration as wt_types
 from allennlp.data.semparse.worlds import WikiTablesWorld
 from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer, TokenCharactersIndexer
-from allennlp.data.tokenizers import Tokenizer, WordTokenizer
+from allennlp.data.tokenizers import Token, Tokenizer, WordTokenizer
 from allennlp.data.tokenizers.word_splitter import SpacyWordSplitter
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -65,10 +65,11 @@ class WikiTablesDatasetReader(DatasetReader):
     max_dpd_tries : ``int`` (optional)
         Sometimes DPD just made bad choices about logical forms and gives us forms that we can't
         parse (most of the time these are very unlikely logical forms, because, e.g., it
-        halucinates a date or number from the table that's not in the question).  But we don't want
-        to spend our time trying to parse thousands of bad logical forms.  We will try to parse
-        only the ``max_dpd_tries`` logical forms before giving up.  Only applicable if
-        ``dpd_output_directory`` is given.  Default is 20.
+        hallucinates a date or number from the table that's not in the question).  But we don't
+        want to spend our time trying to parse thousands of bad logical forms.  We will try to
+        parse only the first ``max_dpd_tries`` logical forms before giving up.  This also speeds up
+        data loading time, because we don't go through the entire DPD file if it's huge.  Only
+        applicable if ``dpd_output_directory`` is given.  Default is 20.
     tokenizer : ``Tokenizer`` (optional)
         Tokenizer to use for the questions. Will default to ``WordTokenizer()`` with Spacy's tagger
         enabled, as we use lemma matches as features for entity linking.
@@ -121,34 +122,53 @@ class WikiTablesDatasetReader(DatasetReader):
 
     @overrides
     def read(self, file_path):
-        instances = []
+        questions = []
+        instance_info = []
         with open(file_path, "r") as data_file:
             logger.info("Reading instances from lines in file: %s", file_path)
             num_dpd_missing = 0
             num_lines = 0
+            logger.info("First pass, just reading the data")
             for line in tqdm.tqdm(data_file.readlines()):
                 line = line.strip("\n")
                 if not line:
                     continue
                 num_lines += 1
-                parsed_info = self._parse_line_as_lisp(line)
+                parsed_info = self._parse_example_line(line)
                 question = parsed_info["question"]
                 # We want the TSV file, but the ``*.examples`` files typically point to CSV.
                 table_filename = os.path.join(self._tables_directory,
-                                              parsed_info["context"].replace(".csv", ".tsv"))
+                                              parsed_info["table_filename"].replace(".csv", ".tsv"))
                 dpd_output_filename = os.path.join(self._dpd_output_directory,
                                                    parsed_info["id"] + '.gz')
                 try:
-                    sempre_forms = [line.strip().decode('utf-8') for line in gzip.open(dpd_output_filename)]
+                    dpd_file = gzip.open(dpd_output_filename)
+                    sempre_forms = []
+                    for line in dpd_file:
+                        sempre_forms.append(line.strip().decode('utf-8'))
+                        if self._max_dpd_tries and len(sempre_forms) >= self._max_dpd_tries:
+                            # TODO(mattg): might want to sort by length here before truncating...
+                            break
                 except FileNotFoundError:
                     logger.debug(f'Missing DPD output for instance {parsed_info["id"]}; skipping...')
                     num_dpd_missing += 1
                     continue
-                instance = self.text_to_instance(question, table_filename, sempre_forms)
-                if instance is not None:
-                    # The DPD output might not actually give us usable logical forms for some
-                    # instances, and in those cases `text_to_instance` returns None.
-                    instances.append(instance)
+                questions.append(question)
+                instance_info.append((table_filename, sempre_forms))
+        logger.info("Batch tokenizing questions")
+        tokenized_questions = self._tokenizer.batch_tokenize(questions)
+        logger.info("Creating instances (including parsing logical forms)")
+        instances = []
+        iterator = tqdm.tqdm(zip(questions, tokenized_questions, instance_info), total=len(questions))
+        for question, tokenized_question, (table_filename, sempre_forms) in iterator:
+            instance = self.text_to_instance(question,
+                                             table_filename,
+                                             sempre_forms,
+                                             tokenized_question)
+            if instance is not None:
+                # The DPD output might not actually give us usable logical forms for some
+                # instances, and in those cases `text_to_instance` returns None.
+                instances.append(instance)
         logger.info(f"Missing DPD info for {num_dpd_missing} out of {num_lines} instances")
         num_instances = len(instances)
         num_with_dpd = num_lines - num_dpd_missing
@@ -165,7 +185,8 @@ class WikiTablesDatasetReader(DatasetReader):
     def text_to_instance(self,  # type: ignore
                          question: str,
                          table_info: Union[str, JsonDict],
-                         dpd_output: List[str] = None) -> Instance:
+                         dpd_output: List[str] = None,
+                         tokenized_question: List[Token] = None) -> Instance:
         """
         Reads text inputs and makes an instance. WikitableQuestions dataset provides tables as TSV
         files, which we use for training. For running a demo, we may want to provide tables in a
@@ -183,9 +204,13 @@ class WikiTablesDatasetReader(DatasetReader):
         dpd_output : List[str] (optional)
             List of logical forms, produced by dynamic programming on denotations. Not required
             during test.
+        tokenized_question : ``List[Token]``
+            If you have already tokenized the question, you can pass that in here, so we don't
+            duplicate that work.  You might, for example, do batch processing on the questions in
+            the whole dataset, then pass the result in here.
         """
         # pylint: disable=arguments-differ
-        tokenized_question = self._tokenizer.tokenize(question)
+        tokenized_question = tokenized_question or self._tokenizer.tokenize(question)
         question_field = TextField(tokenized_question, self._question_token_indexers)
         if isinstance(table_info, str):
             table_knowledge_graph = TableKnowledgeGraph.read_from_file(table_info)
@@ -221,15 +246,16 @@ class WikiTablesDatasetReader(DatasetReader):
             action_map = {action.rule: i for i, action in enumerate(action_field.field_list)}  # type: ignore
 
             action_sequence_fields: List[Field] = []
-            # TODO(mattg): might want to sort by length here before truncating...
-            for logical_form in dpd_output[:self._max_dpd_tries]:
+            for logical_form in dpd_output:
                 if not self._should_keep_logical_form(logical_form):
                     continue
                 try:
                     expression = world.parse_logical_form(logical_form)
                 except ParsingError as error:
                     logger.debug(f'Parsing error: {error.message}, skipping logical form')
+                    logger.debug(f'Question was: {question}')
                     logger.debug(f'Logical form was: {logical_form}')
+                    logger.debug(f'Table info was: {table_info}')
                     continue
                 except:
                     logger.error(logical_form)
@@ -258,7 +284,7 @@ class WikiTablesDatasetReader(DatasetReader):
         return Instance(fields)
 
     @staticmethod
-    def _parse_line_as_lisp(lisp_string: str) -> Dict[str, Union[str, List[str], None]]:
+    def _parse_example_line(lisp_string: str) -> Dict[str, Union[str, List[str], None]]:
         """
         Training data in WikitableQuestions comes with examples in the form of lisp strings in the format:
             (example (id <example-id>)
@@ -266,25 +292,16 @@ class WikiTablesDatasetReader(DatasetReader):
                      (context (graph tables.TableKnowledgeGraph <table-filename>))
                      (targetValue (list (description <answer1>) (description <answer2>) ...)))
 
-        We parse such strings and return the parsed information here.
+        We parse such strings and return the parsed information here.  We don't actually use the
+        target value right now, because we use a pre-computed set of logical forms.  So we don't
+        bother parsing it; we can change that if we ever need to.
         """
         parsed_info = {}
-        input_nested_list = pyparsing.OneOrMore(pyparsing.nestedExpr()).parseString(lisp_string).asList()[0]
-        # Skipping "example"
-        for key, value in input_nested_list[1:]:
-            if key == "id":
-                parsed_info["id"] = value
-            elif key == "utterance":
-                parsed_info["question"] = value.replace("\"", "")
-            elif key == "context":
-                # Skipping "graph" and "tables.TableKnowledgeGraph"
-                parsed_info["context"] = value[-1]
-            elif key == "targetValue":
-                # Skipping "list", and "description" within each nested list.
-                parsed_info["targetValue"] = [x[1] for x in value[1:]]
-        # targetValue may not be present if the answer is not provided.
-        assert all([x in parsed_info for x in ["id", "question", "context"]]), "Invalid format"
-        return parsed_info
+        id_piece, rest = lisp_string.split(') (utterance "')
+        example_id = id_piece.split('(id ')[1]
+        question, rest = rest.split('") (context (graph tables.TableKnowledgeGraph ')
+        table_filename, rest = rest.split(')) (targetValue (list')
+        return {'id': example_id, 'question': question, 'table_filename': table_filename}
 
     @staticmethod
     def _should_keep_logical_form(logical_form: str) -> bool:

--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -143,8 +143,8 @@ class WikiTablesDatasetReader(DatasetReader):
                 try:
                     dpd_file = gzip.open(dpd_output_filename)
                     sempre_forms = []
-                    for line in dpd_file:
-                        sempre_forms.append(line.strip().decode('utf-8'))
+                    for dpd_line in dpd_file:
+                        sempre_forms.append(dpd_line.strip().decode('utf-8'))
                         if self._max_dpd_tries and len(sempre_forms) >= self._max_dpd_tries:
                             # TODO(mattg): might want to sort by length here before truncating...
                             break
@@ -295,7 +295,6 @@ class WikiTablesDatasetReader(DatasetReader):
         target value right now, because we use a pre-computed set of logical forms.  So we don't
         bother parsing it; we can change that if we ever need to.
         """
-        parsed_info = {}
         id_piece, rest = lisp_string.split(') (utterance "')
         example_id = id_piece.split('(id ')[1]
         question, rest = rest.split('") (context (graph tables.TableKnowledgeGraph ')

--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Union
 import gzip
 import logging
 import os
-import pyparsing
 
 from overrides import overrides
 

--- a/allennlp/data/semparse/util.py
+++ b/allennlp/data/semparse/util.py
@@ -1,0 +1,24 @@
+from typing import List
+
+
+def lisp_to_nested_expression(lisp_string: str) -> List:
+    """
+    Takes a logical form as a lisp string and returns a nested list representation of the lisp.
+    For example, "(count (division first))" would get mapped to ['count', ['division',
+    'first']].
+    """
+    stack = []
+    current_expression = []
+    tokens = lisp_string.split()
+    for token in tokens:
+        while token[0] == '(':
+            nested_expression = []
+            current_expression.append(nested_expression)
+            stack.append(current_expression)
+            current_expression = nested_expression
+            token = token[1:]
+        current_expression.append(token.replace(')', ''))
+        while token[-1] == ')':
+            current_expression = stack.pop()
+            token = token[:-1]
+    return current_expression

--- a/allennlp/data/semparse/util.py
+++ b/allennlp/data/semparse/util.py
@@ -4,15 +4,14 @@ from typing import List
 def lisp_to_nested_expression(lisp_string: str) -> List:
     """
     Takes a logical form as a lisp string and returns a nested list representation of the lisp.
-    For example, "(count (division first))" would get mapped to ['count', ['division',
-    'first']].
+    For example, "(count (division first))" would get mapped to ['count', ['division', 'first']].
     """
-    stack = []
-    current_expression = []
+    stack: List = []
+    current_expression: List = []
     tokens = lisp_string.split()
     for token in tokens:
         while token[0] == '(':
-            nested_expression = []
+            nested_expression: List = []
             current_expression.append(nested_expression)
             stack.append(current_expression)
             current_expression = nested_expression

--- a/allennlp/data/semparse/worlds/nlvr_world.py
+++ b/allennlp/data/semparse/worlds/nlvr_world.py
@@ -5,13 +5,13 @@ which mainly contains an execution method and related helper methods.
 from collections import defaultdict
 import operator
 from typing import Any, List, Dict, Set, Callable, TypeVar, Union
-import pyparsing
 
 from nltk.sem.logic import Type
 from overrides import overrides
 
 from allennlp.common import util
 from allennlp.common.util import JsonDict
+from allennlp.data.semparse import util as semparse_util
 from allennlp.data.semparse.type_declarations import nlvr_type_declaration as types
 from allennlp.data.semparse.worlds.world import World
 
@@ -177,7 +177,7 @@ class NlvrWorld(World):
         if not logical_form.startswith("("):
             logical_form = "(%s)" % logical_form
         logical_form = logical_form.replace(",", " ")
-        expression_as_list = pyparsing.OneOrMore(pyparsing.nestedExpr()).parseString(logical_form).asList()
+        expression_as_list = semparse_util.lisp_to_nested_expression(logical_form)
         # The whole expression has to be an assertion expression because it has to return a boolean.
         # TODO(pradeep): May want to make this more general and let the executor deal with questions.
         return self._execute_assertion(expression_as_list)

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Set
 from nltk.sem.logic import Expression, LambdaExpression, BasicType, Type
 
 from allennlp.data.semparse.type_declarations import type_declaration as types
+from allennlp.data.semparse import util as semparse_util
 
 
 class ParsingError(Exception):
@@ -93,36 +94,13 @@ class World:
     def get_basic_types(self) -> Set[Type]:
         raise NotImplementedError
 
-    @staticmethod
-    def _lisp_to_nested_expression(lisp_string: str) -> List:
-        """
-        Takes a logical form as a lisp string and returns a nested list representation of the lisp.
-        For example, "(count (division first))" would get mapped to ['count', ['division',
-        'first']].
-        """
-        stack = []
-        current_expression = []
-        tokens = lisp_string.split()
-        for token in tokens:
-            while token[0] == '(':
-                nested_expression = []
-                current_expression.append(nested_expression)
-                stack.append(current_expression)
-                current_expression = nested_expression
-                token = token[1:]
-            current_expression.append(token.replace(')', ''))
-            while token[-1] == ')':
-                current_expression = stack.pop()
-                token = token[:-1]
-        return current_expression
-
     def parse_logical_form(self, logical_form: str) -> Expression:
         """
         Takes a logical form as a string, maps its tokens using the mapping and returns a parsed expression.
         """
         if not logical_form.startswith("("):
             logical_form = "(%s)" % logical_form
-        parsed_lisp = self._lisp_to_nested_expression(logical_form)
+        parsed_lisp = semparse_util.lisp_to_nested_expression(logical_form)
         translated_string = self._process_nested_expression(parsed_lisp)
         type_signature = self.local_type_signatures.copy()
         type_signature.update(self.global_type_signatures)

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -1,5 +1,4 @@
 from typing import List, Dict, Set
-import pyparsing
 
 from nltk.sem.logic import Expression, LambdaExpression, BasicType, Type
 
@@ -94,13 +93,36 @@ class World:
     def get_basic_types(self) -> Set[Type]:
         raise NotImplementedError
 
+    @staticmethod
+    def _lisp_to_nested_expression(lisp_string: str) -> List:
+        """
+        Takes a logical form as a lisp string and returns a nested list representation of the lisp.
+        For example, "(count (division first))" would get mapped to ['count', ['division',
+        'first']].
+        """
+        stack = []
+        current_expression = []
+        tokens = lisp_string.split()
+        for token in tokens:
+            while token[0] == '(':
+                nested_expression = []
+                current_expression.append(nested_expression)
+                stack.append(current_expression)
+                current_expression = nested_expression
+                token = token[1:]
+            current_expression.append(token.replace(')', ''))
+            while token[-1] == ')':
+                current_expression = stack.pop()
+                token = token[:-1]
+        return current_expression
+
     def parse_logical_form(self, logical_form: str) -> Expression:
         """
         Takes a logical form as a string, maps its tokens using the mapping and returns a parsed expression.
         """
         if not logical_form.startswith("("):
             logical_form = "(%s)" % logical_form
-        parsed_lisp = pyparsing.OneOrMore(pyparsing.nestedExpr()).parseString(logical_form).asList()
+        parsed_lisp = self._lisp_to_nested_expression(logical_form)
         translated_string = self._process_nested_expression(parsed_lisp)
         type_signature = self.local_type_signatures.copy()
         type_signature.update(self.global_type_signatures)

--- a/doc/api/allennlp.data.semparse.rst
+++ b/doc/api/allennlp.data.semparse.rst
@@ -11,3 +11,4 @@ allennlp.data.semparse
    allennlp.data.semparse.knowledge_graphs
    allennlp.data.semparse.type_declarations
    allennlp.data.semparse.worlds
+   allennlp.data.semparse.util

--- a/doc/api/allennlp.data.semparse.util.rst
+++ b/doc/api/allennlp.data.semparse.util.rst
@@ -1,0 +1,7 @@
+allennlp.data.semparse.util
+===========================
+
+.. automodule:: allennlp.data.semparse.util
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
+++ b/tests/data/dataset_readers/wikitables/wikitables_dataset_reader_test.py
@@ -362,3 +362,12 @@ class TestWikiTablesDatasetReader(AllenNlpTestCase):
                            '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]', '<<#1,#2>,<#2,#1>> -> reverse',
                            '<e,r> -> fb:row.row.year', 'r -> [<e,r>, e]', '<e,r> -> fb:row.row.league',
                            'e -> fb:cell.usl_a_league']
+
+    def test_parse_example_line(self):
+        with open("tests/fixtures/data/wikitables/sample_data.examples") as filename:
+            lines = filename.readlines()
+        example_info = WikiTablesDatasetReader._parse_example_line(lines[0])
+        question = 'what was the last year where this team was a part of the usl a-league?'
+        assert example_info == {'id': 'nt-0',
+                                'question': question,
+                                'table_filename': 'tables/590.csv'}

--- a/tests/data/semparse/knowledge_graphs/table_knowledge_graph_test.py
+++ b/tests/data/semparse/knowledge_graphs/table_knowledge_graph_test.py
@@ -101,10 +101,11 @@ class TestTableKnowledgeGraph(AllenNlpTestCase):
                 }
         graph = TableKnowledgeGraph.read_from_json(json)
         neighbors = set(graph.neighbors['fb:row.row.town'])
-        assert neighbors == {'fb:cell.funningsfj_r_ur',
-                             'fb:cell.vi_arei_i',
-                             'fb:cell.fro_ba',
-                             }
+        assert neighbors == {
+                'fb:cell.funningsfj_r_ur',
+                'fb:cell.vi_arei_i',
+                'fb:cell.fro_ba',
+                }
 
         json = {
                 'columns': ['Fate'],

--- a/tests/data/semparse/type_declarations/grammar_state_test.py
+++ b/tests/data/semparse/type_declarations/grammar_state_test.py
@@ -14,23 +14,23 @@ class TestGrammarState(AllenNlpTestCase):
 
     def test_get_valid_actions_uses_top_of_stack(self):
         state = GrammarState(['s'], {}, {'s': [1, 2], 't': [3, 4]}, {})
-        assert state.get_valid_actions() == [1,2]
+        assert state.get_valid_actions() == [1, 2]
         state = GrammarState(['t'], {}, {'s': [1, 2], 't': [3, 4]}, {})
-        assert state.get_valid_actions() == [3,4]
+        assert state.get_valid_actions() == [3, 4]
         state = GrammarState(['e'], {}, {'s': [1, 2], 't': [3, 4], 'e': []}, {})
         assert state.get_valid_actions() == []
 
     def test_get_valid_actions_adds_lambda_productions(self):
         state = GrammarState(['s'], {('s', 'x'): ['s']}, {'s': [1, 2]}, {'s -> x': 5})
-        assert state.get_valid_actions() == [1,2,5]
+        assert state.get_valid_actions() == [1, 2, 5]
         # We're doing this assert twice to make sure we haven't accidentally modified the state.
-        assert state.get_valid_actions() == [1,2,5]
+        assert state.get_valid_actions() == [1, 2, 5]
 
     def test_get_valid_actions_adds_lambda_productions_only_for_correct_type(self):
         state = GrammarState(['t'], {('s', 'x'): ['t']}, {'s': [1, 2], 't': [3, 4]}, {'s -> x': 5})
-        assert state.get_valid_actions() == [3,4]
+        assert state.get_valid_actions() == [3, 4]
         # We're doing this assert twice to make sure we haven't accidentally modified the state.
-        assert state.get_valid_actions() == [3,4]
+        assert state.get_valid_actions() == [3, 4]
 
     def test_take_action_gives_correct_next_states_with_non_lambda_productions(self):
         # state.take_action() doesn't read or change these objects, it just passes them through, so

--- a/tests/data/semparse/util_test.py
+++ b/tests/data/semparse/util_test.py
@@ -8,15 +8,7 @@ from allennlp.data.semparse.worlds import WikiTablesWorld
 from allennlp.data.tokenizers import Token
 
 
-class TestWorld(AllenNlpTestCase):
-    # Most of these tests will use a WikiTablesWorld as a concrete instance to test the base class
-    # methods.
-    def setUp(self):
-        super().setUp()
-        self.table_kg = TableKnowledgeGraph.read_from_file("tests/fixtures/data/wikitables/sample_table.tsv")
-        question_tokens = [Token(x) for x in ['what', 'was', 'the', 'last', 'year', '?']]
-        self.world = WikiTablesWorld(self.table_kg, question_tokens)
-
+class TestSemparseUtil(AllenNlpTestCase):
     def test_lisp_to_nested_expression(self):
         logical_form = "((reverse fb:row.row.year) (fb:row.row.league fb:cell.usl_a_league))"
         expression = self.world._lisp_to_nested_expression(logical_form)

--- a/tests/data/semparse/util_test.py
+++ b/tests/data/semparse/util_test.py
@@ -1,18 +1,13 @@
 # pylint: disable=no-self-use,invalid-name
-import pytest
-
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.data.semparse import ParsingError
-from allennlp.data.semparse.knowledge_graphs.table_knowledge_graph import TableKnowledgeGraph
-from allennlp.data.semparse.worlds import WikiTablesWorld
-from allennlp.data.tokenizers import Token
+from allennlp.data.semparse import util
 
 
 class TestSemparseUtil(AllenNlpTestCase):
     def test_lisp_to_nested_expression(self):
         logical_form = "((reverse fb:row.row.year) (fb:row.row.league fb:cell.usl_a_league))"
-        expression = self.world._lisp_to_nested_expression(logical_form)
+        expression = util.lisp_to_nested_expression(logical_form)
         assert expression == [[['reverse', 'fb:row.row.year'], ['fb:row.row.league', 'fb:cell.usl_a_league']]]
         logical_form = "(count (and (division 1) (tier (!= null))))"
-        expression = self.world._lisp_to_nested_expression(logical_form)
+        expression = util.lisp_to_nested_expression(logical_form)
         assert expression == [['count', ['and', ['division', '1'], ['tier', ['!=', 'null']]]]]

--- a/tests/data/semparse/worlds/nlvr_world_test.py
+++ b/tests/data/semparse/worlds/nlvr_world_test.py
@@ -18,7 +18,7 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
         logical_form_true = "(assert_greater_equals (count (touch_corner (circle (all_objects)))) 1)"
         # Should evaluate to True.
         assert nlvr_world.execute(logical_form_true)
-        logical_form_false = "(assert_equals (count (touch_corner (circle(all_objects)))) 0)"
+        logical_form_false = "(assert_equals (count (touch_corner (circle (all_objects)))) 0)"
         # Should evaluate to False.
         assert not nlvr_world.execute(logical_form_false)
 

--- a/tests/data/semparse/worlds/wikitables_world_test.py
+++ b/tests/data/semparse/worlds/wikitables_world_test.py
@@ -38,7 +38,7 @@ class TestWikiTablesWorldRepresentation(AllenNlpTestCase):
 
     def test_parsing_logical_forms_fails_with_unmapped_names(self):
         with pytest.raises(ParsingError):
-            expression = self.world.parse_logical_form("(number 20)")
+            _ = self.world.parse_logical_form("(number 20)")
 
     def test_world_has_only_basic_numbers(self):
         valid_actions = self.world.get_valid_actions()

--- a/tests/data/semparse/worlds/world_test.py
+++ b/tests/data/semparse/worlds/world_test.py
@@ -1,0 +1,26 @@
+# pylint: disable=no-self-use,invalid-name
+import pytest
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.semparse import ParsingError
+from allennlp.data.semparse.knowledge_graphs.table_knowledge_graph import TableKnowledgeGraph
+from allennlp.data.semparse.worlds import WikiTablesWorld
+from allennlp.data.tokenizers import Token
+
+
+class TestWorld(AllenNlpTestCase):
+    # Most of these tests will use a WikiTablesWorld as a concrete instance to test the base class
+    # methods.
+    def setUp(self):
+        super().setUp()
+        self.table_kg = TableKnowledgeGraph.read_from_file("tests/fixtures/data/wikitables/sample_table.tsv")
+        question_tokens = [Token(x) for x in ['what', 'was', 'the', 'last', 'year', '?']]
+        self.world = WikiTablesWorld(self.table_kg, question_tokens)
+
+    def test_lisp_to_nested_expression(self):
+        logical_form = "((reverse fb:row.row.year) (fb:row.row.league fb:cell.usl_a_league))"
+        expression = self.world._lisp_to_nested_expression(logical_form)
+        assert expression == [[['reverse', 'fb:row.row.year'], ['fb:row.row.league', 'fb:cell.usl_a_league']]]
+        logical_form = "(count (and (division 1) (tier (!= null))))"
+        expression = self.world._lisp_to_nested_expression(logical_form)
+        assert expression == [['count', ['and', ['division', '1'], ['tier', ['!=', 'null']]]]]


### PR DESCRIPTION
I did some profiling to figure out why our data loading code took so long, and fixed some of the worst problems.  These were (1) using a lisp parser to read the example file, which can just as easily be read with some simple string splits, and (2) running spacy's tagger to get lemmas, but not using spacy's batching.  I had to implement batched tokenization for this, and merging this should probably wait until #680 is merged into master.