### PR TITLE
Some minor flag fixes for the beaker script

### DIFF
--- a/scripts/ai2-internal/run_with_beaker.py
+++ b/scripts/ai2-internal/run_with_beaker.py
@@ -69,7 +69,7 @@ def main(param_file: str, extra_beaker_commands: List[str]):
             '/output',
             "--source",
             f"{config_dataset_id}:/config.json",
-            '--gpu-count=1'] + extra_beaker_commands + [image] + allennlp_command
+            '--gpu-count=1'] + env + extra_beaker_commands + [image] + allennlp_command
     print(' '.join(command))
     subprocess.run(command, check=True)
 
@@ -77,9 +77,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument('param_file', type=str, help='The model configuration file.')
-    parser.add_argument('--desc', type=str, required=True, help='A description for the experiment.')
+    parser.add_argument('--desc', type=str, help='A description for the experiment.')
     parser.add_argument('--debug', action='store_true', help='Print verbose stack traces on error.')
-    parser.add_argument('--detach', action='store_true', help='Run experiment in the background and print its ID.')
     parser.add_argument('--env', action='append', help='Set environment variables (e.g. NAME=value or NAME)')
     parser.add_argument('--mount', action='append', help='Bind a host directory (e.g. /host/path:/target/path)')
     parser.add_argument('--source', action='append', help='Bind a remote data source (e.g. source-id:/target/path)')
@@ -89,11 +88,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     extra_beaker_commands = []
-    extra_beaker_commands.append(f'--desc={args.desc}'),
+    if args.desc:
+        extra_beaker_commands.append(f'--desc={args.desc}'),
     if args.debug:
         extra_beaker_commands.append("--debug")
-    if args.detach:
-        extra_beaker_commands.append("--detach")
     if args.env:
         extra_beaker_commands.extend([f"--env={env}" for env in args.env])
     if args.mount:


### PR DESCRIPTION
@schmmd, these are some fixes from me actually using this script today.

I would prefer to have the environment variables in the script; did you ask @nikett, @tusharkhot, or anyone else whether they have a preference here?  Yes, it makes the "experiment" page really ugly, but that's not the page you look at for an allennlp experiment, and it seems fine on the "task" page.

The description should be optional, I think.

And the `--detach` flag doesn't really do anything in beaker at this point, and will probably be removed (per some discussion in the `beaker-users` slack channel).