### PR TITLE
speed up metrics

### DIFF
--- a/allennlp/data/dataset_readers/penn_tree_bank.py
+++ b/allennlp/data/dataset_readers/penn_tree_bank.py
@@ -58,6 +58,10 @@ class PennTreeBankConstituencySpanDatasetReader(DatasetReader):
 
         for parse in BracketParseCorpusReader(root=directory, fileids=[filename]).parsed_sents():
             self._strip_functional_tags(parse)
+            # This is un-needed and clutters the label space.
+            # All the trees also contain a root S node.
+            if parse.label() == "VROOT":
+                parse = parse[0]
             pos_tags = [x[1] for x in parse.pos()] if self._use_pos_tags else None
             yield self.text_to_instance(parse.leaves(), pos_tags, parse)
 

--- a/allennlp/models/constituency_parser.py
+++ b/allennlp/models/constituency_parser.py
@@ -186,7 +186,7 @@ class SpanConstituencyParser(Model):
         }
         if span_labels is not None:
             loss = sequence_cross_entropy_with_logits(logits, span_labels, span_mask)
-            self.tag_accuracy(logits, span_labels, span_mask)
+            self.tag_accuracy(class_probabilities, span_labels, span_mask)
             output_dict["loss"] = loss
 
         # The evalb score is expensive to compute, so we only compute

--- a/allennlp/models/constituency_parser.py
+++ b/allennlp/models/constituency_parser.py
@@ -14,7 +14,7 @@ from allennlp.models.model import Model
 from allennlp.nn import InitializerApplicator, RegularizerApplicator
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 from allennlp.nn.util import last_dim_softmax, get_lengths_from_binary_sequence_mask
-from allennlp.training.metrics import F1Measure
+from allennlp.training.metrics import CategoricalAccuracy
 from allennlp.training.metrics import EvalbBracketingScorer
 
 
@@ -102,8 +102,7 @@ class SpanConstituencyParser(Model):
                                    "stacked encoder output dim",
                                    "feedforward input dim")
 
-        self.metrics = {label: F1Measure(index) for index, label
-                        in self.vocab.get_index_to_token_vocabulary("labels").items()}
+        self.tag_accuracy = CategoricalAccuracy()
 
         if evalb_directory_path is not None:
             self._evalb_score = EvalbBracketingScorer(evalb_directory_path)
@@ -187,8 +186,7 @@ class SpanConstituencyParser(Model):
         }
         if span_labels is not None:
             loss = sequence_cross_entropy_with_logits(logits, span_labels, span_mask)
-            for metric in self.metrics.values():
-                metric(logits, span_labels, span_mask)
+            self.tag_accuracy(logits, span_labels, span_mask)
             output_dict["loss"] = loss
 
         # The evalb score is expensive to compute, so we only compute
@@ -425,28 +423,10 @@ class SpanConstituencyParser(Model):
     @overrides
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         all_metrics = {}
-
-        total_f1 = 0.0
-        total_precision = 0.0
-        total_recall = 0.0
-        # We'll just capture the average f1, precision and recall
-        # because there are 27 constituent types, which makes
-        # for very verbose console output.
-        for metric in self.metrics.values():
-            f1, precision, recall = metric.get_metric(reset) # pylint: disable=invalid-name
-            total_f1 += f1
-            total_precision += precision
-            total_recall += recall
-
-        num_metrics = len(self.metrics)
-        all_metrics["average_f1"] = total_f1 / num_metrics
-        all_metrics["average_precision"] = total_precision / num_metrics
-        all_metrics["average_recall"] = total_recall / num_metrics
-
+        all_metrics["tag_accuracy"] = self.tag_accuracy.get_metric(reset=reset)
         if self._evalb_score is not None:
             evalb_metrics = self._evalb_score.get_metric(reset=reset)
             all_metrics.update(evalb_metrics)
-
         return all_metrics
 
     @classmethod

--- a/allennlp/training/metrics/categorical_accuracy.py
+++ b/allennlp/training/metrics/categorical_accuracy.py
@@ -56,7 +56,7 @@ class CategoricalAccuracy(Metric):
         correct = top_k.eq(gold_labels.long().unsqueeze(-1)).float()
 
         if mask is not None:
-            correct *= mask.unsqueeze(-1)
+            correct *= mask.float().unsqueeze(-1)
             self.total_count += mask.sum()
         else:
             self.total_count += gold_labels.numel()

--- a/allennlp/training/metrics/categorical_accuracy.py
+++ b/allennlp/training/metrics/categorical_accuracy.py
@@ -45,8 +45,12 @@ class CategoricalAccuracy(Metric):
             raise ConfigurationError("A gold label passed to Categorical Accuracy contains an id >= {}, "
                                      "the number of classes.".format(num_classes))
 
-        # Top K indexes of the predictions (or fewer, if there aren't K of them)
-        top_k = predictions.topk(min(self._top_k, predictions.shape[-1]), -1)[1]
+        # Top K indexes of the predictions (or fewer, if there aren't K of them).
+        # Special case topk == 1, because it's common and .max() is much faster than .topk().
+        if self._top_k == 1:
+            top_k = predictions.max(-1)[1]
+        else:
+            top_k = predictions.topk(min(self._top_k, predictions.shape[-1]), -1)[1]
 
         # This is of shape (batch_size, ..., top_k).
         correct = top_k.eq(gold_labels.long().unsqueeze(-1)).float()

--- a/allennlp/training/metrics/categorical_accuracy.py
+++ b/allennlp/training/metrics/categorical_accuracy.py
@@ -48,7 +48,7 @@ class CategoricalAccuracy(Metric):
         # Top K indexes of the predictions (or fewer, if there aren't K of them).
         # Special case topk == 1, because it's common and .max() is much faster than .topk().
         if self._top_k == 1:
-            top_k = predictions.max(-1)[1]
+            top_k = predictions.max(-1)[1].unsqueeze(-1)
         else:
             top_k = predictions.topk(min(self._top_k, predictions.shape[-1]), -1)[1]
 

--- a/allennlp/training/metrics/f1_measure.py
+++ b/allennlp/training/metrics/f1_measure.py
@@ -51,7 +51,7 @@ class F1Measure(Metric):
         positive_label_mask = gold_labels.eq(self._positive_label).float()
         negative_label_mask = 1.0 - positive_label_mask
 
-        argmax_predictions = predictions.topk(1, -1)[1].float().squeeze(-1)
+        argmax_predictions = predictions.max(-1)[1].float().squeeze(-1)
 
         # True Negatives: correct non-positive predictions.
         correct_null_predictions = (argmax_predictions !=

--- a/tests/data/dataset_readers/penn_tree_bank_reader_test.py
+++ b/tests/data/dataset_readers/penn_tree_bank_reader_test.py
@@ -37,7 +37,7 @@ class TestPennTreeBankConstituencySpanReader(AllenNlpTestCase):
                             'NNS', 'IN', 'NN', 'TO', 'VB', 'JJ', 'TO', 'JJ', 'NNS', '.']
 
         assert spans == enumerate_spans(tokens)
-        gold_tree = Tree.fromstring("(VROOT(S(ADVP(RB Also))(, ,)(SBAR(IN because)"
+        gold_tree = Tree.fromstring("(S(ADVP(RB Also))(, ,)(SBAR(IN because)"
                                     "(S(NP(NP(NNP UAL)(NNP Chairman)(NNP Stephen)(NNP Wolf))"
                                     "(CC and)(NP(JJ other)(NNP UAL)(NNS executives)))(VP(VBP have)"
                                     "(VP(VBN joined)(NP(NP(DT the)(NNS pilots)(POS '))(NN bid))))))"
@@ -45,7 +45,7 @@ class TestPennTreeBankConstituencySpanReader(AllenNlpTestCase):
                                     "forced)(S(VP(TO to)(VP(VB exclude)(NP(PRP him))(PP(IN from)"
                                     "(NP(PRP$ its)(NNS deliberations)))(SBAR(IN in)(NN order)(S("
                                     "VP(TO to)(VP(VB be)(ADJP(JJ fair)(PP(TO to)(NP(JJ other)(NNS "
-                                    "bidders))))))))))))))(. .)))")
+                                    "bidders))))))))))))))(. .))")
 
         assert fields["metadata"].metadata["gold_tree"] == gold_tree
         assert fields["metadata"].metadata["tokens"] == tokens
@@ -73,10 +73,10 @@ class TestPennTreeBankConstituencySpanReader(AllenNlpTestCase):
 
         assert spans == enumerate_spans(tokens)
 
-        gold_tree = Tree.fromstring("(VROOT(S(NP(DT That))(VP(MD could)(VP(VB cost)(NP(PRP him))"
+        gold_tree = Tree.fromstring("(S(NP(DT That))(VP(MD could)(VP(VB cost)(NP(PRP him))"
                                     "(NP(DT the)(NN chance)(S(VP(TO to)(VP(VP(VB influence)(NP(DT the)"
                                     "(NN outcome)))(CC and)(VP(ADVP(RB perhaps))(VB join)(NP(DT the)"
-                                    "(VBG winning)(NN bidder)))))))))(. .)))")
+                                    "(VBG winning)(NN bidder)))))))))(. .))")
 
         assert fields["metadata"].metadata["gold_tree"] == gold_tree
         assert fields["metadata"].metadata["tokens"] == tokens


### PR DESCRIPTION
So for the parser, I had approximately 100 F1 metrics, and changing this line in the metric (without actually removing the 100 metrics, which I subsequently did also in this PR because it was super small) pushed the speed from 7.4 iterations/sec to 12/sec. I think i'll switch to accuracy in the future, but this is a general optimisation and a reminder not to do topk unless you definitely need to!