### PR TITLE
NLVR language fixes

### DIFF
--- a/allennlp/data/dataset_readers/nlvr.py
+++ b/allennlp/data/dataset_readers/nlvr.py
@@ -157,16 +157,17 @@ class NlvrDatasetReader(DatasetReader):
         # TODO(pradeep): Add more rules in the mapping?
         # TODO(pradeep): Use approximate and substring matching as well.
         agenda = []
+        sentence = sentence.lower()
         # This takes care of shapes, colors, top, bottom, big, small etc.
         for constant, production in self._terminal_productions.items():
             # TODO(pradeep): Deal with constant names with underscores.
             if constant in sentence:
                 agenda.append(production)
-        if sentence.startswith("There is a "):
-            agenda.append(self._terminal_productions["assert_greater_equals"])
-        if "tower" in sentence or "box" in sentence or "grey" in sentence:
-            # Ensuring box filtering function (filter_*) at top.
-            agenda.append("t -> [<b,t>, b]")
+        if sentence.startswith("there is a box"):
+            agenda.append(self._terminal_productions["box_exists"])
+        elif sentence.startswith("there is a "):
+            agenda.append(self._terminal_productions["object_exists"])
+
         if "touch" in sentence:
             if "top" in sentence:
                 agenda.append(self._terminal_productions["touch_top"])
@@ -174,8 +175,14 @@ class NlvrDatasetReader(DatasetReader):
                 agenda.append(self._terminal_productions["touch_bottom"])
             elif "corner" in sentence:
                 agenda.append(self._terminal_productions["touch_corner"])
+            elif "right" in sentence:
+                agenda.append(self._terminal_productions["touch_right"])
+            elif "right" in sentence:
+                agenda.append(self._terminal_productions["touch_left"])
             elif "wall" or "edge" in sentence:
                 agenda.append(self._terminal_productions["touch_wall"])
+            else:
+                agenda.append(self._terminal_productions["touch_object"])
         else:
             # The words "top" and "bottom" may be referring to top and bottom blocks in a tower.
             if "top" in sentence:
@@ -185,8 +192,6 @@ class NlvrDatasetReader(DatasetReader):
         if " not " in sentence:
             agenda.append(self._terminal_productions["negate_filter"])
         number_productions = self._get_number_productions(sentence)
-        if number_productions or set():
-            agenda.append(self._terminal_productions["count"])
         for production in number_productions:
             agenda.append(production)
         if self._add_paths_to_agenda:
@@ -207,8 +212,6 @@ class NlvrDatasetReader(DatasetReader):
         for word, numeral in number_strings.items():
             if word in sentence or numeral in sentence:
                 number_productions.append(f"e -> {numeral}")
-        if "there is a " in sentence:
-            number_productions.append("e -> 1")
         return number_productions
 
     @staticmethod

--- a/allennlp/data/dataset_readers/nlvr.py
+++ b/allennlp/data/dataset_readers/nlvr.py
@@ -191,6 +191,8 @@ class NlvrDatasetReader(DatasetReader):
                 agenda.append(self._terminal_productions["bottom"])
         if " not " in sentence:
             agenda.append(self._terminal_productions["negate_filter"])
+        if " tower " in sentence or " contains " in sentence or " has " in sentence:
+            agenda.append(self._terminal_productions["all_boxes"])
         number_productions = self._get_number_productions(sentence)
         for production in number_productions:
             agenda.append(production)

--- a/allennlp/data/dataset_readers/nlvr.py
+++ b/allennlp/data/dataset_readers/nlvr.py
@@ -171,15 +171,15 @@ class NlvrDatasetReader(DatasetReader):
         if "touch" in sentence:
             if "top" in sentence:
                 agenda.append(self._terminal_productions["touch_top"])
-            elif "bottom" in sentence:
+            elif "bottom" in sentence or "base" in sentence:
                 agenda.append(self._terminal_productions["touch_bottom"])
             elif "corner" in sentence:
                 agenda.append(self._terminal_productions["touch_corner"])
             elif "right" in sentence:
                 agenda.append(self._terminal_productions["touch_right"])
-            elif "right" in sentence:
+            elif "left" in sentence:
                 agenda.append(self._terminal_productions["touch_left"])
-            elif "wall" or "edge" in sentence:
+            elif "wall" in sentence or "edge" in sentence:
                 agenda.append(self._terminal_productions["touch_wall"])
             else:
                 agenda.append(self._terminal_productions["touch_object"])

--- a/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
@@ -16,8 +16,6 @@ OBJECT_FILTER_TYPE = ComplexType(OBJECT_TYPE, OBJECT_TYPE)
 NEGATE_FILTER_TYPE = ComplexType(ComplexType(OBJECT_TYPE, OBJECT_TYPE),
                                  ComplexType(OBJECT_TYPE, OBJECT_TYPE))
 BOX_MEMBERSHIP_TYPE = ComplexType(BOX_TYPE, OBJECT_TYPE)
-COLOR_FUNCTION_TYPE = ComplexType(OBJECT_TYPE, COLOR_TYPE)
-SHAPE_FUNCTION_TYPE = ComplexType(OBJECT_TYPE, SHAPE_TYPE)
 
 BOX_COLOR_FILTER_TYPE = ComplexType(BOX_TYPE, ComplexType(COLOR_TYPE, BOX_TYPE))
 BOX_SHAPE_FILTER_TYPE = ComplexType(BOX_TYPE, ComplexType(SHAPE_TYPE, BOX_TYPE))
@@ -57,9 +55,7 @@ add_common_name_with_type("shape_square", "S1", SHAPE_TYPE)
 add_common_name_with_type("shape_circle", "S2", SHAPE_TYPE)
 
 
-# Attribute functions
-add_common_name_with_type("color", "C", COLOR_FUNCTION_TYPE)
-add_common_name_with_type("shape", "S", SHAPE_FUNCTION_TYPE)
+# Attribute function
 add_common_name_with_type("object_in_box", "I", BOX_MEMBERSHIP_TYPE)
 
 
@@ -118,8 +114,8 @@ add_common_name_with_type("member_color_count_greater", "F12", BOX_COUNT_FILTER_
 add_common_name_with_type("member_color_count_greater_equals", "F13", BOX_COUNT_FILTER_TYPE)
 add_common_name_with_type("member_color_count_lesser", "F14", BOX_COUNT_FILTER_TYPE)
 add_common_name_with_type("member_color_count_lesser_equals", "F15", BOX_COUNT_FILTER_TYPE)
-add_common_name_with_type("member_shape_count_equals", "F16", BOX_COLOR_FILTER_TYPE)
-add_common_name_with_type("member_shape_count_not_equals", "F17", BOX_COLOR_FILTER_TYPE)
+add_common_name_with_type("member_shape_count_equals", "F16", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_shape_count_not_equals", "F17", BOX_COUNT_FILTER_TYPE)
 add_common_name_with_type("member_shape_count_greater", "F18", BOX_COUNT_FILTER_TYPE)
 add_common_name_with_type("member_shape_count_greater_equals", "F19", BOX_COUNT_FILTER_TYPE)
 add_common_name_with_type("member_shape_count_lesser", "F20", BOX_COUNT_FILTER_TYPE)

--- a/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
+++ b/allennlp/data/semparse/type_declarations/nlvr_type_declaration.py
@@ -1,4 +1,4 @@
-from nltk.sem.logic import TRUTH_TYPE, EntityType, ComplexType, ANY_TYPE
+from nltk.sem.logic import TRUTH_TYPE, EntityType, ComplexType
 
 from allennlp.data.semparse.type_declarations.type_declaration import NamedBasicType
 
@@ -19,12 +19,13 @@ BOX_MEMBERSHIP_TYPE = ComplexType(BOX_TYPE, OBJECT_TYPE)
 COLOR_FUNCTION_TYPE = ComplexType(OBJECT_TYPE, COLOR_TYPE)
 SHAPE_FUNCTION_TYPE = ComplexType(OBJECT_TYPE, SHAPE_TYPE)
 
-BOX_COLOR_FILTER_TYPE = ComplexType(BOX_TYPE, ComplexType(ComplexType(BOX_TYPE, COLOR_TYPE),
-                                                          ComplexType(COLOR_TYPE, BOX_TYPE)))
-BOX_SHAPE_FILTER_TYPE = ComplexType(BOX_TYPE, ComplexType(ComplexType(BOX_TYPE, SHAPE_TYPE),
-                                                          ComplexType(SHAPE_TYPE, BOX_TYPE)))
-BOX_COUNT_FILTER_TYPE = ComplexType(BOX_TYPE, ComplexType(ComplexType(BOX_TYPE, NUM_TYPE),
-                                                          ComplexType(NUM_TYPE, BOX_TYPE)))
+BOX_COLOR_FILTER_TYPE = ComplexType(BOX_TYPE, ComplexType(COLOR_TYPE, BOX_TYPE))
+BOX_SHAPE_FILTER_TYPE = ComplexType(BOX_TYPE, ComplexType(SHAPE_TYPE, BOX_TYPE))
+BOX_COUNT_FILTER_TYPE = ComplexType(BOX_TYPE, ComplexType(NUM_TYPE, BOX_TYPE))
+# This box filter returns boxes where a specified attribute is same or different
+BOX_ATTRIBUTE_SAME_FILTER_TYPE = ComplexType(BOX_TYPE, BOX_TYPE)
+
+
 ASSERT_COLOR_TYPE = ComplexType(OBJECT_TYPE, ComplexType(COLOR_TYPE, TRUTH_TYPE))
 ASSERT_SHAPE_TYPE = ComplexType(OBJECT_TYPE, ComplexType(SHAPE_TYPE, TRUTH_TYPE))
 ASSERT_BOX_COUNT_TYPE = ComplexType(BOX_TYPE, ComplexType(NUM_TYPE, TRUTH_TYPE))
@@ -34,8 +35,8 @@ BOX_EXISTS_TYPE = ComplexType(BOX_TYPE, TRUTH_TYPE)
 OBJECT_EXISTS_TYPE = ComplexType(OBJECT_TYPE, TRUTH_TYPE)
 
 
-COMMON_NAME_MAPPING = {"lambda": "\\", "x": "X"}
-COMMON_TYPE_SIGNATURE = {"X": ANY_TYPE}
+COMMON_NAME_MAPPING = {}
+COMMON_TYPE_SIGNATURE = {}
 
 BASIC_TYPES = {NUM_TYPE, BOX_TYPE, OBJECT_TYPE, COLOR_TYPE, SHAPE_TYPE}
 
@@ -63,10 +64,12 @@ add_common_name_with_type("object_in_box", "I", BOX_MEMBERSHIP_TYPE)
 
 
 # Assert functions
-add_common_name_with_type("color_equals", "A0", ASSERT_COLOR_TYPE)
-add_common_name_with_type("color_not_equals", "A1", ASSERT_COLOR_TYPE)
-add_common_name_with_type("shape_equals", "A2", ASSERT_SHAPE_TYPE)
-add_common_name_with_type("shape_not_equals", "A3", ASSERT_SHAPE_TYPE)
+add_common_name_with_type("object_color_all_equals", "A0", ASSERT_COLOR_TYPE)
+add_common_name_with_type("object_color_any_equals", "A28", ASSERT_COLOR_TYPE)
+add_common_name_with_type("object_color_none_equals", "A1", ASSERT_COLOR_TYPE)
+add_common_name_with_type("object_shape_all_equals", "A2", ASSERT_SHAPE_TYPE)
+add_common_name_with_type("object_shape_any_equals", "A29", ASSERT_SHAPE_TYPE)
+add_common_name_with_type("object_shape_none_equals", "A3", ASSERT_SHAPE_TYPE)
 add_common_name_with_type("box_count_equals", "A4", ASSERT_BOX_COUNT_TYPE)
 add_common_name_with_type("box_count_not_equals", "A5", ASSERT_BOX_COUNT_TYPE)
 add_common_name_with_type("box_count_greater", "A6", ASSERT_BOX_COUNT_TYPE)
@@ -79,19 +82,52 @@ add_common_name_with_type("object_count_greater", "A12", ASSERT_OBJECT_COUNT_TYP
 add_common_name_with_type("object_count_greater_equals", "A13", ASSERT_OBJECT_COUNT_TYPE)
 add_common_name_with_type("object_count_lesser", "A14", ASSERT_OBJECT_COUNT_TYPE)
 add_common_name_with_type("object_count_lesser_equals", "A15", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_color_count_equals", "A16", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_color_count_not_equals", "A17", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_color_count_greater", "A18", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_color_count_greater_equals", "A19", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_color_count_lesser", "A20", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_color_count_lesser_equals", "A21", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_shape_count_equals", "A22", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_shape_count_not_equals", "A23", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_shape_count_greater", "A24", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_shape_count_greater_equals", "A25", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_shape_count_lesser", "A26", ASSERT_OBJECT_COUNT_TYPE)
+add_common_name_with_type("object_shape_count_lesser_equals", "A27", ASSERT_OBJECT_COUNT_TYPE)
+
+add_common_name_with_type("box_exists", "E0", BOX_EXISTS_TYPE)
+add_common_name_with_type("object_exists", "E1", OBJECT_EXISTS_TYPE)
 
 
 # Box filter functions
-add_common_name_with_type("filter_count_equals", "F0", BOX_COUNT_FILTER_TYPE)
-add_common_name_with_type("filter_count_not_equals", "F1", BOX_COUNT_FILTER_TYPE)
-add_common_name_with_type("filter_shape_equals", "F2", BOX_SHAPE_FILTER_TYPE)
-add_common_name_with_type("filter_shape_not_equals", "F3", BOX_SHAPE_FILTER_TYPE)
-add_common_name_with_type("filter_color_equals", "F4", BOX_COLOR_FILTER_TYPE)
-add_common_name_with_type("filter_color_not_equals", "F5", BOX_COLOR_FILTER_TYPE)
-add_common_name_with_type("filter_count_greater", "F6", BOX_COUNT_FILTER_TYPE)
-add_common_name_with_type("filter_count_greater_equals", "F7", BOX_COUNT_FILTER_TYPE)
-add_common_name_with_type("filter_count_lesser", "F8", BOX_COUNT_FILTER_TYPE)
-add_common_name_with_type("filter_count_lesser_equals", "F9", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_count_equals", "F0", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_count_not_equals", "F1", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_shape_all_equals", "F2", BOX_SHAPE_FILTER_TYPE)
+add_common_name_with_type("member_shape_any_equals", "F26", BOX_SHAPE_FILTER_TYPE)
+add_common_name_with_type("member_shape_none_equals", "F3", BOX_SHAPE_FILTER_TYPE)
+add_common_name_with_type("member_color_all_equals", "F4", BOX_COLOR_FILTER_TYPE)
+add_common_name_with_type("member_color_any_equals", "F27", BOX_COLOR_FILTER_TYPE)
+add_common_name_with_type("member_color_none_equals", "F5", BOX_COLOR_FILTER_TYPE)
+add_common_name_with_type("member_count_greater", "F6", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_count_greater_equals", "F7", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_count_lesser", "F8", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_count_lesser_equals", "F9", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_color_count_equals", "F10", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_color_count_not_equals", "F11", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_color_count_greater", "F12", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_color_count_greater_equals", "F13", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_color_count_lesser", "F14", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_color_count_lesser_equals", "F15", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_shape_count_equals", "F16", BOX_COLOR_FILTER_TYPE)
+add_common_name_with_type("member_shape_count_not_equals", "F17", BOX_COLOR_FILTER_TYPE)
+add_common_name_with_type("member_shape_count_greater", "F18", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_shape_count_greater_equals", "F19", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_shape_count_lesser", "F20", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_shape_count_lesser_equals", "F21", BOX_COUNT_FILTER_TYPE)
+add_common_name_with_type("member_shape_same", "F22", BOX_ATTRIBUTE_SAME_FILTER_TYPE)
+add_common_name_with_type("member_color_same", "F23", BOX_ATTRIBUTE_SAME_FILTER_TYPE)
+add_common_name_with_type("member_shape_different", "F24", BOX_ATTRIBUTE_SAME_FILTER_TYPE)
+add_common_name_with_type("member_color_different", "F25", BOX_ATTRIBUTE_SAME_FILTER_TYPE)
 
 
 # Object filter functions
@@ -109,6 +145,7 @@ add_common_name_with_type("touch_top", "T2", OBJECT_FILTER_TYPE)
 add_common_name_with_type("touch_bottom", "T3", OBJECT_FILTER_TYPE)
 add_common_name_with_type("touch_left", "T4", OBJECT_FILTER_TYPE)
 add_common_name_with_type("touch_right", "T5", OBJECT_FILTER_TYPE)
+add_common_name_with_type("touch_object", "T6", OBJECT_FILTER_TYPE)
 add_common_name_with_type("above", "L0", OBJECT_FILTER_TYPE)
 add_common_name_with_type("below", "L1", OBJECT_FILTER_TYPE)
 add_common_name_with_type("top", "L2", OBJECT_FILTER_TYPE)
@@ -116,9 +153,6 @@ add_common_name_with_type("bottom", "L3", OBJECT_FILTER_TYPE)
 add_common_name_with_type("small", "Z0", OBJECT_FILTER_TYPE)
 add_common_name_with_type("medium", "Z1", OBJECT_FILTER_TYPE)
 add_common_name_with_type("big", "Z2", OBJECT_FILTER_TYPE)
-
-add_common_name_with_type("box_exists", "E0", BOX_EXISTS_TYPE)
-add_common_name_with_type("object_exists", "E1", OBJECT_EXISTS_TYPE)
 
 add_common_name_with_type("negate_filter", "N", NEGATE_FILTER_TYPE)
 

--- a/allennlp/data/semparse/worlds/nlvr_world.py
+++ b/allennlp/data/semparse/worlds/nlvr_world.py
@@ -276,7 +276,7 @@ class NlvrWorld(World):
         # target.
         function_name_parts = sub_expression[0].split('_')
         entity_type = function_name_parts[0]
-        target_attribute: AttributeType = None
+        target_attribute = None
         if len(function_name_parts) == 2 and function_name_parts[1] == "exists":
             attribute_type = "count"
             comparison_op = "greater_equals"
@@ -415,16 +415,18 @@ class NlvrWorld(World):
             return self._objects
         elif isinstance(sub_expression[0], str) and len(sub_expression) == 2:
             # These are functions like black, square, same_color etc.
-            arguments = self._execute_object_filter(sub_expression[1])
+            function = None
             try:
                 function = getattr(self, sub_expression[0])
-                return function(arguments)
             except AttributeError:
                 logger.error("Function not found: %s", sub_expression[0])
                 raise ExecutionError("Function not found")
-        elif isinstance(sub_expression, list) and sub_expression[0].startswith("member_") or \
-                sub_expression == 'all_boxes' or sub_expression[0] == 'all_boxes':
-            return self._execute_box_filter(sub_expression)
+            arguments = sub_expression[1]
+            if isinstance(arguments, list) and arguments[0].startswith("member_") or \
+                arguments == 'all_boxes' or arguments[0] == 'all_boxes':
+                return function(self._execute_box_filter(arguments))
+            else:
+                return function(self._execute_object_filter(arguments))
         else:
             logger.error("Invalid object filter expression: %s", sub_expression)
             raise ExecutionError("Invalid object filter expression")

--- a/allennlp/data/semparse/worlds/nlvr_world.py
+++ b/allennlp/data/semparse/worlds/nlvr_world.py
@@ -4,12 +4,11 @@ which mainly contains an execution method and related helper methods.
 """
 from collections import defaultdict
 import operator
-from typing import Any, List, Dict, Set, Callable, TypeVar, Union
+from typing import List, Dict, Set, Callable, TypeVar, Union
 
 from nltk.sem.logic import Type
 from overrides import overrides
 
-from allennlp.common import util
 from allennlp.common.util import JsonDict
 from allennlp.data.semparse import util as semparse_util
 from allennlp.data.semparse.type_declarations import nlvr_type_declaration as types
@@ -32,19 +31,26 @@ class Object:
         The dict for each object from the json file.
     """
     def __init__(self, attributes: JsonDict) -> None:
-        object_color = attributes["color"]
+        object_color = attributes["color"].lower()
         # The dataset has a hex code only for blue for some reason.
         if object_color.startswith("#"):
             self.color = "blue"
         else:
-            self.color = object_color.lower()
-        self.shape = attributes["type"].lower()
+            self.color = object_color
+        object_shape = attributes["type"].lower()
+        self.shape = object_shape
         self.x_loc = attributes["x_loc"]
         self.y_loc = attributes["y_loc"]
         self.size = attributes["size"]
 
     def __str__(self):
-        return "%s %s at (%d, %d)" % (self.color, self.shape, self.x_loc, self.y_loc)
+        if self.size == 10:
+            size = "small"
+        elif self.size == 20:
+            size = "medium"
+        else:
+            size = "big"
+        return "%s %s %s at (%d, %d)" % (size, self.color, self.shape, self.x_loc, self.y_loc)
 
     def __hash__(self):
         return hash(str(self))
@@ -92,16 +98,38 @@ class NlvrWorld(World):
         structured_rep from the JSON file.
     """
     # pylint: disable=too-many-public-methods
-    # TODO(pradeep): Define more spatial relationship methods: above, below, left_of, right_of..
+    # TODO(pradeep): Define more spatial relationship methods: left_of, right_of..
+    # They should be defined for objects within the same box.
     def __init__(self, world_representation: List[List[JsonDict]]) -> None:
         super(NlvrWorld, self).__init__(global_type_signatures=types.COMMON_TYPE_SIGNATURE,
                                         global_name_mapping=types.COMMON_NAME_MAPPING,
-                                        num_nested_lambdas=1)
+                                        num_nested_lambdas=0)
         self._boxes = set([Box(object_list, "box%d" % index)
                            for index, object_list in enumerate(world_representation)])
         self._objects: Set[Object] = set()
         for box in self._boxes:
             self._objects.update(box.objects)
+
+        self._number_operators = {"equals": operator.eq,
+                                  "not_equals": operator.ne,
+                                  "greater": operator.gt,
+                                  "lesser": operator.lt,
+                                  "greater_equals": operator.ge,
+                                  "lesser_equals": operator.le}
+
+        self._set_unary_operators = {"same": self._same,
+                                     "different": self._different}
+
+        self._set_binary_operators = {"all_equals": self._all_equals,
+                                      "any_equals": self._any_equals,
+                                      "none_equals": self._none_equals}
+
+        self._count_functions = {"count": self.count,  # type: ignore
+                                 "color_count": self._color_count,
+                                 "shape_count": self._shape_count}
+
+        self._attribute_functions = {"shape": self.shape,
+                                     "color": self.color}
 
     @overrides
     def get_basic_types(self) -> Set[Type]:
@@ -115,39 +143,56 @@ class NlvrWorld(World):
     def _map_name(self, name: str, keep_mapping: bool = False) -> str:
         return types.COMMON_NAME_MAPPING[name] if name in types.COMMON_NAME_MAPPING else name
 
-    def _apply_function_list(self,
-                             functions: List[str],
-                             argument: Any) -> Any:
-        """
-        Take a flat list of functions in ``NlvrWorld`` and an argument and apply them iteratively in reverse order.
-        """
-        return_value = argument
-        for function_name in reversed(functions):
-            return_value = getattr(self, function_name)(return_value)
-        return return_value
+    @staticmethod
+    def _same(input_set: Set[str]) -> bool:
+        return len(input_set) == 1
+
+    @staticmethod
+    def _different(input_set: Set[str]) -> bool:
+        return len(input_set) != 1
+
+    @staticmethod
+    def _all_equals(input_set: Set[str], target_value) -> bool:
+        return all([x == target_value for x in input_set])
+
+    @staticmethod
+    def _any_equals(input_set: Set[str], target_value) -> bool:
+        return any([x == target_value for x in input_set])
+
+    @staticmethod
+    def _none_equals(input_set: Set[str], target_value) -> bool:
+        return all([x != target_value for x in input_set])
+
+    @classmethod
+    def _shape_count(cls, input_set: Set[Object]) -> int:
+        return len(cls.shape(input_set))
+
+    @classmethod
+    def _color_count(cls, input_set: Set[Object]) -> int:
+        return len(cls.color(input_set))
 
     def execute(self, logical_form: str) -> bool:
         """
         Execute the logical form. The top level function is an assertion function (see below). We
-        just parse the string into a list and pass the whole thing to ``_execute_assertion`` and
-        let the method deal with it. This is because the dataset contains sentences (instead of questions), and
-        they evaluate to either true or false.
+        just parse the string into a list and pass the whole thing to ``_execute_assertion`` and let
+        the method deal with it. This is because the dataset contains sentences (instead of
+        questions), and they evaluate to either true or false.
 
-        The language we defined here contains seven types of functions, five of which return sets,
-        and one returns integers, and one returns booleans.
+        The language we defined here contains six types of functions, five of which return sets,
+        and one returns booleans.
 
         1) Assertion Function : These occur only at the root node of the logical form trees. They
-        take a value obtained from an attribute function (see "Attribute Functions" below), compare
-        it against a target and return True or False. All the functions that have names like
-        `assert_*` are assert functions.
+        take a set of entities, and compare their attributes to a given value, and return true or
+        false. The entities they take can be boxes or objects. If the assertion function takes
+        objects, it may compare their colors or shapes with the given value; If it takes boxes,
+        the attributes it compares are only the counts. The comparison operator can be any of
+        equals, not equals, greater than, etc. So, the function specifies what kind of entities it
+        takes, the attribute being compared and the comparison operator. For example,
+        "object_count_not_equals" takes a set of objects, compares their count to the given value
+        and returns true iff they are not equal. They have names like "object_*" or "box_*"
 
-        2) Attribute Functions : These are of the form ``attribute(set_of_boxes_or_objects)``. There
-        are two types of attribute functions:
-
-            2a) Object Attribute Functions: They take sets of objects and return sets of
-            attributes.  `color`, `shape` are the attribute functions.
-
-            2b) Count Function : Takes a set of objects or boxes and returns its cardinality.
+        2) Object Attribute Functions: They take sets of objects and return sets of attributes.
+        `color` and `shape` are the attribute functions.
 
         3) Box Membership Function : This takes a box as an argument and returns the objects in it.
         This is a special kind of attribute function for two reasons. Firstly, it returns a set of
@@ -189,86 +234,150 @@ class NlvrWorld(World):
 
     def _execute_assertion(self, sub_expression: List) -> bool:
         """
-        Assertion functions are boolean functions. They take two arguments, which
-        evaluate to strings or integers, and compare them. The first element in the input list
-        should be the assertion function name, the second as an attribute function, and the
-        last element should be a constant.
+        Assertion functions are boolean functions. They are of two types:
+        1) Exists functions: They take one argument, a set and check whether it is not empty.
+        Syntax: ``(exists_function function_returning_entities)``
+        Example: ``(object_exists (black (top all_objects)))`` ("There is a black object at the top
+        of a tower.")
+        2) Other assert functions: They take two arguments, which evaluate to strings or integers,
+        and compare them. The first element in the input list should be the assertion function name,
+        the second a function returning entities, and the last element should be a constant. The
+        assertion function should specify the entity type, the attribute being compared, and a
+        comparison operator, in that order separated by underscores. The following are the expected
+        values:
+            Entity types: ``object``, ``box``
+            Attributes being compared: ``color``, ``shape``, ``count``, ``color_count``,
+            ``shape_count``
+            Comparison operator:
+                Applicable to sets: ``all_equals``, ``any_equals``, ``none_equals``, ``same``,
+                ``different``
+                Applicable to counts: ``equals``, ``not_equals``, ``lesser``, ``lesser_equals``,
+                ``greater``, ``greater_equals``
+        Syntax: ``(assertion_function function_returning_entities constant)``
+        Example: ``(box_count_equals (member_shape_equals all_boxes shape_square) 2)``
+        ("There are exactly two boxes with only squares in them")
 
-        Syntax: assertion_function(attribute_function, constant)
+        Note that the first kind is a special case of the second where the attribute type is
+        ``count``, comparison operator is ``greater_equals`` and the constant is ``1``.
         """
         # TODO(pradeep): We may want to change the order of arguments here to make decoding easier.
         assert isinstance(sub_expression, list), "Invalid assertion expression: %s" % sub_expression
         if len(sub_expression) == 1 and isinstance(sub_expression[0], list):
             return self._execute_assertion(sub_expression[0])
-        assert isinstance(sub_expression[0], str) and sub_expression[0].startswith("assert_"),\
+        is_assert_function = sub_expression[0].startswith("object_") or \
+        sub_expression[0].startswith("box_")
+        assert isinstance(sub_expression[0], str) and is_assert_function,\
                "Invalid assertion function: %s" % (sub_expression[0])
-        function = getattr(self, sub_expression[0])
-        attribute_function = sub_expression[1]
-        target_attribute = self._execute_constant(sub_expression[2])
-        if attribute_function[0] == "count":
-            counted_value = self._execute_count_function(attribute_function)
-            return function(counted_value, target_attribute)
-        attribute_set = self._execute_attribute_function(attribute_function)
-        # We defined attribute functions to always return sets. But when this assertion is being executed, for the
-        # assertion to be true, the returned set needs to be singleton. If not, the assertion should fail.
-        if len(attribute_set) != 1:
-            return False
-        (attribute,) = attribute_set
-        return function(attribute, target_attribute)
-
-    def _execute_attribute_function(self, sub_expression: List) -> Set[str]:
-        """
-        Attribute functions return a set of evaluated attributes. The function has to be ``color``
-        or ``shape``, and the only element in the nested list should evaluate to a set of objects.
-
-        Syntax: attribute_function(input_set)
-        """
-        assert isinstance(sub_expression, list), "Invalid attribute expression: %s" % sub_expression
-        function_name = sub_expression[0]
-        arguments_list = sub_expression[1]
-        input_set = self._execute_object_filter(arguments_list)
-        if function_name == "shape":
-            return self.shape(input_set)
-        elif function_name == "color":
-            return self.color(input_set)
+        # Example: box_count_not_equals, entities being evaluated are boxes, the relevant attibute
+        # is their count, and the function will return true if the attribute is not equal to the
+        # target.
+        function_name_parts = sub_expression[0].split('_')
+        entity_type = function_name_parts[0]
+        target_attribute: Union[str, int] = None
+        if len(function_name_parts) == 2 and function_name_parts[1] == "exists":
+            attribute_type = "count"
+            comparison_op = "greater_equals"
+            target_attribute = 1
         else:
-            raise RuntimeError("Invalid attribute function: %s" % sub_expression[0])
+            target_attribute = self._execute_constant(sub_expression[2])
+            # If the length of ``function_name_parts`` is 3, getting the attribute and comparison
+            # operator is easy. However, if it is greater than 3, we need to determine where the
+            # attribute function stops and where the comparison operaot begins.
+            if len(function_name_parts) == 3:
+                # These are cases like ``object_color_equals``, ``box_count_greater`` etc.
+                attribute_type = function_name_parts[1]
+                comparison_op = function_name_parts[2]
+            elif function_name_parts[2] == 'count':
+                # These are cases like ``object_color_count_equals``,
+                # ``object_shape_count_greater_equals`` etc.
+                attribute_type = "_".join(function_name_parts[1:3])
+                comparison_op = "_".join(function_name_parts[3:])
+            else:
+                # These are cases like ``box_count_greater_equals``, ``object_shape_not_equals``
+                # etc.
+                attribute_type = function_name_parts[1]
+                comparison_op = "_".join(function_name_parts[2:])
 
-    def _execute_count_function(self, sub_expression: List) -> int:
-        """
-        Acceptable syntax is count(object_set).
-        """
-        arguments_list = sub_expression[1]
-        if arguments_list[0].startswith("filter_") or arguments_list[0] == "all_boxes":
-            return self.count(self._execute_box_filter(arguments_list))
+        entity_expression = sub_expression[1]
+        returned_count = None
+        returned_attribute = None
+        if entity_type == "box":
+            # You can only count boxes. The other attributes do not apply.
+            returned_count = self.count(self._execute_box_filter(entity_expression))
+        elif "count" in attribute_type:
+            # We're counting objects, colors or shapes.
+            count_function = self._count_functions[attribute_type]
+            returned_count = count_function(self._execute_object_filter(entity_expression))
         else:
-            return self.count(self._execute_object_filter(arguments_list))
+            # We're getting colors or shapes from objects.
+            attribute_function = self._attribute_functions[attribute_type]
+            returned_attribute = attribute_function(self._execute_object_filter(entity_expression))
+
+        if comparison_op in ["all_equals", "any_equals", "none_equals"]:
+            set_comparison = self._set_binary_operators[comparison_op]
+            assert returned_attribute is not None, "Invalid assertion function: %s" % sub_expression[0]
+            return set_comparison(returned_attribute, target_attribute)
+        else:
+            number_comparison = self._number_operators[comparison_op]
+            assert returned_count is not None, "Invalid assertion function: %s" % sub_expression[0]
+            return number_comparison(returned_count, target_attribute)
 
     def _execute_box_filter(self, sub_expression: Union[str, List]) -> Set[Box]:
         """
         Box filtering functions either apply a filter on a set of boxes and return the filtered set,
         or return all the boxes.
         The elements should evaluate to one of the following:
-            box_filtering_function(set_to_filter, attribute_function, constant)
-            all_boxes
+        ``(box_filtering_function set_to_filter constant)`` or
+        ``all_boxes``
+
+        In the first kind of forms, the ``box_filtering_function`` also specifies the attribute
+        being compared and the comparison operator. The attribute is of the objects contained in
+        each box in the ``set_to_filter``.
+        Example: ``(member_color_count_greater all_boxes 1)``
+        filters all boxes by extracting the colors of the objects in each of them, and returns a
+        subset of boxes from the original set where the number of colors of objects is greater than
+        1.
         """
         # TODO(pradeep): We may want to change the order of arguments here to make decoding easier.
-        if sub_expression[0].startswith('filter_'):
-            # filter_* functions are box filtering functions, and have a lambda expression as the
-            # second argument. We'll process the whole nested structure of the lambda expression
-            # here.
-            function = getattr(self, sub_expression[0])
+        if sub_expression[0].startswith('member_'):
+            function_name_parts = sub_expression[0].split("_")
+            if len(function_name_parts) == 3:
+                attribute_type = function_name_parts[1]
+                comparison_op = function_name_parts[2]
+            elif function_name_parts[2] == "count":
+                attribute_type = "_".join(function_name_parts[1:3])
+                comparison_op = "_".join(function_name_parts[3:])
+            else:
+                attribute_type = function_name_parts[1]
+                comparison_op = "_".join(function_name_parts[2:])
             set_to_filter = self._execute_box_filter(sub_expression[1])
-            attribute_function_list = sub_expression[2]
-            assert attribute_function_list[:2] == ['lambda', 'x'], ("Invalid lambda expression: %s" %
-                                                                    attribute_function_list)
-            # The list looks like ['lambda' 'x' ['f' ['g' ['x']]]]. We're flattening the nested list.
-            flattened_lambda_terms = util.flatten_list(attribute_function_list[2])
-            assert flattened_lambda_terms[-2:] == ['var', 'x'], ("Invalid lambda expression: %s" %
-                                                                 attribute_function_list)
-            attribute_function = lambda x: self._apply_function_list(flattened_lambda_terms[:-2], x)
-            attribute = self._execute_constant(sub_expression[-1])
-            return function(set_to_filter, attribute_function, attribute)
+            return_set = set()
+            if comparison_op in ["same", "different"]:
+                # We don't need a target attribute for these functions, and the "comparison" is done
+                # on sets.
+                comparison_function = self._set_unary_operators[comparison_op]
+                for box in set_to_filter:
+                    returned_attribute: Set[str] = self._attribute_functions[attribute_type](box.objects)
+                    if comparison_function(returned_attribute):
+                        return_set.add(box)
+            else:
+                target_attribute = self._execute_constant(sub_expression[-1])
+                is_set_operation = comparison_op in ["all_equals", "any_equals", "none_equals"]
+                # These are comparisons like equals, greater etc, and we need a target attribute
+                # which we first evaluate here. Then, the returned attribute (if it is a singleton
+                # set or an integer), is compared against the target attribute.
+                for box in set_to_filter:
+                    if is_set_operation:
+                        returned_attribute = self._attribute_functions[attribute_type](box.objects)
+                        box_wanted = self._set_binary_operators[comparison_op](returned_attribute,
+                                                                               target_attribute)
+                    else:
+                        returned_count = self._count_functions[attribute_type](box.objects)
+                        box_wanted = self._number_operators[comparison_op](returned_count,
+                                                                           target_attribute)
+                    if box_wanted:
+                        return_set.add(box)
+            return return_set
         elif sub_expression == 'all_boxes' or sub_expression[0] == 'all_boxes':
             return self._boxes
         else:
@@ -301,7 +410,7 @@ class NlvrWorld(World):
             raise RuntimeError("Invalid object filter expression: %s" % sub_expression)
 
     @staticmethod
-    def _execute_constant(sub_expression: str) -> Union[str, int]:
+    def _execute_constant(sub_expression: str):
         """
         Acceptable constants are numbers or strings starting with `shape_` or `color_`
         """
@@ -347,35 +456,6 @@ class NlvrWorld(World):
             if comparison_op(attribute_function(entity), target_attribute):
                 returned_set.add(entity)
         return returned_set
-
-    ## Box filtering functions
-    @classmethod
-    def filter_equals(cls,
-                      set_to_filter: Set[Box],
-                      attribute_function: Callable[[Box], AttributeType],
-                      target_attribute: AttributeType) -> Set[Box]:
-        return cls._filter_boxes(set_to_filter, attribute_function, target_attribute, operator.eq)
-
-    @classmethod
-    def filter_not_equal(cls,
-                         set_to_filter: Set[Box],
-                         attribute_function: Callable[[Box], AttributeType],
-                         target_attribute: AttributeType) -> Set[Box]:
-        return cls._filter_boxes(set_to_filter, attribute_function, target_attribute, operator.ne)
-
-    @classmethod
-    def filter_greater_equal(cls,
-                             set_to_filter: Set[Box],
-                             attribute_function: Callable[[Box], int],
-                             target_attribute: int) -> Set[Box]:
-        return cls._filter_boxes(set_to_filter, attribute_function, target_attribute, operator.ge)
-
-    @classmethod
-    def filter_lesser_equal(cls,
-                            set_to_filter: Set[Box],
-                            attribute_function: Callable[[Box], int],
-                            target_attribute: int) -> Set[Box]:
-        return cls._filter_boxes(set_to_filter, attribute_function, target_attribute, operator.le)
 
     ## Object filtering functions
     @classmethod
@@ -472,21 +552,94 @@ class NlvrWorld(World):
                                 cls.touch_bottom(objects).intersection(cls.touch_right(objects)),
                                 cls.touch_bottom(objects).intersection(cls.touch_left(objects)))
 
-    @classmethod
-    def top(cls, objects: Set[Object]) -> Set[Object]:
+    def touch_object(self, objects: Set[Object]) -> Set[Object]:
         """
-        Return the topmost objects (i.e. maximum y_loc).
+        Returns all objects that touch the given set of objects.
         """
-        max_y_loc = max([obj.y_loc for obj in objects])
-        return set([obj for obj in objects if obj.y_loc == max_y_loc])
+        objects_per_box = self._separate_objects_by_boxes(objects)
+        return_set = set()
+        for box, box_objects in objects_per_box.items():
+            candidate_objects = box.objects
+            for object_ in box_objects:
+                for candidate_object in candidate_objects:
+                    if self._objects_touch_each_other(object_, candidate_object):
+                        return_set.add(candidate_object)
+        return return_set
 
     @classmethod
-    def bottom(cls, objects: Set[Object]) -> Set[Object]:
+    def _objects_touch_each_other(cls, object1: Object, object2: Object) -> bool:
         """
-        Return the bottom most objects(i.e. minimum y_loc).
+        Returns true iff the objects touch each other.
         """
-        min_y_loc = min([obj.y_loc for obj in objects])
-        return set([obj for obj in objects if obj.y_loc == min_y_loc])
+        return object1.x_loc + object1.size == object2.x_loc or \
+               object1.y_loc + object1.size == object2.y_loc or \
+               object2.x_loc + object2.size == object1.x_loc or \
+               object2.y_loc + object2.size == object1.y_loc
+
+    def top(self, objects: Set[Object]) -> Set[Object]:
+        """
+        Return the topmost objects (i.e. maximum y_loc). The comparison is done separately for each
+        box.
+        """
+        objects_per_box = self._separate_objects_by_boxes(objects)
+        return_set: Set[Object] = set()
+        for _, box_objects in objects_per_box.items():
+            max_y_loc = max([obj.y_loc for obj in box_objects])
+            return_set.union(set([obj for obj in box_objects if obj.y_loc == max_y_loc]))
+        return return_set
+
+    def bottom(self, objects: Set[Object]) -> Set[Object]:
+        """
+        Return the bottom most objects(i.e. minimum y_loc). The comparison is done separately for
+        each box.
+        """
+        objects_per_box = self._separate_objects_by_boxes(objects)
+        return_set: Set[Object] = set()
+        for _, box_objects in objects_per_box.items():
+            min_y_loc = min([obj.y_loc for obj in box_objects])
+            return_set.union(set([obj for obj in box_objects if obj.y_loc == min_y_loc]))
+        return return_set
+
+    def above(self, objects: Set[Object]) -> Set[Object]:
+        """
+        Returns the set of objects in the same boxes that are above the given objects. That is, if
+        the input is a set of two objects, one in each box, we will return a union of the objects
+        above the first object in the first box, and those above the second object in the second box.
+        """
+        objects_per_box = self._separate_objects_by_boxes(objects)
+        return_set = set()
+        for box in objects_per_box:
+            max_y_loc = max([obj.y_loc for obj in objects_per_box[box]])
+            for candidate_obj in box.objects:
+                if candidate_obj.y_loc > max_y_loc:
+                    return_set.add(candidate_obj)
+        return return_set
+
+    def below(self, objects: Set[Object]) -> Set[Object]:
+        """
+        Returns the set of objects in the same boxes that are below the given objects. That is, if
+        the input is a set of two objects, one in each box, we will return a union of the objects
+        below the first object in the first box, and those below the second object in the second box.
+        """
+        objects_per_box = self._separate_objects_by_boxes(objects)
+        return_set = set()
+        for box in objects_per_box:
+            min_y_loc = min([obj.y_loc for obj in objects_per_box[box]])
+            for candidate_obj in box.objects:
+                if candidate_obj.y_loc < min_y_loc:
+                    return_set.add(candidate_obj)
+        return return_set
+
+    def _separate_objects_by_boxes(self, objects: Set[Object]) -> Dict[Box, List[Object]]:
+        """
+        Given a set of objects, separate them by the boxes they belong to and return a dict.
+        """
+        objects_per_box: Dict[Box, List[Object]] = defaultdict(list)
+        for box in self._boxes:
+            for object_ in objects:
+                if object_ in box.objects:
+                    objects_per_box[box].append(object_)
+        return objects_per_box
 
     @classmethod
     def small(cls, objects: Set[Object]) -> Set[Object]:
@@ -505,27 +658,3 @@ class NlvrWorld(World):
                       objects: Set[Object]) -> Set[Object]:
         # Negate an object filter.
         return objects.difference(filter_function(objects))
-
-    @staticmethod
-    def assert_equals(actual_attribute: AttributeType, target_attribute: AttributeType) -> bool:
-        return actual_attribute == target_attribute
-
-    @staticmethod
-    def assert_not_equals(actual_attribute: AttributeType, target_attribute: AttributeType) -> bool:
-        return actual_attribute != target_attribute
-
-    @staticmethod
-    def assert_greater(actual_attribute: int, target_attribute: int) -> bool:
-        return actual_attribute > target_attribute
-
-    @staticmethod
-    def assert_lesser(actual_attribute: int, target_attribute: int) -> bool:
-        return actual_attribute < target_attribute
-
-    @staticmethod
-    def assert_greater_equals(actual_attribute: int, target_attribute: int) -> bool:
-        return actual_attribute >= target_attribute
-
-    @staticmethod
-    def assert_lesser_equals(actual_attribute: int, target_attribute: int) -> bool:
-        return actual_attribute <= target_attribute

--- a/allennlp/data/semparse/worlds/nlvr_world.py
+++ b/allennlp/data/semparse/worlds/nlvr_world.py
@@ -436,6 +436,11 @@ class NlvrWorld(World):
         """
         Acceptable constants are numbers or strings starting with `shape_` or `color_`
         """
+        # TODO(pradeep): Let this method call other methods to allow functions that evaluate to
+        # constants as well?
+        if not isinstance(sub_expression, str):
+            logger.error("Invalid constant: %s", sub_expression)
+            raise ExecutionError("Invalid constant")
         if str.isdigit(sub_expression):
             return int(sub_expression)
         elif sub_expression.startswith('color_'):

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -29,7 +29,7 @@ class ParsingError(Exception):
 class ExecutionError(Exception):
     """
     This exception gets raised when you're trying to execute a logical form that your executor does
-    not understand. This may be because your logical form contains an function with an invalid name
+    not understand. This may be because your logical form contains a function with an invalid name
     or a set of arguments whose types do not match those that the fuction expects.
     """
     def __init__(self, message):

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -26,6 +26,20 @@ class ParsingError(Exception):
         return repr(self.message)
 
 
+class ExecutionError(Exception):
+    """
+    This exception gets raised when you're trying to execute a logical form that your executor does
+    not understand. This may be because your logical form contains an function with an invalid name
+    or a set of arguments whose types do not match those that the fuction expects.
+    """
+    def __init__(self, message):
+        super(ExecutionError, self).__init__()
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)
+
+
 class World:
     """
     Base class for defining a world in a new domain. This class defines a method to translate a

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -264,23 +264,26 @@ class World:
                 terminals.append((right_side, self._infer_num_arguments(left_side)))
         partial_logical_forms: List[str] = []
 
-        # We'll handle "reverse" here by looking at the prior terminal to see if it's "reverse"
-        # (and because we're iterating over this backwards, "prior" actually means "next").  If it
-        # is, we'll create a new "terminal" that's the application of "reverse" to that terminal.
-        # This works for most cases, but there are a few edge cases where this breaks, particularly
-        # when there's a lambda involved.  We have a hack to try to handle lambdas, but it doesn't
-        # always work.  TODO(mattg,pradeep): to make this logic more general and remove the need to
-        # special-case reverse, we need to fix some things in the type system.  In particular, we
-        # should remove currying in our action sequences.  If each production accurately reflected
-        # the number of arguments to a function, we could remove most of this logic.
+        # We'll handle higher order functions ("reverse" and "negate_filter") here by looking at the
+        # prior terminal to see if it's a higher order function (and because we're iterating over
+        # this backwards, "prior" actually means "next").  If it is, we'll create a new "terminal"
+        # that's the application of the higher order function to that terminal. This works for most
+        # cases, but there are a few edge cases where this breaks, particularly when there's a
+        # lambda involved (happens only with "reverse" in LambdaDCS).  We have a hack to try to
+        # handle lambdas, but it doesn't always work.  TODO(mattg,pradeep): to make this logic more
+        # general and remove the need to special-case reverse, we need to fix some things in the
+        # type system.  In particular, we should remove currying in our action sequences.  If each
+        # production accurately reflected the number of arguments to a function, we could remove
+        # most of this logic.
         terminals = list(reversed(terminals))
+        higher_order_functions = ['reverse', 'negate_filter']
         for i, (terminal, num_args) in enumerate(terminals):
-            if i < len(terminals) - 1 and terminals[i + 1][0] == 'reverse':
+            if i < len(terminals) - 1 and terminals[i + 1][0] in higher_order_functions:
                 if 'lambda' in terminal:
                     terminal = f"({terminal} {partial_logical_forms.pop()})"
                     num_args -= 1
-                terminal = f"(reverse {terminal})"
-            if terminal == 'reverse':
+                terminal = f"({terminals[i + 1][0]} {terminal})"
+            if terminal in higher_order_functions:
                 continue
             elif num_args == 0:
                 partial_logical_forms.append(terminal)

--- a/allennlp/data/semparse/worlds/world.py
+++ b/allennlp/data/semparse/worlds/world.py
@@ -278,14 +278,21 @@ class World:
         terminals = list(reversed(terminals))
         higher_order_functions = ['reverse', 'negate_filter']
         for i, (terminal, num_args) in enumerate(terminals):
-            if i < len(terminals) - 1 and terminals[i + 1][0] in higher_order_functions:
+            if terminal in higher_order_functions:
+                continue
+            upcoming_higher_order_functions = []
+            for j in range(i + 1, len(terminals)):
+                if terminals[j][0] in higher_order_functions:
+                    upcoming_higher_order_functions.append(terminals[j][0])
+                else:
+                    break
+            if upcoming_higher_order_functions:
                 if 'lambda' in terminal:
                     terminal = f"({terminal} {partial_logical_forms.pop()})"
                     num_args -= 1
-                terminal = f"({terminals[i + 1][0]} {terminal})"
-            if terminal in higher_order_functions:
-                continue
-            elif num_args == 0:
+                for upcoming_function in upcoming_higher_order_functions:
+                    terminal = f"({upcoming_function} {terminal})"
+            if num_args == 0:
                 partial_logical_forms.append(terminal)
             else:
                 args = []

--- a/allennlp/models/encoder_decoders/nlvr_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/nlvr_semantic_parser.py
@@ -14,7 +14,7 @@ from allennlp.common.checks import check_dimensions_match
 from allennlp.data.fields.production_rule_field import ProductionRuleArray
 from allennlp.data.semparse.type_declarations.type_declaration import START_SYMBOL
 from allennlp.data.semparse.type_declarations import GrammarState
-from allennlp.data.semparse.worlds.world import ParsingError
+from allennlp.data.semparse.worlds.world import ParsingError, ExecutionError
 from allennlp.data.semparse.worlds import NlvrWorld
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.modules import Attention, TextFieldEmbedder, Seq2SeqEncoder
@@ -175,7 +175,7 @@ class NlvrSemanticParser(Model):
             denotation = world.execute(logical_form)
             denotation_is_correct = str(denotation).lower() == label.lower()
             return True, denotation_is_correct
-        except ParsingError:
+        except (ParsingError, ExecutionError):
             # TODO (pradeep): Fix the type declaration to make this try-except unnecessary.
             return False, False
 

--- a/allennlp/models/encoder_decoders/nlvr_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/nlvr_semantic_parser.py
@@ -14,7 +14,6 @@ from allennlp.common.checks import check_dimensions_match
 from allennlp.data.fields.production_rule_field import ProductionRuleArray
 from allennlp.data.semparse.type_declarations.type_declaration import START_SYMBOL
 from allennlp.data.semparse.type_declarations import GrammarState
-from allennlp.data.semparse.worlds.world import ParsingError, ExecutionError
 from allennlp.data.semparse.worlds import NlvrWorld
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.modules import Attention, TextFieldEmbedder, Seq2SeqEncoder
@@ -51,7 +50,6 @@ class NlvrSemanticParser(Model):
         super(NlvrSemanticParser, self).__init__(vocab=vocab)
 
         self._sentence_embedder = sentence_embedder
-        self._action_sequence_validity = Average()
         self._denotation_accuracy = Average()
         check_dimensions_match(nonterminal_embedder.get_output_dim(),
                                terminal_embedder.get_output_dim(),
@@ -152,37 +150,30 @@ class NlvrSemanticParser(Model):
         for i in range(batch_size):
             batch_actions = actions[i]
             batch_best_sequences = best_action_sequences[i]
-            sequence_is_valid = False
             sequence_is_correct = False
             if batch_best_sequences:
                 action_strings = [get_action_string(batch_actions[rule_id]) for rule_id in
                                   batch_best_sequences[0][0]]
                 label_string = self.vocab.get_token_from_index(int(labels_data[i]), "denotations")
                 instance_world = world[i]
-                sequence_is_valid, sequence_is_correct = self._check_denotation(action_strings,
-                                                                                label_string,
-                                                                                instance_world)
-            self._action_sequence_validity(1 if sequence_is_valid else 0)
+                sequence_is_correct = self._check_denotation(action_strings,
+                                                             label_string,
+                                                             instance_world)
             self._denotation_accuracy(1 if sequence_is_correct else 0)
         return outputs
 
     @staticmethod
     def _check_denotation(best_action_sequence: List[str],
                           label: str,
-                          world: NlvrWorld) -> Tuple[bool, bool]:
-        try:
-            logical_form = world.get_logical_form(best_action_sequence)
-            denotation = world.execute(logical_form)
-            denotation_is_correct = str(denotation).lower() == label.lower()
-            return True, denotation_is_correct
-        except (ParsingError, ExecutionError):
-            # TODO (pradeep): Fix the type declaration to make this try-except unnecessary.
-            return False, False
+                          world: NlvrWorld) -> bool:
+        logical_form = world.get_logical_form(best_action_sequence)
+        denotation = world.execute(logical_form)
+        denotation_is_correct = str(denotation).lower() == label.lower()
+        return denotation_is_correct
 
     @overrides
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         return {
-                'sequence_validity': self._action_sequence_validity.get_metric(reset),
                 'denotation_accuracy': self._denotation_accuracy.get_metric(reset)
         }
 

--- a/allennlp/models/encoder_decoders/nlvr_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/nlvr_semantic_parser.py
@@ -14,6 +14,7 @@ from allennlp.common.checks import check_dimensions_match
 from allennlp.data.fields.production_rule_field import ProductionRuleArray
 from allennlp.data.semparse.type_declarations.type_declaration import START_SYMBOL
 from allennlp.data.semparse.type_declarations import GrammarState
+from allennlp.data.semparse.worlds.world import ParsingError
 from allennlp.data.semparse.worlds import NlvrWorld
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.modules import Attention, TextFieldEmbedder, Seq2SeqEncoder
@@ -174,7 +175,7 @@ class NlvrSemanticParser(Model):
             denotation = world.execute(logical_form)
             denotation_is_correct = str(denotation).lower() == label.lower()
             return True, denotation_is_correct
-        except (RuntimeError, AssertionError, TypeError):
+        except ParsingError:
             # TODO (pradeep): Fix the type declaration to make this try-except unnecessary.
             return False, False
 

--- a/tests/data/dataset_readers/nlvr_test.py
+++ b/tests/data/dataset_readers/nlvr_test.py
@@ -18,7 +18,7 @@ class TestNlvrDatasetReader(AllenNlpTestCase):
                            'a', 'box', '.']
         assert [t.text for t in sentence_tokens] == expected_tokens
         actions = [action.rule for action in instance.fields["actions"].field_list]
-        assert len(actions) == 125
+        assert len(actions) == 121
         agenda = [item.sequence_index for item in instance.fields["agenda"].field_list]
         agenda_strings = [actions[rule_id] for rule_id in agenda]
         assert agenda_strings == ['<o,o> -> circle', '<o,t> -> object_exists',

--- a/tests/data/dataset_readers/nlvr_test.py
+++ b/tests/data/dataset_readers/nlvr_test.py
@@ -18,11 +18,11 @@ class TestNlvrDatasetReader(AllenNlpTestCase):
                            'a', 'box', '.']
         assert [t.text for t in sentence_tokens] == expected_tokens
         actions = [action.rule for action in instance.fields["actions"].field_list]
-        assert len(actions) == 126
+        assert len(actions) == 125
         agenda = [item.sequence_index for item in instance.fields["agenda"].field_list]
-        agenda_actions = [actions[i] for i in agenda]
-        assert agenda_actions == ['<o,o> -> circle', '<e,<e,t>> -> assert_greater_equals',
-                                  't -> [<b,t>, b]', '<o,o> -> touch_corner']
+        agenda_strings = [actions[rule_id] for rule_id in agenda]
+        assert agenda_strings == ['<o,o> -> circle', '<o,t> -> object_exists',
+                                  '<o,o> -> touch_corner']
         world = instance.fields["world"].as_tensor({})
         assert isinstance(world, NlvrWorld)
         label = instance.fields["label"].label

--- a/tests/data/semparse/worlds/nlvr_world_test.py
+++ b/tests/data/semparse/worlds/nlvr_world_test.py
@@ -89,36 +89,3 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
                                    'b -> [<c,b>, c]', '<c,b> -> [<b,<c,b>>, b]',
                                    '<b,<c,b>> -> member_color_none_equals', 'b -> all_boxes',
                                    'c -> color_blue']
-
-    def test_get_logical_form_with_real_logical_forms(self):
-        nlvr_world = self.worlds[0]
-        logical_form = ("(box_count_greater_equals (member_color_count_equals all_boxes 0) 1)")
-        parsed_logical_form = nlvr_world.parse_logical_form(logical_form)
-        action_sequence = nlvr_world.get_action_sequence(parsed_logical_form)
-        reconstructed_logical_form = nlvr_world.get_logical_form(action_sequence)
-        parsed_reconstructed_logical_form = nlvr_world.parse_logical_form(reconstructed_logical_form)
-        # It makes more sense to compare parsed logical forms instead of actual logical forms.
-        assert parsed_logical_form == parsed_reconstructed_logical_form
-        assert nlvr_world.execute(logical_form) == nlvr_world.execute(reconstructed_logical_form)
-        logical_form = "(object_color_all_equals (circle (touch_wall (all_objects))) color_black)"
-        parsed_logical_form = nlvr_world.parse_logical_form(logical_form)
-        action_sequence = nlvr_world.get_action_sequence(parsed_logical_form)
-        reconstructed_logical_form = nlvr_world.get_logical_form(action_sequence)
-        parsed_reconstructed_logical_form = nlvr_world.parse_logical_form(reconstructed_logical_form)
-        assert parsed_logical_form == parsed_reconstructed_logical_form
-        assert nlvr_world.execute(logical_form) == nlvr_world.execute(reconstructed_logical_form)
-
-    def test_get_logical_form_fails_with_incomplete_action_sequence(self):
-        nlvr_world = self.worlds[0]
-        action_sequence = ['@START@ -> t', 't -> [<b,t>, b]', '<b,t> -> box_exists']
-        with self.assertRaises(ParsingError):
-            nlvr_world.get_logical_form(action_sequence)
-
-    def test_get_logical_form_fails_with_action_sequence_in_wrong_order(self):
-        nlvr_world = self.worlds[0]
-        action_sequence = ['@START@ -> t', 't -> [<b,t>, b]', '<b,t> -> box_exists',
-                           'b -> [<c,b>, c]', '<c,b> -> [<b,<c,b>>, b]',
-                           'b -> all_boxes', '<b,<c,b>> -> member_color_none_equals',
-                           'c -> color_blue']
-        with self.assertRaises(ParsingError):
-            nlvr_world.get_logical_form(action_sequence)

--- a/tests/data/semparse/worlds/nlvr_world_test.py
+++ b/tests/data/semparse/worlds/nlvr_world_test.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-self-use,invalid-name
 import json
 
-from allennlp.data.semparse.worlds.world import ParsingError
+from allennlp.data.semparse.worlds.world import ExecutionError
 from allennlp.data.semparse.worlds.nlvr_world import NlvrWorld
 from allennlp.common.testing import AllenNlpTestCase
 
@@ -12,6 +12,17 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
         test_filename = "tests/fixtures/data/nlvr/sample_data.jsonl"
         data = [json.loads(line)["structured_rep"] for line in open(test_filename).readlines()]
         self.worlds = [NlvrWorld(rep) for rep in data]
+        custom_rep = [[{"y_loc": 21, "size": 20, "type": "triangle", "x_loc": 27, "color":
+                        "Yellow"},
+                       {"y_loc": 45, "size": 10, "type": "circle", "x_loc": 47, "color":
+                        "Black"}],
+                      [{"y_loc": 56, "size": 30, "type": "square", "x_loc": 10, "color":
+                        "#0099ff"},
+                       {"y_loc": 26, "size": 30, "type": "square", "x_loc": 40, "color":
+                        "Yellow"}],
+                      [{"y_loc": 40, "size": 10, "type": "triangle", "x_loc": 12, "color":
+                        "#0099ff"}]]
+        self.custom_world = NlvrWorld(custom_rep)
 
     def test_logical_form_with_assert_executes_correctly(self):
         nlvr_world = self.worlds[0]
@@ -60,7 +71,7 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
     def test_logical_form_with_not_executes_correctly(self):
         nlvr_world = self.worlds[2]
         # Utterance is "There are at most two medium triangles not touching a wall." and label is "True".
-        logical_form = ("(object_count_lesser_equals (negate_filter (touch_wall) \
+        logical_form = ("(object_count_lesser_equals ((negate_filter touch_wall) \
                                                                      (medium (triangle (all_objects)))) 2)")
         assert nlvr_world.execute(logical_form)
 
@@ -89,3 +100,61 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
                                    'b -> [<c,b>, c]', '<c,b> -> [<b,<c,b>>, b]',
                                    '<b,<c,b>> -> member_color_none_equals', 'b -> all_boxes',
                                    'c -> color_blue']
+
+    def test_spatial_relations_return_objects_in_the_same_box(self):
+        # "above", "below", "top", "bottom" are relations defined only for objects within the same
+        # box. So they should not return objects from other boxes.
+        world = self.custom_world
+        # Asserting that the color of the objects above the yellow triangle is only black (it is not
+        # yellow or blue, which are colors of objects from other boxes)
+        assert world.execute("(object_color_all_equals (above (yellow (triangle all_objects)))"
+                             " color_black)")
+        # Asserting that the only shape below the blue square is a square.
+        assert world.execute("(object_shape_all_equals (below (blue (square all_objects)))"
+                             " shape_square)")
+        # Asserting the shape of the object at the bottom in the box with a circle is triangle.
+        assert world.execute("(object_shape_all_equals (bottom (object_in_box"
+                             " (member_shape_any_equals all_boxes shape_circle))) shape_triangle)")
+
+        # Asserting the shape of the object at the top of the box with all squares is a square (!).
+        assert world.execute("(object_shape_all_equals (top (object_in_box"
+                             " (member_shape_all_equals all_boxes shape_square))) shape_square)")
+
+    def test_touch_object_executes_correctly(self):
+        world = self.custom_world
+        # Assert that there is a yellow square touching a blue square.
+        assert world.execute("(object_exists"
+                             " (yellow (square (touch_object (blue (square all_objects))))))")
+        # Assert that the triangle does not touch the circle (they are out of vertical range).
+        assert world.execute("(object_shape_none_equals (touch_object (triangle all_objects))"
+                             " shape_circle)")
+
+    def test_spatial_relations_with_objects_from_different_boxes(self):
+        # When the objects are from different boxes, top and bottom should return objects from
+        # respective boxes.
+        world = self.custom_world
+        # There are triangles in two boxes, so top should return the top objects from both boxes.
+        assert world.execute("(object_count_equals (top (object_in_box (member_shape_any_equals "
+                             "all_boxes shape_triangle))) 2)")
+
+    def test_count_with_all_equals_throws_execution_error(self):
+        world = self.custom_world
+        with self.assertRaises(ExecutionError):
+            world.execute("(object_count_all_equals (top (object_in_box (member_shape_any_equals "
+                          "all_boxes shape_triangle))) 2)")
+
+    def test_shape_with_equals_throws_execution_error(self):
+        world = self.custom_world
+        with self.assertRaises(ExecutionError):
+            world.execute("(object_shape_equals (top (object_in_box (member_shape_any_equals "
+                          "all_boxes shape_triangle))) shape_triangle)")
+
+    def test_same_and_different_execute_correctly(self):
+        world = self.custom_world
+        # All the objects in the box with two objects of the same shape are squares.
+        assert world.execute("(object_shape_all_equals "
+                             "(object_in_box (member_shape_same (member_count_equals all_boxes 2)))"
+                             " shape_square)")
+        # There is a circle in the box with objects of different shapes.
+        assert world.execute("(object_shape_any_equals "
+                             "(object_in_box (member_shape_different all_boxes)) shape_circle)")

--- a/tests/data/semparse/worlds/nlvr_world_test.py
+++ b/tests/data/semparse/worlds/nlvr_world_test.py
@@ -12,74 +12,65 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
         test_filename = "tests/fixtures/data/nlvr/sample_data.jsonl"
         data = [json.loads(line)["structured_rep"] for line in open(test_filename).readlines()]
         self.worlds = [NlvrWorld(rep) for rep in data]
-        custom_rep = [[{"y_loc": 21, "size": 20, "type": "triangle", "x_loc": 27, "color":
-                        "Yellow"},
-                       {"y_loc": 45, "size": 10, "type": "circle", "x_loc": 47, "color":
-                        "Black"}],
-                      [{"y_loc": 56, "size": 30, "type": "square", "x_loc": 10, "color":
-                        "#0099ff"},
-                       {"y_loc": 26, "size": 30, "type": "square", "x_loc": 40, "color":
-                        "Yellow"}],
-                      [{"y_loc": 40, "size": 10, "type": "triangle", "x_loc": 12, "color":
-                        "#0099ff"}]]
+        custom_rep = [[{"y_loc": 21, "size": 20, "type": "triangle", "x_loc": 27, "color": "Yellow"},
+                       {"y_loc": 45, "size": 10, "type": "circle", "x_loc": 47, "color": "Black"}],
+                      [{"y_loc": 56, "size": 30, "type": "square", "x_loc": 10, "color": "#0099ff"},
+                       {"y_loc": 26, "size": 30, "type": "square", "x_loc": 40, "color": "Yellow"}],
+                      [{"y_loc": 40, "size": 10, "type": "triangle", "x_loc": 12, "color": "#0099ff"}]]
         self.custom_world = NlvrWorld(custom_rep)
 
     def test_logical_form_with_assert_executes_correctly(self):
         nlvr_world = self.worlds[0]
         # Utterance is "There is a circle closely touching a corner of a box." and label is "True".
         logical_form_true = "(object_count_greater_equals (touch_corner (circle (all_objects))) 1)"
-        # Should evaluate to True.
-        assert nlvr_world.execute(logical_form_true)
+        assert nlvr_world.execute(logical_form_true) is True
         logical_form_false = "(object_count_equals (touch_corner (circle (all_objects))) 0)"
-        # Should evaluate to False.
-        assert not nlvr_world.execute(logical_form_false)
+        assert nlvr_world.execute(logical_form_false) is False
 
     def test_logical_form_with_box_filter_executes_correctly(self):
         nlvr_world = self.worlds[2]
         # Utterance is "There is a box without a blue item." and label is "False".
         logical_form = "(box_exists (member_color_none_equals all_boxes color_blue))"
-        # Should evaluate to False.
-        assert not nlvr_world.execute(logical_form)
+        assert nlvr_world.execute(logical_form) is False
 
     def test_logical_form_with_box_filter_within_object_filter_executes_correctly(self):
         nlvr_world = self.worlds[2]
-        # Utterance is "There are atleast three blue items in boxes with blue items" and label
+        # Utterance is "There are at least three blue items in boxes with blue items" and label
         # is "True".
         logical_form = "(object_count_greater_equals \
                             (object_in_box (member_color_any_equals all_boxes color_blue)) 3)"
-        # Should evaluate to True.
-        assert nlvr_world.execute(logical_form)
+        assert nlvr_world.execute(logical_form) is True
 
     def test_logical_form_with_same_color_executes_correctly(self):
         nlvr_world = self.worlds[1]
         # Utterance is "There are exactly two blocks of the same color." and label is "True".
         logical_form = "(object_count_equals (same_color all_objects) 2)"
-        assert nlvr_world.execute(logical_form)
+        assert nlvr_world.execute(logical_form) is True
 
     def test_logical_form_with_same_shape_executes_correctly(self):
         nlvr_world = self.worlds[0]
         # Utterance is "There are less than three black objects of the same shape" and label is "False".
         logical_form = "(object_count_lesser (same_shape (black (all_objects))) 3)"
-        assert not nlvr_world.execute(logical_form)
+        assert nlvr_world.execute(logical_form) is False
 
     def test_logical_form_with_touch_wall_executes_correctly(self):
         nlvr_world = self.worlds[0]
         # Utterance is "There are two black circles touching a wall" and label is "False".
         logical_form = "(object_count_greater_equals (touch_wall (black (circle (all_objects)))) 2)"
-        assert not nlvr_world.execute(logical_form)
+        assert nlvr_world.execute(logical_form) is False
 
     def test_logical_form_with_not_executes_correctly(self):
         nlvr_world = self.worlds[2]
         # Utterance is "There are at most two medium triangles not touching a wall." and label is "True".
         logical_form = ("(object_count_lesser_equals ((negate_filter touch_wall) \
                                                                      (medium (triangle (all_objects)))) 2)")
-        assert nlvr_world.execute(logical_form)
+        assert nlvr_world.execute(logical_form) is True
 
     def test_logical_form_with_color_comparison_executes_correctly(self):
         nlvr_world = self.worlds[0]
         # Utterance is "The color of the circle touching the wall is black." and label is "True".
         logical_form = "(object_color_all_equals (circle (touch_wall (all_objects))) color_black)"
-        assert nlvr_world.execute(logical_form)
+        assert nlvr_world.execute(logical_form) is True
 
     def test_logical_form_with_object_filter_returns_correct_action_sequence(self):
         nlvr_world = self.worlds[0]
@@ -108,26 +99,28 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
         # Asserting that the color of the objects above the yellow triangle is only black (it is not
         # yellow or blue, which are colors of objects from other boxes)
         assert world.execute("(object_color_all_equals (above (yellow (triangle all_objects)))"
-                             " color_black)")
+                             " color_black)") is True
         # Asserting that the only shape below the blue square is a square.
         assert world.execute("(object_shape_all_equals (below (blue (square all_objects)))"
-                             " shape_square)")
+                             " shape_square)") is True
         # Asserting the shape of the object at the bottom in the box with a circle is triangle.
-        assert world.execute("(object_shape_all_equals (bottom (object_in_box"
-                             " (member_shape_any_equals all_boxes shape_circle))) shape_triangle)")
+        logical_form = ("(object_shape_all_equals (bottom (object_in_box"
+                        " (member_shape_any_equals all_boxes shape_circle))) shape_triangle)")
+        assert world.execute(logical_form) is True
 
         # Asserting the shape of the object at the top of the box with all squares is a square (!).
-        assert world.execute("(object_shape_all_equals (top (object_in_box"
-                             " (member_shape_all_equals all_boxes shape_square))) shape_square)")
+        logical_form = ("(object_shape_all_equals (top (object_in_box"
+                        " (member_shape_all_equals all_boxes shape_square))) shape_square)")
+        assert world.execute(logical_form) is True
 
     def test_touch_object_executes_correctly(self):
         world = self.custom_world
         # Assert that there is a yellow square touching a blue square.
-        assert world.execute("(object_exists"
-                             " (yellow (square (touch_object (blue (square all_objects))))))")
+        assert world.execute("(object_exists (yellow (square (touch_object (blue "
+                             "(square all_objects))))))") is True
         # Assert that the triangle does not touch the circle (they are out of vertical range).
         assert world.execute("(object_shape_none_equals (touch_object (triangle all_objects))"
-                             " shape_circle)")
+                             " shape_circle)") is True
 
     def test_spatial_relations_with_objects_from_different_boxes(self):
         # When the objects are from different boxes, top and bottom should return objects from
@@ -135,15 +128,19 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
         world = self.custom_world
         # There are triangles in two boxes, so top should return the top objects from both boxes.
         assert world.execute("(object_count_equals (top (object_in_box (member_shape_any_equals "
-                             "all_boxes shape_triangle))) 2)")
+                             "all_boxes shape_triangle))) 2)") is True
 
     def test_count_with_all_equals_throws_execution_error(self):
+        # "*_all_equals" is a comparison valid only for sets (of colors and shapes). A comparison
+        # with count should use "*_equals" instead.
         world = self.custom_world
         with self.assertRaises(ExecutionError):
             world.execute("(object_count_all_equals (top (object_in_box (member_shape_any_equals "
                           "all_boxes shape_triangle))) 2)")
 
     def test_shape_with_equals_throws_execution_error(self):
+        # "*_all_equals" is a comparison valid only for counts. A comparison with sets should use
+        # "*_equals", "*_any_equals" or "*_non_equals" instead.
         world = self.custom_world
         with self.assertRaises(ExecutionError):
             world.execute("(object_shape_equals (top (object_in_box (member_shape_any_equals "
@@ -154,7 +151,7 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
         # All the objects in the box with two objects of the same shape are squares.
         assert world.execute("(object_shape_all_equals "
                              "(object_in_box (member_shape_same (member_count_equals all_boxes 2)))"
-                             " shape_square)")
+                             " shape_square)") is True
         # There is a circle in the box with objects of different shapes.
-        assert world.execute("(object_shape_any_equals "
-                             "(object_in_box (member_shape_different all_boxes)) shape_circle)")
+        assert world.execute("(object_shape_any_equals (object_in_box "
+                             "(member_shape_different all_boxes)) shape_circle)") is True

--- a/tests/data/semparse/worlds/nlvr_world_test.py
+++ b/tests/data/semparse/worlds/nlvr_world_test.py
@@ -15,78 +15,100 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
     def test_logical_form_with_assert_executes_correctly(self):
         nlvr_world = self.worlds[0]
         # Utterance is "There is a circle closely touching a corner of a box." and label is "True".
-        logical_form_true = "(assert_greater_equals (count (touch_corner (circle (all_objects)))) 1)"
+        logical_form_true = "(object_count_greater_equals (touch_corner (circle (all_objects))) 1)"
         # Should evaluate to True.
         assert nlvr_world.execute(logical_form_true)
-        logical_form_false = "(assert_equals (count (touch_corner (circle (all_objects)))) 0)"
+        logical_form_false = "(object_count_equals (touch_corner (circle (all_objects))) 0)"
         # Should evaluate to False.
         assert not nlvr_world.execute(logical_form_false)
 
-    def test_logical_form_with_filter_executes_correctly(self):
+    def test_logical_form_with_box_filter_executes_correctly(self):
         nlvr_world = self.worlds[2]
         # Utterance is "There is a box without a blue item." and label is "False".
-        logical_form = "(assert_greater_equals \
-                         (count (filter_equals all_boxes (lambda x (count (blue (object_in_box (var x))))) 0)) \
-                         1)"
+        logical_form = "(box_exists (member_color_none_equals all_boxes color_blue))"
         # Should evaluate to False.
         assert not nlvr_world.execute(logical_form)
 
     def test_logical_form_with_same_color_executes_correctly(self):
         nlvr_world = self.worlds[1]
-        # Utterance is "There is exactly one tower with two blocks of the same color." and label is "True".
-        logical_form = "(assert_equals \
-                         (count \
-                          (filter_equals all_boxes (lambda x (count (same_color (object_in_box (var x))))) 2)) \
-                         1)"
+        # Utterance is "There are exactly two blocks of the same color." and label is "True".
+        logical_form = "(object_count_equals (same_color all_objects) 2)"
         assert nlvr_world.execute(logical_form)
 
     def test_logical_form_with_same_shape_executes_correctly(self):
         nlvr_world = self.worlds[0]
         # Utterance is "There are less than three black objects of the same shape" and label is "False".
-        logical_form = "(assert_lesser (count (same_shape (black (all_objects)))) 3)"
+        logical_form = "(object_count_lesser (same_shape (black (all_objects))) 3)"
         assert not nlvr_world.execute(logical_form)
 
     def test_logical_form_with_touch_wall_executes_correctly(self):
         nlvr_world = self.worlds[0]
         # Utterance is "There are two black circles touching a wall" and label is "False".
-        logical_form = "(assert_greater_equals (count (touch_wall (black (circle (all_objects))))) 2)"
+        logical_form = "(object_count_greater_equals (touch_wall (black (circle (all_objects)))) 2)"
         assert not nlvr_world.execute(logical_form)
 
     def test_logical_form_with_not_executes_correctly(self):
         nlvr_world = self.worlds[2]
         # Utterance is "There are at most two medium triangles not touching a wall." and label is "True".
-        logical_form = ("(assert_lesser_equals (count (negate_filter (touch_wall) \
-                                                                     (medium (triangle (all_objects))))) 2)")
+        logical_form = ("(object_count_lesser_equals (negate_filter (touch_wall) \
+                                                                     (medium (triangle (all_objects)))) 2)")
         assert nlvr_world.execute(logical_form)
 
     def test_logical_form_with_color_comparison_executes_correctly(self):
         nlvr_world = self.worlds[0]
         # Utterance is "The color of the circle touching the wall is black." and label is "True".
-        logical_form = "(assert_equals (color (circle (touch_wall (all_objects)))) color_black)"
+        logical_form = "(object_color_all_equals (circle (touch_wall (all_objects))) color_black)"
         assert nlvr_world.execute(logical_form)
 
     def test_logical_form_with_object_filter_returns_correct_action_sequence(self):
         nlvr_world = self.worlds[0]
-        logical_form = "(assert_equals (color (circle (touch_wall (all_objects)))) color_black)"
+        logical_form = "(object_color_all_equals (circle (touch_wall (all_objects))) color_black)"
         expression = nlvr_world.parse_logical_form(logical_form)
         action_sequence = nlvr_world.get_action_sequence(expression)
-        assert action_sequence == ['@START@ -> t', 't -> [<c,t>, c]', '<c,t> -> [<#1,<#1,t>>, c]',
-                                   '<#1,<#1,t>> -> assert_equals', 'c -> [<o,c>, o]', '<o,c> -> color',
-                                   'o -> [<o,o>, o]', '<o,o> -> circle', 'o -> [<o,o>, o]',
-                                   '<o,o> -> touch_wall', 'o -> all_objects', 'c -> color_black']
+        assert action_sequence == ['@START@ -> t', 't -> [<c,t>, c]', '<c,t> -> [<o,<c,t>>, o]',
+                                   '<o,<c,t>> -> object_color_all_equals', 'o -> [<o,o>, o]',
+                                   '<o,o> -> circle', 'o -> [<o,o>, o]', '<o,o> -> touch_wall',
+                                   'o -> all_objects', 'c -> color_black']
 
     def test_logical_form_with_box_filter_returns_correct_action_sequence(self):
         nlvr_world = self.worlds[0]
-        logical_form = ("(assert_greater_equals \
-                          (count (filter_equals all_boxes (lambda x (count (blue (object_in_box (var (x)))))) 0)) \
-                          1)")
-        expression = nlvr_world.parse_logical_form(logical_form, remove_var_function=False)
+        logical_form = "(box_exists (member_color_none_equals all_boxes color_blue))"
+        expression = nlvr_world.parse_logical_form(logical_form)
         action_sequence = nlvr_world.get_action_sequence(expression)
-        assert action_sequence == ['@START@ -> t', 't -> [<e,t>, e]', '<e,t> -> [<e,<e,t>>, e]',
-                                   '<e,<e,t>> -> assert_greater_equals', 'e -> [<#1,e>, b]', '<#1,e> -> count',
-                                   'b -> [<e,b>, e]', '<e,b> -> [<<b,e>,<e,b>>, <b,e>]',
-                                   '<<b,e>,<e,b>> -> [<b,<<b,#1>,<#1,b>>>, b]',
-                                   '<b,<<b,#1>,<#1,b>>> -> filter_equals', 'b -> all_boxes',
-                                   "<b,e> -> ['lambda x', e]", 'e -> [<#1,e>, o]', '<#1,e> -> count',
-                                   'o -> [<o,o>, o]', '<o,o> -> blue', 'o -> [<b,o>, b]', '<b,o> -> object_in_box',
-                                   'b -> [<#1,#1>, b]', '<#1,#1> -> var', 'b -> x', 'e -> 0', 'e -> 1']
+        assert action_sequence == ['@START@ -> t', 't -> [<b,t>, b]', '<b,t> -> box_exists',
+                                   'b -> [<c,b>, c]', '<c,b> -> [<b,<c,b>>, b]',
+                                   '<b,<c,b>> -> member_color_none_equals', 'b -> all_boxes',
+                                   'c -> color_blue']
+
+    def test_get_logical_form_with_real_logical_forms(self):
+        nlvr_world = self.worlds[0]
+        logical_form = ("(box_count_greater_equals (member_color_count_equals all_boxes 0) 1)")
+        parsed_logical_form = nlvr_world.parse_logical_form(logical_form)
+        action_sequence = nlvr_world.get_action_sequence(parsed_logical_form)
+        reconstructed_logical_form = nlvr_world.get_logical_form(action_sequence)
+        parsed_reconstructed_logical_form = nlvr_world.parse_logical_form(reconstructed_logical_form)
+        # It makes more sense to compare parsed logical forms instead of actual logical forms.
+        assert parsed_logical_form == parsed_reconstructed_logical_form
+        assert nlvr_world.execute(logical_form) == nlvr_world.execute(reconstructed_logical_form)
+        logical_form = "(object_color_all_equals (circle (touch_wall (all_objects))) color_black)"
+        parsed_logical_form = nlvr_world.parse_logical_form(logical_form)
+        action_sequence = nlvr_world.get_action_sequence(parsed_logical_form)
+        reconstructed_logical_form = nlvr_world.get_logical_form(action_sequence)
+        parsed_reconstructed_logical_form = nlvr_world.parse_logical_form(reconstructed_logical_form)
+        assert parsed_logical_form == parsed_reconstructed_logical_form
+        assert nlvr_world.execute(logical_form) == nlvr_world.execute(reconstructed_logical_form)
+
+    def test_get_logical_form_fails_with_incomplete_action_sequence(self):
+        nlvr_world = self.worlds[0]
+        action_sequence = ['@START@ -> t', 't -> [<b,t>, b]', '<b,t> -> box_exists']
+        with self.assertRaises(AssertionError):
+            nlvr_world.get_logical_form(action_sequence)
+
+    def test_get_logical_form_fails_with_action_sequence_in_wrong_order(self):
+        nlvr_world = self.worlds[0]
+        action_sequence = ['@START@ -> t', 't -> [<b,t>, b]', '<b,t> -> box_exists',
+                           'b -> [<c,b>, c]', '<c,b> -> [<b,<c,b>>, b]',
+                           'b -> all_boxes', '<b,<c,b>> -> member_color_none_equals',
+                           'c -> color_blue']
+        with self.assertRaises(AssertionError):
+            nlvr_world.get_logical_form(action_sequence)

--- a/tests/data/semparse/worlds/world_test.py
+++ b/tests/data/semparse/worlds/world_test.py
@@ -90,42 +90,18 @@ class WorldTest(AllenNlpTestCase):
     # world.
 
     def test_get_action_sequence_removes_and_retains_var_correctly(self):
-        nlvr_world = self.nlvr_world
-        logical_form = ("(assert_greater_equals \
-                          (count (filter_equals all_boxes (lambda x (count (blue (object_in_box (var x))))) 0)) \
-                          1)")
-        parsed_logical_form_without_var = nlvr_world.parse_logical_form(logical_form)
-        action_sequence_without_var = nlvr_world.get_action_sequence(parsed_logical_form_without_var)
+        world = self.wikitables_world
+        logical_form = ("((reverse fb:row.row.league) (argmin (number 1) (number 1) "
+                        "(fb:type.object.type fb:type.row) "
+                        "(reverse (lambda x ((reverse fb:row.row.index) (var x))))))")
+        parsed_logical_form_without_var = world.parse_logical_form(logical_form)
+        action_sequence_without_var = world.get_action_sequence(parsed_logical_form_without_var)
         assert '<#1,#1> -> var' not in action_sequence_without_var
 
-        parsed_logical_form_with_var = nlvr_world.parse_logical_form(logical_form,
-                                                                     remove_var_function=False)
-        action_sequence_with_var = nlvr_world.get_action_sequence(parsed_logical_form_with_var)
+        parsed_logical_form_with_var = world.parse_logical_form(logical_form,
+                                                                remove_var_function=False)
+        action_sequence_with_var = world.get_action_sequence(parsed_logical_form_with_var)
         assert '<#1,#1> -> var' in action_sequence_with_var
-
-    def test_get_logical_form_with_real_logical_forms(self):
-        nlvr_world = self.nlvr_world
-        logical_form = ("(assert_greater_equals \
-                          (count (filter_equals all_boxes (lambda x (count (blue (object_in_box (var x))))) 0)) \
-                          1)")
-        parsed_logical_form = nlvr_world.parse_logical_form(logical_form)
-        action_sequence = nlvr_world.get_action_sequence(parsed_logical_form)
-        reconstructed_logical_form = nlvr_world.get_logical_form(action_sequence)
-        parsed_reconstructed_logical_form = nlvr_world.parse_logical_form(reconstructed_logical_form)
-        # It makes more sense to compare parsed logical forms instead of actual logical forms
-        # because there can be slight differences between the actual logical form strings, like
-        # extra set of parentheses or spaces, which neither the type inference logic nor the
-        # executor cares about. So the test shouldn't either.
-        assert parsed_logical_form == parsed_reconstructed_logical_form
-        assert nlvr_world.execute(logical_form) == nlvr_world.execute(reconstructed_logical_form)
-
-        logical_form = "(assert_equals (color (circle (touch_wall (all_objects)))) color_black)"
-        parsed_logical_form = nlvr_world.parse_logical_form(logical_form)
-        action_sequence = nlvr_world.get_action_sequence(parsed_logical_form)
-        reconstructed_logical_form = nlvr_world.get_logical_form(action_sequence)
-        parsed_reconstructed_logical_form = nlvr_world.parse_logical_form(reconstructed_logical_form)
-        assert parsed_logical_form == parsed_reconstructed_logical_form
-        assert nlvr_world.execute(logical_form) == nlvr_world.execute(reconstructed_logical_form)
 
     def test_get_logical_form_handles_reverse(self):
         world = self.wikitables_world
@@ -155,62 +131,74 @@ class WorldTest(AllenNlpTestCase):
         parsed_reconstructed_logical_form = world.parse_logical_form(reconstructed_logical_form)
         assert parsed_logical_form == parsed_reconstructed_logical_form
 
-    def test_get_logical_form_with_decoded_action_sequence(self):
-        # This is identical to the previous test except that we are testing it on a real action
-        # sequence the decoder produced.
+    def test_get_logical_form_with_real_logical_forms(self):
         nlvr_world = self.nlvr_world
-        action_sequence = ['@START@ -> t', 't -> [<b,t>, b]', '<b,t> -> [<#1,<#1,t>>, b]',
-                           '<#1,<#1,t>> -> assert_not_equals', 'b -> all_boxes', 'b -> all_boxes']
-        logical_form = nlvr_world.get_logical_form(action_sequence)
-        # Note that while the grammar allows this logical form, it is not valid according to the
-        # executor because `assert_*` functions take attributes (counts, shapes and colors) as both
-        # the arguments. The signature is "<#1,<#1,t>>" because we do not have a generic attribute
-        # type, and hence it is more lenient than it should be. We should ideally have hierarchical
-        # types to deal with these.
-        assert logical_form == '(assert_not_equals all_boxes all_boxes)'
+        logical_form = ("(box_count_greater_equals (member_color_count_equals all_boxes 0) 1)")
+        parsed_logical_form = nlvr_world.parse_logical_form(logical_form)
+        action_sequence = nlvr_world.get_action_sequence(parsed_logical_form)
+        reconstructed_logical_form = nlvr_world.get_logical_form(action_sequence)
+        parsed_reconstructed_logical_form = nlvr_world.parse_logical_form(reconstructed_logical_form)
+        # It makes more sense to compare parsed logical forms instead of actual logical forms.
+        assert parsed_logical_form == parsed_reconstructed_logical_form
+        assert nlvr_world.execute(logical_form) == nlvr_world.execute(reconstructed_logical_form)
+        logical_form = "(object_color_all_equals (circle (touch_wall (all_objects))) color_black)"
+        parsed_logical_form = nlvr_world.parse_logical_form(logical_form)
+        action_sequence = nlvr_world.get_action_sequence(parsed_logical_form)
+        reconstructed_logical_form = nlvr_world.get_logical_form(action_sequence)
+        parsed_reconstructed_logical_form = nlvr_world.parse_logical_form(reconstructed_logical_form)
+        assert parsed_logical_form == parsed_reconstructed_logical_form
+        assert nlvr_world.execute(logical_form) == nlvr_world.execute(reconstructed_logical_form)
 
     def test_get_logical_form_fails_with_incomplete_action_sequence(self):
         nlvr_world = self.nlvr_world
-        action_sequence = ['@START@ -> t', 't -> [<b,t>, b]', '<b,t> -> [<#1,<#1,t>>, b]',
-                           '<#1,<#1,t>> -> assert_not_equals']
+        action_sequence = ['@START@ -> t', 't -> [<b,t>, b]', '<b,t> -> box_exists']
         with self.assertRaises(ParsingError):
             nlvr_world.get_logical_form(action_sequence)
 
     def test_get_logical_form_fails_with_action_sequence_in_wrong_order(self):
         nlvr_world = self.nlvr_world
-        action_sequence = ['@START@ -> t', 't -> [<b,t>, b]', '<b,t> -> [<#1,<#1,t>>, b]',
-                           'b -> all_boxes', '<#1,<#1,t>> -> assert_not_equals', 'b -> all_boxes']
+        action_sequence = ['@START@ -> t', 't -> [<b,t>, b]', '<b,t> -> box_exists',
+                           'b -> [<c,b>, c]', '<c,b> -> [<b,<c,b>>, b]',
+                           'b -> all_boxes', '<b,<c,b>> -> member_color_none_equals',
+                           'c -> color_blue']
         with self.assertRaises(ParsingError):
             nlvr_world.get_logical_form(action_sequence)
 
     def test_get_logical_form_adds_var_correctly(self):
-        nlvr_world = self.nlvr_world
-        action_sequence = ['@START@ -> t', 't -> [<e,t>, e]', '<e,t> -> [<e,<e,t>>, e]',
-                           '<e,<e,t>> -> assert_greater_equals', 'e -> [<#1,e>, b]',
-                           '<#1,e> -> count', 'b -> [<e,b>, e]', '<e,b> -> [<<b,e>,<e,b>>, <b,e>]',
-                           '<<b,e>,<e,b>> -> [<b,<<b,#1>,<#1,b>>>, b]',
-                           '<b,<<b,#1>,<#1,b>>> -> filter_equals', 'b -> all_boxes',
-                           "<b,e> -> ['lambda x', e]", 'e -> [<#1,e>, o]', '<#1,e> -> count',
-                           'o -> [<o,o>, o]', '<o,o> -> blue', 'o -> [<b,o>, b]',
-                           '<b,o> -> object_in_box', 'b -> x', 'e -> 0', 'e -> 1']
-        logical_form = nlvr_world.get_logical_form(action_sequence)
-        expected_logical_form = ("(assert_greater_equals \
-                                 (count (filter_equals all_boxes (lambda x (count (blue \
-                                 (object_in_box (var (x)))))) 0)) 1)")
-        parsed_logical_form = nlvr_world.parse_logical_form(logical_form)
-        parsed_expected_logical_form = nlvr_world.parse_logical_form(expected_logical_form)
+        world = self.wikitables_world
+        action_sequence = ['@START@ -> e', 'e -> [<r,e>, r]', '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]',
+                           '<<#1,#2>,<#2,#1>> -> reverse', '<e,r> -> fb:row.row.league',
+                           'r -> [<<d,r>,r>, <d,r>]', '<<d,r> ,r> -> [<r,<<d,r>,r>>, r]',
+                           '<r,<<d,r>,r>> -> [<d,<r,<<d,r>,r>>>, d]',
+                           '<d,<r,<<d,r>,r>>> -> [<d,<d,<#1,<<d,#1>,#1>>>>, d]',
+                           '<d,<d,<#1,<<d,#1>,#1>>>> -> argmin', 'd -> [<e,d>, e]', '<e,d> -> number',
+                           'e -> 1', ' d -> [<e,d>, e]', '<e,d> -> number', 'e -> 1',
+                           'r -> [<#1,#1>, r]', '<#1,#1> -> fb:type.object.type', 'r -> fb:type.row',
+                           '<d,r> -> [<<#1,#2>,<#2,#1>>,  <r,d>]', '<<#1,#2>,<#2,#1>> -> reverse',
+                           "<r,d> -> ['lambda x', d]", 'd -> [<r,d>, r]',
+                           '<r,d> -> [<<#1,#2>,<#2,#1>>, <d,r>]', '<<#1,#2>,<#2,#1>> -> reverse',
+                           '<d,r> -> fb:row.row.index', 'r -> x']
+        logical_form = world.get_logical_form(action_sequence)
+        expected_logical_form = ("((reverse fb:row.row.league) (argmin (number 1) (number 1) "
+                                 "(fb:type.object.type fb:type.row) "
+                                 "(reverse (lambda x ((reverse fb:row.row.index) (var x))))))")
+        parsed_logical_form = world.parse_logical_form(logical_form)
+        parsed_expected_logical_form = world.parse_logical_form(expected_logical_form)
         assert parsed_logical_form == parsed_expected_logical_form
 
     def test_get_logical_form_fails_with_unnecessary_add_var(self):
-        nlvr_world = self.nlvr_world
-        action_sequence = ['@START@ -> t', 't -> [<e,t>, e]', '<e,t> -> [<e,<e,t>>, e]',
-                           '<e,<e,t>> -> assert_greater_equals', 'e -> [<#1,e>, b]',
-                           '<#1,e> -> count', 'b -> [<e,b>, e]', '<e,b> -> [<<b,e>,<e,b>>, <b,e>]',
-                           '<<b,e>,<e,b>> -> [<b,<<b,#1>,<#1,b>>>, b]',
-                           '<b,<<b,#1>,<#1,b>>> -> filter_equals', 'b -> all_boxes',
-                           "<b,e> -> ['lambda x', e]", 'e -> [<#1,e>, o]', '<#1,e> -> count',
-                           'o -> [<o,o>, o]', '<o,o> -> blue', 'o -> [<b,o>, b]',
-                           '<b,o> -> object_in_box', 'b -> [<#1,#1>, b]', '<#1,#1> -> var',
-                           'b -> x', 'e -> 0', 'e -> 1']
+        world = self.wikitables_world
+        action_sequence = ['@START@ -> e', 'e -> [<r,e>, r]', '<r,e> -> [<<#1,#2>,<#2,#1>>, <e,r>]',
+                           '<<#1,#2>,<#2,#1>> -> reverse', '<e,r> -> fb:row.row.league',
+                           'r -> [<<d,r>,r>, <d,r>]', '<<d,r> ,r> -> [<r,<<d,r>,r>>, r]',
+                           '<r,<<d,r>,r>> -> [<d,<r,<<d,r>,r>>>, d]',
+                           '<d,<r,<<d,r>,r>>> -> [<d,<d,<#1,<<d,#1>,#1>>>>, d]',
+                           '<d,<d,<#1,<<d,#1>,#1>>>> -> argmin', 'd -> [<e,d>, e]', '<e,d> -> number',
+                           'e -> 1', ' d -> [<e,d>, e]', '<e,d> -> number', 'e -> 1',
+                           'r -> [<#1,#1>, r]', '<#1,#1> -> fb:type.object.type', 'r -> fb:type.row',
+                           '<d,r> -> [<<#1,#2>,<#2,#1>>,  <r,d>]', '<<#1,#2>,<#2,#1>> -> reverse',
+                           "<r,d> -> ['lambda x', d]", 'd -> [<r,d>, r]',
+                           '<r,d> -> [<<#1,#2>,<#2,#1>>, <d,r>]', '<<#1,#2>,<#2,#1>> -> reverse',
+                           '<d,r> -> fb:row.row.index', 'r -> [<#1,#1>, r]', '<#1,#1> -> var', 'r -> x']
         with self.assertRaises(RuntimeError):
-            nlvr_world.get_logical_form(action_sequence)
+            world.get_logical_form(action_sequence)


### PR DESCRIPTION
This PR includes several changes to the NLVR language:
1) I removed lambda functions from the language. This made the box filters less expressive, but the output space is more restricted. The reduced expressivity is not really a problem though. I tried to annotate a random set of 25 sentences, of which I could not annotate only 2 due to the lack of lambdas.
2) I converted each function that had placeholder types into multiple functions where the types of the arguments are unique. This increased the number of terminals, but the grammar now disallows unintended argument types that placeholders earlier allowed.
3) Related to the above change, I removed the attribute functions: "count", "color" and "shape", and pulled them into the assertion and filtering functions. This again increased the number of terminals, but the grammar now requires that the first argument of assertions and filters be sets of entities , and the last arguments be constants. Due to this change, the grammar disallows  trivial contradictions or tautologies like `(assert_greater 3 2)`, and ensures that one of the arguments is really a constant (earlier the decoder was also generating logical forms like `(assert_greater (count (object_in_box all_boxes)) (count (color (object_in_box all_boxes))))`).

After these changes, the number of terminal productions went up from 56 to 101, but the number of non-terminals went down from 48 to 26, and the total number of productions remained unchanged at 121. The average branching factor (number of productions per non-terminal) went up from 2.5 to 4.6, and the maximum branching factor is unchanged at 23 (due to object filtering functions like `square`, `above`, `yellow` etc.). When trained on 1000 questions, all the logical forms produced by the decoder, both during training and validation were valid executable sequences.