### PR TITLE
Fix masked_log_softmax when the entire vector is masked

### DIFF
--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -172,7 +172,7 @@ def masked_log_softmax(vector, mask):
         # zero in the mask for these cases.  This logic replaces zeros in the mask with 1e-45
         # before calling mask.log().  We use 1e-45 because 1e-46 is so small it becomes 0 - this is
         # just the smallest value we can actually use.
-        mask = (mask.float() + 1e-45) * (1 - mask) + mask
+        mask = (mask + 1e-45) * (1 - mask) + mask
         vector = vector + mask.log()
     return torch.nn.functional.log_softmax(vector, dim=1)
 

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -165,6 +165,10 @@ def masked_log_softmax(vector, mask):
     In the case that the input vector is completely masked, the return value of this function is
     arbitrary, but not ``nan``.  You should be masking the result of whatever computation comes out
     of this in that case, anyway, so the specific values returned shouldn't matter.
+
+    If your logits are all extremely negative (i.e., the max value in your logit vector is -50 or
+    lower), the way we handle masking here could mess you up.  But if you've got logit values that
+    extreme, you've got bigger problems than this.
     """
     if mask is not None:
         # vector + mask.log() is an easy way to zero out masked elements in logspace, but it

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -169,11 +169,10 @@ def masked_log_softmax(vector, mask):
     if mask is not None:
         # vector + mask.log() is an easy way to zero out masked elements in logspace, but it
         # results in nans when the whole vector is masked.  We need a very small value instead of a
-        # zero in the mask for these cases.  This logic replaces zeros in the mask with 1e-45
-        # before calling mask.log().  We use 1e-45 because 1e-46 is so small it becomes 0 - this is
-        # just the smallest value we can actually use.
-        mask = (mask + 1e-45) * (1 - mask) + mask
-        vector = vector + mask.log()
+        # zero in the mask for these cases.  log(1 + 1e-45) is still basically 0, so we can safely
+        # just add 1e-45 before calling mask.log().  We use 1e-45 because 1e-46 is so small it
+        # becomes 0 - this is just the smallest value we can actually use.
+        vector = vector + (mask + 1e-45).log()
     return torch.nn.functional.log_softmax(vector, dim=1)
 
 

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -164,7 +164,9 @@ def masked_log_softmax(vector, mask):
 
     In the case that the input vector is completely masked, the return value of this function is
     arbitrary, but not ``nan``.  You should be masking the result of whatever computation comes out
-    of this in that case, anyway, so the specific values returned shouldn't matter.
+    of this in that case, anyway, so the specific values returned shouldn't matter.  Also, the way
+    that we deal with this case relies on having single-precision floats; mixing half-precision
+    floats with fully-masked vectors will likely give you ``nans``.
 
     If your logits are all extremely negative (i.e., the max value in your logit vector is -50 or
     lower), the way we handle masking here could mess you up.  But if you've got logit values that

--- a/tests/nn/util_test.py
+++ b/tests/nn/util_test.py
@@ -198,12 +198,11 @@ class TestNnUtil(AllenNlpTestCase):
                                   numpy.array([[0., 0., 0., 1.]]))
 
         # Testing the masked 1D case where the input is not all 0s
-        # and the mask is all 0s.
+        # and the mask is all 0s.  The output here will be arbitrary, but it should not be nan.
         vector_1d = Variable(torch.FloatTensor([[0.0, 2.0, 3.0, 4.0]]))
         mask_1d = Variable(torch.FloatTensor([[0.0, 0.0, 0.0, 0.0]]))
-        vector_1d_softmaxed = util.masked_softmax(vector_1d, mask_1d).data.numpy()
-        assert_array_almost_equal(numpy.exp(vector_1d_softmaxed),
-                                  numpy.array([[1.0, 1.0, 1.0, 1.0]]))
+        vector_1d_softmaxed = util.masked_log_softmax(vector_1d, mask_1d).data.numpy()
+        assert not numpy.isnan(vector_1d_softmaxed).any()
 
     def test_get_text_field_mask_returns_a_correct_mask(self):
         text_field_tensors = {


### PR DESCRIPTION
Fixes #890.