### PR TITLE
Speed up get_linking_probabilities

### DIFF
--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -427,7 +427,7 @@ class WikiTablesSemanticParser(Model):
             Has shape ``(batch_size, num_question_tokens, num_entities)``.
             Contains all the probabilities for an entity given a question word.
         """
-        batch_size, num_question_tokens, num_entities = linking_scores.size()
+        _, num_question_tokens, num_entities = linking_scores.size()
         batch_probabilities = []
 
         for batch_index, world in enumerate(worlds):

--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -462,8 +462,8 @@ class WikiTablesSemanticParser(Model):
             to_cat = [probabilities_cell[:, 1:], probabilities_row[:, 1:]]
             num_kept_entities = len(cell_type_index) + len(row_type_index) - 2
             if num_kept_entities != num_entities:
-                zeros = Variable(probabilities.data.new(num_question_tokens,
-                                                        num_entities - num_kept_entities).fill_(0))
+                zeros = Variable(linking_scores.data.new(num_question_tokens,
+                                                         num_entities - num_kept_entities).fill_(0))
                 to_cat.append(zeros)
 
             # (num_question_tokens, num_entities)

--- a/scripts/ai2-internal/run_with_beaker.sh
+++ b/scripts/ai2-internal/run_with_beaker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SOURCES_ARG="--source squad.latest:/squad --source glove.latest:/glove"
+SOURCES_ARG="--source wikitables_preprocessed_7k:/wikitables_preprocessed"
 RESULT_ARG="--result-path /output"
 GPU_ARG="--gpu-count=1"
 DETACH_ARG="--detach"  # or ""


### PR DESCRIPTION
This reduces the percent of computation done in `_get_linking_probabilities` to approximately zero, giving a roughly 30% reduction in training time.

@rajasagashe, github isn't letting me add you as a reviewer, or I would have done it.