### PR TITLE
make driver config robust to nvidia-docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,12 @@ ENV LANG=C.UTF-8
 ENV PATH /usr/local/nvidia/bin/:$PATH
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
-# Tell nvidia-docker that we need the driver, which gets mounted at /usr/local/nvidia.
+# Tell nvidia-docker the driver spec that we need as well as to
+# use all available devices, which are mounted at /usr/local/nvidia.
+# The LABEL supports an older version of nvidia-docker, the env
+# variables a newer one.
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 
 WORKDIR /stage


### PR DESCRIPTION
The `LABEL` was one way of doing this supported by an older version of nvidia-docker - the env variables are the new way, so let's have both for super-duper compatibility.