### PR TITLE
Warn on duplicate sentences

### DIFF
--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -258,11 +258,14 @@ class ElmoEmbedder():
         logger.info("Processing sentences.")
         with h5py.File(output_file_path, 'w') as fout:
             for key, embeddings in Tqdm.tqdm(embedded_sentences):
-                fout.create_dataset(
-                        str(key),
-                        embeddings.shape, dtype='float32',
-                        data=embeddings
-                )
+                if key in fout.keys():
+                    logger.warning(f"Key already exists in {output_file_path}, skipping: {key}")
+                else:
+                    fout.create_dataset(
+                            str(key),
+                            embeddings.shape, dtype='float32',
+                            data=embeddings
+                    )
         input_file.close()
 
 def elmo_command(args):

--- a/tests/commands/elmo_test.py
+++ b/tests/commands/elmo_test.py
@@ -78,8 +78,8 @@ class TestElmoCommand(ElmoTestCase):
         output_path = os.path.join(tempdir, "output.txt")
 
         sentences = [
-            "Michael went to the store to buy some eggs .",
-            "Michael went to the store to buy some eggs .",
+                "Michael went to the store to buy some eggs .",
+                "Michael went to the store to buy some eggs .",
         ]
 
         with open(sentences_path, 'w') as f:

--- a/tests/commands/elmo_test.py
+++ b/tests/commands/elmo_test.py
@@ -100,6 +100,7 @@ class TestElmoCommand(ElmoTestCase):
         assert os.path.exists(output_path)
 
         with h5py.File(output_path, 'r') as h5py_file:
+            assert len(h5py_file.keys()) == 1
             assert set(h5py_file.keys()) == set(sentences)
             # The vectors in the test configuration are smaller (32 length)
             for sentence in set(sentences):

--- a/tests/commands/elmo_test.py
+++ b/tests/commands/elmo_test.py
@@ -72,6 +72,39 @@ class TestElmoCommand(ElmoTestCase):
             for sentence in sentences:
                 assert h5py_file.get(sentence).shape == (3, len(sentence.split()), 32)
 
+    def test_duplicate_sentences(self):
+        tempdir = tempfile.mkdtemp()
+        sentences_path = os.path.join(tempdir, "sentences.txt")
+        output_path = os.path.join(tempdir, "output.txt")
+
+        sentences = [
+            "Michael went to the store to buy some eggs .",
+            "Michael went to the store to buy some eggs .",
+        ]
+
+        with open(sentences_path, 'w') as f:
+            for line in sentences:
+                f.write(line + '\n')
+
+        sys.argv = ["run.py",  # executable
+                    "elmo",  # command
+                    sentences_path,
+                    output_path,
+                    "--options-file",
+                    self.options_file,
+                    "--weight-file",
+                    self.weight_file]
+
+        main()
+
+        assert os.path.exists(output_path)
+
+        with h5py.File(output_path, 'r') as h5py_file:
+            assert set(h5py_file.keys()) == set(sentences)
+            # The vectors in the test configuration are smaller (32 length)
+            for sentence in set(sentences):
+                assert h5py_file.get(sentence).shape == (3, len(sentence.split()), 32)
+
 
 class TestElmoEmbedder(ElmoTestCase):
     def test_embeddings_are_as_expected(self):


### PR DESCRIPTION
Previously duplicate sentences would cause an error when running the ELMo command.  This change outputs a warning and continues instead.