### PR TITLE
Make BasicTextFieldEmbedder handle higher-order inputs

### DIFF
--- a/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
@@ -7,6 +7,7 @@ from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.data import Vocabulary
 from allennlp.modules.text_field_embedders.text_field_embedder import TextFieldEmbedder
+from allennlp.modules.time_distributed import TimeDistributed
 from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 
 
@@ -34,7 +35,7 @@ class BasicTextFieldEmbedder(TextFieldEmbedder):
             output_dim += embedder.get_output_dim()
         return output_dim
 
-    def forward(self, text_field_input: Dict[str, torch.Tensor]) -> torch.Tensor:
+    def forward(self, text_field_input: Dict[str, torch.Tensor], num_wrapping_dims: int = 0) -> torch.Tensor:
         if self._token_embedders.keys() != text_field_input.keys():
             message = "Mismatched token keys: %s and %s" % (str(self._token_embedders.keys()),
                                                             str(text_field_input.keys()))
@@ -46,6 +47,8 @@ class BasicTextFieldEmbedder(TextFieldEmbedder):
             # Note: need to use getattr here so that the pytorch voodoo
             # with submodules works with multiple GPUs.
             embedder = getattr(self, 'token_embedder_{}'.format(key))
+            for _ in range(num_wrapping_dims):
+                embedder = TimeDistributed(embedder)
             token_vectors = embedder(tensor)
             embedded_representations.append(token_vectors)
         return torch.cat(embedded_representations, dim=-1)

--- a/allennlp/modules/text_field_embedders/text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/text_field_embedder.py
@@ -25,7 +25,21 @@ class TextFieldEmbedder(torch.nn.Module, Registrable):
     default_implementation = 'basic'
 
     def forward(self,  # pylint: disable=arguments-differ
-                text_field_input: Dict[str, torch.Tensor]) -> torch.Tensor:
+                text_field_input: Dict[str, torch.Tensor],
+                num_wrapping_dims: int = 0) -> torch.Tensor:
+        """
+        Parameters
+        ----------
+        text_field_input : ``Dict[str, torch.Tensor]``
+            A dictionary that was the output of a call to ``TextField.as_tensor``.  Each tensor in
+            here is assumed to have a shape roughly similar to ``(batch_size, sequence_length)``
+            (perhaps with an extra trailing dimension for the characters in each token).
+        num_wrapping_dims : ``int``, optional (default=0)
+            If you have a ``ListField[TextField]`` that created the ``text_field_input``, you'll
+            end up with tensors of shape ``(batch_size, wrapping_dim1, wrapping_dim2, ...,
+            sequence_length)``.  This parameter tells us how many wrapping dimensions there are, so
+            that we can correctly ``TimeDistribute`` the embedding of each named representation.
+        """
         raise NotImplementedError
 
     def get_output_dim(self) -> int:

--- a/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
+++ b/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
@@ -53,3 +53,31 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
 
     def test_forward_concats_resultant_embeddings(self):
         assert self.token_embedder(self.inputs).size() == (1, 4, 10)
+
+    def test_forward_works_on_higher_order_input(self):
+        params = Params({
+                "words": {
+                        "type": "embedding",
+                        "num_embeddings": 20,
+                        "embedding_dim": 2,
+                        },
+                "characters": {
+                        "type": "character_encoding",
+                        "embedding": {
+                                "embedding_dim": 4,
+                                "num_embeddings": 15,
+                                },
+                        "encoder": {
+                                "type": "cnn",
+                                "embedding_dim": 4,
+                                "num_filters": 10,
+                                "ngram_filter_sizes": [3],
+                                },
+                        }
+                })
+        token_embedder = BasicTextFieldEmbedder.from_params(self.vocab, params)
+        inputs = {
+                'words': Variable(torch.rand(3, 4, 5, 6) * 20).long(),
+                'characters': Variable(torch.rand(3, 4, 5, 6, 7) * 15).long(),
+                }
+        assert token_embedder(inputs, num_wrapping_dims=2).size() == (3, 4, 5, 6, 12)


### PR DESCRIPTION
Fixes #820.

We already require a `num_wrapping_dims` argument to `get_text_field_mask`.  It turns out we need a similar argument to the `BasicTextFieldEmbedder` also, so that CNNs work correctly (an `Embedding` is fine on higher-order input, which is probably why we didn't see this earlier).  The test I added fails before the addition of the `num_wrapping_dims` argument.