### PR TITLE
Implement lazy behavior in DatasetReader

### DIFF
--- a/allennlp/data/__init__.py
+++ b/allennlp/data/__init__.py
@@ -1,4 +1,4 @@
-from allennlp.data.dataset import InstanceCollection
+from allennlp.data.dataset import InstanceCollection, Dataset, LazyDataset
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields.field import DataArray, Field
 from allennlp.data.instance import Instance

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -63,6 +63,7 @@ class Conll2003DatasetReader(DatasetReader):
                  token_indexers: Dict[str, TokenIndexer] = None,
                  tag_label: str = "ner",
                  feature_labels: Sequence[str] = ()) -> None:
+        super(Conll2003DatasetReader, self).__init__()
         self._token_indexers = token_indexers or {'tokens': SingleIdTokenIndexer()}
         if tag_label is not None and tag_label not in _VALID_LABELS:
             raise ConfigurationError("unknown tag label type: {}".format(tag_label))

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -79,6 +79,7 @@ class ConllCorefReader(DatasetReader):
     def __init__(self,
                  max_span_width: int,
                  token_indexers: Dict[str, TokenIndexer] = None) -> None:
+        super(ConllCorefReader, self).__init__()
         self._max_span_width = max_span_width
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
 

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -1,4 +1,6 @@
-from allennlp.data.dataset import InstanceCollection
+from typing import Iterator
+
+from allennlp.data.dataset import Dataset, InstanceCollection, LazyDataset
 from allennlp.data.instance import Instance
 from allennlp.common import Params
 from allennlp.common.registrable import Registrable
@@ -6,15 +8,45 @@ from allennlp.common.registrable import Registrable
 
 class DatasetReader(Registrable):
     """
-    A ``DatasetReader`` reads data from some location and constructs a :class:`Dataset`.  All
-    parameters necessary to read the data apart from the filepath should be passed to the
-    constructor of the ``DatasetReader``.
+    A ``DatasetReader`` reads data from some location and constructs an
+    :class:`InstanceCollection`.  All parameters necessary to read the data apart from the filepath
+    should be passed to the constructor of the ``DatasetReader``.
     """
+    def __init__(self, lazy: bool = False) -> None:
+        self._lazy = lazy
+
     def read(self, file_path: str) -> InstanceCollection:
         """
-        Actually reads some data from the `file_path` and returns a :class:`Dataset`.
+        Actually reads some data from the `file_path` and returns an :class:`InstanceCollection`.
+
+        The base class implementation passes this off to :func:`_read_instances`, and then uses the
+        resulting iterator to create either a :class:`~allennlp.data.dataset.Dataset` (which is
+        `not` lazy, and stores all of the instances in memory) or a
+        :class:`~allennlp.data.dataset.LazyDataset` (which `is` lazy, and reads, tokenizes, and
+        indexes the instances at every pass through the data).
+
+        If you want your ``DatasetReader`` to have this kind of lazy option built in, you should
+        override :func:`_read_instances`.  Otherwise, you can just override this method, and that
+        will still work fine with the API.
         """
-        raise NotImplementedError
+        if self._lazy:
+            return LazyDataset(lambda: self._read_instances(file_path))
+        return Dataset(list(self._read_instances(file_path)))
+
+    def _read_instances(self, file_path: str) -> Iterator[Instance]:
+        """
+        A helper method for easily adding lazy functionality to your ``DatasetReader``.  Instead of
+        implementing :func:`read` directly and constructing a list of instances that goes into a
+        :class:`Dataset`, you can implement this method that returns an ``Iterator`` over
+        instances.  Where you would have added an instance to a list in :func:`read`, you can
+        instead just ``yield`` the instance from this method, and then you get lazy behavior for
+        free from the superclass by passing the ``lazy`` flag when calling the superclass
+        constructor.
+
+        The default implementation here raises a ``RuntimeError`` instead of a
+        ``NotImplementedError``, because it is not required that a subclass implement this method.
+        """
+        raise RuntimeError("Not implemented!")
 
     def text_to_instance(self, *inputs) -> Instance:
         """

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -46,6 +46,7 @@ class DatasetReader(Registrable):
         The default implementation here raises a ``RuntimeError`` instead of a
         ``NotImplementedError``, because it is not required that a subclass implement this method.
         """
+        # pylint: disable=no-self-use,unused-argument
         raise RuntimeError("Not implemented!")
 
     def text_to_instance(self, *inputs) -> Instance:

--- a/allennlp/data/dataset_readers/language_modeling.py
+++ b/allennlp/data/dataset_readers/language_modeling.py
@@ -48,6 +48,7 @@ class LanguageModelingReader(DatasetReader):
                  tokens_per_instance: int = None,
                  tokenizer: Tokenizer = None,
                  token_indexers: Dict[str, TokenIndexer] = None) -> None:
+        super(LanguageModelingReader, self).__init__()
         self._tokenizer = tokenizer or WordTokenizer()
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._tokens_per_instance = tokens_per_instance

--- a/allennlp/data/dataset_readers/reading_comprehension/squad.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/squad.py
@@ -42,6 +42,7 @@ class SquadReader(DatasetReader):
     def __init__(self,
                  tokenizer: Tokenizer = None,
                  token_indexers: Dict[str, TokenIndexer] = None) -> None:
+        super(SquadReader, self).__init__()
         self._tokenizer = tokenizer or WordTokenizer()
         self._token_indexers = token_indexers or {'tokens': SingleIdTokenIndexer()}
 

--- a/allennlp/data/dataset_readers/reading_comprehension/triviaqa.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/triviaqa.py
@@ -58,6 +58,7 @@ class TriviaQaReader(DatasetReader):
                  unfiltered_tarball_path: str = None,
                  tokenizer: Tokenizer = None,
                  token_indexers: Dict[str, TokenIndexer] = None) -> None:
+        super(TriviaQaReader, self).__init__()
         self._base_tarball_path = base_tarball_path
         self._unfiltered_tarball_path = unfiltered_tarball_path
         self._tokenizer = tokenizer or WordTokenizer()

--- a/allennlp/data/dataset_readers/semantic_role_labeling.py
+++ b/allennlp/data/dataset_readers/semantic_role_labeling.py
@@ -44,6 +44,7 @@ class SrlReader(DatasetReader):
 
     """
     def __init__(self, token_indexers: Dict[str, TokenIndexer] = None) -> None:
+        super(SrlReader, self).__init__()
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
 
     @overrides

--- a/allennlp/data/dataset_readers/seq2seq.py
+++ b/allennlp/data/dataset_readers/seq2seq.py
@@ -56,6 +56,7 @@ class Seq2SeqDatasetReader(DatasetReader):
                  source_token_indexers: Dict[str, TokenIndexer] = None,
                  target_token_indexers: Dict[str, TokenIndexer] = None,
                  source_add_start_token: bool = True) -> None:
+        super(Seq2SeqDatasetReader, self).__init__()
         self._source_tokenizer = source_tokenizer or WordTokenizer()
         self._target_tokenizer = target_tokenizer or self._source_tokenizer
         self._source_token_indexers = source_token_indexers or {"tokens": SingleIdTokenIndexer()}

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -44,6 +44,7 @@ class SequenceTaggingDatasetReader(DatasetReader):
                  word_tag_delimiter: str = DEFAULT_WORD_TAG_DELIMITER,
                  token_delimiter: str = None,
                  token_indexers: Dict[str, TokenIndexer] = None) -> None:
+        super(SequenceTaggingDatasetReader, self).__init__()
         self._token_indexers = token_indexers or {'tokens': SingleIdTokenIndexer()}
         self._word_tag_delimiter = word_tag_delimiter
         self._token_delimiter = token_delimiter

--- a/allennlp/data/dataset_readers/snli.py
+++ b/allennlp/data/dataset_readers/snli.py
@@ -37,6 +37,7 @@ class SnliReader(DatasetReader):
     def __init__(self,
                  tokenizer: Tokenizer = None,
                  token_indexers: Dict[str, TokenIndexer] = None) -> None:
+        super(SnliReader, self).__init__()
         self._tokenizer = tokenizer or WordTokenizer()
         self._token_indexers = token_indexers or {'tokens': SingleIdTokenIndexer()}
 

--- a/tests/commands/train_test.py
+++ b/tests/commands/train_test.py
@@ -97,6 +97,7 @@ class TestTrain(AllenNlpTestCase):
 class LazyFakeReader(DatasetReader):
     # pylint: disable=abstract-method
     def __init__(self) -> None:
+        super().__init__()
         self.reader = DatasetReader.from_params(Params({'type': 'sequence_tagging'}))
 
     def _generator_for_file(self, file_path: str):

--- a/tests/data/dataset_readers/dataset_reader_test.py
+++ b/tests/data/dataset_readers/dataset_reader_test.py
@@ -1,0 +1,31 @@
+# pylint: disable=no-self-use,invalid-name,protected-access
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import DatasetReader, Instance, LazyDataset, Token
+from allennlp.data.fields import TextField
+
+
+class TestDatasetReader(AllenNlpTestCase):
+    def setUp(self):
+        super().setUp()
+        field1 = TextField([Token(t) for t in ["this", "is", "a", "sentence", "."]], None)
+        field2 = TextField([Token(t) for t in ["this", "is", "a", "different", "sentence", "."]], None)
+        field3 = TextField([Token(t) for t in ["here", "is", "a", "sentence", "."]], None)
+        field4 = TextField([Token(t) for t in ["this", "is", "short"]], None)
+        self.instances = [Instance({"text1": field1, "text2": field2}),
+                          Instance({"text1": field3, "text2": field4})]
+
+    def get_lazy_dataset(self):
+        return LazyDataset(lambda: iter(self.instances))
+
+    def test_read_works_with_lazy_option(self):
+        reader = DatasetReader(lazy=True)
+        reader._read_instances = lambda x: self.get_lazy_dataset()
+        dataset = reader.read('ignored')
+
+        assert isinstance(dataset, LazyDataset)
+        instances = list(iter(dataset))
+        assert instances == self.instances
+
+        # We'll make sure we can go over the dataset twice without issue.
+        instances = list(iter(dataset))
+        assert instances == self.instances


### PR DESCRIPTION
This is fully backwards-compatible.  Any `DatasetReader` that already overrides `read` will still work.  This just gives you another option when implementing a `DatasetReader`, if you want to be able to easily switch between lazy and not lazy, for whatever reason.  I didn't change any existing readers to use this, I just tested it in the base class.