### PR TITLE
Parameterized selection of in-agenda actions

### DIFF
--- a/allennlp/data/semparse/worlds/nlvr_world.py
+++ b/allennlp/data/semparse/worlds/nlvr_world.py
@@ -246,6 +246,12 @@ class NlvrWorld(World):
         number_productions = self._get_number_productions(sentence)
         for production in number_productions:
             agenda.append(production)
+        if not agenda:
+            # None of the rules above was triggered!
+            if "box" in sentence:
+                agenda.append(self.terminal_productions["all_boxes"])
+            else:
+                agenda.append(self.terminal_productions["all_objects"])
         if add_paths_to_agenda:
             agenda = self._add_nonterminal_productions(agenda)
         return agenda

--- a/allennlp/models/encoder_decoders/nlvr_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/nlvr_semantic_parser.py
@@ -94,11 +94,10 @@ class NlvrSemanticParser(Model):
         self._encoder = encoder
         self._decoder_trainer = decoder_trainer
         self._max_decoding_steps = max_decoding_steps
-        attention_function = attention_function
         action_embedding_dim = nonterminal_embedder.get_output_dim() * 2
 
         # Instantiating an empty NlvrWorld just to get the number of terminals.
-        num_terminals = len(NlvrWorld({}).terminal_productions)
+        num_terminals = len(NlvrWorld([]).terminal_productions)
         self._decoder_step = NlvrDecoderStep(encoder_output_dim=self._encoder.get_output_dim(),
                                              action_embedding_dim=action_embedding_dim,
                                              attention_function=attention_function,

--- a/tests/fixtures/encoder_decoder/nlvr_semantic_parser/experiment.json
+++ b/tests/fixtures/encoder_decoder/nlvr_semantic_parser/experiment.json
@@ -45,7 +45,6 @@
     },
     "max_decoding_steps": 20,
     "attention_function": {"type": "dot_product"},
-    "checklist_selection_weight": 0.5,
     "checklist_cost_weight": 0.8,
     "penalize_non_agenda_actions": true
   },

--- a/tests/models/encoder_decoders/nlvr_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/nlvr_semantic_parser_test.py
@@ -1,11 +1,9 @@
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=no-self-use,protected-access,invalid-name
 from numpy.testing import assert_almost_equal
 import torch
 from torch.autograd import Variable
 
-from allennlp.common.testing import ModelTestCase, AllenNlpTestCase
-from allennlp.models.encoder_decoders.nlvr_semantic_parser import NlvrDecoderState
-
+from allennlp.common.testing import ModelTestCase
 
 class NlvrSemanticParserTest(ModelTestCase):
     def setUp(self):
@@ -16,7 +14,7 @@ class NlvrSemanticParserTest(ModelTestCase):
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)
 
-    def test_get_checklist_target(self):
+    def test_get_checklist_info(self):
         # Creating a fake all_actions field where actions 0, 2 and 4 are terminal productions.
         all_actions = [{"left": ("", True, {}), "right": ("", False, {})},
                        {"left": ("", True, {}), "right": ("", True, {})},
@@ -26,16 +24,8 @@ class NlvrSemanticParserTest(ModelTestCase):
         # Of the actions above, those at indices 0 and 4 are on the agenda, and there are padding
         # indices at the end.
         test_agenda = Variable(torch.Tensor([[0], [4], [-1], [-1]]))
-        target_checklist, relevant_actions = self.model._get_checklist_target(test_agenda,
-                                                                              all_actions)
+        checklist_info = self.model._get_checklist_info(test_agenda, all_actions)
+        target_checklist, terminal_actions, checklist_mask = checklist_info
         assert_almost_equal(target_checklist.data.numpy(), [[1], [0], [1]])
-        assert_almost_equal(relevant_actions.data.numpy(), [[0], [2], [4]])
-
-
-class NlvrDecoderStateTest(AllenNlpTestCase):
-    def test_get_checklist_balance(self):
-        fake_target = Variable(torch.Tensor([[1], [1], [1], [1], [0]]))
-        fake_checklist = Variable(torch.Tensor([[0], [2], [0], [1], [0]]))
-        # pylint: disable=protected-access
-        balance = NlvrDecoderState._get_checklist_balance(fake_target, fake_checklist)
-        assert_almost_equal(balance.data.numpy(), [[1], [0], [1], [0], [0]])
+        assert_almost_equal(terminal_actions.data.numpy(), [[0], [2], [4]])
+        assert_almost_equal(checklist_mask.data.numpy(), [[1], [1], [1]])


### PR DESCRIPTION
The model used to assign uniform probabilities to all allowed in-agenda actions. This PR makes this parameterized by changing the output projection layer to project the concatenation of the current hidden state, attended encoder outputs, and now also the checklist difference. Doing this eliminates the `checklist_selection_weight` hyperparameter, which was the mixing weight for in-agenda probabilities and model assigned probabilities. Also, this makes our plans for eventually using linking scores in the checklist easier.