### PR TITLE
Add a fine-tune command for continuing training on a new dataset

### DIFF
--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -3,35 +3,39 @@ import argparse
 import logging
 import sys
 
-from allennlp.commands.serve import Serve
-from allennlp.commands.predict import Predict
-from allennlp.commands.train import Train
-from allennlp.commands.evaluate import Evaluate
-from allennlp.commands.make_vocab import MakeVocab
 from allennlp.commands.elmo import Elmo
+from allennlp.commands.evaluate import Evaluate
+from allennlp.commands.fine_tune import FineTune
+from allennlp.commands.make_vocab import MakeVocab
+from allennlp.commands.predict import Predict
+from allennlp.commands.serve import Serve
 from allennlp.commands.subcommand import Subcommand
+from allennlp.commands.train import Train
 from allennlp.service.predictors import DemoModel
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
 
 def main(prog: str = None,
          model_overrides: Dict[str, DemoModel] = {},
          predictor_overrides: Dict[str, str] = {},
          subcommand_overrides: Dict[str, Subcommand] = {}) -> None:
     """
-    The :mod:`~allennlp.run` command only knows about the registered classes
-    in the ``allennlp`` codebase. In particular, once you start creating your own
-    ``Model`` s and so forth, it won't work for them. However, ``allennlp.run`` is
-    simply a wrapper around this function. To use the command line interface with your
-    own custom classes, just create your own script that imports all of the classes you want
-    and then calls ``main()``.
+    The :mod:`~allennlp.run` command only knows about the registered classes in the ``allennlp``
+    codebase. In particular, once you start creating your own ``Model`` s and so forth, it won't
+    work for them, unless you use the ``--include-package`` flag available for most commands.
 
-    The default models for ``serve`` and the default predictors for ``predict`` are
-    defined above. If you'd like to add more or use different ones, the
-    ``model_overrides`` and ``predictor_overrides`` arguments will take precedence over the defaults.
+    The default models for ``serve`` and the default predictors for ``predict`` are defined above.
+    If you'd like to add more or use different ones, the ``model_overrides`` and
+    ``predictor_overrides`` arguments will take precedence over the defaults.
     """
     # pylint: disable=dangerous-default-value
 
+    # TODO(mattg): is it feasible to add `--include-package` somewhere in here, so it's included by
+    # all commands, instead of needing to be added manually for each one?
+
+    # TODO(mattg): is it the `[command]` here in the usage parameter that causes the funny
+    # duplication we see in the module docstrings?
     parser = argparse.ArgumentParser(description="Run AllenNLP", usage='%(prog)s [command]', prog=prog)
     subparsers = parser.add_subparsers(title='Commands', metavar='')
 
@@ -43,6 +47,7 @@ def main(prog: str = None,
             "serve": Serve(model_overrides),
             "make-vocab": MakeVocab(),
             "elmo": Elmo(),
+            "fine-tune": FineTune(),
 
             # Superseded by overrides
             **subcommand_overrides

--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -24,12 +24,14 @@ def main(prog: str = None,
     The :mod:`~allennlp.run` command only knows about the registered classes in the ``allennlp``
     codebase. In particular, once you start creating your own ``Model`` s and so forth, it won't
     work for them, unless you use the ``--include-package`` flag available for most commands.
-
-    The default models for ``serve`` and the default predictors for ``predict`` are defined above.
-    If you'd like to add more or use different ones, the ``model_overrides`` and
-    ``predictor_overrides`` arguments will take precedence over the defaults.
     """
     # pylint: disable=dangerous-default-value
+
+    # TODO(mattg): document and/or remove the `predictor_overrides` and `model_overrides` commands.
+    # The `--predictor` option for the `predict` command largely removes the need for
+    # `predictor_overrides`, and I think the simple server largely removes the need for
+    # `model_overrides`, and maybe the whole `serve` command as a public API (we only need that
+    # path for demo.allennlp.org, and it's not likely anyone else would host that particular demo).
 
     # TODO(mattg): is it feasible to add `--include-package` somewhere in here, so it's included by
     # all commands, instead of needing to be added manually for each one?

--- a/allennlp/commands/fine_tune.py
+++ b/allennlp/commands/fine_tune.py
@@ -1,0 +1,202 @@
+"""
+The ``fine-tune`` subcommand is used to continue training (or `fine-tune`) a model on a `different
+dataset` than the one it was originally trained on.  It requires a saved model archive file, a path
+to the data you will continue training with, and a directory in which to write the results.
+
+Run ``python -m allennlp.run fine-tune --help`` for detailed usage information.
+"""
+import argparse
+import json
+import logging
+import os
+import sys
+from copy import deepcopy
+
+from allennlp.commands.subcommand import Subcommand
+from allennlp.commands.train import datasets_from_params
+from allennlp.common.tee_logger import TeeLogger
+from allennlp.common.tqdm import Tqdm
+from allennlp.common.util import prepare_environment, import_submodules
+from allennlp.data.iterators.data_iterator import DataIterator
+from allennlp.models import Archive, load_archive, archive_model
+from allennlp.models.archival import CONFIG_NAME
+from allennlp.models.model import Model
+from allennlp.training.trainer import Trainer
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+class FineTune(Subcommand):
+    def add_subparser(self, name: str, parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
+        # pylint: disable=protected-access
+        description = """Continues training a saved model on a new dataset."""
+        subparser = parser.add_parser(name,
+                                      description=description,
+                                      help='Continue training a model on a new dataset')
+
+        subparser.add_argument('-m', '--model-archive',
+                               required=True,
+                               type=str,
+                               help='path to the saved model archive from training on the original data')
+
+        subparser.add_argument('-d', '--data-path',
+                               required=True,
+                               type=str,
+                               help='path to data to use for continuing training')
+
+        subparser.add_argument('--validation-data-path',
+                               type=str,
+                               help='path to validation data to use for continuing training')
+
+        subparser.add_argument('-s', '--serialization-dir',
+                               required=True,
+                               type=str,
+                               help='directory in which to save the fine-tuned model and its logs')
+
+        subparser.add_argument('-o', '--overrides',
+                               type=str,
+                               default="",
+                               help='a HOCON structure used to override the experiment configuration')
+
+        subparser.add_argument('--include-package',
+                               type=str,
+                               action='append',
+                               default=[],
+                               help='additional packages to include')
+
+        subparser.add_argument('--file-friendly-logging',
+                               action='store_true',
+                               default=False,
+                               help='outputs tqdm status on separate lines and slows tqdm refresh rate')
+
+        subparser.set_defaults(func=fine_tune_model_from_args)
+
+        return subparser
+
+
+def fine_tune_model_from_args(args: argparse.Namespace):
+    """
+    Just converts from an ``argparse.Namespace`` object to string paths.
+    """
+    # Import any additional modules needed (to register custom classes)
+    for package_name in args.include_package:
+        import_submodules(package_name)
+    fine_tune_model_from_file_paths(model_archive_path=args.model_archive,
+                                    train_data_path=args.data_path,
+                                    serialization_dir=args.serialization_dir,
+                                    overrides=args.overrides,
+                                    file_friendly_logging=args.file_friendly_logging)
+
+
+def fine_tune_model_from_file_paths(model_archive_path: str,
+                                    train_data_path: str,
+                                    serialization_dir: str,
+                                    validation_data_path: str = None,
+                                    overrides: str = "",
+                                    file_friendly_logging: bool = False) -> Model:
+    """
+    A wrapper around :func:`fine_tune_model` which loads the model archive from a file.
+
+    Parameters
+    ----------
+    model_archive_path : ``str``
+        Path to a saved model archive that is the result of running the ``train`` command.
+    data_path : ``str``
+        The training data to use for continuing training the saved model.  We just pass this along
+        to :func:`fine_tune_model`.
+    serialization_dir : ``str``
+        The directory in which to save results and logs. We just pass this along to
+        :func:`fine_tune_model`.
+    validation_data_path : ``str``, optional
+        If given, the validation data to use when continuing training the saved model.  We just
+        pass this along to :func:`fine_tune_model`.
+    overrides : ``str``
+        A HOCON string that we will use to override values in the input parameter file.
+    file_friendly_logging : ``bool``, optional (default=False)
+        If ``True``, we make our output more friendly to saved model files.  We just pass this
+        along to :func:`fine_tune_model`.
+    """
+    # We don't need to pass in `cuda_device` here, because the trainer will call `model.cuda()` if
+    # necessary.
+    archive = load_archive(model_archive_path, overrides=overrides)
+    return fine_tune_model(archive=archive,
+                           train_data_path=train_data_path,
+                           serialization_dir=serialization_dir,
+                           validation_data_path=validation_data_path,
+                           file_friendly_logging=file_friendly_logging)
+
+
+def fine_tune_model(archive: Archive,
+                    train_data_path: str,
+                    serialization_dir: str,
+                    validation_data_path: str = None,
+                    file_friendly_logging: bool = False) -> Model:
+    """
+    Fine tunes the model in the given archive, using the the same configuration as found in the
+    archive, except with the new data provided.
+
+    Parameters
+    ----------
+    archive : ``Archive``
+        A saved model archive that is the result of running the ``train`` command.
+    train_data_path : ``str``
+        Path to the training data to use for fine-tuning.
+    serialization_dir : ``str``
+        The directory in which to save results and logs.
+    validation_data_path : ``str``, optional
+        Path to the validation data to use while fine-tuning.
+    file_friendly_logging : ``bool``, optional (default=False)
+        If ``True``, we add newlines to tqdm output, even on an interactive terminal, and we slow
+        down tqdm's output to only once every 10 seconds.
+    """
+    params = archive.config
+    model = archive.model
+    prepare_environment(params)
+
+    os.makedirs(serialization_dir)
+    Tqdm.set_slower_interval(file_friendly_logging)
+    sys.stdout = TeeLogger(os.path.join(serialization_dir, "stdout.log"), # type: ignore
+                           sys.stdout,
+                           file_friendly_logging)
+    sys.stderr = TeeLogger(os.path.join(serialization_dir, "stderr.log"), # type: ignore
+                           sys.stderr,
+                           file_friendly_logging)
+    handler = logging.FileHandler(os.path.join(serialization_dir, "python_logging.log"))
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(name)s - %(message)s'))
+    logging.getLogger().addHandler(handler)
+    serialization_params = deepcopy(params).as_dict(quiet=True)
+    with open(os.path.join(serialization_dir, CONFIG_NAME), "w") as param_file:
+        json.dump(serialization_params, param_file, indent=4)
+
+    vocab = archive.model.vocab
+    vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
+
+    iterator = DataIterator.from_params(params.pop("iterator"))
+    iterator.index_with(vocab)
+
+    params['train_data_path'] = train_data_path
+    params['validation_data_path'] = validation_data_path
+    params['test_data_path'] = None
+    all_datasets = datasets_from_params(params)
+
+    train_data = all_datasets['train']
+    validation_data = all_datasets.get('validation')
+
+    trainer_params = params.pop("trainer")
+    trainer = Trainer.from_params(model,
+                                  serialization_dir,
+                                  iterator,
+                                  train_data,
+                                  validation_data,
+                                  trainer_params)
+    metrics = trainer.train()
+
+    # Now tar up results
+    archive_model(serialization_dir, files_to_archive=params.files_to_archive)
+
+    metrics_json = json.dumps(metrics, indent=2)
+    with open(os.path.join(serialization_dir, "metrics.json"), "w") as metrics_file:
+        metrics_file.write(metrics_json)
+    logger.info("Metrics: %s", metrics_json)
+
+    return model

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -6,11 +6,11 @@ which to write the results.
 .. code-block:: bash
 
    $ python -m allennlp.run train --help
-   usage: python -m allennlp.run [command] train [-h] -s SERIALIZATION_DIR
-                                               [-o OVERRIDES]
-                                               [--include-package INCLUDE_PACKAGE]
-                                               [--file-friendly-logging]
-                                               param_path
+   usage: python -m allennlp.run train [-h] -s SERIALIZATION_DIR
+                                            [-o OVERRIDES]
+                                            [--include-package INCLUDE_PACKAGE]
+                                            [--file-friendly-logging]
+                                            param_path
 
    Train the specified model on the specified dataset.
 
@@ -61,18 +61,15 @@ class Train(Subcommand):
     def add_subparser(self, name: str, parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
         # pylint: disable=protected-access
         description = '''Train the specified model on the specified dataset.'''
-        subparser = parser.add_parser(
-                name, description=description, help='Train a model')
+        subparser = parser.add_parser(name, description=description, help='Train a model')
 
         subparser.add_argument('param_path',
                                type=str,
                                help='path to parameter file describing the model to be trained')
 
-        # This is necessary to preserve backward compatibility
-        serialization = subparser.add_mutually_exclusive_group(required=True)
-        serialization.add_argument('-s', '--serialization-dir',
-                                   type=str,
-                                   help='directory in which to save the model and its logs')
+        subparser.add_argument('-s', '--serialization-dir',
+                               type=str,
+                               help='directory in which to save the model and its logs')
 
         subparser.add_argument('-r', '--recover',
                                action='store_true',
@@ -117,20 +114,26 @@ def train_model_from_args(args: argparse.Namespace):
     train_model_from_file(args.param_path, args.serialization_dir, args.overrides, args.file_friendly_logging)
 
 
-def train_model_from_file(parameter_filename: str, serialization_dir: str, overrides: str = "",
+def train_model_from_file(parameter_filename: str,
+                          serialization_dir: str,
+                          overrides: str = "",
                           file_friendly_logging: bool = False) -> Model:
     """
     A wrapper around :func:`train_model` which loads the params from a file.
 
     Parameters
     ----------
-    param_path: str, required.
+    param_path : ``str``
         A json parameter file specifying an AllenNLP experiment.
-    serialization_dir: str, required
-        The directory in which to save results and logs.
+    serialization_dir : ``str``
+        The directory in which to save results and logs. We just pass this along to
+        :func:`train_model`.
+    overrides : ``str``
+        A HOCON string that we will use to override values in the input parameter file.
+    file_friendly_logging : ``bool``, optional (default=False)
+        If ``True``, we make our output more friendly to saved model files.  We just pass this
+        along to :func:`train_model`.
     """
-    if file_friendly_logging:
-        Tqdm.set_default_mininterval(10.0)
     # Load the experiment config from a file and pass it to ``train_model``.
     params = Params.from_file(parameter_filename, overrides)
     return train_model(params, serialization_dir, file_friendly_logging)
@@ -218,30 +221,30 @@ def create_serialization_dir(params: Params, serialization_dir: str) -> None:
 
 def train_model(params: Params, serialization_dir: str, file_friendly_logging: bool = False) -> Model:
     """
-    This function can be used as an entry point to running models in AllenNLP
-    directly from a JSON specification using a :class:`Driver`. Note that if
-    you care about reproducibility, you should avoid running code using Pytorch
-    or numpy which affect the reproducibility of your experiment before you
-    import and use this function, these libraries rely on random seeds which
-    can be set in this function via a JSON specification file. Note that this
-    function performs training and will also evaluate the trained model on
-    development and test sets if provided in the parameter json.
+    Trains the model specified in the given :class:`Params` object, using the data and training
+    parameters also specified in that object, and saves the results in ``serialization_dir``.
 
     Parameters
     ----------
-    params: Params, required.
+    params : ``Params``
         A parameter object specifying an AllenNLP Experiment.
-    serialization_dir: str, required
+    serialization_dir : ``str``
         The directory in which to save results and logs.
+    file_friendly_logging : ``bool``, optional (default=False)
+        If ``True``, we add newlines to tqdm output, even on an interactive terminal, and we slow
+        down tqdm's output to only once every 10 seconds.
     """
     prepare_environment(params)
 
     create_serialization_dir(params, serialization_dir)
 
+    Tqdm.set_slower_interval(file_friendly_logging)
     sys.stdout = TeeLogger(os.path.join(serialization_dir, "stdout.log"), # type: ignore
-                           sys.stdout, file_friendly_logging)
+                           sys.stdout,
+                           file_friendly_logging)
     sys.stderr = TeeLogger(os.path.join(serialization_dir, "stderr.log"), # type: ignore
-                           sys.stderr, file_friendly_logging)
+                           sys.stderr,
+                           file_friendly_logging)
     handler = logging.FileHandler(os.path.join(serialization_dir, "python_logging.log"))
     handler.setLevel(logging.INFO)
     handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(name)s - %(message)s'))

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -68,6 +68,7 @@ class Train(Subcommand):
                                help='path to parameter file describing the model to be trained')
 
         subparser.add_argument('-s', '--serialization-dir',
+                               required=True,
                                type=str,
                                help='directory in which to save the model and its logs')
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -42,9 +42,7 @@ from copy import deepcopy
 from allennlp.commands.evaluate import evaluate
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError
-from allennlp.common.params import Params
-from allennlp.common.tee_logger import TeeLogger
-from allennlp.common.tqdm import Tqdm
+from allennlp.common import Params, TeeLogger, Tqdm
 from allennlp.common.util import prepare_environment, import_submodules
 from allennlp.data import Vocabulary
 from allennlp.data.instance import Instance
@@ -239,6 +237,8 @@ def train_model(params: Params, serialization_dir: str, file_friendly_logging: b
 
     create_serialization_dir(params, serialization_dir)
 
+    # TODO(mattg): pull this block out into a separate function (maybe just add this to
+    # `prepare_environment`?)
     Tqdm.set_slower_interval(file_friendly_logging)
     sys.stdout = TeeLogger(os.path.join(serialization_dir, "stdout.log"), # type: ignore
                            sys.stdout,
@@ -250,6 +250,7 @@ def train_model(params: Params, serialization_dir: str, file_friendly_logging: b
     handler.setLevel(logging.INFO)
     handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(name)s - %(message)s'))
     logging.getLogger().addHandler(handler)
+
     serialization_params = deepcopy(params).as_dict(quiet=True)
     with open(os.path.join(serialization_dir, CONFIG_NAME), "w") as param_file:
         json.dump(serialization_params, param_file, indent=4)

--- a/allennlp/common/__init__.py
+++ b/allennlp/common/__init__.py
@@ -1,4 +1,5 @@
 from allennlp.common.params import Params
 from allennlp.common.registrable import Registrable
+from allennlp.common.tee_logger import TeeLogger
 from allennlp.common.tqdm import Tqdm
 from allennlp.common.util import JsonDict

--- a/allennlp/common/tqdm.py
+++ b/allennlp/common/tqdm.py
@@ -14,6 +14,19 @@ class Tqdm:
         Tqdm.default_mininterval = value
 
     @staticmethod
+    def set_slower_interval(use_slower_interval: bool) -> None:
+        """
+        If ``use_slower_interval`` is ``True``, we will dramatically slow down ``tqdm's`` default
+        output rate.  ``tqdm's`` default output rate is great for interactively watching progress,
+        but it is not great for log files.  You might want to set this if you are primarily going
+        to be looking at output through log files, not the terminal.
+        """
+        if use_slower_interval:
+            Tqdm.default_mininterval = 10.0
+        else:
+            Tqdm.default_mininterval = 0.1
+
+    @staticmethod
     def tqdm(*args, **kwargs):
         new_kwargs = {
                 'mininterval': Tqdm.default_mininterval,

--- a/allennlp/models/__init__.py
+++ b/allennlp/models/__init__.py
@@ -3,7 +3,7 @@ These submodules contain the classes for AllenNLP models,
 all of which are subclasses of :class:`~allennlp.models.model.Model`.
 """
 
-from allennlp.models.archival import archive_model, load_archive
+from allennlp.models.archival import archive_model, load_archive, Archive
 from allennlp.models.crf_tagger import CrfTagger
 from allennlp.models.decomposable_attention import DecomposableAttention
 from allennlp.models.encoder_decoders.simple_seq2seq import SimpleSeq2Seq

--- a/doc/api/allennlp.commands.fine_tune.rst
+++ b/doc/api/allennlp.commands.fine_tune.rst
@@ -1,0 +1,4 @@
+allennlp.commands.fine_tune
+===========================
+
+.. automodule:: allennlp.commands.fine_tune

--- a/doc/api/allennlp.commands.rst
+++ b/doc/api/allennlp.commands.rst
@@ -37,6 +37,7 @@ calls ``main()``.
     allennlp.commands.predict
     allennlp.commands.serve
     allennlp.commands.train
+    allennlp.commands.fine_tune
     allennlp.commands.elmo
 
 .. automodule:: allennlp.commands

--- a/doc/api/allennlp.commands.train.rst
+++ b/doc/api/allennlp.commands.train.rst
@@ -1,4 +1,4 @@
 allennlp.commands.train
-==========================
+=======================
 
 .. automodule:: allennlp.commands.train

--- a/tests/commands/fine_tune_test.py
+++ b/tests/commands/fine_tune_test.py
@@ -1,0 +1,54 @@
+# pylint: disable=invalid-name,no-self-use
+import argparse
+import os
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.commands.fine_tune import FineTune, fine_tune_model_from_file_paths, fine_tune_model_from_args
+
+class TestFineTune(AllenNlpTestCase):
+    def setUp(self):
+        super().setUp()
+        self.model_archive = 'tests/fixtures/decomposable_attention/serialization/model.tar.gz'
+        self.train_data_path = 'tests/fixtures/data/snli.jsonl'
+        self.validation_data_path = 'tests/fixtures/data/snli.jsonl'
+        self.serialization_dir = os.path.join(self.TEST_DIR, 'fine_tune')
+
+        self.parser = argparse.ArgumentParser(description="Testing")
+        subparsers = self.parser.add_subparsers(title='Commands', metavar='')
+        FineTune().add_subparser('fine-tune', subparsers)
+
+    def test_fine_tune_model_runs_from_file_paths(self):
+        fine_tune_model_from_file_paths(model_archive_path=self.model_archive,
+                                        train_data_path=self.train_data_path,
+                                        serialization_dir=self.serialization_dir,
+                                        validation_data_path=self.validation_data_path)
+
+    def test_fine_tune_runs_from_parser_arguments(self):
+        raw_args = ["fine-tune",
+                    "-m", self.model_archive,
+                    "-d", self.train_data_path,
+                    "-s", self.serialization_dir]
+
+        args = self.parser.parse_args(raw_args)
+
+        assert args.func == fine_tune_model_from_args
+        assert args.model_archive == self.model_archive
+        assert args.data_path == self.train_data_path
+        assert args.serialization_dir == self.serialization_dir
+        fine_tune_model_from_args(args)
+
+    def test_fine_tune_fails_without_required_args(self):
+        # Training data is required.
+        with self.assertRaises(SystemExit) as context:
+            self.parser.parse_args(["fine-tune", "-m", "path/to/archive", "-s", "serialization_dir"])
+            assert context.exception.code == 2  # argparse code for incorrect usage
+
+        # Serialization dir is required.
+        with self.assertRaises(SystemExit) as context:
+            self.parser.parse_args(["fine-tune", "-m", "path/to/archive", "-d", "path/to/data"])
+            assert context.exception.code == 2  # argparse code for incorrect usage
+
+        # Model archive is required.
+        with self.assertRaises(SystemExit) as context:
+            self.parser.parse_args(["fine-tune", "-s", "serialization_dir", "-d", "path/to/data"])
+            assert context.exception.code == 2  # argparse code for incorrect usage

--- a/tests/commands/fine_tune_test.py
+++ b/tests/commands/fine_tune_test.py
@@ -9,8 +9,7 @@ class TestFineTune(AllenNlpTestCase):
     def setUp(self):
         super().setUp()
         self.model_archive = 'tests/fixtures/decomposable_attention/serialization/model.tar.gz'
-        self.train_data_path = 'tests/fixtures/data/snli.jsonl'
-        self.validation_data_path = 'tests/fixtures/data/snli.jsonl'
+        self.config_file = 'tests/fixtures/decomposable_attention/experiment.json'
         self.serialization_dir = os.path.join(self.TEST_DIR, 'fine_tune')
 
         self.parser = argparse.ArgumentParser(description="Testing")
@@ -19,36 +18,35 @@ class TestFineTune(AllenNlpTestCase):
 
     def test_fine_tune_model_runs_from_file_paths(self):
         fine_tune_model_from_file_paths(model_archive_path=self.model_archive,
-                                        train_data_path=self.train_data_path,
-                                        serialization_dir=self.serialization_dir,
-                                        validation_data_path=self.validation_data_path)
+                                        config_file=self.config_file,
+                                        serialization_dir=self.serialization_dir)
 
     def test_fine_tune_runs_from_parser_arguments(self):
         raw_args = ["fine-tune",
                     "-m", self.model_archive,
-                    "-d", self.train_data_path,
+                    "-c", self.config_file,
                     "-s", self.serialization_dir]
 
         args = self.parser.parse_args(raw_args)
 
         assert args.func == fine_tune_model_from_args
         assert args.model_archive == self.model_archive
-        assert args.data_path == self.train_data_path
+        assert args.config_file == self.config_file
         assert args.serialization_dir == self.serialization_dir
         fine_tune_model_from_args(args)
 
     def test_fine_tune_fails_without_required_args(self):
-        # Training data is required.
+        # Configuration file is required.
         with self.assertRaises(SystemExit) as context:
             self.parser.parse_args(["fine-tune", "-m", "path/to/archive", "-s", "serialization_dir"])
             assert context.exception.code == 2  # argparse code for incorrect usage
 
         # Serialization dir is required.
         with self.assertRaises(SystemExit) as context:
-            self.parser.parse_args(["fine-tune", "-m", "path/to/archive", "-d", "path/to/data"])
+            self.parser.parse_args(["fine-tune", "-m", "path/to/archive", "-c", "path/to/config"])
             assert context.exception.code == 2  # argparse code for incorrect usage
 
         # Model archive is required.
         with self.assertRaises(SystemExit) as context:
-            self.parser.parse_args(["fine-tune", "-s", "serialization_dir", "-d", "path/to/data"])
+            self.parser.parse_args(["fine-tune", "-s", "serialization_dir", "-c", "path/to/config"])
             assert context.exception.code == 2  # argparse code for incorrect usage


### PR DESCRIPTION
Fixes #879.

I'm sure that we'll want to add more to this eventually, but this _should_ be the minimum functionality needed for continuing training a model on a new dataset.

I based this off of the `train` command, and I cleaned up some of what was there as I went, so there are also some minor changes to existing files.

@danyaljj, FYI.

I'm "requesting a review" now.  I'm working on the weekend because my family is gone for a few hours this morning, and I wanted to get this done.  I sometimes time-shift my hours a bit so that I can help with family stuff during the week.  _Please_ don't anyone feel pressure to work on the weekends just because I am doing this now.