### PR TITLE
Fix bugs related to y-coordinates and object hashes

### DIFF
--- a/allennlp/data/semparse/worlds/nlvr_world.py
+++ b/allennlp/data/semparse/worlds/nlvr_world.py
@@ -71,13 +71,13 @@ class Box:
     ----------
     objects_list : ``List[JsonDict]``
         List of objects in the box, as given by the json file.
+    box_id : ``int``
+        An integer identifying the box index (0, 1 or 2).
     """
-    _id = 1
-
     def __init__(self,
-                 objects_list: List[JsonDict]) -> None:
-        self._name = f"box {Box._id}"
-        Box._id += 1
+                 objects_list: List[JsonDict],
+                 box_id: int) -> None:
+        self._name = f"box {box_id + 1}"
         self.objects = set([Object(object_dict, self._name) for object_dict in objects_list])
 
     def __str__(self):
@@ -107,7 +107,8 @@ class NlvrWorld(World):
         super(NlvrWorld, self).__init__(global_type_signatures=types.COMMON_TYPE_SIGNATURE,
                                         global_name_mapping=types.COMMON_NAME_MAPPING,
                                         num_nested_lambdas=0)
-        self._boxes = set([Box(object_list) for object_list in world_representation])
+        self._boxes = set([Box(object_list, box_id) for box_id, object_list in
+                           enumerate(world_representation)])
         self._objects: Set[Object] = set()
         for box in self._boxes:
             self._objects.update(box.objects)

--- a/scripts/get_nlvr_logical_forms.py
+++ b/scripts/get_nlvr_logical_forms.py
@@ -37,21 +37,22 @@ def process_data(input_file: str,
     walker = ActionSpaceWalker(NlvrWorld({}), max_path_length=max_path_length)
     for line in open(input_file):
         instance_id, sentence, world, label = read_json_line(line)
-        sentence_agenda = world.get_agenda_for_sentence(sentence, add_paths_to_agenda=False)
-        logical_forms = walker.get_logical_forms_with_agenda(sentence_agenda,
-                                                             max_num_logical_forms * 10)
         correct_logical_forms = []
         incorrect_logical_forms = []
-        for logical_form in logical_forms:
-            if world.execute(logical_form) == label:
-                if len(correct_logical_forms) <= max_num_logical_forms:
-                    correct_logical_forms.append(logical_form)
-            else:
-                if len(incorrect_logical_forms) <= max_num_logical_forms:
-                    incorrect_logical_forms.append(logical_form)
-            if len(correct_logical_forms) >= max_num_logical_forms \
-               and len(incorrect_logical_forms) >= max_num_logical_forms:
-                break
+        sentence_agenda = world.get_agenda_for_sentence(sentence, add_paths_to_agenda=False)
+        if sentence_agenda:
+            logical_forms = walker.get_logical_forms_with_agenda(sentence_agenda,
+                                                                 max_num_logical_forms * 10)
+            for logical_form in logical_forms:
+                if world.execute(logical_form) == label:
+                    if len(correct_logical_forms) <= max_num_logical_forms:
+                        correct_logical_forms.append(logical_form)
+                else:
+                    if len(incorrect_logical_forms) <= max_num_logical_forms:
+                        incorrect_logical_forms.append(logical_form)
+                if len(correct_logical_forms) >= max_num_logical_forms \
+                   and len(incorrect_logical_forms) >= max_num_logical_forms:
+                    break
         processed_data.append({"id": instance_id,
                                "sentence": sentence,
                                "label": str(label),

--- a/tests/data/semparse/worlds/nlvr_world_test.py
+++ b/tests/data/semparse/worlds/nlvr_world_test.py
@@ -12,11 +12,13 @@ class TestNlvrWorldRepresentation(AllenNlpTestCase):
         test_filename = "tests/fixtures/data/nlvr/sample_data.jsonl"
         data = [json.loads(line)["structured_rep"] for line in open(test_filename).readlines()]
         self.worlds = [NlvrWorld(rep) for rep in data]
-        custom_rep = [[{"y_loc": 21, "size": 20, "type": "triangle", "x_loc": 27, "color": "Yellow"},
-                       {"y_loc": 45, "size": 10, "type": "circle", "x_loc": 47, "color": "Black"}],
-                      [{"y_loc": 56, "size": 30, "type": "square", "x_loc": 10, "color": "#0099ff"},
-                       {"y_loc": 26, "size": 30, "type": "square", "x_loc": 40, "color": "Yellow"}],
-                      [{"y_loc": 40, "size": 10, "type": "triangle", "x_loc": 12, "color": "#0099ff"}]]
+        # y_loc increases as we go down from top to bottom, and x_loc from left to right. That is,
+        # the origin is at the top-left corner.
+        custom_rep = [[{"y_loc": 79, "size": 20, "type": "triangle", "x_loc": 27, "color": "Yellow"},
+                       {"y_loc": 55, "size": 10, "type": "circle", "x_loc": 47, "color": "Black"}],
+                      [{"y_loc": 44, "size": 30, "type": "square", "x_loc": 10, "color": "#0099ff"},
+                       {"y_loc": 74, "size": 30, "type": "square", "x_loc": 40, "color": "Yellow"}],
+                      [{"y_loc": 60, "size": 10, "type": "triangle", "x_loc": 12, "color": "#0099ff"}]]
         self.custom_world = NlvrWorld(custom_rep)
 
     def test_logical_form_with_assert_executes_correctly(self):


### PR DESCRIPTION
This PR fixes two things:
1) The value of the `y_pos` attribute in NLVR increases from top to bottom of each block in the figure. That means, for an object to be at the top, its `y_pos` needs to be closer to 0. The way I originally implemented vertical spatial relations (above, below, top, bottom etc.) got this backwards. I fixed it in this PR.
2) Object names (and their hashes) originally did not include the identities of the boxes they belonged to. This caused the executor to not distinguish between objects that are the same shape, color and size, at the same x and y coordinates in different boxes.  I added box ids to object names now.