### PR TITLE
integrate span_extractors into coref model

### DIFF
--- a/allennlp/models/coreference_resolution/coref_v2.py
+++ b/allennlp/models/coreference_resolution/coref_v2.py
@@ -88,9 +88,9 @@ class CoreferenceResolverV2(Model):
 
         self._endpoint_span_extractor = EndpointSpanExtractor(context_layer.get_output_dim(),
                                                               combination="x,y",
-                                                              num_width_buckets=max_span_width,
+                                                              num_width_embeddings=max_span_width,
                                                               span_width_embedding_dim=feature_size,
-                                                              use_bucket_widths=False)
+                                                              bucket_widths=False)
         self._attentive_span_extractor = SelfAttentiveSpanExtractor(input_dim=text_field_embedder.get_output_dim())
 
         # 10 possible distance buckets.

--- a/allennlp/models/coreference_resolution/coref_v2.py
+++ b/allennlp/models/coreference_resolution/coref_v2.py
@@ -13,6 +13,7 @@ from allennlp.models.model import Model
 from allennlp.modules.token_embedders import Embedding
 from allennlp.modules import FeedForward
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder, SpanPruner
+from allennlp.modules.span_extractors import SelfAttentiveSpanExtractor, EndpointSpanExtractor
 from allennlp.nn import util, InitializerApplicator, RegularizerApplicator
 from allennlp.training.metrics import MentionRecall, ConllCorefScores
 
@@ -84,12 +85,17 @@ class CoreferenceResolverV2(Model):
                 TimeDistributed(torch.nn.Linear(mention_feedforward.get_output_dim(), 1)))
         self._mention_pruner = SpanPruner(feedforward_scorer)
         self._antecedent_scorer = TimeDistributed(torch.nn.Linear(antecedent_feedforward.get_output_dim(), 1))
-        self._head_scorer = TimeDistributed(torch.nn.Linear(context_layer.get_output_dim(), 1))
+
+        self._endpoint_span_extractor = EndpointSpanExtractor(context_layer.get_output_dim(),
+                                                              combination="x,y",
+                                                              num_width_buckets=max_span_width,
+                                                              span_width_embedding_dim=feature_size,
+                                                              use_bucket_widths=False)
+        self._attentive_span_extractor = SelfAttentiveSpanExtractor(input_dim=text_field_embedder.get_output_dim())
 
         # 10 possible distance buckets.
         self._num_distance_buckets = 10
         self._distance_embedding = Embedding(self._num_distance_buckets, feature_size)
-        self._span_width_embedding = Embedding(max_span_width, feature_size)
 
         self._max_span_width = max_span_width
         self._spans_per_word = spans_per_word
@@ -165,12 +171,19 @@ class CoreferenceResolverV2(Model):
         # consider a masked span.
         span_starts = F.relu(span_starts.float()).long()
         span_ends = F.relu(span_ends.float()).long()
+        # Shape: (batch_size, num_spans, 2)
+        span_indices = torch.cat([span_starts, span_ends], -1)
 
-        # Shape: (batch_size, num_spans, embedding_size)
-        span_embeddings = self._compute_span_representations(text_embeddings,
-                                                             text_mask,
-                                                             span_starts,
-                                                             span_ends)
+        # Shape: (batch_size, document_length, encoding_dim)
+        contextualized_embeddings = self._context_layer(text_embeddings, text_mask)
+        # Shape: (batch_size, num_spans, 2 * encoding_dim + feature_size)
+        endpoint_span_embeddings = self._endpoint_span_extractor(contextualized_embeddings, span_indices)
+        # Shape: (batch_size, num_spans, emebedding_size)
+        attended_span_embeddings = self._attentive_span_extractor(text_embeddings, span_indices)
+
+        # Shape: (batch_size, num_spans, emebedding_size + 2 * encoding_dim + feature_size)
+        span_embeddings = torch.cat([endpoint_span_embeddings, attended_span_embeddings], -1)
+
         # Prune based on mention scores.
         num_spans_to_keep = int(math.floor(self._spans_per_word * document_length))
 
@@ -373,134 +386,6 @@ class CoreferenceResolverV2(Model):
                 "coref_recall": coref_recall,
                 "coref_f1": coref_f1,
                 "mention_recall": mention_recall}
-
-    def _create_attended_span_representations(self,
-                                              head_scores: torch.FloatTensor,
-                                              text_embeddings: torch.FloatTensor,
-                                              span_ends: torch.IntTensor,
-                                              span_widths: torch.IntTensor) -> torch.FloatTensor:
-        """
-        Given a tensor of unnormalized attention scores for each word in the document, compute
-        distributions over every span with respect to these scores by normalising the headedness
-        scores for words inside the span.
-
-        Given these headedness distributions over every span, weight the corresponding vector
-        representations of the words in the span by this distribution, returning a weighted
-        representation of each span.
-
-        Parameters
-        ----------
-        head_scores : ``torch.FloatTensor``, required.
-            Unnormalized headedness scores for every word. This score is shared for every
-            candidate. The only way in which the headedness scores differ over different
-            spans is in the set of words over which they are normalized.
-        text_embeddings: ``torch.FloatTensor``, required.
-            The embeddings with shape  (batch_size, document_length, embedding_size)
-            over which we are computing a weighted sum.
-        span_ends: ``torch.IntTensor``, required.
-            A tensor of shape (batch_size, num_spans, 1), representing the end indices
-            of each span.
-        span_widths : ``torch.IntTensor``, required.
-            A tensor of shape (batch_size, num_spans, 1) representing the width of each
-            span candidates.
-        Returns
-        -------
-        attended_text_embeddings : ``torch.FloatTensor``
-            A tensor of shape (batch_size, num_spans, embedding_dim) - the result of
-            applying attention over all words within each candidate span.
-        """
-        # Shape: (1, 1, max_span_width)
-        max_span_range_indices = util.get_range_vector(self._max_span_width,
-                                                       text_embeddings.is_cuda).view(1, 1, -1)
-
-        # Shape: (batch_size, num_spans, max_span_width)
-        # This is a broadcasted comparison - for each span we are considering,
-        # we are creating a range vector of size max_span_width, but masking values
-        # which are greater than the actual length of the span.
-        span_mask = (max_span_range_indices <= span_widths).float()
-        raw_span_indices = span_ends - max_span_range_indices
-        # We also don't want to include span indices which are less than zero,
-        # which happens because some spans near the beginning of the document
-        # are of a smaller width than max_span_width, so we add this to the mask here.
-        span_mask = span_mask * (raw_span_indices >= 0).float()
-        # Spans
-        span_indices = F.relu(raw_span_indices.float()).long()
-
-        # Shape: (batch_size * num_spans * max_span_width)
-        flat_span_indices = util.flatten_and_batch_shift_indices(span_indices, text_embeddings.size(1))
-
-        # Shape: (batch_size, num_spans, max_span_width, embedding_dim)
-        span_text_embeddings = util.batched_index_select(text_embeddings, span_indices, flat_span_indices)
-
-        # Shape: (batch_size, num_spans, max_span_width)
-        span_head_scores = util.batched_index_select(head_scores, span_indices, flat_span_indices).squeeze(-1)
-
-        # Shape: (batch_size, num_spans, max_span_width)
-        span_head_weights = util.last_dim_softmax(span_head_scores, span_mask)
-
-        # Do a weighted sum of the embedded spans with
-        # respect to the normalised head score distributions.
-        # Shape: (batch_size, num_spans, embedding_dim)
-        attended_text_embeddings = util.weighted_sum(span_text_embeddings, span_head_weights)
-
-        return attended_text_embeddings
-
-    def _compute_span_representations(self,
-                                      text_embeddings: torch.FloatTensor,
-                                      text_mask: torch.FloatTensor,
-                                      span_starts: torch.IntTensor,
-                                      span_ends: torch.IntTensor) -> torch.FloatTensor:
-        """
-        Computes an embedded representation of every candidate span. This is a concatenation
-        of the contextualized endpoints of the span, an embedded representation of the width of
-        the span and a representation of the span's predicted head.
-
-        Parameters
-        ----------
-        text_embeddings : ``torch.FloatTensor``, required.
-            The embedded document of shape (batch_size, document_length, embedding_dim)
-            over which we are computing a weighted sum.
-        text_mask : ``torch.FloatTensor``, required.
-            A mask of shape (batch_size, document_length) representing non-padding entries of
-            ``text_embeddings``.
-        span_starts : ``torch.IntTensor``, required.
-            A tensor of shape (batch_size, num_spans) representing the start of each span candidate.
-        span_ends : ``torch.IntTensor``, required.
-            A tensor of shape (batch_size, num_spans) representing the end of each span candidate.
-        Returns
-        -------
-        span_embeddings : ``torch.FloatTensor``
-            An embedded representation of every candidate span with shape:
-            (batch_size, num_spans, context_layer.get_output_dim() * 2 + embedding_size + feature_size)
-        """
-        # Shape: (batch_size, document_length, encoding_dim)
-        contextualized_embeddings = self._context_layer(text_embeddings, text_mask)
-
-        # Shape: (batch_size, num_spans, encoding_dim)
-        start_embeddings = util.batched_index_select(contextualized_embeddings, span_starts.squeeze(-1))
-        end_embeddings = util.batched_index_select(contextualized_embeddings, span_ends.squeeze(-1))
-
-        # Compute and embed the span_widths (strictly speaking the span_widths - 1)
-        # Shape: (batch_size, num_spans, 1)
-        span_widths = span_ends - span_starts
-        # Shape: (batch_size, num_spans, encoding_dim)
-        span_width_embeddings = self._span_width_embedding(span_widths.squeeze(-1))
-
-        # Shape: (batch_size, document_length, 1)
-        head_scores = self._head_scorer(contextualized_embeddings)
-
-        # Shape: (batch_size, num_spans, embedding_dim)
-        # Note that we used the original text embeddings, not the contextual ones here.
-        attended_text_embeddings = self._create_attended_span_representations(head_scores,
-                                                                              text_embeddings,
-                                                                              span_ends,
-                                                                              span_widths)
-        # (batch_size, num_spans, context_layer.get_output_dim() * 2 + embedding_dim + feature_dim)
-        span_embeddings = torch.cat([start_embeddings,
-                                     end_embeddings,
-                                     span_width_embeddings,
-                                     attended_text_embeddings], -1)
-        return span_embeddings
 
     @staticmethod
     def _generate_valid_antecedents(num_spans_to_keep: int,

--- a/allennlp/modules/span_extractors/endpoint_span_extractor.py
+++ b/allennlp/modules/span_extractors/endpoint_span_extractor.py
@@ -64,7 +64,10 @@ class EndpointSpanExtractor(SpanExtractor):
         return self._input_dim
 
     def get_output_dim(self) -> int:
-        return get_combined_dim(self._combination, [self._input_dim, self._input_dim])
+        combined_dim = get_combined_dim(self._combination, [self._input_dim, self._input_dim])
+        if self._span_width_embedding is not None:
+            return combined_dim + self._span_width_embedding.get_output_dim()
+        return combined_dim
 
     @overrides
     def forward(self, # pylint: disable=arguments-differ

--- a/allennlp/modules/span_extractors/endpoint_span_extractor.py
+++ b/allennlp/modules/span_extractors/endpoint_span_extractor.py
@@ -31,30 +31,30 @@ class EndpointSpanExtractor(SpanExtractor):
     combination : str, optional (default = "x-y").
         The method used to combine the ``start_embedding`` and ``end_embedding``
         representations. See above for a full description.
-    num_width_buckets : ``int``, optional (default = None).
+    num_width_embeddings : ``int``, optional (default = None).
         Specifies the number of buckets to use when representing
         span width features.
     span_width_embedding_dim : ``int``, optional (default = None).
         The embedding size for the span_width features.
-    use_bucket_widths : ``int``, optional (default = False).
+    bucket_widths : ``bool``, optional (default = False).
         Whether to bucket the span widths into log-space buckets. If ``False``,
         the raw span widths are used.
     """
     def __init__(self,
                  input_dim: int,
                  combination: str = "x-y",
-                 num_width_buckets: int = None,
+                 num_width_embeddings: int = None,
                  span_width_embedding_dim: int = None,
-                 use_bucket_widths: bool = False) -> None:
+                 bucket_widths: bool = False) -> None:
         super().__init__()
         self._input_dim = input_dim
         self._combination = combination
-        self._num_width_buckets = num_width_buckets
-        self._use_bucket_widths = use_bucket_widths
+        self._num_width_embeddings = num_width_embeddings
+        self._bucket_widths = bucket_widths
 
-        if num_width_buckets is not None and span_width_embedding_dim is not None:
-            self._span_width_embedding = Embedding(num_width_buckets, span_width_embedding_dim)
-        elif not all([num_width_buckets is None, span_width_embedding_dim is None]):
+        if num_width_embeddings is not None and span_width_embedding_dim is not None:
+            self._span_width_embedding = Embedding(num_width_embeddings, span_width_embedding_dim)
+        elif not all([num_width_embeddings is None, span_width_embedding_dim is None]):
             raise ConfigurationError("To use a span width embedding representation, you must"
                                      "specify both num_width_buckets and span_width_embedding_dim.")
         else:
@@ -81,9 +81,9 @@ class EndpointSpanExtractor(SpanExtractor):
         combined_tensors = combine_tensors(self._combination, [start_embeddings, end_embeddings])
         if self._span_width_embedding is not None:
             # Embed the span widths and concatenate to the rest of the representations.
-            if self._use_bucket_widths:
+            if self._bucket_widths:
                 span_widths = bucket_values(span_ends - span_starts,
-                                            num_total_buckets=self._num_width_buckets)
+                                            num_total_buckets=self._num_width_embeddings)
             else:
                 span_widths = span_ends - span_starts
 
@@ -96,10 +96,11 @@ class EndpointSpanExtractor(SpanExtractor):
     def from_params(cls, params: Params) -> "EndpointSpanExtractor":
         input_dim = params.pop_int("input_dim")
         combination = params.pop("combination", "x-y")
-        num_width_buckets = params.pop_int("num_width_buckets", None)
+        num_width_embeddings = params.pop_int("num_width_embeddings", None)
         span_width_embedding_dim = params.pop_int("span_width_embedding_dim", None)
-
+        bucket_widths = params.pop_bool("bucket_widths", False)
         return EndpointSpanExtractor(input_dim=input_dim,
                                      combination=combination,
-                                     num_width_buckets=num_width_buckets,
-                                     span_width_embedding_dim=span_width_embedding_dim)
+                                     num_width_embeddings=num_width_embeddings,
+                                     span_width_embedding_dim=span_width_embedding_dim,
+                                     bucket_widths=bucket_widths)

--- a/tests/modules/span_extractors/endpoint_span_extractor_test.py
+++ b/tests/modules/span_extractors/endpoint_span_extractor_test.py
@@ -14,7 +14,7 @@ class TestEndpointSpanExtractor:
                 "input_dim": 7,
                 "num_width_buckets": 5,
                 "span_width_embedding_dim": 3
-            })
+                })
         extractor = SpanExtractor.from_params(params)
         assert isinstance(extractor, EndpointSpanExtractor)
         assert extractor.get_output_dim() == 10

--- a/tests/modules/span_extractors/endpoint_span_extractor_test.py
+++ b/tests/modules/span_extractors/endpoint_span_extractor_test.py
@@ -9,9 +9,15 @@ from allennlp.nn.util import batched_index_select
 
 class TestEndpointSpanExtractor:
     def test_endpoint_span_extractor_can_build_from_params(self):
-        params = Params({"type": "endpoint", "input_dim": 7})
+        params = Params({
+                "type": "endpoint",
+                "input_dim": 7,
+                "num_width_buckets": 5,
+                "span_width_embedding_dim": 3
+            })
         extractor = SpanExtractor.from_params(params)
         assert isinstance(extractor, EndpointSpanExtractor)
+        assert extractor.get_output_dim() == 10
 
     def test_correct_sequence_elements_are_embedded(self):
         sequence_tensor = Variable(torch.randn([2, 5, 7]))

--- a/tests/modules/span_extractors/endpoint_span_extractor_test.py
+++ b/tests/modules/span_extractors/endpoint_span_extractor_test.py
@@ -12,7 +12,7 @@ class TestEndpointSpanExtractor:
         params = Params({
                 "type": "endpoint",
                 "input_dim": 7,
-                "num_width_buckets": 5,
+                "num_width_embeddings": 5,
                 "span_width_embedding_dim": 3
                 })
         extractor = SpanExtractor.from_params(params)


### PR DESCRIPTION
replaces the two relevant methods in the coref model with their corresponding `SpanExtractors`.