### PR TITLE
add constrained decoding for CRFs

### DIFF
--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -32,7 +32,7 @@ class CrfTagger(Model):
         This is needed to compute the SpanBasedF1Measure metric.
         Unless you did something unusual, the default value should be what you want.
     constraint_type : ``str``, optional (default=``None``)
-        If provided, the CRF will be constrained at inference time
+        If provided, the CRF will be constrained at decoding time
         to produce valid labels based on the specified type (e.g. "BIO", or "BIOUL").
     initializer : ``InitializerApplicator``, optional (default=``InitializerApplicator()``)
         Used to initialize the model parameters.

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -53,14 +53,13 @@ class CrfTagger(Model):
         self.tag_projection_layer = TimeDistributed(Linear(self.encoder.get_output_dim(),
                                                            self.num_tags))
 
-
         if constraint_type is not None:
             labels = self.vocab.get_index_to_token_vocabulary(label_namespace)
-            allowed_trans = allowed_transitions(constraint_type, labels)
+            constraints = allowed_transitions(constraint_type, labels)
         else:
-            allowed_trans = None
+            constraints = None
 
-        self.crf = ConditionalRandomField(self.num_tags, allowed_trans)
+        self.crf = ConditionalRandomField(self.num_tags, constraints)
 
         self.span_metric = SpanBasedF1Measure(vocab, tag_namespace=label_namespace)
 

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -31,6 +31,9 @@ class CrfTagger(Model):
     label_namespace : ``str``, optional (default=``labels``)
         This is needed to compute the SpanBasedF1Measure metric.
         Unless you did something unusual, the default value should be what you want.
+    constraint_type : ``str``, optional (default=``None``)
+        If provided, the CRF will be constrained at inference time
+        to produce valid labels based on the specified type (e.g. "BIO", or "BIOUL").
     initializer : ``InitializerApplicator``, optional (default=``InitializerApplicator()``)
         Used to initialize the model parameters.
     regularizer : ``RegularizerApplicator``, optional (default=``None``)

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -8,6 +8,7 @@ from allennlp.common import Params
 from allennlp.common.checks import check_dimensions_match
 from allennlp.data import Vocabulary
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder, ConditionalRandomField
+from allennlp.modules.conditional_random_field import allowed_transitions
 from allennlp.models.model import Model
 from allennlp.nn import InitializerApplicator, RegularizerApplicator
 import allennlp.nn.util as util
@@ -40,6 +41,7 @@ class CrfTagger(Model):
                  text_field_embedder: TextFieldEmbedder,
                  encoder: Seq2SeqEncoder,
                  label_namespace: str = "labels",
+                 constraint_type: str = None,
                  initializer: InitializerApplicator = InitializerApplicator(),
                  regularizer: Optional[RegularizerApplicator] = None) -> None:
         super().__init__(vocab, regularizer)
@@ -50,7 +52,15 @@ class CrfTagger(Model):
         self.encoder = encoder
         self.tag_projection_layer = TimeDistributed(Linear(self.encoder.get_output_dim(),
                                                            self.num_tags))
-        self.crf = ConditionalRandomField(self.num_tags)
+
+
+        if constraint_type is not None:
+            labels = self.vocab.get_index_to_token_vocabulary(label_namespace)
+            allowed_trans = allowed_transitions(constraint_type, labels)
+        else:
+            allowed_trans = None
+
+        self.crf = ConditionalRandomField(self.num_tags, allowed_trans)
 
         self.span_metric = SpanBasedF1Measure(vocab, tag_namespace=label_namespace)
 
@@ -143,6 +153,7 @@ class CrfTagger(Model):
         text_field_embedder = TextFieldEmbedder.from_params(vocab, embedder_params)
         encoder = Seq2SeqEncoder.from_params(params.pop("encoder"))
         label_namespace = params.pop("label_namespace", "labels")
+        constraint_type = params.pop("constraint_type", None)
         initializer = InitializerApplicator.from_params(params.pop('initializer', []))
         regularizer = RegularizerApplicator.from_params(params.pop('regularizer', []))
 
@@ -152,5 +163,6 @@ class CrfTagger(Model):
                    text_field_embedder=text_field_embedder,
                    encoder=encoder,
                    label_namespace=label_namespace,
+                   constraint_type=constraint_type,
                    initializer=initializer,
                    regularizer=regularizer)

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -68,7 +68,8 @@ class ConditionalRandomField(torch.nn.Module):
     num_tags : int, required
         The number of tags.
     constraints : List[Tuple[int, int]], optional (default: None)
-        If provided, only these transitions are allowed.
+        An optional list of allowed transitions (from_tag_id, to_tag_id).
+        These are applied to ``viterbi_tags()`` but do not affect ``forward()``.
     """
     def __init__(self,
                  num_tags: int,

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -16,10 +16,8 @@ def allowed_transitions(constraint_type: str, tokens: Dict[int, str]) -> List[Tu
     """
     allowed = []
     if constraint_type == "BIOUL":
-        for i, from_label in tokens.items():
-            from_bioul, *from_entity = from_label
-            for j, to_label in tokens.items():
-                to_bioul, *to_entity = to_label
+        for i, (from_bioul, *from_entity) in tokens.items():
+            for j, (to_bioul, *to_entity) in tokens.items():
 
                 is_allowed = any([
                         # O can transition to O, B-* or U-*
@@ -35,16 +33,14 @@ def allowed_transitions(constraint_type: str, tokens: Dict[int, str]) -> List[Tu
                     allowed.append((i, j))
 
     elif constraint_type == "BIO":
-        for i, from_label in tokens.items():
-            from_bio, *from_entity = from_label
-            for j, to_label in tokens.items():
-                to_bio, *to_entity = to_label
+        for i, (from_bio, *from_entity) in tokens.items():
+            for j, (to_bio, *to_entity) in tokens.items():
 
                 is_allowed = any([
                         # Can always transition to O or B-x
                         to_bio in ('O', 'B'),
                         # Can only transition to I-x from B-x or I-x
-                        from_bio in ('B', 'I') and to_bio == 'I' and from_entity == to_entity
+                        to_bio == 'I' and from_bio in ('B', 'I') and from_entity == to_entity
                 ])
 
                 if is_allowed:

--- a/tests/modules/conditional_random_field_test.py
+++ b/tests/modules/conditional_random_field_test.py
@@ -171,7 +171,7 @@ class TestConditionalRandomField(AllenNlpTestCase):
         bio_labels = ['O', 'B-X', 'I-X', 'B-Y', 'I-Y']
         #              0     1      2      3      4
         allowed = allowed_transitions("BIO", dict(enumerate(bio_labels)))
-        assert allowed == {
+        assert set(allowed) == {
             (0, 0), (0, 1),         (0, 3),
             (1, 0), (1, 1), (1, 2), (1, 3),
             (2, 0), (2, 1), (2, 2), (2, 3),
@@ -182,7 +182,7 @@ class TestConditionalRandomField(AllenNlpTestCase):
         bioul_labels = ['O', 'B-X', 'I-X', 'L-X', 'U-X', 'B-Y', 'I-Y', 'L-Y', 'U-Y']
         #                0     1      2      3      4      5      6      7      8
         allowed = allowed_transitions("BIOUL", dict(enumerate(bioul_labels)))
-        assert allowed == {
+        assert set(allowed) == {
             (0, 0), (0, 1),                 (0, 4), (0, 5),                 (0, 8),
                             (1, 2), (1, 3),
                             (2, 2), (2, 3),

--- a/tests/modules/conditional_random_field_test.py
+++ b/tests/modules/conditional_random_field_test.py
@@ -171,6 +171,8 @@ class TestConditionalRandomField(AllenNlpTestCase):
         bio_labels = ['O', 'B-X', 'I-X', 'B-Y', 'I-Y']
         #              0     1      2      3      4
         allowed = allowed_transitions("BIO", dict(enumerate(bio_labels)))
+
+        # The empty spaces in this matrix indicate disallowed transitions.
         assert set(allowed) == {
             (0, 0), (0, 1),         (0, 3),
             (1, 0), (1, 1), (1, 2), (1, 3),
@@ -182,6 +184,8 @@ class TestConditionalRandomField(AllenNlpTestCase):
         bioul_labels = ['O', 'B-X', 'I-X', 'L-X', 'U-X', 'B-Y', 'I-Y', 'L-Y', 'U-Y']
         #                0     1      2      3      4      5      6      7      8
         allowed = allowed_transitions("BIOUL", dict(enumerate(bioul_labels)))
+
+        # The empty spaces in this matrix indicate disallowed transitions.
         assert set(allowed) == {
             (0, 0), (0, 1),                 (0, 4), (0, 5),                 (0, 8),
                             (1, 2), (1, 3),

--- a/tests/modules/conditional_random_field_test.py
+++ b/tests/modules/conditional_random_field_test.py
@@ -2,11 +2,13 @@
 import itertools
 import math
 
-from pytest import approx
+from pytest import approx, raises
 import torch
 from torch.autograd import Variable
 
 from allennlp.modules import ConditionalRandomField
+from allennlp.modules.conditional_random_field import allowed_transitions
+from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
 
 
@@ -138,3 +140,59 @@ class TestConditionalRandomField(AllenNlpTestCase):
             most_likely_tags.append(list(most_likely))
 
         assert viterbi_tags == most_likely_tags
+
+    def test_constrained_viterbi_tags(self):
+        constraints = {(0, 0), (0, 1),
+                       (1, 1), (1, 2),
+                       (2, 2), (2, 3),
+                       (3, 3), (3, 4),
+                       (4, 4), (4, 0)}
+
+        crf = ConditionalRandomField(num_tags=5, constraints=constraints)
+        crf.transitions = torch.nn.Parameter(self.transitions)
+        crf.start_transitions = torch.nn.Parameter(self.transitions_from_start)
+        crf.end_transitions = torch.nn.Parameter(self.transitions_to_end)
+
+        mask = Variable(torch.LongTensor([
+                [1, 1, 1],
+                [1, 1, 0]
+        ]))
+
+        viterbi_tags = crf.viterbi_tags(self.logits, mask)
+
+        # Now the tags should respect the constraints
+        assert viterbi_tags == [
+                [2, 3, 3],
+                [2, 3]
+        ]
+
+    def test_allowed_transitions(self):
+        # pylint: disable=bad-whitespace,bad-continuation
+        bio_labels = ['O', 'B-X', 'I-X', 'B-Y', 'I-Y']
+        #              0     1      2      3      4
+        allowed = allowed_transitions("BIO", dict(enumerate(bio_labels)))
+        assert allowed == {
+            (0, 0), (0, 1),         (0, 3),
+            (1, 0), (1, 1), (1, 2), (1, 3),
+            (2, 0), (2, 1), (2, 2), (2, 3),
+            (3, 0), (3, 1),         (3, 3), (3, 4),
+            (4, 0), (4, 1),         (4, 3), (4, 4)
+        }
+
+        bioul_labels = ['O', 'B-X', 'I-X', 'L-X', 'U-X', 'B-Y', 'I-Y', 'L-Y', 'U-Y']
+        #                0     1      2      3      4      5      6      7      8
+        allowed = allowed_transitions("BIOUL", dict(enumerate(bioul_labels)))
+        assert allowed == {
+            (0, 0), (0, 1),                 (0, 4), (0, 5),                 (0, 8),
+                            (1, 2), (1, 3),
+                            (2, 2), (2, 3),
+            (3, 0), (3, 1),                 (3, 4), (3, 5),                 (3, 8),
+            (4, 0), (4, 1),                 (4, 4), (4, 5),                 (4, 8),
+                                                            (5, 6), (5, 7),
+                                                            (6, 6), (6, 7),
+            (7, 0), (7, 1),                 (7, 4), (7, 5),                 (7, 8),
+            (8, 0), (8, 1),                 (8, 4), (8, 5),                 (8, 8)
+        }
+
+        with raises(ConfigurationError):
+            allowed_transitions("allennlp", {})


### PR DESCRIPTION
not 100% sure this is the best way to implement it, lmk what you think.

```
echo '{"sentence": "Sailing around the New York Harbor can be as educating as it is soothing."}' > examples.jsonl && python -m allennlp.run predict     https://s3-us-west-2.amazonaws.com/allennlp/models/ner-model-2017.11.15.tar.gz     examples.jsonl
```

results in 

```
"tags": ["O", "O", "O", "B-LOC", "I-MISC", "L-MISC", "O", "O", "O", "O", "O", "O", "O", "O", "O"]
```

but if you specify BIOUL constraints

```
echo '{"sentence": "Sailing around the New York Harbor can be as educating as it is soothing."}' > examples.jsonl && python -m allennlp.run predict     https://s3-us-west-2.amazonaws.com/allennlp/models/ner-model-2017.11.15.tar.gz     examples.jsonl -o '{"model":{"constraint_type":"BIOUL"}}'
```

you get

```
"tags": ["O", "O", "O", "B-MISC", "I-MISC", "L-MISC", "O", "O", "O", "O", "O", "O", "O", "O", "O"]
```