### PR TITLE
Handle padding correctly in _compute_new_states

### DIFF
--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -1134,12 +1134,10 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
             for action_index, action in enumerate(group_actions):
                 # `action` is currently the index in `log_probs`, not the actual action ID.  To get
                 # the action ID, we need to go through `considered_actions`.
-                if action >= len(considered_actions[group_index]):
-                    # This was padding.  We can check either `action_index` or `action` here - it's
-                    # really `action` that we care about, but our masking should have sorted all of
-                    # the higher actions to the end, anyway.
-                    continue
                 action = considered_actions[group_index][action]
+                if action == -1:
+                    # This was padding.
+                    continue
                 if allowed_actions is not None and action not in allowed_actions[group_index]:
                     # This happens when our _decoder trainer_ wants us to only evaluate certain
                     # actions, likely because they are the gold actions in this state.  We just skip

--- a/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
@@ -406,14 +406,14 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
     def test_compute_new_states(self):
         # pylint: disable=protected-access
         log_probs = Variable(torch.FloatTensor([[.1, .9, -.1, .2],
-                                                [.3, .1, 0, .8],
+                                                [.3, 1.1, .1, .8],
                                                 [.1, .25, .3, .4]]))
-        considered_actions = [[0, 1, 2, 3], [0, 3], [0, 2, 4]]
+        considered_actions = [[0, 1, 2, 3], [0, -1, 3, -1], [0, 2, 4, -1]]
         allowed_actions = [{2, 3}, {0}, {4}]
         max_actions = 1
-        step_action_embeddings = torch.FloatTensor([[[1, 1], [0, 0], [2, 2], [3, 3]],
-                                                    [[4, 4], [3, 3], [0, 0], [0, 0]],
-                                                    [[1, 1], [2, 2], [5, 5], [0, 0]]])
+        step_action_embeddings = torch.FloatTensor([[[1, 1], [9, 9], [2, 2], [3, 3]],
+                                                    [[4, 4], [9, 9], [3, 3], [9, 9]],
+                                                    [[1, 1], [2, 2], [5, 5], [9, 9]]])
         new_hidden_state = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(allowed_actions))]
         new_memory_cell = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(allowed_actions))]
         new_attended_question = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(allowed_actions))]
@@ -429,17 +429,20 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
 
         assert len(new_states) == 2
         new_state = new_states[0]
+        # For batch instance 0, we should have selected action 4 from group index 2.
         assert new_state.batch_indices == [0]
+        # These three have values taken from what's defined in setUp() - the prior action history
+        # (empty in this case), the initial score (2.2), and the nonterminals corresponding to the
+        # action we picked ('j').
         assert new_state.action_history == [[4]]
         assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [2.2 + .3])
+        assert new_state.grammar_state[0]._nonterminal_stack == ['j']
+        # All of these values come from the objects instantiated directly above.
         assert_almost_equal(new_state.hidden_state[0].cpu().numpy().tolist(), [3, 3])
         assert_almost_equal(new_state.memory_cell[0].cpu().numpy().tolist(), [3, 3])
-
-        # (batch_index, action_index) of (0, 4) maps to action 5 in the global action space, which
-        # has embedding [5, 5].
         assert_almost_equal(new_state.previous_action_embedding[0].cpu().numpy().tolist(), [5, 5])
         assert_almost_equal(new_state.attended_question[0].cpu().numpy().tolist(), [3, 3])
-        assert new_state.grammar_state[0]._nonterminal_stack == ['j']
+        # And these should just be copied from the prior state.
         assert_almost_equal(new_state.encoder_outputs.cpu().numpy(),
                             self.encoder_outputs.cpu().numpy())
         assert_almost_equal(new_state.encoder_output_mask.data.cpu().numpy(),
@@ -450,16 +453,94 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         assert new_state.possible_actions == self.possible_actions
 
         new_state = new_states[1]
+        # For batch instance 1, we should have selected action 0 from group index 1.
         assert new_state.batch_indices == [1]
+        # These three have values taken from what's defined in setUp() - the prior action history
+        # ([3, 4]), the initial score (1.1), and the nonterminals corresponding to the action we
+        # picked ('q').
         assert new_state.action_history == [[3, 4, 0]]
         assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [1.1 + .3])
+        assert new_state.grammar_state[0]._nonterminal_stack == ['q']
+        # All of these values come from the objects instantiated directly above.
         assert_almost_equal(new_state.hidden_state[0].cpu().numpy().tolist(), [2, 2])
         assert_almost_equal(new_state.memory_cell[0].cpu().numpy().tolist(), [2, 2])
-        # (batch_index, action_index) of (1, 0) maps to action 4 in the global action space, which
-        # has embedding [4, 4].
         assert_almost_equal(new_state.previous_action_embedding[0].cpu().numpy().tolist(), [4, 4])
         assert_almost_equal(new_state.attended_question[0].cpu().numpy().tolist(), [2, 2])
+        # And these should just be copied from the prior state.
+        assert_almost_equal(new_state.encoder_outputs.cpu().numpy(),
+                            self.encoder_outputs.cpu().numpy())
+        assert_almost_equal(new_state.encoder_output_mask.data.cpu().numpy(),
+                            self.encoder_output_mask.data.cpu().numpy())
+        assert_almost_equal(new_state.action_embeddings.cpu().numpy(),
+                            self.action_embeddings.cpu().numpy())
+        assert new_state.action_indices == self.action_indices
+        assert new_state.possible_actions == self.possible_actions
+
+    def test_compute_new_states_with_no_action_constraints(self):
+        # pylint: disable=protected-access
+        # This test is basically identical to the previous one, but without specifying
+        # `allowed_actions`.  This makes sure we get the right behavior at test time.
+        log_probs = Variable(torch.FloatTensor([[.1, .9, -.1, .2],
+                                                [.3, 1.1, .1, .8],
+                                                [.1, .25, .3, .4]]))
+        considered_actions = [[0, 1, 2, 3], [0, -1, 3, -1], [0, 2, 4, -1]]
+        max_actions = 1
+        step_action_embeddings = torch.FloatTensor([[[1, 1], [9, 9], [2, 2], [3, 3]],
+                                                    [[4, 4], [9, 9], [3, 3], [9, 9]],
+                                                    [[1, 1], [2, 2], [5, 5], [9, 9]]])
+        new_hidden_state = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(considered_actions))]
+        new_memory_cell = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(considered_actions))]
+        new_attended_question = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(considered_actions))]
+        new_states = WikiTablesDecoderStep._compute_new_states(self.state,
+                                                               log_probs,
+                                                               new_hidden_state,
+                                                               new_memory_cell,
+                                                               step_action_embeddings,
+                                                               new_attended_question,
+                                                               considered_actions,
+                                                               allowed_actions=None,
+                                                               max_actions=max_actions)
+
+        assert len(new_states) == 2
+        new_state = new_states[0]
+        # For batch instance 0, we should have selected action 1 from group index 0.
+        assert new_state.batch_indices == [0]
+        # These three have values taken from what's defined in setUp() - the prior action history
+        # ([1]), the initial score (0.1), and the nonterminals corresponding to the
+        # action we picked ('j').
+        assert new_state.action_history == [[1, 1]]
+        assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [0.1 + .9])
+        assert new_state.grammar_state[0]._nonterminal_stack == ['g']
+        # All of these values come from the objects instantiated directly above.
+        assert_almost_equal(new_state.hidden_state[0].cpu().numpy().tolist(), [1, 1])
+        assert_almost_equal(new_state.memory_cell[0].cpu().numpy().tolist(), [1, 1])
+        assert_almost_equal(new_state.previous_action_embedding[0].cpu().numpy().tolist(), [9, 9])
+        assert_almost_equal(new_state.attended_question[0].cpu().numpy().tolist(), [1, 1])
+        # And these should just be copied from the prior state.
+        assert_almost_equal(new_state.encoder_outputs.cpu().numpy(),
+                            self.encoder_outputs.cpu().numpy())
+        assert_almost_equal(new_state.encoder_output_mask.data.cpu().numpy(),
+                            self.encoder_output_mask.data.cpu().numpy())
+        assert_almost_equal(new_state.action_embeddings.cpu().numpy(),
+                            self.action_embeddings.cpu().numpy())
+        assert new_state.action_indices == self.action_indices
+        assert new_state.possible_actions == self.possible_actions
+
+        new_state = new_states[1]
+        # For batch instance 0, we should have selected action 0 from group index 1.
+        assert new_state.batch_indices == [1]
+        # These three have values taken from what's defined in setUp() - the prior action history
+        # ([3, 4]), the initial score (1.1), and the nonterminals corresponding to the action we
+        # picked ('q').
+        assert new_state.action_history == [[3, 4, 0]]
+        assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [1.1 + .3])
         assert new_state.grammar_state[0]._nonterminal_stack == ['q']
+        # All of these values come from the objects instantiated directly above.
+        assert_almost_equal(new_state.hidden_state[0].cpu().numpy().tolist(), [2, 2])
+        assert_almost_equal(new_state.memory_cell[0].cpu().numpy().tolist(), [2, 2])
+        assert_almost_equal(new_state.previous_action_embedding[0].cpu().numpy().tolist(), [4, 4])
+        assert_almost_equal(new_state.attended_question[0].cpu().numpy().tolist(), [2, 2])
+        # And these should just be copied from the prior state.
         assert_almost_equal(new_state.encoder_outputs.cpu().numpy(),
                             self.encoder_outputs.cpu().numpy())
         assert_almost_equal(new_state.encoder_output_mask.data.cpu().numpy(),


### PR DESCRIPTION
I also added a test that failed before I made the change.  Almost all of the changes here are in test code.  And I tried to add some better comments for what's going on in the tests, as this code is far too complex...