### PR TITLE
Fix tqdm behavior around lazy datasets

### DIFF
--- a/allennlp/common/__init__.py
+++ b/allennlp/common/__init__.py
@@ -1,3 +1,4 @@
 from allennlp.common.params import Params
 from allennlp.common.registrable import Registrable
+from allennlp.common.tqdm import Tqdm
 from allennlp.common.util import JsonDict

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -7,7 +7,6 @@ from overrides import overrides
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
-from allennlp.common.tqdm import Tqdm
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import TextField, SequenceLabelField, Field
 from allennlp.data.instance import Instance
@@ -83,7 +82,7 @@ class Conll2003DatasetReader(DatasetReader):
             logger.info("Reading instances from lines in file at: %s", file_path)
 
             # Group into alternative divider / sentence chunks.
-            for is_divider, lines in Tqdm.tqdm(itertools.groupby(data_file, _is_divider)):
+            for is_divider, lines in itertools.groupby(data_file, _is_divider):
                 # Ignore the divider chunks, so that `lines` corresponds to the words
                 # of a single sentence.
                 if not is_divider:
@@ -113,7 +112,6 @@ class Conll2003DatasetReader(DatasetReader):
                         instance_fields['tags'] = SequenceLabelField(chunk_tags, sequence)
 
                     yield Instance(instance_fields)
-
 
     def text_to_instance(self, tokens: List[Token]) -> Instance:  # type: ignore
         """

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -6,7 +6,6 @@ from overrides import overrides
 
 from allennlp.common import Params
 from allennlp.common.file_utils import cached_path
-from allennlp.common.tqdm import Tqdm
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import Field, ListField, TextField, SpanField, MetadataField, SequenceLabelField
 from allennlp.data.instance import Instance
@@ -87,7 +86,7 @@ class ConllCorefReader(DatasetReader):
         file_path = cached_path(file_path)
 
         ontonotes_reader = Ontonotes()
-        for sentences in Tqdm.tqdm(ontonotes_reader.dataset_document_iterator(file_path)):
+        for sentences in ontonotes_reader.dataset_document_iterator(file_path):
             clusters: DefaultDict[int, List[Tuple[int, int]]] = collections.defaultdict(list)
 
             total_tokens = 0

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -2,7 +2,7 @@ from typing import Iterable, Iterator, Callable
 import logging
 
 from allennlp.data.instance import Instance
-from allennlp.common import Params
+from allennlp.common import Params, Tqdm
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.registrable import Registrable
 from allennlp.common.util import ensure_list
@@ -49,9 +49,7 @@ class DatasetReader(Registrable):
         in the specified dataset.
 
         If ``self.lazy`` is False, this calls ``self._read()``,
-        calls ``ensure_list`` on the result (which is a no-op if
-        self._read() returns a list, which most of the existing
-        dataset readers do), and returns the resulting list.
+        ensures that the result is a list, then returns the resulting list.
 
         If ``self.lazy`` is True, this returns an object whose
         ``__iter__`` method calls ``self._read()`` each iteration.
@@ -71,7 +69,9 @@ class DatasetReader(Registrable):
         if lazy:
             return _LazyInstances(lambda: iter(self._read(file_path)))
         else:
-            instances = ensure_list(self._read(file_path))
+            instances = self._read(file_path)
+            if not isinstance(instances, list):
+                instances = [instance for instance in Tqdm.tqdm(instances)]
             if not instances:
                 raise ConfigurationError("No instances were read from the given filepath {}. "
                                          "Is the path correct?".format(file_path))

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -5,7 +5,6 @@ from allennlp.data.instance import Instance
 from allennlp.common import Params, Tqdm
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.registrable import Registrable
-from allennlp.common.util import ensure_list
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/allennlp/data/dataset_readers/dataset_utils/ontonotes.py
+++ b/allennlp/data/dataset_readers/dataset_utils/ontonotes.py
@@ -6,8 +6,6 @@ import logging
 
 from nltk import Tree
 
-from allennlp.common.tqdm import Tqdm
-
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 TypedSpan = Tuple[int, Tuple[int, int]]  # pylint: disable=invalid-name
@@ -189,7 +187,7 @@ class Ontonotes:
         containing CONLL-formatted files.
         """
         logger.info("Reading CONLL sentences from dataset files at: %s", file_path)
-        for root, _, files in Tqdm.tqdm(list(os.walk(file_path))):
+        for root, _, files in list(os.walk(file_path)):
             for data_file in files:
                 # These are a relic of the dataset pre-processing. Every
                 # file will be duplicated - one file called filename.gold_skel

--- a/allennlp/data/dataset_readers/penn_tree_bank.py
+++ b/allennlp/data/dataset_readers/penn_tree_bank.py
@@ -10,7 +10,6 @@ from nltk.tree import Tree
 
 from allennlp.common import Params
 from allennlp.common.file_utils import cached_path
-from allennlp.common.tqdm import Tqdm
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import TextField, SpanField, SequenceLabelField, ListField, Field
 from allennlp.data.instance import Instance
@@ -52,7 +51,7 @@ class PennTreeBankConstituencySpanDatasetReader(DatasetReader):
         directory, filename = os.path.split(file_path)
         logger.info("Reading instances from lines in file at: %s", file_path)
 
-        for parse in Tqdm.tqdm(BracketParseCorpusReader(root=directory, fileids=[filename]).parsed_sents()):
+        for parse in BracketParseCorpusReader(root=directory, fileids=[filename]).parsed_sents():
             yield self.text_to_instance(parse.leaves(), [x[1] for x in parse.pos()], parse)
 
     @overrides

--- a/allennlp/data/dataset_readers/reading_comprehension/squad.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/squad.py
@@ -6,7 +6,6 @@ from overrides import overrides
 
 from allennlp.common import Params
 from allennlp.common.file_utils import cached_path
-from allennlp.common.tqdm import Tqdm
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.instance import Instance
 from allennlp.data.dataset_readers.reading_comprehension import util
@@ -55,7 +54,7 @@ class SquadReader(DatasetReader):
             dataset_json = json.load(dataset_file)
             dataset = dataset_json['data']
         logger.info("Reading the dataset")
-        for article in Tqdm.tqdm(dataset):
+        for article in dataset:
             for paragraph_json in article['paragraphs']:
                 paragraph = paragraph_json["context"]
                 tokenized_paragraph = self._tokenizer.tokenize(paragraph)

--- a/allennlp/data/dataset_readers/reading_comprehension/triviaqa.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/triviaqa.py
@@ -8,7 +8,6 @@ from overrides import overrides
 
 from allennlp.common import Params
 from allennlp.common.file_utils import cached_path
-from allennlp.common.tqdm import Tqdm
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.instance import Instance
 from allennlp.data.dataset_readers.reading_comprehension import util
@@ -78,7 +77,7 @@ class TriviaQaReader(DatasetReader):
             data_json = json.loads(base_tarball.extractfile(path).read().decode('utf-8'))
 
         logger.info("Reading the dataset")
-        for question_json in Tqdm.tqdm(data_json['Data']):
+        for question_json in data_json['Data']:
             question_text = question_json['Question']
             question_tokens = self._tokenizer.tokenize(question_text)
 

--- a/allennlp/data/dataset_readers/seq2seq.py
+++ b/allennlp/data/dataset_readers/seq2seq.py
@@ -5,7 +5,6 @@ from overrides import overrides
 
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
-from allennlp.common.tqdm import Tqdm
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import TextField
 from allennlp.data.instance import Instance
@@ -66,7 +65,7 @@ class Seq2SeqDatasetReader(DatasetReader):
     def _read(self, file_path):
         with open(file_path, "r") as data_file:
             logger.info("Reading instances from lines in file at: %s", file_path)
-            for line_num, line in enumerate(Tqdm.tqdm(data_file)):
+            for line_num, line in enumerate(data_file):
                 line = line.strip("\n")
 
                 if not line:

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -5,7 +5,6 @@ from overrides import overrides
 
 from allennlp.common import Params
 from allennlp.common.file_utils import cached_path
-from allennlp.common.tqdm import Tqdm
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import TextField, SequenceLabelField
 from allennlp.data.instance import Instance
@@ -56,7 +55,7 @@ class SequenceTaggingDatasetReader(DatasetReader):
         with open(file_path, "r") as data_file:
 
             logger.info("Reading instances from lines in file at: %s", file_path)
-            for line in Tqdm.tqdm(data_file):
+            for line in data_file:
                 line = line.strip("\n")
 
                 # skip blank lines

--- a/allennlp/data/dataset_readers/snli.py
+++ b/allennlp/data/dataset_readers/snli.py
@@ -6,7 +6,6 @@ from overrides import overrides
 
 from allennlp.common import Params
 from allennlp.common.file_utils import cached_path
-from allennlp.common.tqdm import Tqdm
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.fields import Field, TextField, LabelField
 from allennlp.data.instance import Instance
@@ -47,7 +46,7 @@ class SnliReader(DatasetReader):
 
         with open(file_path, 'r') as snli_file:
             logger.info("Reading SNLI instances from jsonl dataset at: %s", file_path)
-            for line in Tqdm.tqdm(snli_file):
+            for line in snli_file:
                 example = json.loads(line)
 
                 label = example["gold_label"]


### PR DESCRIPTION
Fixes #814.

Having `tqdm` in the `DatasetReader` subclasses doesn't play nicely with `lazy=True`, because you get a `tqdm` line for the dataset reader in every batch during training.  The better place to have `tqdm` is in the base class, when converting the generator into a list.  This PR removes the `tqdm` calls from the subclasses and adds one to the base class.