### PR TITLE
Fix key error, update training configuration

### DIFF
--- a/allennlp/data/semparse/worlds/wikitables_world.py
+++ b/allennlp/data/semparse/worlds/wikitables_world.py
@@ -92,6 +92,10 @@ class WikiTablesWorld(World):
         del valid_actions['<p,p>']
         del valid_actions['<p,r>']
 
+        # The argmax type generates an action that takes a date as an argument, which it turns out
+        # we don't need for parts.
+        self._remove_action_from_type(valid_actions, 'p', lambda x: '<d,p>' in x)
+
         # Our code that generates lambda productions similarly creates more than we need.
         for type_ in ['<c,p>', '<c,r>', '<d,c>', '<d,r>', '<n,c>', '<n,p>', '<n,r>', '<p,c>',
                       '<r,c>', '<r,r>']:

--- a/tests/data/semparse/worlds/wikitables_world_test.py
+++ b/tests/data/semparse/worlds/wikitables_world_test.py
@@ -226,11 +226,8 @@ class TestWikiTablesWorld(AllenNlpTestCase):
                                  '[<nd,nd>, n]',
                                  '[<r,n>, r]'])
 
-        # TODO(mattg): There should be a bunch of terminal productions here, but those aren't
-        # implemented at this point.
         check_productions_match(valid_actions['p'],
-                                ['[<n,<n,<#1,<<#2,#1>,#1>>>>, n, n, p, <d,p>]',
-                                 '[<n,<n,<#1,<<#2,#1>,#1>>>>, n, n, p, <n,p>]',
+                                ['[<n,<n,<#1,<<#2,#1>,#1>>>>, n, n, p, <n,p>]',
                                  '[<#1,#1>, p]',
                                  '[<c,p>, c]',
                                  '[<#1,<#1,#1>>, p, p]',

--- a/training_config/wikitables_parser.json
+++ b/training_config/wikitables_parser.json
@@ -9,8 +9,8 @@
   "vocabulary": {
     "min_count": {"tokens": 3}
   },
-  "train_data_path": "/wikitables_preprocessed/with_part_implemented/train.jsonl",
-  "validation_data_path": "/wikitables_preprocessed/with_part_implemented/validation.jsonl",
+  "train_data_path": "/wikitables_preprocessed/train.jsonl",
+  "validation_data_path": "/wikitables_preprocessed/validation.jsonl",
   "model": {
     "type": "wikitables_parser",
     "question_embedder": {
@@ -59,7 +59,12 @@
     "cuda_device": 0,
     "validation_metric": "+parse_acc",
     "optimizer": {
-      "type": "adam"
+      "type": "sgd",
+      "lr": 0.1
+    },
+    "learning_rate_scheduler": {
+      "type": "exponential",
+      "gamma": 0.99
     }
   }
 }


### PR DESCRIPTION
This is actually a very small change, but it depends on #947.  @rajasagashe, this should fix the key errors we were seeing.  It also has an updated training config, with optimizer parameters that match those in the original paper.  I had more luck with using a learning rate of 0.01, though - the 0.1 run I did crashed with an error I'm still looking into.