### PR TITLE
Pass through Beaker commands in run_with_beaker.py.

### DIFF
--- a/scripts/ai2-internal/run_with_beaker.py
+++ b/scripts/ai2-internal/run_with_beaker.py
@@ -6,13 +6,14 @@ import argparse
 import os
 import subprocess
 import sys
+from typing import List
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(os.path.join(__file__, os.pardir), os.pardir))))
 
 from allennlp.commands.train import Train
 from allennlp.common.params import Params
 
-def main(param_file, extra_beaker_commands):
+def main(param_file: str, extra_beaker_commands: List[str]):
     ecr_repository = "896129387501.dkr.ecr.us-west-2.amazonaws.com"
     commit = subprocess.check_output(["git", "rev-parse", "HEAD"], universal_newlines=True).strip()
     image = f"{ecr_repository}/allennlp/allennlp:{commit}"

--- a/scripts/ai2-internal/run_with_beaker.py
+++ b/scripts/ai2-internal/run_with_beaker.py
@@ -29,16 +29,15 @@ def main(param_file, extra_beaker_commands):
     # Get temporary ecr login. For this command to work, you need the python awscli
     # package with a version more recent than 1.11.91.
     print("Logging into ECR")
-    # subprocess.run('eval $(aws --region=us-west-2 ecr get-login --no-include-email)', shell=True, check=True)
+    subprocess.run('eval $(aws --region=us-west-2 ecr get-login --no-include-email)', shell=True, check=True)
 
     print(f"Building the Docker image ({image})")
-    # subprocess.run(f'docker build -t {image} .', shell=True, check=True)
+    subprocess.run(f'docker build -t {image} .', shell=True, check=True)
 
     print(f"Pushing the Docker image ({image})")
-    # subprocess.run(f'docker push {image}', shell=True, check=True)
+    subprocess.run(f'docker push {image}', shell=True, check=True)
 
-    # config_dataset_id = subprocess.check_output(f'beaker dataset create --quiet {param_file}', shell=True, universal_newlines=True).strip()
-    config_dataset_id = "BOGUS"
+    config_dataset_id = subprocess.check_output(f'beaker dataset create --quiet {param_file}', shell=True, universal_newlines=True).strip()
     filename = os.path.basename(param_file)
 
     allennlp_command = [
@@ -64,7 +63,7 @@ def main(param_file, extra_beaker_commands):
             f"{config_dataset_id}:/config.json",
             '--gpu-count=1'] + extra_beaker_commands + [image] + allennlp_command
     print(' '.join(command))
-    # subprocess.run(command, check=True)
+    subprocess.run(command, check=True)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/scripts/ai2-internal/run_with_beaker.py
+++ b/scripts/ai2-internal/run_with_beaker.py
@@ -93,8 +93,8 @@ if __name__ == "__main__":
     if args.source:
         extra_beaker_commands.extend([f"--source={source}" for source in args.source])
     if args.cpu:
-        extra_beaker_commands.append(f"--cpu={cpu}")
+        extra_beaker_commands.append(f"--cpu={args.cpu}")
     if args.memory:
-        extra_beaker_commands.append(f"--memory={memory}")
+        extra_beaker_commands.append(f"--memory={args.memory}")
 
     main(args.param_file, extra_beaker_commands)


### PR DESCRIPTION
Adding each command is a bit of a pain, but it provides excellent usage strings for our users.  Unfortunately `run_with_beaker.py` needs to be modified when Beaker changes it's commands under `beaker experiment run`.