### PR TITLE
Handle padding in ListField[ArrayField]

### DIFF
--- a/allennlp/data/fields/array_field.py
+++ b/allennlp/data/fields/array_field.py
@@ -45,4 +45,6 @@ class ArrayField(Field[numpy.ndarray]):
 
     @overrides
     def empty_field(self):  # pylint: disable=no-self-use
-        return ArrayField(numpy.array([], dtype="float32"))
+        # pass the padding_value, so that any outer field, e.g., ` ListField[ArrayField]` uses the
+        # same padding_value in the padded ArrayFields
+        return ArrayField(numpy.array([], dtype="float32"), padding_value=self.padding_value)

--- a/allennlp/data/fields/array_field.py
+++ b/allennlp/data/fields/array_field.py
@@ -45,6 +45,6 @@ class ArrayField(Field[numpy.ndarray]):
 
     @overrides
     def empty_field(self):  # pylint: disable=no-self-use
-        # Pass the padding_value, so that any outer field, e.g., ` ListField[ArrayField]` uses the
+        # Pass the padding_value, so that any outer field, e.g., `ListField[ArrayField]` uses the
         # same padding_value in the padded ArrayFields
         return ArrayField(numpy.array([], dtype="float32"), padding_value=self.padding_value)

--- a/allennlp/data/fields/array_field.py
+++ b/allennlp/data/fields/array_field.py
@@ -45,6 +45,6 @@ class ArrayField(Field[numpy.ndarray]):
 
     @overrides
     def empty_field(self):  # pylint: disable=no-self-use
-        # pass the padding_value, so that any outer field, e.g., ` ListField[ArrayField]` uses the
+        # Pass the padding_value, so that any outer field, e.g., ` ListField[ArrayField]` uses the
         # same padding_value in the padded ArrayFields
         return ArrayField(numpy.array([], dtype="float32"), padding_value=self.padding_value)

--- a/tests/data/fields/array_field_test.py
+++ b/tests/data/fields/array_field_test.py
@@ -38,3 +38,18 @@ class TestArrayField(AllenNlpTestCase):
                                       [[0., 0., 0., 0., 0.],
                                        [0., 0., 0., 0., 0.]]])
         numpy.testing.assert_array_equal(returned_tensor, correct_tensor)
+
+    def test_padding_handles_list_fields_with_padding_values(self):
+        array1 = ArrayField(numpy.ones([2, 3]), padding_value=-1)
+        array2 = ArrayField(numpy.ones([1, 5]), padding_value=-1)
+        empty_array = array1.empty_field()
+        list_field = ListField([array1, array2, empty_array])
+
+        returned_tensor = list_field.as_tensor(list_field.get_padding_lengths()).data.cpu().numpy()
+        correct_tensor = numpy.array([[[1., 1., 1., -1., -1.],
+                                       [1., 1., 1., -1., -1.]],
+                                      [[1., 1., 1., 1., 1.],
+                                       [-1., -1., -1., -1., -1.]],
+                                      [[-1., -1., -1., -1., -1.],
+                                       [-1., -1., -1., -1., -1.]]])
+        numpy.testing.assert_array_equal(returned_tensor, correct_tensor)


### PR DESCRIPTION
`ListField[ArrayField]` pads the list with empty `ArrayField`s. But it uses the default padding value=0 and can lead to the model incorrectly assuming the padded arrays to be filled. This change modifies the `empty_field` to also pass the `padding_value` to the padded `ArrayField` object.

Thoughts ?