### PR TITLE
Agenda improvements

### DIFF
--- a/allennlp/data/dataset_readers/nlvr.py
+++ b/allennlp/data/dataset_readers/nlvr.py
@@ -233,7 +233,7 @@ class NlvrDatasetReader(DatasetReader):
         sentence_token_indexers = TokenIndexer.dict_from_params(params.pop('sentence_token_indexers', {}))
         terminal_indexers = TokenIndexer.dict_from_params(params.pop('terminal_indexers', {}))
         nonterminal_indexers = TokenIndexer.dict_from_params(params.pop('nonterminal_indexers', {}))
-        add_paths_to_agenda = params.pop("add_paths_to_agenda")
+        add_paths_to_agenda = params.pop("add_paths_to_agenda", True)
         params.assert_empty(cls.__name__)
         return NlvrDatasetReader(tokenizer=tokenizer,
                                  sentence_token_indexers=sentence_token_indexers,

--- a/allennlp/data/dataset_readers/nlvr.py
+++ b/allennlp/data/dataset_readers/nlvr.py
@@ -116,7 +116,7 @@ class NlvrDatasetReader(DatasetReader):
         world = NlvrWorld(structured_representation)
         tokenized_sentence = self._tokenizer.tokenize(sentence)
         sentence_field = TextField(tokenized_sentence, self._sentence_token_indexers)
-        agenda = self._get_agenda_for_sentence(sentence)
+        agenda = self._get_agenda_for_sentence(sentence, world)
         assert agenda, "No agenda found for sentence: %s" % sentence
         production_rule_fields: List[Field] = []
         instance_action_ids: Dict[str, int] = {}
@@ -142,12 +142,12 @@ class NlvrDatasetReader(DatasetReader):
             fields["label"] = label_field
         return Instance(fields)
 
-    def _get_agenda_for_sentence(self, sentence: str) -> List[str]:
+    def _get_agenda_for_sentence(self, sentence: str, world: NlvrWorld) -> List[str]:
         """
-        Given a ``sentence``, return a list of actions it triggers. The model tries to include as
-        many of these actions in the decoded sequences as possible. Hence, this method defines a
-        mapping from sentence level features to actions. This is a simplistic mapping at this point,
-        and can be expanded.
+        Given a ``sentence``, and a corresponding ``NlvrWorld`` returns a list of actions the
+        sentence triggers. The model tries to include as many of these actions in the decoded
+        sequences as possible. Hence, this method defines a mapping from sentence level features to
+        actions. This is a simplistic mapping at this point, and can be expanded.
         """
         # TODO(pradeep): Add more rules in the mapping?
         # TODO(pradeep): Use approximate and substring matching as well.
@@ -162,7 +162,62 @@ class NlvrDatasetReader(DatasetReader):
         if "tower" in sentence or "box" in sentence or "grey" in sentence:
             # Ensuring box filtering function (filter_*) at top.
             agenda.append("t -> [<b,t>, b]")
+        if "touch" in sentence:
+            if "top" in sentence:
+                agenda.append(self._terminal_productions["touch_top"])
+            elif "bottom" in sentence:
+                agenda.append(self._terminal_productions["touch_bottom"])
+            elif "corner" in sentence:
+                agenda.append(self._terminal_productions["touch_corner"])
+            elif "wall" or "edge" in sentence:
+                agenda.append(self._terminal_productions["touch_wall"])
+        else:
+            # The words "top" and "bottom" may be referring to top and bottom blocks in a tower.
+            if "top" in sentence:
+                agenda.append(self._terminal_productions["top"])
+            elif "bottom" in sentence or "base" in sentence:
+                agenda.append(self._terminal_productions["bottom"])
+        if " not " in sentence:
+            agenda.append(self._terminal_productions["negate_filter"])
+        number_productions = self._get_number_productions(sentence)
+        if number_productions or set():
+            agenda.append(self._terminal_productions["count"])
+        for production in number_productions:
+            agenda.append(production)
+        agenda = self._add_nonterminal_productions(agenda, world)
         return agenda
+
+    @staticmethod
+    def _get_number_productions(sentence: str) -> List[str]:
+        """
+        Gathers all the numbers in the sentence, and returns productions that lead to them.
+        """
+        # The mapping here is very simple and limited, which also shouldn't be a problem
+        # because numbers seem to be represented fairly regularly.
+        number_strings = {"one": "1", "two": "2", "three": "3", "four": "4", "five": "5", "six":
+                          "6", "seven": "7", "eight": "8", "nine": "9", "ten": "10"}
+        number_productions = []
+        for word, numeral in number_strings.items():
+            if word in sentence or numeral in sentence:
+                number_productions.append(f"e -> {numeral}")
+        if "there is a " in sentence:
+            number_productions.append("e -> 1")
+        return number_productions
+
+    @staticmethod
+    def _add_nonterminal_productions(agenda: List[str], world: NlvrWorld) -> List[str]:
+        """
+        Given a partially populated agenda with (mostly) terminal productions, this method adds the
+        nonterminal productions that lead from the root to the terminal productions.
+        """
+        nonterminal_productions = set(agenda)
+        for action in agenda:
+            paths = world.get_paths_to_root(action, max_num_paths=5)
+            for path in paths:
+                for path_action in path:
+                    nonterminal_productions.add(path_action)
+        new_agenda = list(nonterminal_productions)
+        return new_agenda
 
     @classmethod
     def from_params(cls, params: Params) -> 'NlvrDatasetReader':

--- a/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
@@ -192,3 +192,10 @@ add_common_name_with_type("medium", "Z1", OBJECT_FILTER_TYPE)
 add_common_name_with_type("big", "Z2", OBJECT_FILTER_TYPE)
 
 add_common_name_with_type("negate_filter", "N", NEGATE_FILTER_TYPE)
+
+# Adding numbers because they commonly occur in utterances. They're usually between 1 and 9. Since
+# they're not too many of these productions, we're adding them to the global mapping instead of a
+# local mapping in each world.
+for num in range(1, 10):
+    num_string = str(num)
+    add_common_name_with_type(num_string, num_string, NUM_TYPE)

--- a/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
@@ -194,7 +194,7 @@ add_common_name_with_type("big", "Z2", OBJECT_FILTER_TYPE)
 add_common_name_with_type("negate_filter", "N", NEGATE_FILTER_TYPE)
 
 # Adding numbers because they commonly occur in utterances. They're usually between 1 and 9. Since
-# they're not too many of these productions, we're adding them to the global mapping instead of a
+# there are not too many of these productions, we're adding them to the global mapping instead of a
 # local mapping in each world.
 for num in range(1, 10):
     num_string = str(num)

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -67,6 +67,7 @@ class World:
                                       "most three nested lambda expressions")
         self._logic_parser = types.DynamicTypeLogicParser(constant_type_prefixes=type_prefixes,
                                                           type_signatures=self.global_type_signatures)
+        self._right_side_indexed_actions: Dict[str, List[Tuple[str, str]]] = None
 
     def get_name_mapping(self) -> Dict[str, str]:
         # Python 3.5 syntax for merging two dictionaries.
@@ -92,31 +93,25 @@ class World:
         For a given action, returns at most ``max_num_paths`` paths to the root (production with
         ``@START@``) that are not longer than ``max_path_length``.
         """
-        all_actions = self.all_possible_actions()
-        rhs_indexed_actions: Dict[str, List[Tuple[str, str]]] = defaultdict(list)
-        for possible_action in all_actions:
-            lhs, rhs = possible_action.split(' -> ')
-            if '[' not in rhs:
-                rhs_indexed_actions[rhs].append((lhs, possible_action))
-            else:
-                rhs_parts = rhs[1:-1].split(', ')
-                for rhs_part in rhs_parts:
-                    rhs_indexed_actions[rhs_part].append((lhs, possible_action))
-        action_lhs, _ = action.split(' -> ')
-        lists_to_expand: List[Tuple[str, List[str]]] = [(action_lhs, [action])]
+        action_left_side, _ = action.split(' -> ')
+        right_side_indexed_actions = self._get_right_side_indexed_actions()
+        lists_to_expand: List[Tuple[str, List[str]]] = [(action_left_side, [action])]
         completed_paths = []
         while lists_to_expand:
             need_to_expand = False
-            for lhs, path in lists_to_expand:
-                if lhs == types.START_SYMBOL:
+            for left_side, path in lists_to_expand:
+                if left_side == types.START_SYMBOL:
                     completed_paths.append(path)
                 else:
                     need_to_expand = True
             if not need_to_expand or len(completed_paths) >= max_num_paths:
                 break
-            new_lists = []
-            for lhs, actions in lists_to_expand:
-                for next_lhs, next_action in rhs_indexed_actions[lhs]:
+            # We keep track of finished and unfinished lists separately because we truncate the beam
+            # later, and we want the finished lists to be at the top of the beam.
+            finished_new_lists = []
+            unfinished_new_lists = []
+            for left_side, actions in lists_to_expand:
+                for next_left_side, next_action in right_side_indexed_actions[left_side]:
                     if next_action in actions:
                         # Ignoring paths with loops (of size 1)
                         continue
@@ -124,8 +119,12 @@ class World:
                     new_actions.append(next_action)
                     # Ignoring lists that are too long, and have too many repetitions.
                     path_length = len(new_actions)
-                    if path_length <= max_path_length or next_lhs == types.START_SYMBOL:
-                        new_lists.append((next_lhs, new_actions))
+                    if path_length <= max_path_length or next_left_side == types.START_SYMBOL:
+                        if next_left_side == types.START_SYMBOL:
+                            finished_new_lists.append((next_left_side, new_actions))
+                        else:
+                            unfinished_new_lists.append((next_left_side, new_actions))
+            new_lists = finished_new_lists + unfinished_new_lists
             lists_to_expand = new_lists[:beam_size]
         return completed_paths[:max_num_paths]
 
@@ -139,6 +138,21 @@ class World:
                 production = f"{basic_type} -> {lambda_var}"
                 all_actions.add(production)
         return sorted(all_actions)
+
+    def _get_right_side_indexed_actions(self):
+        if not self._right_side_indexed_actions:
+            self._right_side_indexed_actions = defaultdict(list)
+            all_actions = self.all_possible_actions()
+            for possible_action in all_actions:
+                left_side, right_side = possible_action.split(' -> ')
+                if '[' not in right_side:
+                    self._right_side_indexed_actions[right_side].append((left_side, possible_action))
+                else:
+                    right_side_parts = right_side[1:-1].split(', ')
+                    for right_side_part in right_side_parts:
+                        self._right_side_indexed_actions[right_side_part].append((left_side,
+                                                                                  possible_action))
+        return self._right_side_indexed_actions
 
     def get_basic_types(self) -> Set[Type]:
         """

--- a/allennlp/models/encoder_decoders/nlvr_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/nlvr_semantic_parser.py
@@ -64,7 +64,6 @@ class NlvrSemanticParser(Model):
         self._attention_function = attention_function
         action_embedding_dim = nonterminal_embedder.get_output_dim() * 2
 
-        # self._decoder_step would be set to ``WikiTablesDecoderStep``. Rewriting it.
         self._decoder_step = NlvrDecoderStep(encoder_output_dim=self._encoder.get_output_dim(),
                                              action_embedding_dim=action_embedding_dim,
                                              attention_function=attention_function)
@@ -75,14 +74,14 @@ class NlvrSemanticParser(Model):
                 actions: List[List[ProductionRuleArray]],
                 agenda: torch.LongTensor,
                 label: torch.LongTensor = None) -> Dict[str, torch.Tensor]:
-        # pylint: disable=arguments-differ,unused-argument
+        # pylint: disable=arguments-differ
         """
         Decoder logic for producing type constrained target sequences, that maximize coverage of
         their respective agendas. This will change soon, to include a denotation based score as
         well, once we have a way to transform action sequences into logical forms that can be
         executed to produce denotations.
         """
-        # TODO(pradeep): Use labels.
+        # TODO(pradeep): Use labels for loss computation.
         embedded_input = self._sentence_embedder(sentence)
         # (batch_size, sentence_length)
         sentence_mask = nn_util.get_text_field_mask(sentence).float()

--- a/tests/data/dataset_readers/nlvr_test.py
+++ b/tests/data/dataset_readers/nlvr_test.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-self-use
+# pylint: disable=invalid-name
 from allennlp.data.semparse.worlds import NlvrWorld
 from allennlp.data.dataset_readers import NlvrDatasetReader
 from allennlp.common.testing import AllenNlpTestCase
@@ -7,7 +8,7 @@ from allennlp.common.testing import AllenNlpTestCase
 class TestNlvrDatasetReader(AllenNlpTestCase):
     def test_reader_reads(self):
         test_file = "tests/fixtures/data/nlvr/sample_data.jsonl"
-        dataset = NlvrDatasetReader().read(test_file)
+        dataset = NlvrDatasetReader(add_paths_to_agenda=False).read(test_file)
         assert len(dataset.instances) == 3
         instance = dataset.instances[0]
         assert instance.fields.keys() == {'sentence', 'agenda', 'world', 'actions', 'label'}
@@ -16,17 +17,17 @@ class TestNlvrDatasetReader(AllenNlpTestCase):
                            'a', 'box', '.']
         assert [t.text for t in sentence_tokens] == expected_tokens
         agenda = [item.sequence_index for item in instance.fields["agenda"].field_list]
-        assert agenda == [56, 32, 112]
+        assert agenda == [56, 32, 121, 64]
         world = instance.fields["world"].as_tensor({})
         assert isinstance(world, NlvrWorld)
         actions = [action.rule for action in instance.fields["actions"].field_list]
-        assert len(actions) == 117
+        assert len(actions) == 126
         label = instance.fields["label"].label
         assert label == "true"
 
-    def test_agenda_indices_are_correct(self):
+    def test_agenda_indices_are_correct_without_paths(self):
+        reader = NlvrDatasetReader(add_paths_to_agenda=False)
         test_file = "tests/fixtures/data/nlvr/sample_data.jsonl"
-        reader = NlvrDatasetReader()
         dataset = reader.read(test_file)
         instance = dataset.instances[0]
         sentence_tokens = instance.fields["sentence"].tokens
@@ -36,4 +37,18 @@ class TestNlvrDatasetReader(AllenNlpTestCase):
         agenda_actions = [actions[i] for i in agenda]
         # pylint: disable=protected-access
         expected_agenda_actions = reader._get_agenda_for_sentence(sentence)
+        assert expected_agenda_actions == agenda_actions
+
+    def test_agenda_indices_are_correct_with_paths(self):
+        reader = NlvrDatasetReader()
+        test_file = "tests/fixtures/data/nlvr/sample_data.jsonl"
+        dataset = reader.read(test_file)
+        instance = dataset.instances[0]
+        sentence_tokens = instance.fields["sentence"].tokens
+        sentence = " ".join([t.text for t in sentence_tokens])
+        agenda = [item.sequence_index for item in instance.fields["agenda"].field_list]
+        actions = [action.rule for action in instance.fields["actions"].field_list]
+        agenda_actions = [actions[i] for i in agenda]
+        # pylint: disable=protected-access
+        expected_agenda_actions = reader._get_agenda_for_sentence(sentence, NlvrWorld({}))
         assert expected_agenda_actions == agenda_actions

--- a/tests/data/dataset_readers/nlvr_test.py
+++ b/tests/data/dataset_readers/nlvr_test.py
@@ -16,12 +16,14 @@ class TestNlvrDatasetReader(AllenNlpTestCase):
         expected_tokens = ['There', 'is', 'a', 'circle', 'closely', 'touching', 'a', 'corner', 'of',
                            'a', 'box', '.']
         assert [t.text for t in sentence_tokens] == expected_tokens
-        agenda = [item.sequence_index for item in instance.fields["agenda"].field_list]
-        assert agenda == [56, 32, 121, 64]
-        world = instance.fields["world"].as_tensor({})
-        assert isinstance(world, NlvrWorld)
         actions = [action.rule for action in instance.fields["actions"].field_list]
         assert len(actions) == 126
+        agenda = [item.sequence_index for item in instance.fields["agenda"].field_list]
+        agenda_actions = [actions[i] for i in agenda]
+        assert agenda_actions == ['<o,o> -> circle', '<e,<e,t>> -> assert_greater_equals',
+                                  't -> [<b,t>, b]', '<o,o> -> touch_corner']
+        world = instance.fields["world"].as_tensor({})
+        assert isinstance(world, NlvrWorld)
         label = instance.fields["label"].label
         assert label == "true"
 

--- a/tests/data/semparse/worlds/world_test.py
+++ b/tests/data/semparse/worlds/world_test.py
@@ -1,0 +1,72 @@
+from overrides import overrides
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.semparse.worlds.world import World
+
+
+class FakeWorldWithoutRecursion(World):
+    # pylint: disable=abstract-method
+    @overrides
+    def all_possible_actions(self):
+        # The logical forms this grammar allows are
+        # (unary_function argument)
+        # (binary_function argument argument)
+        actions = ['@START@ -> t',
+                   't -> [<e,t>, e]',
+                   '<e,t> -> unary_function',
+                   '<e,t> -> [<e,<e,t>>, e]',
+                   '<e,<e,t>> -> binary_function',
+                   'e -> argument']
+        return actions
+
+
+class FakeWorldWithRecursion(FakeWorldWithoutRecursion):
+    # pylint: disable=abstract-method
+    @overrides
+    def all_possible_actions(self):
+        # In addition to the forms allowed by ``FakeWorldWithoutRecursion``, this world allows
+        # (unary_function (identity .... (argument)))
+        # (binary_function (identity .... (argument)) (identity .... (argument)))
+        actions = super(FakeWorldWithRecursion, self).all_possible_actions()
+        actions.extend(['e -> [<e,e>, e]',
+                        '<e,e> -> identity'])
+        return actions
+
+
+class WorldTest(AllenNlpTestCase):
+    def setUp(self):
+        super(WorldTest, self).setUp()
+        self.world_without_recursion = FakeWorldWithoutRecursion()
+        self.world_with_recursion = FakeWorldWithRecursion()
+
+    def test_get_paths_to_root_without_recursion(self):
+        argument_paths = self.world_without_recursion.get_paths_to_root('e -> argument')
+        assert argument_paths == [['e -> argument', 't -> [<e,t>, e]', '@START@ -> t'],
+                                  ['e -> argument', '<e,t> -> [<e,<e,t>>, e]', 't -> [<e,t>, e]',
+                                   '@START@ -> t']]
+        unary_function_paths = self.world_without_recursion.get_paths_to_root('<e,t> -> unary_function')
+        assert unary_function_paths == [['<e,t> -> unary_function', 't -> [<e,t>, e]',
+                                         '@START@ -> t']]
+        binary_function_paths = \
+                self.world_without_recursion.get_paths_to_root('<e,<e,t>> -> binary_function')
+        assert binary_function_paths == [['<e,<e,t>> -> binary_function',
+                                          '<e,t> -> [<e,<e,t>>, e]', 't -> [<e,t>, e]',
+                                          '@START@ -> t']]
+
+    def test_get_paths_to_root_with_recursion(self):
+        argument_paths = self.world_with_recursion.get_paths_to_root('e -> argument')
+        # Argument now has 4 paths, and the two new paths are with the identity function occurring
+        # (only once) within unary and binary functions.
+        assert argument_paths == [['e -> argument', 't -> [<e,t>, e]', '@START@ -> t'],
+                                  ['e -> argument', '<e,t> -> [<e,<e,t>>, e]', 't -> [<e,t>, e]',
+                                   '@START@ -> t'],
+                                  ['e -> argument', 'e -> [<e,e>, e]', 't -> [<e,t>, e]',
+                                   '@START@ -> t'],
+                                  ['e -> argument', 'e -> [<e,e>, e]', '<e,t> -> [<e,<e,t>>, e]',
+                                   't -> [<e,t>, e]', '@START@ -> t']]
+        identity_paths = self.world_with_recursion.get_paths_to_root('<e,e> -> identity')
+        # Two identity paths, one through each of unary and binary function productions.
+        assert identity_paths == [['<e,e> -> identity', 'e -> [<e,e>, e]', 't -> [<e,t>, e]',
+                                   '@START@ -> t'],
+                                  ['<e,e> -> identity', 'e -> [<e,e>, e]',
+                                   '<e,t> -> [<e,<e,t>>, e]', 't -> [<e,t>, e]', '@START@ -> t']]

--- a/tests/fixtures/encoder_decoder/nlvr_semantic_parser/experiment.json
+++ b/tests/fixtures/encoder_decoder/nlvr_semantic_parser/experiment.json
@@ -1,6 +1,7 @@
 {
   "dataset_reader": {
-    "type": "nlvr"
+    "type": "nlvr",
+    "add_paths_to_agenda": true
   },
   "vocabulary": {
     "non_padded_namespaces": ["actions", "denotations"]


### PR DESCRIPTION
I've added more rules in the agenda mapping scheme.
From the training logs, it seemed like the parser was having difficulty reaching the terminal states because it does not have any signal indicating whether it is taking the right path. So I added an option to include the non-terminal productions from the paths to the agenda as well. However, I do not see noticeable differences in the parser's training yet.

This PR depends on #713 (which depends on #607)