### PR TITLE
Span field

### DIFF
--- a/allennlp/data/fields/__init__.py
+++ b/allennlp/data/fields/__init__.py
@@ -11,4 +11,5 @@ from allennlp.data.fields.list_field import ListField
 from allennlp.data.fields.metadata_field import MetadataField
 from allennlp.data.fields.sequence_field import SequenceField
 from allennlp.data.fields.sequence_label_field import SequenceLabelField
+from allennlp.data.fields.span_field import SpanField
 from allennlp.data.fields.text_field import TextField

--- a/allennlp/data/fields/index_field.py
+++ b/allennlp/data/fields/index_field.py
@@ -38,7 +38,7 @@ class IndexField(Field[torch.Tensor]):
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:
-        return {'num_options': self.sequence_field.sequence_length()}
+        return {}
 
     @overrides
     def as_tensor(self,

--- a/allennlp/data/fields/span_field.py
+++ b/allennlp/data/fields/span_field.py
@@ -31,17 +31,17 @@ class SpanField(Field[torch.Tensor]):
         self.span_end = span_end
         self.sequence_field = sequence_field
 
-        if not isinstance(span_start, int) or not isinstance(span_start, int):
-            raise ConfigurationError(f"SpanFields must be passed integer indices. Found span indices: "
-                                     f"({span_start}, {span_end}) with types "
-                                     f"({type(span_start)} {type(span_end)})")
+        if not isinstance(span_start, int) or not isinstance(span_end, int):
+            raise TypeError(f"SpanFields must be passed integer indices. Found span indices: "
+                            f"({span_start}, {span_end}) with types "
+                            f"({type(span_start)} {type(span_end)})")
         if span_start > span_end:
-            raise ConfigurationError(f"span_start must be greater than span_end, "
-                                     f"but found ({span_start}, {span_end}).")
+            raise ValueError(f"span_start must be less than span_end, "
+                             f"but found ({span_start}, {span_end}).")
 
         if span_end > self.sequence_field.sequence_length() - 1:
-            raise ConfigurationError(f"span_end must be < len(sequence_length) - 1, but found "
-                                     f"{span_end} and {self.sequence_field.sequence_length() - 1} respectively.")
+            raise ValueError(f"span_end must be < len(sequence_length) - 1, but found "
+                             f"{span_end} and {self.sequence_field.sequence_length() - 1} respectively.")
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:

--- a/allennlp/data/fields/span_field.py
+++ b/allennlp/data/fields/span_field.py
@@ -7,7 +7,6 @@ from torch.autograd import Variable
 
 from allennlp.data.fields.field import Field
 from allennlp.data.fields.sequence_field import SequenceField
-from allennlp.common.checks import ConfigurationError
 
 
 class SpanField(Field[torch.Tensor]):

--- a/allennlp/data/fields/span_field.py
+++ b/allennlp/data/fields/span_field.py
@@ -1,0 +1,61 @@
+# pylint: disable=no-self-use
+from typing import Dict
+
+from overrides import overrides
+import torch
+from torch.autograd import Variable
+
+from allennlp.data.fields.field import Field
+from allennlp.data.fields.sequence_field import SequenceField
+from allennlp.common.checks import ConfigurationError
+
+
+class SpanField(Field[torch.Tensor]):
+    """
+    A ``SpanField`` is a pair of inclusive, zero-indexed (start, end) indices into a
+    :class:`~allennlp.data.fields.sequence_field.SequenceField`, used to represent a span of text.
+    Because it's a pair of indices into a :class:`SequenceField`, we take one of those as input
+    to make the span's dependence explicit and to validate that the span is well defined.
+
+    Parameters
+    ----------
+    span_start : ``int``, required.
+        The index of the start of the span in the :class:`SequenceField`.
+    span_end : ``int``, required.
+        The inclusive index of the end of the span in the :class:`SequenceField`.
+    sequence_field : ``SequenceField``, required.
+        A field containing the sequence that this ``SpanField`` is a span inside.
+    """
+    def __init__(self, span_start: int, span_end: int, sequence_field: SequenceField) -> None:
+        self.span_start = span_start
+        self.span_end = span_end
+        self.sequence_field = sequence_field
+
+        if not isinstance(span_start, int) or not isinstance(span_start, int):
+            raise ConfigurationError(f"SpanFields must be passed integer indices. Found span indices: "
+                                     f"({span_start}, {span_end}) with types "
+                                     f"({type(span_start)} {type(span_end)})")
+        if span_start > span_end:
+            raise ConfigurationError(f"span_start must be greater than span_end, "
+                                     f"but found ({span_start}, {span_end}).")
+
+        if span_end > self.sequence_field.sequence_length() - 1:
+            raise ConfigurationError(f"span_end must be < len(sequence_length) - 1, but found "
+                                     f"{span_end} and {self.sequence_field.sequence_length() - 1} respectively.")
+
+    @overrides
+    def get_padding_lengths(self) -> Dict[str, int]:
+        return {}
+
+    @overrides
+    def as_tensor(self,
+                  padding_lengths: Dict[str, int],
+                  cuda_device: int = -1,
+                  for_training: bool = True) -> torch.Tensor:
+        # pylint: disable=unused-argument
+        tensor = Variable(torch.LongTensor([self.span_start, self.span_end]), volatile=not for_training)
+        return tensor if cuda_device == -1 else tensor.cuda(cuda_device)
+
+    @overrides
+    def empty_field(self):
+        return SpanField(-1, -1, self.sequence_field.empty_field())

--- a/doc/api/allennlp.data.fields.rst
+++ b/doc/api/allennlp.data.fields.rst
@@ -8,6 +8,7 @@ allennlp.data.fields
 
 * :ref:`Field<field>`
 * :ref:`IndexField<index-field>`
+* :ref:`SpanField<span-field>`
 * :ref:`LabelField<label-field>`
 * :ref:`ListField<list-field>`
 * :ref:`MetadataField<metadata-field>`
@@ -24,6 +25,12 @@ allennlp.data.fields
 
 .. _index-field:
 .. automodule:: allennlp.data.fields.index_field
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _span-field:
+.. automodule:: allennlp.data.fields.span_field
    :members:
    :undoc-members:
    :show-inheritance:

--- a/tests/data/fields/index_field_test.py
+++ b/tests/data/fields/index_field_test.py
@@ -14,11 +14,6 @@ class TestIndexField(AllenNlpTestCase):
         self.text = TextField([Token(t) for t in ["here", "is", "a", "sentence", "."]],
                               {"words": SingleIdTokenIndexer("words")})
 
-    def test_index_field_inherits_padding_lengths_from_text_field(self):
-
-        index_field = IndexField(4, self.text)
-        assert index_field.get_padding_lengths() == {"num_options": 5}
-
     def test_as_tensor_converts_field_correctly(self):
         index_field = IndexField(4, self.text)
         tensor = index_field.as_tensor(index_field.get_padding_lengths()).data.cpu().numpy()

--- a/tests/data/fields/span_field_test.py
+++ b/tests/data/fields/span_field_test.py
@@ -2,7 +2,6 @@
 import numpy
 import pytest
 
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Token
 from allennlp.data.fields import TextField, SpanField

--- a/tests/data/fields/span_field_test.py
+++ b/tests/data/fields/span_field_test.py
@@ -20,15 +20,15 @@ class TestSpanField(AllenNlpTestCase):
         numpy.testing.assert_array_equal(tensor, numpy.array([2, 3]))
 
     def test_span_field_raises_on_incorrect_label_type(self):
-        with pytest.raises(ConfigurationError):
+        with pytest.raises(TypeError):
             _ = SpanField("hello", 3, self.text)
 
     def test_span_field_raises_on_ill_defined_span(self):
-        with pytest.raises(ConfigurationError):
+        with pytest.raises(ValueError):
             _ = SpanField(4, 1, self.text)
 
     def test_span_field_raises_if_span_end_is_greater_than_sentence_length(self):
-        with pytest.raises(ConfigurationError):
+        with pytest.raises(ValueError):
             _ = SpanField(1, 30, self.text)
 
     def test_empty_span_field_works(self):

--- a/tests/data/fields/span_field_test.py
+++ b/tests/data/fields/span_field_test.py
@@ -1,0 +1,38 @@
+# pylint: disable=no-self-use,invalid-name
+import numpy
+import pytest
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Token
+from allennlp.data.fields import TextField, SpanField
+from allennlp.data.token_indexers import SingleIdTokenIndexer
+
+class TestSpanField(AllenNlpTestCase):
+    def setUp(self):
+        super(TestSpanField, self).setUp()
+        self.text = TextField([Token(t) for t in ["here", "is", "a", "sentence", "for", "spans", "."]],
+                              {"words": SingleIdTokenIndexer("words")})
+
+    def test_as_tensor_converts_span_field_correctly(self):
+        span_field = SpanField(2, 3, self.text)
+        tensor = span_field.as_tensor(span_field.get_padding_lengths()).data.cpu().numpy()
+        numpy.testing.assert_array_equal(tensor, numpy.array([2, 3]))
+
+    def test_span_field_raises_on_incorrect_label_type(self):
+        with pytest.raises(ConfigurationError):
+            _ = SpanField("hello", 3, self.text)
+
+    def test_span_field_raises_on_ill_defined_span(self):
+        with pytest.raises(ConfigurationError):
+            _ = SpanField(4, 1, self.text)
+
+    def test_span_field_raises_if_span_end_is_greater_than_sentence_length(self):
+        with pytest.raises(ConfigurationError):
+            _ = SpanField(1, 30, self.text)
+
+    def test_empty_span_field_works(self):
+        span_field = SpanField(1, 3, self.text)
+        empty_span = span_field.empty_field()
+        assert empty_span.span_start == -1
+        assert empty_span.span_end == -1


### PR DESCRIPTION
Whilst doing this I came across [this](https://github.com/allenai/allennlp/blob/master/allennlp/data/fields/index_field.py#L41), which I think is redundant. I can add a commit to remove it and it's associated test, but I wasn't sure if there was something non-obvious it was used for, as you're more familiar with the Bidaf code than I am.