### PR TITLE
Revert "programmatic imports of third-party models"

### DIFF
--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -28,7 +28,7 @@ import logging
 import tqdm
 
 from allennlp.commands.subcommand import Subcommand
-from allennlp.common.util import prepare_environment, import_submodules
+from allennlp.common.util import prepare_environment
 from allennlp.data import InstanceCollection
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.iterators import DataIterator
@@ -70,12 +70,6 @@ class Evaluate(Subcommand):
                                default="",
                                help='a HOCON structure used to override the experiment configuration')
 
-        subparser.add_argument('--include-package',
-                               type=str,
-                               action='append',
-                               default=[],
-                               help='additional packages to include')
-
         subparser.set_defaults(func=evaluate_from_args)
 
         return subparser
@@ -104,10 +98,6 @@ def evaluate_from_args(args: argparse.Namespace) -> Dict[str, Any]:
     logging.getLogger('allennlp.common.params').disabled = True
     logging.getLogger('allennlp.nn.initializers').disabled = True
     logging.getLogger('allennlp.modules.token_embedders.embedding').setLevel(logging.INFO)
-
-    # Import any additional modules needed (to register custom classes)
-    for package_name in args.include_package:
-        import_submodules(package_name)
 
     # Load from archive
     archive = load_archive(args.archive_file, args.cuda_device, args.overrides)

--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -28,7 +28,6 @@ from typing import Optional, IO, Dict
 
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError
-from allennlp.common.util import import_submodules
 from allennlp.models.archival import load_archive
 from allennlp.service.predictors import Predictor
 
@@ -74,32 +73,17 @@ class Predict(Subcommand):
                                default="",
                                help='a HOCON structure used to override the experiment configuration')
 
-        subparser.add_argument('--include-package',
-                               type=str,
-                               action='append',
-                               default=[],
-                               help='additional packages to include')
-
-        subparser.add_argument('--predictor',
-                               type=str,
-                               help='optionally specify a specific predictor to use')
-
         subparser.set_defaults(func=_predict(self.predictors))
 
         return subparser
 
 def _get_predictor(args: argparse.Namespace, predictors: Dict[str, str]) -> Predictor:
     archive = load_archive(args.archive_file, cuda_device=args.cuda_device, overrides=args.overrides)
-
-    if args.predictor:
-        # Predictor explicitly specified, so use it
-        return Predictor.from_archive(archive, args.predictor)
-
-    # Otherwise, use the mapping
     model_type = archive.config.get("model").get("type")
     if model_type not in predictors:
         raise ConfigurationError("no known predictor for model type {}".format(model_type))
-    return Predictor.from_archive(archive, predictors[model_type])
+    predictor = Predictor.from_archive(archive, predictors[model_type])
+    return predictor
 
 def _run(predictor: Predictor,
          input_file: IO,
@@ -143,10 +127,6 @@ def _run(predictor: Predictor,
 
 def _predict(predictors: Dict[str, str]):
     def predict_inner(args: argparse.Namespace) -> None:
-        # Import any additional modules needed (to register custom classes)
-        for package_name in args.include_package:
-            import_submodules(package_name)
-
         predictor = _get_predictor(args, predictors)
         output_file = None
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -31,7 +31,7 @@ from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.params import Params
 from allennlp.common.tee_logger import TeeLogger
-from allennlp.common.util import prepare_environment, import_submodules
+from allennlp.common.util import prepare_environment
 from allennlp.data import InstanceCollection, Vocabulary
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.iterators.data_iterator import DataIterator
@@ -66,23 +66,15 @@ class Train(Subcommand):
                                default="",
                                help='a HOCON structure used to override the experiment configuration')
 
-        subparser.add_argument('--include-package',
-                               type=str,
-                               action='append',
-                               default=[],
-                               help='additional packages to include')
-
         subparser.set_defaults(func=train_model_from_args)
 
         return subparser
+
 
 def train_model_from_args(args: argparse.Namespace):
     """
     Just converts from an ``argparse.Namespace`` object to string paths.
     """
-    # Import any additional modules needed (to register custom classes)
-    for package_name in args.include_package:
-        import_submodules(package_name)
     train_model_from_file(args.param_path, args.serialization_dir, args.overrides)
 
 

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -4,8 +4,6 @@ Various utilities that don't fit anwhere else.
 
 from itertools import zip_longest
 from typing import Any, Callable, Dict, List, Tuple, TypeVar
-import importlib
-import pkgutil
 import random
 import resource
 import sys
@@ -188,17 +186,6 @@ def get_spacy_model(spacy_model_name: str, pos_tags: bool, parse: bool, ner: boo
         spacy_model = spacy.load(spacy_model_name, disable=disable)
         LOADED_SPACY_MODELS[options] = spacy_model
     return LOADED_SPACY_MODELS[options]
-
-def import_submodules(package_name: str) -> None:
-    """
-    Import all submodules under the given package.
-    Primarily useful so that people using AllenNLP as a library
-    can specify their own custom packages and have their custom
-    classes get loaded and registered.
-    """
-    module = importlib.import_module(package_name)
-    for _, name, _ in pkgutil.walk_packages(getattr(module, "__path__", "")):
-        importlib.import_module(package_name + '.' + name)
 
 def peak_memory_mb() -> float:
     """

--- a/allennlp/service/server_simple.py
+++ b/allennlp/service/server_simple.py
@@ -2,21 +2,8 @@
 A `Flask <http://flask.pocoo.org/>`_ server for serving predictions
 from a single AllenNLP model. It also includes a very, very bare-bones
 web front-end for exploring predictions (or you can provide your own).
-
-For example, if you have your own predictor and model in the `my_stuff` package,
-and you want to use the default HTML, you could run this like
-
-```
-python -m allennlp.service.server_simple \
-    --archive-path /path/to/trained/model/archive.tar.gz \
-    --predictor my-predictor-name \
-    --title "Demo of My Stuff" \
-    --field-name question --field-name passage --field-name hint \
-    --include-package my_stuff
-```
 """
 from typing import List, Callable
-import argparse
 import json
 import logging
 import os
@@ -28,7 +15,6 @@ from flask_cors import CORS
 from gevent.wsgi import WSGIServer
 
 from allennlp.common import JsonDict
-from allennlp.common.util import import_submodules
 from allennlp.models.archival import load_archive
 from allennlp.service.predictors import Predictor
 from allennlp.service.server_flask import ServerError
@@ -114,39 +100,29 @@ def make_app(predictor: Predictor,
         return app
 
 
-def main(args):
-    # Executing this file with no extra options runs the simple service with the bidaf test fixture
+def main():
+    # Executing this file runs the simple service with the bidaf test fixture
     # and the machine-comprehension predictor. There's no good reason you'd want
-    # to do this, except possibly to test changes to the stock HTML).
+    # to do this (except maybe to test changes to the stock HTML), but this shows
+    # you what you'd do in your own code to run your own demo.
 
-    parser = argparse.ArgumentParser(description='Serve up a simple model')
+    # Make sure all the classes you need for your Model / Predictor / DatasetReader / etc...
+    # are imported here, because otherwise they can't be constructed ``from_params``.
 
-    parser.add_argument('--archive-path', type=str, help='path to trained archive file')
-    parser.add_argument('--predictor', type=str, help='name of predictor')
-    parser.add_argument('--static-dir', type=str, help='serve index.html from this directory')
-    parser.add_argument('--title', type=str, help='change the default page title', default="AllenNLP Demo")
-    parser.add_argument('--field-name', type=str, action='append', help='field names to include in the demo')
+    archive = load_archive('tests/fixtures/bidaf/serialization/model.tar.gz')
+    predictor = Predictor.from_archive(archive, 'machine-comprehension')
 
-    parser.add_argument('--include-package',
-                        type=str,
-                        action='append',
-                        default=[],
-                        help='additional packages to include')
-
-    args = parser.parse_args(args)
-
-    # Load modules
-    for package_name in args.include_package:
-        import_submodules(package_name)
-
-    archive = load_archive(args.archive_path or 'tests/fixtures/bidaf/serialization/model.tar.gz')
-    predictor = Predictor.from_archive(archive, args.predictor or 'machine-comprehension')
-    field_names = args.field_name or ['passage', 'question']
+    def sanitizer(prediction: JsonDict) -> JsonDict:
+        """
+        Only want best_span results.
+        """
+        return {key: value
+                for key, value in prediction.items()
+                if key.startswith("best_span")}
 
     app = make_app(predictor=predictor,
-                   field_names=field_names,
-                   static_dir=args.static_dir,
-                   title=args.title)
+                   field_names=['passage', 'question'],
+                   sanitizer=sanitizer)
 
     http_server = WSGIServer(('0.0.0.0', 8888), app)
     http_server.serve_forever()
@@ -713,4 +689,4 @@ def _html(title: str, field_names: List[str]) -> str:
                                      qfl=quoted_field_list)
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/tests/commands/evaluate_test.py
+++ b/tests/commands/evaluate_test.py
@@ -1,32 +1,20 @@
 # pylint: disable=invalid-name,no-self-use
 import argparse
-import json
-import os
-import shutil
-import sys
-import tarfile
 
 from flaky import flaky
-import pytest
 
-from allennlp.commands.evaluate import evaluate_from_args, Evaluate
-from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.models.archival import archive_model
+from allennlp.commands.evaluate import evaluate_from_args, Evaluate
 
 
 class TestEvaluate(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.parser = argparse.ArgumentParser(description="Testing")
-        subparsers = self.parser.add_subparsers(title='Commands', metavar='')
-        Evaluate().add_subparser('evaluate', subparsers)
-
 
     @flaky
     def test_evaluate_from_args(self):
+        parser = argparse.ArgumentParser(description="Testing")
+        subparsers = parser.add_subparsers(title='Commands', metavar='')
+        Evaluate().add_subparser('evaluate', subparsers)
+
         snake_args = ["evaluate",
                       "--archive_file", "tests/fixtures/bidaf/serialization/model.tar.gz",
                       "--evaluation_data_file", "tests/fixtures/data/squad.json",
@@ -38,61 +26,6 @@ class TestEvaluate(AllenNlpTestCase):
                       "--cuda-device", "-1"]
 
         for raw_args in [snake_args, kebab_args]:
-            args = self.parser.parse_args(raw_args)
+            args = parser.parse_args(raw_args)
             metrics = evaluate_from_args(args)
             assert metrics.keys() == {'span_acc', 'end_acc', 'start_acc', 'em', 'f1'}
-
-    def test_external_modules(self):
-        sys.path.insert(0, self.TEST_DIR)
-
-        original_serialization_dir = 'tests/fixtures/bidaf/serialization'
-        serialization_dir = os.path.join(self.TEST_DIR, 'serialization')
-        shutil.copytree(original_serialization_dir, serialization_dir)
-
-        # Get original model config
-        tf = tarfile.open(os.path.join(original_serialization_dir, 'model.tar.gz'))
-        tf.extract('config.json', self.TEST_DIR)
-
-        # Write out modified config file
-        params = Params.from_file(os.path.join(self.TEST_DIR, 'config.json'))
-        params['model']['type'] = 'bidaf-duplicate'
-
-        config_file = os.path.join(serialization_dir, 'model_params.json')
-        with open(config_file, 'w') as f:
-            f.write(json.dumps(params.as_dict(quiet=True)))
-
-        # And create an archive
-        archive_model(serialization_dir)
-
-        # Write out modified model.py
-        module_dir = os.path.join(self.TEST_DIR, 'bidaf_duplicate')
-        os.makedirs(module_dir)
-
-        from allennlp.models.reading_comprehension import bidaf
-        with open(bidaf.__file__) as f:
-            code = f.read().replace("""@Model.register("bidaf")""",
-                                    """@Model.register('bidaf-duplicate')""")
-
-        with open(os.path.join(module_dir, 'model.py'), 'w') as f:
-            f.write(code)
-
-        archive_file = os.path.join(serialization_dir, 'model.tar.gz')
-
-        raw_args = ["evaluate",
-                    "--archive-file", archive_file,
-                    "--evaluation-data-file", "tests/fixtures/data/squad.json"]
-
-        args = self.parser.parse_args(raw_args)
-
-        # Raise configuration error without extra modules
-        with pytest.raises(ConfigurationError):
-            metrics = evaluate_from_args(args)
-
-        # Specify the additional module
-        raw_args.extend(['--include-package', 'bidaf_duplicate'])
-        args = self.parser.parse_args(raw_args)
-        metrics = evaluate_from_args(args)
-
-        assert metrics.keys() == {'span_acc', 'end_acc', 'start_acc', 'em', 'f1'}
-
-        sys.path.remove(self.TEST_DIR)

--- a/tests/commands/predict_test.py
+++ b/tests/commands/predict_test.py
@@ -4,22 +4,18 @@ import csv
 import io
 import json
 import os
-import pathlib
 import shutil
 import sys
 import tempfile
+from unittest import TestCase
 
-import pytest
-
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.util import JsonDict
-from allennlp.common.testing import AllenNlpTestCase
 from allennlp.commands import main
 from allennlp.commands.predict import Predict, DEFAULT_PREDICTORS
 from allennlp.service.predictors import Predictor, BidafPredictor
 
 
-class TestPredict(AllenNlpTestCase):
+class TestPredict(TestCase):
 
     def test_add_predict_subparser(self):
         parser = argparse.ArgumentParser(description="Testing")
@@ -171,108 +167,6 @@ class TestPredict(AllenNlpTestCase):
                                           "best_span_str", "overridden"}
 
         shutil.rmtree(tempdir)
-
-
-    def test_can_specify_predictor(self):
-
-        @Predictor.register('bidaf-explicit')  # pylint: disable=unused-variable
-        class Bidaf3Predictor(BidafPredictor):
-            """same as bidaf predictor but with an extra field"""
-            def predict_json(self, inputs: JsonDict, cuda_device: int = -1) -> JsonDict:
-                result = super().predict_json(inputs)
-                result["explicit"] = True
-                return result
-
-        tempdir = tempfile.mkdtemp()
-        infile = os.path.join(tempdir, "inputs.txt")
-        outfile = os.path.join(tempdir, "outputs.txt")
-
-        with open(infile, 'w') as f:
-            f.write("""{"passage": "the seahawks won the super bowl in 2016", """
-                    """ "question": "when did the seahawks win the super bowl?"}\n""")
-            f.write("""{"passage": "the mariners won the super bowl in 2037", """
-                    """ "question": "when did the mariners win the super bowl?"}\n""")
-
-        sys.argv = ["run.py",      # executable
-                    "predict",     # command
-                    "tests/fixtures/bidaf/serialization/model.tar.gz",
-                    infile,     # input_file
-                    "--output-file", outfile,
-                    "--predictor", "bidaf-explicit",
-                    "--silent"]
-
-        main()
-        assert os.path.exists(outfile)
-
-        with open(outfile, 'r') as f:
-            results = [json.loads(line) for line in f]
-
-        assert len(results) == 2
-        # Overridden predictor should output extra field
-        for result in results:
-            assert set(result.keys()) == {"span_start_logits", "span_end_logits",
-                                          "span_start_probs", "span_end_probs", "best_span",
-                                          "best_span_str", "explicit"}
-
-        shutil.rmtree(tempdir)
-
-    def test_other_modules(self):
-        # Create a new package in a temporary dir
-        packagedir = os.path.join(self.TEST_DIR, 'testpackage')
-        pathlib.Path(packagedir).mkdir()
-        pathlib.Path(os.path.join(packagedir, '__init__.py')).touch()
-
-        # And add that directory to the path
-        sys.path.insert(0, self.TEST_DIR)
-
-        # Write out a duplicate predictor there, but registered under a different name.
-        from allennlp.service.predictors import bidaf
-        with open(bidaf.__file__) as f:
-            code = f.read().replace("""@Predictor.register('machine-comprehension')""",
-                                    """@Predictor.register('duplicate-test-predictor')""")
-
-        with open(os.path.join(packagedir, 'predictor.py'), 'w') as f:
-            f.write(code)
-
-        infile = os.path.join(self.TEST_DIR, "inputs.txt")
-        outfile = os.path.join(self.TEST_DIR, "outputs.txt")
-
-        with open(infile, 'w') as f:
-            f.write("""{"passage": "the seahawks won the super bowl in 2016", """
-                    """ "question": "when did the seahawks win the super bowl?"}\n""")
-            f.write("""{"passage": "the mariners won the super bowl in 2037", """
-                    """ "question": "when did the mariners win the super bowl?"}\n""")
-
-        sys.argv = ["run.py",      # executable
-                    "predict",     # command
-                    "tests/fixtures/bidaf/serialization/model.tar.gz",
-                    infile,     # input_file
-                    "--output-file", outfile,
-                    "--predictor", "duplicate-test-predictor",
-                    "--silent"]
-
-        # Should raise ConfigurationError, because predictor is unknown
-        with pytest.raises(ConfigurationError):
-            main()
-
-        # But once we include testpackage, it should be known
-        sys.argv.extend(["--include-package", "testpackage"])
-        main()
-
-        assert os.path.exists(outfile)
-
-        with open(outfile, 'r') as f:
-            results = [json.loads(line) for line in f]
-
-        assert len(results) == 2
-        # Overridden predictor should output extra field
-        for result in results:
-            assert set(result.keys()) == {"span_start_logits", "span_end_logits",
-                                          "span_start_probs", "span_end_probs", "best_span",
-                                          "best_span_str"}
-
-        sys.path.remove(self.TEST_DIR)
-
 
     def test_alternative_file_formats(self):
         tempdir = tempfile.mkdtemp()

--- a/tests/commands/train_test.py
+++ b/tests/commands/train_test.py
@@ -1,17 +1,9 @@
 # pylint: disable=invalid-name,no-self-use
 import argparse
 from typing import Iterator
-import os
-import pathlib
-import shutil
-import sys
-
-import pytest
 
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.commands import main
 from allennlp.commands.train import Train, train_model, train_model_from_args
 from allennlp.data import DatasetReader, Instance, InstanceCollection
 from allennlp.data.dataset import LazyDataset
@@ -100,75 +92,6 @@ class TestTrain(AllenNlpTestCase):
         with self.assertRaises(SystemExit) as cm:  # pylint: disable=invalid-name
             args = parser.parse_args(["train", "path/to/params"])
             assert cm.exception.code == 2  # argparse code for incorrect usage
-
-    def test_other_modules(self):
-        # Create a new package in a temporary dir
-        packagedir = os.path.join(self.TEST_DIR, 'testpackage')
-        pathlib.Path(packagedir).mkdir()
-        pathlib.Path(os.path.join(packagedir, '__init__.py')).touch()
-
-        # And add that directory to the path
-        sys.path.insert(0, self.TEST_DIR)
-
-        # Write out a duplicate model there, but registered under a different name.
-        from allennlp.models import simple_tagger
-        with open(simple_tagger.__file__) as f:
-            code = f.read().replace("""@Model.register("simple_tagger")""",
-                                    """@Model.register("duplicate-test-tagger")""")
-
-        with open(os.path.join(packagedir, 'model.py'), 'w') as f:
-            f.write(code)
-
-        # Copy fixture there too.
-        shutil.copy(os.path.join(os.getcwd(), 'tests/fixtures/data/sequence_tagging.tsv'), self.TEST_DIR)
-        data_path = os.path.join(self.TEST_DIR, 'sequence_tagging.tsv')
-
-        # Write out config file
-        config_path = os.path.join(self.TEST_DIR, 'config.json')
-        with open(config_path, 'w') as f:
-            f.write("""
-                "model": {
-                        "type": "duplicate-test-tagger",
-                        "text_field_embedder": {
-                                "tokens": {
-                                        "type": "embedding",
-                                        "embedding_dim": 5
-                                }
-                        },
-                        "stacked_encoder": {
-                                "type": "lstm",
-                                "input_size": 5,
-                                "hidden_size": 7,
-                                "num_layers": 2
-                        }
-                },
-                "dataset_reader": {"type": "sequence_tagging"},
-                "train_data_path": $$$,
-                "validation_data_path": $$$,
-                "iterator": {"type": "basic", "batch_size": 2},
-                "trainer": {
-                        "num_epochs": 2,
-                        "optimizer": "adam"
-                }
-            """.replace('$$$', data_path))
-
-        serialization_dir = os.path.join(self.TEST_DIR, 'serialization')
-
-        # Run train with using the non-allennlp module.
-        sys.argv = ["python -m allennlp.run",
-                    "train", config_path,
-                    "-s", serialization_dir]
-
-        # Shouldn't be able to find the model.
-        with pytest.raises(ConfigurationError):
-            main()
-
-        # Now add the --include-package flag and it should work.
-        sys.argv.extend(["--include-package", 'testpackage'])
-
-        main()
-
-        sys.path.remove(self.TEST_DIR)
 
 @DatasetReader.register('lazy-test')
 class LazyFakeReader(DatasetReader):

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -1,8 +1,4 @@
 # pylint: disable=no-self-use,invalid-name
-import os
-import pathlib
-import sys
-
 import torch
 
 from allennlp.common import util
@@ -28,21 +24,3 @@ class TestCommonUtils(AllenNlpTestCase):
     def test_sanitize(self):
         assert util.sanitize(torch.Tensor([1, 2])) == [1, 2]
         assert util.sanitize(torch.LongTensor([1, 2])) == [1, 2]
-
-    def test_import_submodules(self):
-        os.makedirs(os.path.join(self.TEST_DIR, 'mymodule'))
-        pathlib.Path(os.path.join(self.TEST_DIR, 'mymodule/__init__.py')).touch()
-        os.makedirs(os.path.join(self.TEST_DIR, 'mymodule/submodule'))
-        pathlib.Path(os.path.join(self.TEST_DIR, 'mymodule/submodule/__init__.py')).touch()
-
-        sys.path.insert(0, self.TEST_DIR)
-
-        assert 'mymodule' not in sys.modules
-        assert 'mymodule.submodule' not in sys.modules
-
-        util.import_submodules('mymodule')
-
-        assert 'mymodule' in sys.modules
-        assert 'mymodule.submodule' in sys.modules
-
-        sys.path.remove(self.TEST_DIR)

--- a/tutorials/getting_started/creating_a_model.md
+++ b/tutorials/getting_started/creating_a_model.md
@@ -163,34 +163,24 @@ We don't *need* to, but we also make a few other changes
 
 At this point we're ready to train the model.
 In this case our new classes are part of the `allennlp` library,
-which means we can just use `python -m allennlp.run train`:
+which means we can just use `allennlp/run.py train`,
+but if you were to create your own model they wouldn't be.
 
-```bash
-$ python -m allennlp.run train \
-    tutorials/getting_started/crf_tagger.json \
-    -s /tmp/crf_model
-```
-
-If you were to create your own model outside of
-the allennlp codebase, they wouldn't be.
-
-In that case `allennlp.run` needs extra info to load the modules in which
+In that case `allennlp/run.py` never loads the modules in which
 you've defined your classes, they never get registered, and then
 AllenNLP is unable to instantiate them based on the configuration file.
 
-You can specify one more more extra packages using the
-`--include-packages` flag. For example, imagine that
-your model is in the module `myallennlp.model`
-and your dataset reader is in the module `myallennlp.dataset_reader`.
+In such a case you'll need to create your own such script.
+You can actually copy that one, the only change you need to make
+is to import all of your custom classes at the top:
 
-Then you would just
-```bash
-$ python -m allennlp.run train \
-    /path/to/your/model/configuration \
-    -s /path/to/serialization/dir \
-    --include-package myallennlp
+```python
+from myallennlp.data.dataset_readers import Conll2003DatasetReader
+from myallennlp.models import CrfTagger
 ```
 
-and (as long as your package is somewhere on the PATH
-where Python looks for packages), your custom classes
-will all get registered and used correctly.
+and so on. After which you're ready to train:
+
+```bash
+$ my_run.py train tutorials/getting_started/crf_tagger.json -s /tmp/crf_model
+```

--- a/tutorials/getting_started/using_in_your_repo.md
+++ b/tutorials/getting_started/using_in_your_repo.md
@@ -473,10 +473,38 @@ Now let's train it on some real data!
 
 ## Step five: train the model
 
-As per our [getting started tutorial](training_and_evaluating.md),
-you can use `python -m allennlp.run train` to train a model.
+Our [getting started tutorial](training_and_evaluating.md) says to use `python -m allennlp.run
+train CONFIG_FILE` to train a model.  That's not going to work for us, however, because
+`allennlp.run` doesn't know about the `DatasetReader` and `Model` classes that we added to the
+registry, so it will fail to load our configuration files.  Instead, we need to write our own
+`run.py` script:
 
-To do that, we need a configuration file.  You can see the full file
+```python
+#!/usr/bin/env python
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir))))
+logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s - %(message)s',
+                    level=logging.INFO)
+
+# NOTE: This line is important!  It's what makes all of the classes in `my_library` findable by
+# AllenNLP's registry.
+from my_library import *
+
+from allennlp.commands import main  # pylint: disable=wrong-import-position
+
+if __name__ == "__main__":
+    main(prog="python run.py")
+```
+
+This is just copied directly from `allennlp.run`, with one crucial addition: the line `from
+my_library import *`.  We set up imports in our `__init__.py` files such that this line imports
+our `DatasetReader` and `Model` classes, which adds them to the registry so that AllenNLP can find
+them.  Now we can train our model with `python run.py train CONFIG_FILE -s SAVE_DIR`.
+
+The only thing we're missing is the configuration file.  You can see the full file
 [here](https://github.com/allenai/allennlp-as-a-library-example/blob/master/experiments/venue_classifier.json).
 We'll look at it in chunks.
 
@@ -577,33 +605,12 @@ The feed-forward network has a configurable depth, width, and activation.  You c
 `FeedForward` for more information on these parameters.
 
 And that's it!  You're now the proud owner of a new `DatasetReader`, `Model`, and means to train
-the model on your favorite data.
-
-The only remaining twist is that `allennlp.run` doesn't know about
-our custom `Model` and `DatasetReader`, which means we'll need to
-provide an extra parameter so that it loads and registers them.
-
-Here our custom code all lives in the `my_library` module,
-which means we need to add an extra parameter
-
-```
---include-package my_library
-```
-
-which (as long that package is somewhere visible on our PATH)
-will load all of the `my_library/...` submodules
-(and hence register all of our custom classes)
-before training the model.
-
-You can checkout the code from the [github
+the model on your favorite data.  You can checkout the code from the [github
 repository](https://github.com/allenai/allennlp-as-a-library-example/), run the setup commands
 mentioned above to install AllenNLP, pytorch, and spacy, and try training this with:
 
 ```bash
-python -m allennlp.run train \
-    experiments/venue_classifier.json \
-    -s /tmp/venue_output_dir \
-    --include-package my_library
+python run.py train experiments/venue_classifier.json -s /tmp/venue_output_dir
 ```
 
 When we do this, we get to around 80% validation accuracy after a few epochs of training.


### PR DESCRIPTION
Reverts allenai/allennlp#695

although the tests all pass on teamcity, they now fail on my machine, in weird non-deterministic ways, and I'm having a really hard time debugging why, so I'm going to revert this for now so it doesn't bite anyone else