### PR TITLE
Set refresh to False when training to prevent extra TQDM output.

### DIFF
--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -93,7 +93,7 @@ def evaluate(model: Model,
         model(**batch)
         metrics = model.get_metrics()
         description = ', '.join(["%s: %.2f" % (name, value) for name, value in metrics.items()]) + " ||"
-        generator_tqdm.set_description(description)
+        generator_tqdm.set_description(description, refresh=False)
 
     return model.get_metrics()
 

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -227,7 +227,8 @@ class Trainer:
             # Update the description with the latest metrics
             metrics = self._get_metrics(train_loss, batch_num)
             description = self._description_from_metrics(metrics)
-            train_generator_tqdm.set_description(description)
+
+            train_generator_tqdm.set_description(description, refresh=False)
 
             # Log parameter values to Tensorboard
             batch_num_total = num_training_batches * epoch + batch_num

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -354,7 +354,7 @@ class Trainer:
             # Update the description with the latest metrics
             val_metrics = self._get_metrics(val_loss, batch_num)
             description = self._description_from_metrics(val_metrics)
-            val_generator_tqdm.set_description(description)
+            val_generator_tqdm.set_description(description, refresh=False)
 
         return val_loss, batch_num
 


### PR DESCRIPTION
When training models there's significant output because `tqdm.set_description` updates the tqdm output immediately instead of waiting for `mininterval` to pass.  I didn't notice this when testing locally because training is slow without a GPU.