### PR TITLE
Penalize non agenda actions

### DIFF
--- a/allennlp/nn/decoding/expected_risk_minimization.py
+++ b/allennlp/nn/decoding/expected_risk_minimization.py
@@ -46,11 +46,10 @@ class ExpectedRiskMinimization(DecoderTrainer):
             grouped_state = states[0].combine_states(states)
             # These states already come sorted.
             for next_state in decode_step.take_step(grouped_state):
-                finished, not_finished = next_state.split_finished()
-                if finished is not None:
-                    finished_states.append(finished)
-                if not_finished is not None:
-                    next_states.append(not_finished)
+                if next_state.is_finished():
+                    finished_states.append(next_state)
+                else:
+                    next_states.append(next_state)
 
             states = self._prune_beam(next_states)
             num_steps += 1

--- a/tests/fixtures/encoder_decoder/nlvr_semantic_parser/experiment.json
+++ b/tests/fixtures/encoder_decoder/nlvr_semantic_parser/experiment.json
@@ -46,7 +46,8 @@
     "max_decoding_steps": 20,
     "attention_function": {"type": "dot_product"},
     "checklist_selection_weight": 0.5,
-    "checklist_cost_weight": 0.8
+    "checklist_cost_weight": 0.8,
+    "penalize_non_agenda_actions": true
   },
   "iterator": {
     "type": "bucket",

--- a/tests/models/encoder_decoders/nlvr_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/nlvr_semantic_parser_test.py
@@ -1,4 +1,5 @@
-import numpy
+# pylint: disable=no-self-use,protected-access
+from numpy.testing import assert_almost_equal
 import torch
 from torch.autograd import Variable
 
@@ -22,27 +23,19 @@ class NlvrSemanticParserTest(ModelTestCase):
                        {"left": ("", True, {}), "right": ("", False, {})},
                        {"left": ("", True, {}), "right": ("", True, {})},
                        {"left": ("", True, {}), "right": ("", False, {})}]
-        # Of the actions above, those at indices 0 and 2 are on the agenda, and there are padding
+        # Of the actions above, those at indices 0 and 4 are on the agenda, and there are padding
         # indices at the end.
         test_agenda = Variable(torch.Tensor([[0], [4], [-1], [-1]]))
-        # pylint: disable=protected-access
         target_checklist, relevant_actions = self.model._get_checklist_target(test_agenda,
                                                                               all_actions)
-        checklist_data = target_checklist.data.numpy()
-        expected_checklist_data = numpy.asarray([[1], [0], [1]])
-        numpy.testing.assert_array_equal(checklist_data, expected_checklist_data)
-        agenda_data = relevant_actions.data.numpy()
-        expected_agenda_data = numpy.asarray([[0], [2], [4]])
-        numpy.testing.assert_array_equal(agenda_data, expected_agenda_data)
+        assert_almost_equal(target_checklist.data.numpy(), [[1], [0], [1]])
+        assert_almost_equal(relevant_actions.data.numpy(), [[0], [2], [4]])
 
 
 class NlvrDecoderStateTest(AllenNlpTestCase):
     def test_get_checklist_balance(self):
-        # pylint: disable=no-self-use
         fake_target = Variable(torch.Tensor([[1], [1], [1], [1], [0]]))
         fake_checklist = Variable(torch.Tensor([[0], [2], [0], [1], [0]]))
         # pylint: disable=protected-access
         balance = NlvrDecoderState._get_checklist_balance(fake_target, fake_checklist)
-        balance_data = balance.data.numpy()
-        expected_balance_data = numpy.asarray([[1], [0], [1], [0], [0]])
-        numpy.testing.assert_array_equal(balance_data, expected_balance_data)
+        assert_almost_equal(balance.data.numpy(), [[1], [0], [1], [0], [0]])

--- a/tests/models/encoder_decoders/nlvr_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/nlvr_semantic_parser_test.py
@@ -1,4 +1,9 @@
-from allennlp.common.testing import ModelTestCase
+import numpy
+import torch
+from torch.autograd import Variable
+
+from allennlp.common.testing import ModelTestCase, AllenNlpTestCase
+from allennlp.models.encoder_decoders.nlvr_semantic_parser import NlvrDecoderState
 
 
 class NlvrSemanticParserTest(ModelTestCase):
@@ -9,3 +14,35 @@ class NlvrSemanticParserTest(ModelTestCase):
 
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)
+
+    def test_get_checklist_target(self):
+        # Creating a fake all_actions field where actions 0, 2 and 4 are terminal productions.
+        all_actions = [{"left": ("", True, {}), "right": ("", False, {})},
+                       {"left": ("", True, {}), "right": ("", True, {})},
+                       {"left": ("", True, {}), "right": ("", False, {})},
+                       {"left": ("", True, {}), "right": ("", True, {})},
+                       {"left": ("", True, {}), "right": ("", False, {})}]
+        # Of the actions above, those at indices 0 and 2 are on the agenda, and there are padding
+        # indices at the end.
+        test_agenda = Variable(torch.Tensor([[0], [4], [-1], [-1]]))
+        # pylint: disable=protected-access
+        target_checklist, relevant_actions = self.model._get_checklist_target(test_agenda,
+                                                                              all_actions)
+        checklist_data = target_checklist.data.numpy()
+        expected_checklist_data = numpy.asarray([[1], [0], [1]])
+        numpy.testing.assert_array_equal(checklist_data, expected_checklist_data)
+        agenda_data = relevant_actions.data.numpy()
+        expected_agenda_data = numpy.asarray([[0], [2], [4]])
+        numpy.testing.assert_array_equal(agenda_data, expected_agenda_data)
+
+
+class NlvrDecoderStateTest(AllenNlpTestCase):
+    def test_get_checklist_balance(self):
+        # pylint: disable=no-self-use
+        fake_target = Variable(torch.Tensor([[1], [1], [1], [1], [0]]))
+        fake_checklist = Variable(torch.Tensor([[0], [2], [0], [1], [0]]))
+        # pylint: disable=protected-access
+        balance = NlvrDecoderState._get_checklist_balance(fake_target, fake_checklist)
+        balance_data = balance.data.numpy()
+        expected_balance_data = numpy.asarray([[1], [0], [1], [0], [0]])
+        numpy.testing.assert_array_equal(balance_data, expected_balance_data)


### PR DESCRIPTION
I see that penalizing non-agenda actions makes the model overfit less. The accuracy on a small validation set I've been experimenting with went down after we removed currying, but the coverage went up. After I made this change, we're back to having the same accuracy as we did with currying (63%.. not great) but with higher coverage, now close to 80%.
In addition to adding the option of penalizing non-agenda actions, I also moved the code for computing model scores and checklists into `take_step`, as recommended by @matt-gardner in the review of #926.