### PR TITLE
Use split() to get a minor speedup

### DIFF
--- a/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables_semantic_parser.py
@@ -1337,6 +1337,15 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
                             considered_actions: List[List[int]],
                             allowed_actions: List[Set[int]],
                             max_actions: int = None) -> List[WikiTablesDecoderState]:
+        # Each group index here might get accessed multiple times, and doing the slicing operation
+        # each time is more expensive than doing it once upfront.  These three lines give about a
+        # 10% speedup in training time.  I also tried this with sorted_log_probs and
+        # action_embeddings, but those get accessed for _each action_, so doing the splits there
+        # didn't help.
+        hidden_state = [x.squeeze(0) for x in hidden_state.split(1, 0)]
+        memory_cell = [x.squeeze(0) for x in memory_cell.split(1, 0)]
+        attended_question = [x.squeeze(0) for x in attended_question.split(1, 0)]
+
         sorted_log_probs, sorted_actions = log_probs.sort(dim=-1, descending=True)
         if max_actions is not None:
             # We might need a version of `sorted_log_probs` on the CPU later, but only if we need

--- a/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/wikitables_semantic_parser_test.py
@@ -312,10 +312,10 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         batch_indices = [0, 1, 0]
         action_history = [[1], [3, 4], []]
         score = [Variable(torch.FloatTensor([x])) for x in [.1, 1.1, 2.2]]
-        hidden_state = [torch.FloatTensor([i, i]) for i in range(len(batch_indices))]
-        memory_cell = [torch.FloatTensor([i, i]) for i in range(len(batch_indices))]
-        previous_action_embedding = [torch.FloatTensor([i, i]) for i in range(len(batch_indices))]
-        attended_question = [torch.FloatTensor([i, i]) for i in range(len(batch_indices))]
+        hidden_state = torch.FloatTensor([[i, i] for i in range(len(batch_indices))])
+        memory_cell = torch.FloatTensor([[i, i] for i in range(len(batch_indices))])
+        previous_action_embedding = torch.FloatTensor([[i, i] for i in range(len(batch_indices))])
+        attended_question = torch.FloatTensor([[i, i] for i in range(len(batch_indices))])
         grammar_state = [GrammarState(['e'], {}, {}, {}) for _ in batch_indices]
         self.encoder_outputs = torch.FloatTensor([[1, 2], [3, 4], [5, 6]])
         self.encoder_output_mask = Variable(torch.FloatTensor([[1, 1], [1, 0], [1, 1]]))
@@ -495,9 +495,9 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         step_action_embeddings = torch.FloatTensor([[[1, 1], [9, 9], [2, 2], [3, 3]],
                                                     [[4, 4], [9, 9], [3, 3], [9, 9]],
                                                     [[1, 1], [2, 2], [5, 5], [9, 9]]])
-        new_hidden_state = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(allowed_actions))]
-        new_memory_cell = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(allowed_actions))]
-        new_attended_question = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(allowed_actions))]
+        new_hidden_state = torch.FloatTensor([[i + 1, i + 1] for i in range(len(allowed_actions))])
+        new_memory_cell = torch.FloatTensor([[i + 1, i + 1] for i in range(len(allowed_actions))])
+        new_attended_question = torch.FloatTensor([[i + 1, i + 1] for i in range(len(allowed_actions))])
         new_states = WikiTablesDecoderStep._compute_new_states(self.state,
                                                                log_probs,
                                                                new_hidden_state,
@@ -569,9 +569,9 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         step_action_embeddings = torch.FloatTensor([[[1, 1], [9, 9], [2, 2], [3, 3]],
                                                     [[4, 4], [9, 9], [3, 3], [9, 9]],
                                                     [[1, 1], [2, 2], [5, 5], [9, 9]]])
-        new_hidden_state = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(considered_actions))]
-        new_memory_cell = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(considered_actions))]
-        new_attended_question = [torch.FloatTensor([i + 1, i + 1]) for i in range(len(considered_actions))]
+        new_hidden_state = torch.FloatTensor([[i + 1, i + 1] for i in range(len(considered_actions))])
+        new_memory_cell = torch.FloatTensor([[i + 1, i + 1] for i in range(len(considered_actions))])
+        new_attended_question = torch.FloatTensor([[i + 1, i + 1] for i in range(len(considered_actions))])
         new_states = WikiTablesDecoderStep._compute_new_states(self.state,
                                                                log_probs,
                                                                new_hidden_state,


### PR DESCRIPTION
@DeNeutoy's #730 reminded me that I wanted to try using `split()` instead of slicing when we're regrouping all of the intermediate states in the decoder.  I looked at a profiler to see where we were spending the most time in slicing operations, and tried converting all of them to `split()`.  These are the ones that helped.  The comment should explain what's going on here.