### PR TITLE
Constituency js

### DIFF
--- a/allennlp/data/dataset_readers/penn_tree_bank.py
+++ b/allennlp/data/dataset_readers/penn_tree_bank.py
@@ -125,8 +125,11 @@ class PennTreeBankConstituencySpanDatasetReader(DatasetReader):
                 else:
                     gold_labels.append("NO-LABEL")
 
+        metadata = {"tokens": tokens}
         if gold_tree:
-            fields["gold_tree"] = MetadataField(gold_tree)
+            metadata["gold_tree"] = gold_tree
+
+        fields["metadata"] = MetadataField(metadata)
 
         span_list_field: ListField = ListField(spans)
         fields["spans"] = span_list_field

--- a/allennlp/service/predictors/constituency_parser.py
+++ b/allennlp/service/predictors/constituency_parser.py
@@ -23,7 +23,7 @@ class ConstituencyParserPredictor(Predictor):
         Expects JSON that looks like ``{"sentence": "..."}``.
         """
         sentence_text = [token.text for token in self._tokenizer.split_words(json_dict["sentence"])]
-        return self._dataset_reader.text_to_instance(sentence_text), {"sentence": sentence_text}
+        return self._dataset_reader.text_to_instance(sentence_text), {}
 
     @overrides
     def predict_json(self, inputs: JsonDict, cuda_device: int = -1) -> JsonDict:

--- a/allennlp/service/predictors/constituency_parser.py
+++ b/allennlp/service/predictors/constituency_parser.py
@@ -82,21 +82,17 @@ class ConstituencyParserPredictor(Predictor):
                 # the word to the character index.
                 index += len(child)
 
-        span = " ".join(tree.leaves())
         label = tree.label()
+        span = " ".join(tree.leaves())
         hierplane_node = {
                 "word": span,
                 "nodeType": label,
                 "attributes": [label],
-                "link": label,
-                #"spans": [{"start": index, "end": index + len(word) + 1,}],
+                "link": label
         }
         if children:
             hierplane_node["children"] = children
-        else:
-            # Only add spans to leaves. TODO: Ask Sam about this.
-            hierplane_node["spans"] = [{"start": index, "end": index + len(span) + 1,}]
-
+        # TODO(Mark): Figure out how to span highlighting to the leaves.
         if is_root:
             hierplane_node = {
                     "text": span,

--- a/allennlp/service/server_flask.py
+++ b/allennlp/service/server_flask.py
@@ -254,11 +254,13 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> F
 
     # As a SPA, we need to return index.html for /model-name and /model-name/permalink
     @app.route('/semantic-role-labeling')
+    @app.route('/constituency-parsing')
     @app.route('/machine-comprehension')
     @app.route('/textual-entailment')
     @app.route('/coreference-resolution')
     @app.route('/named-entity-recognition')
     @app.route('/semantic-role-labeling/<permalink>')
+    @app.route('/constituency-parsing/<permalink>')
     @app.route('/machine-comprehension/<permalink>')
     @app.route('/textual-entailment/<permalink>')
     @app.route('/coreference-resolution/<permalink>')

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -6,6 +6,7 @@ import TeComponent from './components/TeComponent';
 import McComponent from './components/McComponent';
 import CorefComponent from './components/CorefComponent'
 import NamedEntityComponent from './components/NamedEntityComponent'
+import ConstituencyParserComponent from './components/ConstituencyParserComponent'
 import Header from './components/Header';
 import WaitingForPermalink from './components/WaitingForPermalink'
 
@@ -115,6 +116,9 @@ class Demo extends React.Component {
       }
       else if (selectedModel === "named-entity-recognition") {
         return (<NamedEntityComponent requestData={requestData} responseData={responseData}/>)
+      }
+      else if (selectedModel === "constituency-parsing") {
+        return (<ConstituencyParserComponent requestData={requestData} responseData={responseData}/>)
       }
     }
 

--- a/demo/src/components/ConstituencyParserComponent.js
+++ b/demo/src/components/ConstituencyParserComponent.js
@@ -188,7 +188,7 @@ class _ConstituencyParserComponent extends React.Component {
         break;
       case VisualizationType.TREE:
       default:
-        viz = <HierplaneVisualization tree={responseData ? responseData.trees : null} />
+        viz = <HierplaneVisualization tree={responseData ? responseData.hierplane_tree : null} />
         break;
     }
 

--- a/demo/src/components/ConstituencyParserComponent.js
+++ b/demo/src/components/ConstituencyParserComponent.js
@@ -1,0 +1,229 @@
+import React from 'react';
+import { API_ROOT } from '../api-config';
+import { withRouter } from 'react-router-dom';
+import { PaneLeft, PaneRight } from './Pane'
+import Button from './Button'
+import ModelIntro from './ModelIntro'
+import { Tree } from 'hierplane';
+
+/*******************************************************************************
+  <ConstituencyParserInput /> Component
+*******************************************************************************/
+
+const constituencyParserSentences = [
+  "The keys, which were needed to access the building, were locked in the car.",
+  "However, voters decided that if the stadium was such a good idea someone would build it himself, and rejected it 59% to 41%.",
+  "Did Uriah honestly think he could beat the game in under three hours?",
+  "If you liked the music we were playing last night, you will absolutely love what we're playing tomorrow!",
+  "More than a few CEOs say the red-carpet treatment tempts them to return to a heartland city for future meetings.",
+];
+
+const title = "Constituency Parsing";
+const description = (
+  <span>
+    <span>
+        Constituency Parsing yo
+    </span>
+    <a href="https://www.semanticscholar.org/paper/Deep-Semantic-Role-Labeling-What-Works-and-What-s-He-Lee/a3ccff7ad63c2805078b34b8514fa9eab80d38e9" target="_blank" rel="noopener noreferrer">{' '} a deep BiLSTM model (He et al, 2017)</a>
+  </span>
+);
+
+function getStrIndex(words, wordIdx) {
+  if (wordIdx < 0) throw new Error(`Invalid word index: ${wordIdx}`);
+  return words.slice(0, wordIdx).join(' ').length;
+}
+
+class ConstituencyParserInput extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // If we're showing a permalinked result, we'll get passed in a sentence.
+    const { sentence } = props;
+
+    this.state = {
+      sentenceValue: sentence || "",
+    };
+    this.handleListChange = this.handleListChange.bind(this);
+    this.handleSentenceChange = this.handleSentenceChange.bind(this);
+  }
+
+  handleListChange(e) {
+    if (e.target.value !== "") {
+      this.setState({
+        constituencyParserSentenceValue: constituencyParserSentences[e.target.value],
+      });
+    }
+  }
+
+  handleSentenceChange(e) {
+    this.setState({
+      constituencyParserSentenceValue: e.target.value,
+    });
+  }
+
+  render() {
+    const { constituencyParserSentenceValue } = this.state;
+    const { outputState, runConstituencyParserModel } = this.props;
+
+    const constituencyParserInputs = {
+      "sentenceValue": constituencyParserSentenceValue,
+    };
+
+    return (
+      <div className="model__content">
+        <ModelIntro title={title} description={description} />
+        <div className="form__instructions"><span>Enter text or</span>
+          <select disabled={outputState === "working"} onChange={this.handleListChange}>
+            <option>Choose an example...</option>
+            {constituencyParserSentences.map((sentence, index) => {
+              return (
+                <option value={index} key={index}>{sentence}</option>
+              );
+            })}
+          </select>
+        </div>
+        <div className="form__field">
+          <label htmlFor="#input--srl-sentence">Sentence</label>
+          <input onChange={this.handleSentenceChange} value={constituencyParserSentenceValue} id="input--srl-sentence" ref="constituencyParserSentence" type="text" required="true" autoFocus="true" placeholder="E.g. &quot;John likes and Bill hates ice cream.&quot;" />
+        </div>
+        <div className="form__field form__field--btn">
+          <Button enabled={outputState !== "working"} outputState={outputState} runModel={runConstituencyParserModel} inputs={constituencyParserInputs} />
+        </div>
+      </div>
+    );
+  }
+}
+
+class HierplaneVisualization extends React.Component {
+  render() {
+    if (this.props.tree) {
+      return (
+        <div className="hierplane__visualization">
+          <div className="hierplane__visualization-verbs">
+            <a className="hierplane__visualization-verbs__prev">
+              <svg width="12" height="12">
+                <use xlinkHref="#icon__disclosure"></use>
+              </svg>
+            </a>
+          </div>
+          <Tree tree={this.props.tree} theme="light" />
+        </div>
+      )
+    } else {
+      return null;
+    }
+  }
+}
+
+/*******************************************************************************
+  <ConstituencyParserComponent /> Component
+*******************************************************************************/
+
+const VisualizationType = {
+  TREE: 'Tree',
+  TEXT: 'Text'
+};
+Object.freeze(VisualizationType);
+
+class _ConstituencyParserComponent extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const { requestData, responseData } = props;
+
+    this.state = {
+      requestData: requestData,
+      responseData: responseData,
+      // valid values: "working", "empty", "received", "error",
+      outputState: responseData ? "received" : "empty",
+      visualizationType: VisualizationType.TREE
+    };
+
+    this.runConstituencyParserModel = this.runConstituencyParserModel.bind(this);
+  }
+
+  runConstituencyParserModel(event, inputs) {
+    this.setState({outputState: "working"});
+
+    var payload = {sentence: inputs.sentenceValue};
+
+    fetch(`${API_ROOT}/predict/constituency-parsing`, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload)
+    }).then(function (response) {
+      return response.json();
+    }).then((json) => {
+      // If the response contains a `slug` for a permalink, we want to redirect
+      // to the corresponding path using `history.push`.
+      const { slug } = json;
+      const newPath = slug ? '/constituency-parsing/' + slug : '/constituency-parsing';
+
+      // We'll pass the request and response data along as part of the location object
+      // so that the `Demo` component can use them to re-render.
+      const location = {
+        pathname: newPath,
+        state: { requestData: payload, responseData: json }
+      }
+      this.props.history.push(location);
+    }).catch((error) => {
+      this.setState({ outputState: "error" });
+      console.error(error);
+    });
+  }
+
+  render() {
+    const { requestData, responseData } = this.props;
+    const { visualizationType } = this.state;
+
+    const sentence = requestData && requestData.sentence;
+    console.log(responseData);
+    let viz = null;
+    switch(visualizationType) {
+      case VisualizationType.TEXT:
+        viz = <div><p>{responseData.trees}</p></div>;
+        break;
+      case VisualizationType.TREE:
+      default:
+        viz = <HierplaneVisualization tree={responseData ? responseData.trees : null} />
+        break;
+    }
+
+    return (
+      <div className="pane model">
+        <PaneLeft>
+          <ConstituencyParserInput runConstituencyParserModel={this.runConstituencyParserModel}
+            outputState={this.state.outputState}
+            sentence={sentence} />
+        </PaneLeft>
+        <PaneRight outputState={this.state.outputState}>
+          <ul className="srl__vizualization-types">
+            {Object.keys(VisualizationType).map(tpe => {
+              const vizType = VisualizationType[tpe];
+              const className = (
+                visualizationType === vizType
+                  ? 'srl__vizualization-types__active-type'
+                  : null
+              );
+              return (
+                <li key={vizType} className={className}>
+                  <a onClick={() => this.setState({ visualizationType: vizType })}>
+                    {vizType}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+          {viz}
+        </PaneRight>
+      </div>
+    );
+  }
+}
+
+const ConstituencyParserComponent = withRouter(_ConstituencyParserComponent)
+
+export default ConstituencyParserComponent;

--- a/demo/src/components/ConstituencyParserComponent.js
+++ b/demo/src/components/ConstituencyParserComponent.js
@@ -28,11 +28,6 @@ const description = (
   </span>
 );
 
-function getStrIndex(words, wordIdx) {
-  if (wordIdx < 0) throw new Error(`Invalid word index: ${wordIdx}`);
-  return words.slice(0, wordIdx).join(' ').length;
-}
-
 class ConstituencyParserInput extends React.Component {
   constructor(props) {
     super(props);
@@ -84,7 +79,7 @@ class ConstituencyParserInput extends React.Component {
         </div>
         <div className="form__field">
           <label htmlFor="#input--srl-sentence">Sentence</label>
-          <input onChange={this.handleSentenceChange} value={constituencyParserSentenceValue} id="input--srl-sentence" ref="constituencyParserSentence" type="text" required="true" autoFocus="true" placeholder="E.g. &quot;John likes and Bill hates ice cream.&quot;" />
+          <input onChange={this.handleSentenceChange} value={constituencyParserSentenceValue} id="input--parser-sentence" ref="constituencyParserSentence" type="text" required="true" autoFocus="true" placeholder="E.g. &quot;John likes and Bill hates ice cream.&quot;" />
         </div>
         <div className="form__field form__field--btn">
           <Button enabled={outputState !== "working"} outputState={outputState} runModel={runConstituencyParserModel} inputs={constituencyParserInputs} />
@@ -99,13 +94,6 @@ class HierplaneVisualization extends React.Component {
     if (this.props.tree) {
       return (
         <div className="hierplane__visualization">
-          <div className="hierplane__visualization-verbs">
-            <a className="hierplane__visualization-verbs__prev">
-              <svg width="12" height="12">
-                <use xlinkHref="#icon__disclosure"></use>
-              </svg>
-            </a>
-          </div>
           <Tree tree={this.props.tree} theme="light" />
         </div>
       )
@@ -119,11 +107,6 @@ class HierplaneVisualization extends React.Component {
   <ConstituencyParserComponent /> Component
 *******************************************************************************/
 
-const VisualizationType = {
-  TREE: 'Tree',
-  TEXT: 'Text'
-};
-Object.freeze(VisualizationType);
 
 class _ConstituencyParserComponent extends React.Component {
   constructor(props) {
@@ -136,9 +119,7 @@ class _ConstituencyParserComponent extends React.Component {
       responseData: responseData,
       // valid values: "working", "empty", "received", "error",
       outputState: responseData ? "received" : "empty",
-      visualizationType: VisualizationType.TREE
     };
-
     this.runConstituencyParserModel = this.runConstituencyParserModel.bind(this);
   }
 
@@ -177,20 +158,7 @@ class _ConstituencyParserComponent extends React.Component {
 
   render() {
     const { requestData, responseData } = this.props;
-    const { visualizationType } = this.state;
-
     const sentence = requestData && requestData.sentence;
-    console.log(responseData);
-    let viz = null;
-    switch(visualizationType) {
-      case VisualizationType.TEXT:
-        viz = <div><p>{responseData.trees}</p></div>;
-        break;
-      case VisualizationType.TREE:
-      default:
-        viz = <HierplaneVisualization tree={responseData ? responseData.hierplane_tree : null} />
-        break;
-    }
 
     return (
       <div className="pane model">
@@ -200,24 +168,7 @@ class _ConstituencyParserComponent extends React.Component {
             sentence={sentence} />
         </PaneLeft>
         <PaneRight outputState={this.state.outputState}>
-          <ul className="srl__vizualization-types">
-            {Object.keys(VisualizationType).map(tpe => {
-              const vizType = VisualizationType[tpe];
-              const className = (
-                visualizationType === vizType
-                  ? 'srl__vizualization-types__active-type'
-                  : null
-              );
-              return (
-                <li key={vizType} className={className}>
-                  <a onClick={() => this.setState({ visualizationType: vizType })}>
-                    {vizType}
-                  </a>
-                </li>
-              );
-            })}
-          </ul>
-          {viz}
+          <HierplaneVisualization tree={responseData ? responseData.hierplane_tree : null} />
         </PaneRight>
       </div>
     );

--- a/demo/src/components/ConstituencyParserComponent.js
+++ b/demo/src/components/ConstituencyParserComponent.js
@@ -22,9 +22,13 @@ const title = "Constituency Parsing";
 const description = (
   <span>
     <span>
-        Constituency Parsing yo
+      A constituency parse tree breaks a text into sub-phrases, or constituents. Non-terminals in the tree are types of phrases, the terminals are the words in the sentence.
+      This demo is an implementation of a minimal neural model for constituency parsing based on an independent scoring of labels and spans from 
     </span>
-    <a href="https://www.semanticscholar.org/paper/Deep-Semantic-Role-Labeling-What-Works-and-What-s-He-Lee/a3ccff7ad63c2805078b34b8514fa9eab80d38e9" target="_blank" rel="noopener noreferrer">{' '} a deep BiLSTM model (He et al, 2017)</a>
+    <a href="https://www.semanticscholar.org/paper/A-Minimal-Span-Based-Neural-Constituency-Parser-Stern-Andreas/593e4e749bd2dbcaf8dc25298d830b41d435e435" target="_blank" rel="noopener noreferrer">{' '} a Minimal Span Based Constituency Parser (Stern et al, 2017)</a>
+    <span>
+      . This model achieved state of the art single model performance on the Penn Tree Bank in 2017.
+    </span> 
   </span>
 );
 

--- a/demo/src/components/Header.js
+++ b/demo/src/components/Header.js
@@ -31,6 +31,7 @@ class Header extends React.Component {
                 {buildLink("semantic-role-labeling", "Semantic Role Labeling")}
                 {buildLink("coreference-resolution", "Coreference Resolution")}
                 {buildLink("named-entity-recognition", "Named Entity Recognition")}
+                {buildLink("constituency-parsing", "Constituency Parsing")}
               </ul>
             </nav>
             <h1 className="header__content__logo">

--- a/tests/data/dataset_readers/penn_tree_bank_reader_test.py
+++ b/tests/data/dataset_readers/penn_tree_bank_reader_test.py
@@ -47,7 +47,8 @@ class TestPennTreeBankConstituencySpanReader(AllenNlpTestCase):
                                     "VP(TO to)(VP(VB be)(ADJP(JJ fair)(PP(TO to)(NP(JJ other)(NNS "
                                     "bidders))))))))))))))(. .)))")
 
-        assert fields["gold_tree"].metadata == gold_tree
+        assert fields["metadata"].metadata["gold_tree"] == gold_tree
+        assert fields["metadata"].metadata["tokens"] == tokens
 
         correct_spans_and_labels = {}
         ptb_reader._get_gold_spans(gold_tree, 0, correct_spans_and_labels)
@@ -77,7 +78,8 @@ class TestPennTreeBankConstituencySpanReader(AllenNlpTestCase):
                                     "(NN outcome)))(CC and)(VP(ADVP(RB perhaps))(VB join)(NP(DT the)"
                                     "(VBG winning)(NN bidder)))))))))(. .)))")
 
-        assert fields["gold_tree"].metadata == gold_tree
+        assert fields["metadata"].metadata["gold_tree"] == gold_tree
+        assert fields["metadata"].metadata["tokens"] == tokens
 
         correct_spans_and_labels = {}
         ptb_reader._get_gold_spans(gold_tree, 0, correct_spans_and_labels)

--- a/tests/models/constituency_parser_test.py
+++ b/tests/models/constituency_parser_test.py
@@ -42,7 +42,7 @@ class SpanConstituencyParserTest(ModelTestCase):
         output_dict = self.model(**training_tensors)
         decode_output_dict = self.model.decode(output_dict)
         assert set(decode_output_dict.keys()) == {'spans', 'class_probabilities', 'trees',
-                                                  'tokens', 'sentence_lengths', 'num_spans', 'loss'}
+                                                  'tokens', 'num_spans', 'loss'}
         metrics = self.model.get_metrics(reset=True)
         metric_keys = set(metrics.keys())
         assert "evalb_precision" in metric_keys

--- a/tests/models/constituency_parser_test.py
+++ b/tests/models/constituency_parser_test.py
@@ -34,7 +34,7 @@ class SpanConstituencyParserTest(ModelTestCase):
         text = {"tokens": Variable(torch.LongTensor([[1]]).long())}
         spans = Variable(torch.LongTensor([[[0, 0]]]))
         label = Variable(torch.LongTensor([[1]]))
-        self.model(text, spans, label)
+        self.model(text, spans, [{"tokens": ["hello"]}], label)
 
     def test_decode_runs(self):
         self.model.eval()

--- a/tests/service/predictors/constituency_parser_test.py
+++ b/tests/service/predictors/constituency_parser_test.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-self-use,invalid-name
+# pylint: disable=no-self-use,invalid-name,protected-access
 from unittest import TestCase
 
 from nltk import Tree
@@ -57,9 +57,8 @@ class TestConstituencyParserPredictor(TestCase):
     def test_build_hierplane_tree(self):
         tree = Tree.fromstring("(S (NP (D the) (N dog)) (VP (V chased) (NP (D the) (N cat))))")
         archive = load_archive('tests/fixtures/constituency_parser/serialization/model.tar.gz')
-        predictor = Predictor.from_archive(archive, 'constituency-parser') 
+        predictor = Predictor.from_archive(archive, 'constituency-parser')
 
         hierplane_tree = predictor._build_hierplane_tree(tree, 0, is_root=True)
 
-        text = " ".join(tree.leaves())
         print(hierplane_tree)

--- a/tests/service/predictors/constituency_parser_test.py
+++ b/tests/service/predictors/constituency_parser_test.py
@@ -61,4 +61,66 @@ class TestConstituencyParserPredictor(TestCase):
 
         hierplane_tree = predictor._build_hierplane_tree(tree, 0, is_root=True)
 
-        print(hierplane_tree)
+        # pylint: disable=bad-continuation
+        correct_tree = {
+                'text': 'the dog chased the cat',
+                'root': {
+                        'word': 'the dog chased the cat',
+                        'nodeType': 'S',
+                        'attributes': ['S'],
+                        'link': 'S',
+                        'children': [{
+                                'word': 'the dog',
+                                'nodeType': 'NP',
+                                'attributes': ['NP'],
+                                'link': 'NP',
+                                'children': [{
+                                        'word': 'the',
+                                        'nodeType': 'D',
+                                        'attributes': ['D'],
+                                        'link': 'D'
+                                        },
+                                        {
+                                        'word': 'dog',
+                                        'nodeType': 'N',
+                                        'attributes': ['N'],
+                                        'link': 'N'}
+                                        ]
+                                },
+                                {
+                                'word': 'chased the cat',
+                                'nodeType': 'VP',
+                                'attributes': ['VP'],
+                                'link': 'VP',
+                                'children': [{
+                                    'word': 'chased',
+                                    'nodeType': 'V',
+                                    'attributes': ['V'],
+                                    'link': 'V'
+                                    },
+                                    {
+                                    'word':
+                                    'the cat',
+                                    'nodeType': 'NP',
+                                    'attributes': ['NP'],
+                                    'link': 'NP',
+                                    'children': [{
+                                            'word': 'the',
+                                            'nodeType': 'D',
+                                            'attributes': ['D'],
+                                            'link': 'D'
+                                            },
+                                            {
+                                            'word': 'cat',
+                                            'nodeType': 'N',
+                                            'attributes': ['N'],
+                                            'link': 'N'}
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+        # pylint: enable=bad-continuation
+        assert correct_tree == hierplane_tree

--- a/tests/service/predictors/constituency_parser_test.py
+++ b/tests/service/predictors/constituency_parser_test.py
@@ -1,6 +1,8 @@
 # pylint: disable=no-self-use,invalid-name
 from unittest import TestCase
 
+from nltk import Tree
+
 from allennlp.models.archival import load_archive
 from allennlp.service.predictors import Predictor
 
@@ -51,3 +53,13 @@ class TestConstituencyParserPredictor(TestCase):
 
         for class_distribution in result["class_probabilities"]:
             self.assertAlmostEqual(sum(class_distribution), 1.0, places=4)
+
+    def test_build_hierplane_tree(self):
+        tree = Tree.fromstring("(S (NP (D the) (N dog)) (VP (V chased) (NP (D the) (N cat))))")
+        archive = load_archive('tests/fixtures/constituency_parser/serialization/model.tar.gz')
+        predictor = Predictor.from_archive(archive, 'constituency-parser') 
+
+        hierplane_tree = predictor._build_hierplane_tree(tree, 0, is_root=True)
+
+        text = " ".join(tree.leaves())
+        print(hierplane_tree)

--- a/tests/service/predictors/constituency_parser_test.py
+++ b/tests/service/predictors/constituency_parser_test.py
@@ -17,7 +17,7 @@ class TestConstituencyParserPredictor(TestCase):
 
         assert len(result["spans"]) == 21 # number of possible substrings of the sentence.
         assert len(result["class_probabilities"]) == 21
-        assert result["sentence"] == ["What", "a", "great", "test", "sentence", "."]
+        assert result["tokens"] == ["What", "a", "great", "test", "sentence", "."]
         assert isinstance(result["trees"], str)
 
         for class_distribution in result["class_probabilities"]:
@@ -36,7 +36,7 @@ class TestConstituencyParserPredictor(TestCase):
         result = results[0]
         assert len(result["spans"]) == 21 # number of possible substrings of the sentence.
         assert len(result["class_probabilities"]) == 21
-        assert result["sentence"] == ["What", "a", "great", "test", "sentence", "."]
+        assert result["tokens"] == ["What", "a", "great", "test", "sentence", "."]
         assert isinstance(result["trees"], str)
 
         for class_distribution in result["class_probabilities"]:
@@ -46,7 +46,7 @@ class TestConstituencyParserPredictor(TestCase):
 
         assert len(result["spans"]) == 36 # number of possible substrings of the sentence.
         assert len(result["class_probabilities"]) == 36
-        assert result["sentence"] == ["Here", "'s", "another", "good", ",", "interesting", "one", "."]
+        assert result["tokens"] == ["Here", "'s", "another", "good", ",", "interesting", "one", "."]
         assert isinstance(result["trees"], str)
 
         for class_distribution in result["class_probabilities"]:


### PR DESCRIPTION
- Adds a Hierplane demo for the constituency parser.
- Weaves a new bit of metadata through the model so that we don't get unknown words in the demo (and actually, simplified things quite a bit)
- I haven't added the model yet, because it's not good enough and I still need to figure out why. But merging this doesn't depend on that, so I figured it would be best to split it up here.


The demo looks like this:
(We've hit maximum text wrapping capacity on a mac on the demo - we're going to need a "Select a demo model" page pretty soon.... [it could look like this but for deep learning models](https://bl.ocks.org/))
![image](https://user-images.githubusercontent.com/16001974/36610861-81987d3a-1886-11e8-8981-31327d75e5ea.png)
