### PR TITLE
Use the sentence as the key in elmo command.

### DIFF
--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -251,7 +251,7 @@ class ElmoEmbedder():
 
         # Tokenizes the sentences.
         sentences = [line.strip() for line in input_file]
-        split_sentences = map(lambda sentence: sentence.split(), sentences)
+        split_sentences = [sentence.split() for sentence in sentences]
         # Uses the sentence as the key.
         embedded_sentences = zip(sentences, self.embed_sentences(split_sentences, batch_size))
 

--- a/tests/commands/elmo_test.py
+++ b/tests/commands/elmo_test.py
@@ -35,9 +35,9 @@ class TestElmoCommand(ElmoTestCase):
         assert os.path.exists(output_path)
 
         with h5py.File(output_path, 'r') as h5py_file:
-            assert list(h5py_file.keys()) == ["0"]
+            assert list(h5py_file.keys()) == [sentence]
             # The vectors in the test configuration are smaller (32 length)
-            assert h5py_file.get("0").shape == (3, len(sentence.split()), 32)
+            assert h5py_file.get(sentence).shape == (3, len(sentence.split()), 32)
 
     def test_batch_embedding_works(self):
         tempdir = tempfile.mkdtemp()
@@ -67,44 +67,10 @@ class TestElmoCommand(ElmoTestCase):
         assert os.path.exists(output_path)
 
         with h5py.File(output_path, 'r') as h5py_file:
-            assert list(h5py_file.keys()) == ["0", "1"]
+            assert set(h5py_file.keys()) == set(sentences)
             # The vectors in the test configuration are smaller (32 length)
-            for i, sentence in enumerate(sentences):
-                assert h5py_file.get(str(i)).shape == (3, len(sentence.split()), 32)
-
-    def test_batch_embedding_works_with_sentence_key(self):
-        tempdir = tempfile.mkdtemp()
-        sentences_path = os.path.join(tempdir, "sentences.txt")
-        output_path = os.path.join(tempdir, "output.txt")
-
-        sentences = [
-                "A Michael went to the store to buy some eggs .",
-                "B Joel rolled down the street on his skateboard ."
-        ]
-
-        with open(sentences_path, 'w') as f:
-            for line in sentences:
-                f.write(line + '\n')
-
-        sys.argv = ["run.py",  # executable
-                    "elmo",  # command
-                    sentences_path,
-                    output_path,
-                    "--options-file",
-                    self.options_file,
-                    "--weight-file",
-                    self.weight_file,
-                    "--use-sentence-key"]
-
-        main()
-
-        assert os.path.exists(output_path)
-
-        with h5py.File(output_path, 'r') as h5py_file:
-            assert list(h5py_file.keys()) == ["A", "B"]
-            # The vectors in the test configuration are smaller (32 length)
-            assert h5py_file.get("A").shape == (3, len(sentences[0].split()) - 1, 32)
-            assert h5py_file.get("B").shape == (3, len(sentences[1].split()) - 1, 32)
+            for sentence in sentences:
+                assert h5py_file.get(sentence).shape == (3, len(sentence.split()), 32)
 
 
 class TestElmoEmbedder(ElmoTestCase):


### PR DESCRIPTION
I think this is an improvement:

* It removes an argument that's a bit confusing.
* We no longer use stringified numbers as keys.
* When you run elmo, you don't need a separate file for the source sentences.

It's reasonably clear that sentences are encoded in UTF when used as names for datasets (see http://docs.h5py.org/en/latest/high/group.html?highlight=utf).

If for some reason we don't want this, I plan to store the sentence text as an attribute on the dataset.