### PR TITLE
Move --include-packages flag up to top level

### DIFF
--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -34,9 +34,7 @@ def main(prog: str = None,
     # `model_overrides`, and maybe the whole `serve` command as a public API (we only need that
     # path for demo.allennlp.org, and it's not likely anyone else would host that particular demo).
 
-    # TODO(mattg): is it the `[command]` here in the usage parameter that causes the funny
-    # duplication we see in the module docstrings?
-    parser = argparse.ArgumentParser(description="Run AllenNLP", usage='%(prog)s [command]', prog=prog)
+    parser = argparse.ArgumentParser(description="Run AllenNLP", usage='%(prog)s', prog=prog)
 
     subparsers = parser.add_subparsers(title='Commands', metavar='')
 

--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -62,7 +62,7 @@ def main(prog: str = None,
 
     args = parser.parse_args()
 
-    # Import any additional modules needed (to register custom classes)
+    # Import any additional modules needed (to register custom classes).
     for package_name in args.include_package:
         import_submodules(package_name)
 

--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -35,7 +35,7 @@ import argparse
 import logging
 
 from allennlp.commands.subcommand import Subcommand
-from allennlp.common.util import prepare_environment, import_submodules
+from allennlp.common.util import prepare_environment
 from allennlp.common.tqdm import Tqdm
 from allennlp.data import Instance
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
@@ -74,12 +74,6 @@ class Evaluate(Subcommand):
                                default="",
                                help='a HOCON structure used to override the experiment configuration')
 
-        subparser.add_argument('--include-package',
-                               type=str,
-                               action='append',
-                               default=[],
-                               help='additional packages to include')
-
         subparser.set_defaults(func=evaluate_from_args)
 
         return subparser
@@ -108,10 +102,6 @@ def evaluate_from_args(args: argparse.Namespace) -> Dict[str, Any]:
     logging.getLogger('allennlp.common.params').disabled = True
     logging.getLogger('allennlp.nn.initializers').disabled = True
     logging.getLogger('allennlp.modules.token_embedders.embedding').setLevel(logging.INFO)
-
-    # Import any additional modules needed (to register custom classes)
-    for package_name in args.include_package:
-        import_submodules(package_name)
 
     # Load from archive
     archive = load_archive(args.archive_file, args.cuda_device, args.overrides, args.weights_file)

--- a/allennlp/commands/fine_tune.py
+++ b/allennlp/commands/fine_tune.py
@@ -16,7 +16,7 @@ from allennlp.commands.evaluate import evaluate
 from allennlp.commands.subcommand import Subcommand
 from allennlp.commands.train import datasets_from_params
 from allennlp.common import Params, TeeLogger, Tqdm
-from allennlp.common.util import prepare_environment, import_submodules
+from allennlp.common.util import prepare_environment
 from allennlp.data.iterators.data_iterator import DataIterator
 from allennlp.models import load_archive, archive_model
 from allennlp.models.archival import CONFIG_NAME
@@ -55,12 +55,6 @@ class FineTune(Subcommand):
                                help='a HOCON structure used to override the training configuration '
                                '(only affects the config_file, _not_ the model_archive)')
 
-        subparser.add_argument('--include-package',
-                               type=str,
-                               action='append',
-                               default=[],
-                               help='additional packages to include')
-
         subparser.add_argument('--file-friendly-logging',
                                action='store_true',
                                default=False,
@@ -75,9 +69,6 @@ def fine_tune_model_from_args(args: argparse.Namespace):
     """
     Just converts from an ``argparse.Namespace`` object to string paths.
     """
-    # Import any additional modules needed (to register custom classes)
-    for package_name in args.include_package:
-        import_submodules(package_name)
     fine_tune_model_from_file_paths(model_archive_path=args.model_archive,
                                     config_file=args.config_file,
                                     serialization_dir=args.serialization_dir,

--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -46,7 +46,6 @@ from typing import Optional, IO, Dict
 
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError
-from allennlp.common.util import import_submodules
 from allennlp.models.archival import load_archive
 from allennlp.service.predictors import Predictor
 
@@ -92,12 +91,6 @@ class Predict(Subcommand):
                                type=str,
                                default="",
                                help='a HOCON structure used to override the experiment configuration')
-
-        subparser.add_argument('--include-package',
-                               type=str,
-                               action='append',
-                               default=[],
-                               help='additional packages to include')
 
         subparser.add_argument('--predictor',
                                type=str,
@@ -165,10 +158,6 @@ def _run(predictor: Predictor,
 
 def _predict(predictors: Dict[str, str]):
     def predict_inner(args: argparse.Namespace) -> None:
-        # Import any additional modules needed (to register custom classes)
-        for package_name in args.include_package:
-            import_submodules(package_name)
-
         predictor = _get_predictor(args, predictors)
         output_file = None
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -43,7 +43,7 @@ from allennlp.commands.evaluate import evaluate
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError
 from allennlp.common import Params, TeeLogger, Tqdm
-from allennlp.common.util import prepare_environment, import_submodules
+from allennlp.common.util import prepare_environment
 from allennlp.data import Vocabulary
 from allennlp.data.instance import Instance
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
@@ -80,12 +80,6 @@ class Train(Subcommand):
                                default="",
                                help='a HOCON structure used to override the experiment configuration')
 
-        subparser.add_argument('--include-package',
-                               type=str,
-                               action='append',
-                               default=[],
-                               help='additional packages to include')
-
         subparser.add_argument('--file-friendly-logging',
                                action='store_true',
                                default=False,
@@ -99,10 +93,6 @@ def train_model_from_args(args: argparse.Namespace):
     """
     Just converts from an ``argparse.Namespace`` object to string paths.
     """
-    # Import any additional modules needed (to register custom classes)
-    for package_name in args.include_package:
-        import_submodules(package_name)
-
     train_model_from_file(args.param_path,
                           args.serialization_dir,
                           args.overrides,

--- a/tests/commands/evaluate_test.py
+++ b/tests/commands/evaluate_test.py
@@ -24,7 +24,6 @@ class TestEvaluate(AllenNlpTestCase):
         subparsers = self.parser.add_subparsers(title='Commands', metavar='')
         Evaluate().add_subparser('evaluate', subparsers)
 
-
     @flaky
     def test_evaluate_from_args(self):
         kebab_args = ["evaluate", "tests/fixtures/bidaf/serialization/model.tar.gz",
@@ -34,57 +33,3 @@ class TestEvaluate(AllenNlpTestCase):
         args = self.parser.parse_args(kebab_args)
         metrics = evaluate_from_args(args)
         assert metrics.keys() == {'span_acc', 'end_acc', 'start_acc', 'em', 'f1'}
-
-    def test_external_modules(self):
-        sys.path.insert(0, self.TEST_DIR)
-
-        original_serialization_dir = 'tests/fixtures/bidaf/serialization'
-        serialization_dir = os.path.join(self.TEST_DIR, 'serialization')
-        shutil.copytree(original_serialization_dir, serialization_dir)
-
-        # Get original model config
-        tf = tarfile.open(os.path.join(original_serialization_dir, 'model.tar.gz'))
-        tf.extract('config.json', self.TEST_DIR)
-
-        # Write out modified config file
-        params = Params.from_file(os.path.join(self.TEST_DIR, 'config.json'))
-        params['model']['type'] = 'bidaf-duplicate'
-
-        config_file = os.path.join(serialization_dir, 'config.json')
-        with open(config_file, 'w') as f:
-            f.write(json.dumps(params.as_dict(quiet=True)))
-
-        # And create an archive
-        archive_model(serialization_dir)
-
-        # Write out modified model.py
-        module_dir = os.path.join(self.TEST_DIR, 'bidaf_duplicate')
-        os.makedirs(module_dir)
-
-        from allennlp.models.reading_comprehension import bidaf
-        with open(bidaf.__file__) as f:
-            code = f.read().replace("""@Model.register("bidaf")""",
-                                    """@Model.register('bidaf-duplicate')""")
-
-        with open(os.path.join(module_dir, 'model.py'), 'w') as f:
-            f.write(code)
-
-        archive_file = os.path.join(serialization_dir, 'model.tar.gz')
-
-        raw_args = ["evaluate", archive_file,
-                    "--evaluation-data-file", "tests/fixtures/data/squad.json"]
-
-        args = self.parser.parse_args(raw_args)
-
-        # Raise configuration error without extra modules
-        with pytest.raises(ConfigurationError):
-            metrics = evaluate_from_args(args)
-
-        # Specify the additional module
-        raw_args.extend(['--include-package', 'bidaf_duplicate'])
-        args = self.parser.parse_args(raw_args)
-        metrics = evaluate_from_args(args)
-
-        assert metrics.keys() == {'span_acc', 'end_acc', 'start_acc', 'em', 'f1'}
-
-        sys.path.remove(self.TEST_DIR)

--- a/tests/commands/evaluate_test.py
+++ b/tests/commands/evaluate_test.py
@@ -1,19 +1,10 @@
 # pylint: disable=invalid-name,no-self-use
 import argparse
-import json
-import os
-import shutil
-import sys
-import tarfile
 
 from flaky import flaky
-import pytest
 
 from allennlp.commands.evaluate import evaluate_from_args, Evaluate
-from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.models.archival import archive_model
 
 
 class TestEvaluate(AllenNlpTestCase):

--- a/tests/commands/main_test.py
+++ b/tests/commands/main_test.py
@@ -1,5 +1,4 @@
 # pytest: disable=no-self-use,invalid-name
-from unittest import TestCase
 import pathlib
 import shutil
 import sys
@@ -60,12 +59,12 @@ class TestMain(AllenNlpTestCase):
 
         # Write out a duplicate model there, but registered under a different name.
         from allennlp.models import simple_tagger
-        with open(simple_tagger.__file__) as f:
-            code = f.read().replace("""@Model.register("simple_tagger")""",
-                                    """@Model.register("duplicate-test-tagger")""")
+        with open(simple_tagger.__file__) as model_file:
+            code = model_file.read().replace("""@Model.register("simple_tagger")""",
+                                             """@Model.register("duplicate-test-tagger")""")
 
-        with open(os.path.join(packagedir, 'model.py'), 'w') as f:
-            f.write(code)
+        with open(os.path.join(packagedir, 'model.py'), 'w') as new_model_file:
+            new_model_file.write(code)
 
         # Copy fixture there too.
         shutil.copy(os.path.join(os.getcwd(), 'tests/fixtures/data/sequence_tagging.tsv'), self.TEST_DIR)
@@ -98,8 +97,8 @@ class TestMain(AllenNlpTestCase):
                         "optimizer": "adam"
                 }
             """.replace('$$$', data_path)
-        with open(config_path, 'w') as f:
-            f.write(config_json)
+        with open(config_path, 'w') as config_file:
+            config_file.write(config_json)
 
         serialization_dir = os.path.join(self.TEST_DIR, 'serialization')
 
@@ -119,8 +118,8 @@ class TestMain(AllenNlpTestCase):
         main()
 
         # Rewrite out config file, but change a value.
-        with open(config_path, 'w') as f:
-            f.write(config_json.replace('"num_epochs": 2,', '"num_epochs": 4,'))
+        with open(config_path, 'w') as new_config_file:
+            new_config_file.write(config_json.replace('"num_epochs": 2,', '"num_epochs": 4,'))
 
         # This should fail because the config.json does not match that in the serialization directory.
         with pytest.raises(ConfigurationError):

--- a/tests/commands/main_test.py
+++ b/tests/commands/main_test.py
@@ -1,11 +1,17 @@
 from unittest import TestCase
+import pathlib
+import shutil
 import sys
+import os
+
+import pytest
 
 from allennlp.commands import main
 from allennlp.commands.subcommand import Subcommand
+from allennlp.common.checks import ConfigurationError
+from allennlp.common.testing import AllenNlpTestCase
 
-class TestMain(TestCase):
-
+class TestMain(AllenNlpTestCase):
     def test_fails_on_unknown_command(self):
         sys.argv = ["bogus",         # command
                     "unknown_model", # model_name
@@ -37,7 +43,86 @@ class TestMain(TestCase):
 
         fake_evaluate = FakeEvaluate()
 
-        sys.argv = ["evaluate"]
+        sys.argv = ["allennlp.run", "evaluate"]
         main(subcommand_overrides={"evaluate": fake_evaluate})
 
         assert fake_evaluate.add_subparser_called
+
+    def test_other_modules(self):
+        # Create a new package in a temporary dir
+        packagedir = os.path.join(self.TEST_DIR, 'testpackage')
+        pathlib.Path(packagedir).mkdir()
+        pathlib.Path(os.path.join(packagedir, '__init__.py')).touch()
+
+        # And add that directory to the path
+        sys.path.insert(0, self.TEST_DIR)
+
+        # Write out a duplicate model there, but registered under a different name.
+        from allennlp.models import simple_tagger
+        with open(simple_tagger.__file__) as f:
+            code = f.read().replace("""@Model.register("simple_tagger")""",
+                                    """@Model.register("duplicate-test-tagger")""")
+
+        with open(os.path.join(packagedir, 'model.py'), 'w') as f:
+            f.write(code)
+
+        # Copy fixture there too.
+        shutil.copy(os.path.join(os.getcwd(), 'tests/fixtures/data/sequence_tagging.tsv'), self.TEST_DIR)
+        data_path = os.path.join(self.TEST_DIR, 'sequence_tagging.tsv')
+
+        # Write out config file
+        config_path = os.path.join(self.TEST_DIR, 'config.json')
+        config_json = """
+                "model": {
+                        "type": "duplicate-test-tagger",
+                        "text_field_embedder": {
+                                "tokens": {
+                                        "type": "embedding",
+                                        "embedding_dim": 5
+                                }
+                        },
+                        "encoder": {
+                                "type": "lstm",
+                                "input_size": 5,
+                                "hidden_size": 7,
+                                "num_layers": 2
+                        }
+                },
+                "dataset_reader": {"type": "sequence_tagging"},
+                "train_data_path": $$$,
+                "validation_data_path": $$$,
+                "iterator": {"type": "basic", "batch_size": 2},
+                "trainer": {
+                        "num_epochs": 2,
+                        "optimizer": "adam"
+                }
+            """.replace('$$$', data_path)
+        with open(config_path, 'w') as f:
+            f.write(config_json)
+
+        serialization_dir = os.path.join(self.TEST_DIR, 'serialization')
+
+        # Run train with using the non-allennlp module.
+        sys.argv = ["python -m allennlp.run",
+                    "train", config_path,
+                    "-s", serialization_dir]
+
+        # Shouldn't be able to find the model.
+        with pytest.raises(ConfigurationError):
+            main()
+
+        # Now add the --include-package flag and it should work.
+        # We also need to add --recover since the output directory already exists.
+        sys.argv.extend(["--recover", "--include-package", 'testpackage'])
+
+        main()
+
+        # Rewrite out config file, but change a value.
+        with open(config_path, 'w') as f:
+            f.write(config_json.replace('"num_epochs": 2,', '"num_epochs": 4,'))
+
+        # This should fail because the config.json does not match that in the serialization directory.
+        with pytest.raises(ConfigurationError):
+            main()
+
+        sys.path.remove(self.TEST_DIR)

--- a/tests/commands/main_test.py
+++ b/tests/commands/main_test.py
@@ -1,3 +1,4 @@
+# pytest: disable=no-self-use,invalid-name
 from unittest import TestCase
 import pathlib
 import shutil

--- a/tests/commands/train_test.py
+++ b/tests/commands/train_test.py
@@ -2,16 +2,9 @@
 import argparse
 from typing import Iterable
 import os
-import pathlib
-import shutil
-import sys
-
-import pytest
 
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.commands import main
 from allennlp.commands.train import Train, train_model, train_model_from_args
 from allennlp.data import DatasetReader, Instance
 
@@ -99,85 +92,6 @@ class TestTrain(AllenNlpTestCase):
         with self.assertRaises(SystemExit) as cm:  # pylint: disable=invalid-name
             args = parser.parse_args(["train", "path/to/params"])
             assert cm.exception.code == 2  # argparse code for incorrect usage
-
-    def test_other_modules(self):
-        # Create a new package in a temporary dir
-        packagedir = os.path.join(self.TEST_DIR, 'testpackage')
-        pathlib.Path(packagedir).mkdir()
-        pathlib.Path(os.path.join(packagedir, '__init__.py')).touch()
-
-        # And add that directory to the path
-        sys.path.insert(0, self.TEST_DIR)
-
-        # Write out a duplicate model there, but registered under a different name.
-        from allennlp.models import simple_tagger
-        with open(simple_tagger.__file__) as f:
-            code = f.read().replace("""@Model.register("simple_tagger")""",
-                                    """@Model.register("duplicate-test-tagger")""")
-
-        with open(os.path.join(packagedir, 'model.py'), 'w') as f:
-            f.write(code)
-
-        # Copy fixture there too.
-        shutil.copy(os.path.join(os.getcwd(), 'tests/fixtures/data/sequence_tagging.tsv'), self.TEST_DIR)
-        data_path = os.path.join(self.TEST_DIR, 'sequence_tagging.tsv')
-
-        # Write out config file
-        config_path = os.path.join(self.TEST_DIR, 'config.json')
-        config_json = """
-                "model": {
-                        "type": "duplicate-test-tagger",
-                        "text_field_embedder": {
-                                "tokens": {
-                                        "type": "embedding",
-                                        "embedding_dim": 5
-                                }
-                        },
-                        "encoder": {
-                                "type": "lstm",
-                                "input_size": 5,
-                                "hidden_size": 7,
-                                "num_layers": 2
-                        }
-                },
-                "dataset_reader": {"type": "sequence_tagging"},
-                "train_data_path": $$$,
-                "validation_data_path": $$$,
-                "iterator": {"type": "basic", "batch_size": 2},
-                "trainer": {
-                        "num_epochs": 2,
-                        "optimizer": "adam"
-                }
-            """.replace('$$$', data_path)
-        with open(config_path, 'w') as f:
-            f.write(config_json)
-
-        serialization_dir = os.path.join(self.TEST_DIR, 'serialization')
-
-        # Run train with using the non-allennlp module.
-        sys.argv = ["python -m allennlp.run",
-                    "train", config_path,
-                    "-s", serialization_dir]
-
-        # Shouldn't be able to find the model.
-        with pytest.raises(ConfigurationError):
-            main()
-
-        # Now add the --include-package flag and it should work.
-        # We also need to add --recover since the output directory already exists.
-        sys.argv.extend(["--recover", "--include-package", 'testpackage'])
-
-        main()
-
-        # Rewrite out config file, but change a value.
-        with open(config_path, 'w') as f:
-            f.write(config_json.replace('"num_epochs": 2,', '"num_epochs": 4,'))
-
-        # This should fail because the config.json does not match that in the serialization directory.
-        with pytest.raises(ConfigurationError):
-            main()
-
-        sys.path.remove(self.TEST_DIR)
 
 
 @DatasetReader.register('lazy-test')


### PR DESCRIPTION
Fixes #961.  Now any command will be able to include submodules, and new commands will get this automatically.  The elmo command doesn't really need this, but all of the others do.