### PR TITLE
Fix OntoNotes dataset path iterator test by using set equality

### DIFF
--- a/tests/data/dataset_readers/dataset_utils/ontonotes_test.py
+++ b/tests/data/dataset_readers/dataset_utils/ontonotes_test.py
@@ -122,8 +122,10 @@ class TestOntonotes(AllenNlpTestCase):
     def test_dataset_path_iterator(self):
         reader = Ontonotes()
         files = list(reader.dataset_path_iterator('tests/fixtures/conll_2012/'))
-        assert files == ['tests/fixtures/conll_2012/subdomain/example.gold_conll',
-                         'tests/fixtures/conll_2012/subdomain2/example.gold_conll']
+        expected_paths = ['tests/fixtures/conll_2012/subdomain/example.gold_conll',
+                          'tests/fixtures/conll_2012/subdomain2/example.gold_conll']
+        assert len(files) == len(expected_paths)
+        assert set(files) == set(expected_paths)
 
     def test_ontonotes_can_read_conll_file_with_multiple_documents(self):
         reader = Ontonotes()


### PR DESCRIPTION
`Ontonotes.dataset_path_iterator` uses `os.walk` to iterate over files. `os.walk` makes no guarantees w.r.t the order of returned files (officially, [they're returned in arbitrary order](https://docs.python.org/3/library/os.html#os.listdir)). 

The test was failing on one of the machines I ran it on, so I edited the it to compare lengths and set equality.