### PR TITLE
Fix max_vocab_size bug (#964)

### DIFF
--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -172,7 +172,8 @@ class Vocabulary:
         self._padding_token = DEFAULT_PADDING_TOKEN
         self._oov_token = DEFAULT_OOV_TOKEN
         if not isinstance(max_vocab_size, dict):
-            max_vocab_size = defaultdict(lambda: max_vocab_size)  # type: ignore
+            max_vocab_size_notdict = max_vocab_size
+            max_vocab_size = defaultdict(lambda: max_vocab_size_notdict)  # type: ignore
         self._non_padded_namespaces = non_padded_namespaces
         self._token_to_index = _TokenToIndexDefaultDict(non_padded_namespaces,
                                                         self._padding_token,
@@ -190,7 +191,7 @@ class Vocabulary:
                     pretrained_list = None
                 token_counts = list(counter[namespace].items())
                 token_counts.sort(key=lambda x: x[1], reverse=True)
-                max_vocab = max_vocab_size.get(namespace)
+                max_vocab = max_vocab_size[namespace]
                 if max_vocab:
                     token_counts = token_counts[:max_vocab]
                 for token, count in token_counts:

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -172,8 +172,8 @@ class Vocabulary:
         self._padding_token = DEFAULT_PADDING_TOKEN
         self._oov_token = DEFAULT_OOV_TOKEN
         if not isinstance(max_vocab_size, dict):
-            max_vocab_size_notdict = max_vocab_size
-            max_vocab_size = defaultdict(lambda: max_vocab_size_notdict)  # type: ignore
+            int_max_vocab_size = max_vocab_size
+            max_vocab_size = defaultdict(lambda: int_max_vocab_size)  # type: ignore
         self._non_padded_namespaces = non_padded_namespaces
         self._token_to_index = _TokenToIndexDefaultDict(non_padded_namespaces,
                                                         self._padding_token,

--- a/tests/data/vocabulary_test.py
+++ b/tests/data/vocabulary_test.py
@@ -25,8 +25,18 @@ class TestVocabulary(AllenNlpTestCase):
         self.dataset = Batch([self.instance])
         super(TestVocabulary, self).setUp()
 
-    def test_from_dataset_respects_min_count(self):
+    def test_from_dataset_respects_max_vocab_size_single_int(self):
+        max_vocab_size = 1
+        vocab = Vocabulary.from_instances(self.dataset, max_vocab_size=max_vocab_size)
+        words = vocab.get_index_to_token_vocabulary().values()
+        # Additional 2 tokens are '@@PADDING@@' and '@@UNKNOWN@@' by default
+        assert len(words) == max_vocab_size + 2
 
+        vocab = Vocabulary.from_instances(self.dataset, min_count=None)
+        words = vocab.get_index_to_token_vocabulary().values()
+        assert len(words) == 5
+
+    def test_from_dataset_respects_min_count(self):
         vocab = Vocabulary.from_instances(self.dataset, min_count={'tokens': 4})
         words = vocab.get_index_to_token_vocabulary().values()
         assert 'a' in words


### PR DESCRIPTION
There were 2 problems here:

1) `max_vocab_size = defaultdict(lambda: max_vocab_size)`
default value for the new dictionary becomes `defaultdict` itself, and not the int as supposed
2) `max_vocab = max_vocab_size.get(namespace)`
probably it supposed to be `max_vocab_size[namespace]` instead (since it also adds a new element to the `defaultdict`)

Fixes #964.