### PR TITLE
Fix simple tagger link in creating a model tutorial

### DIFF
--- a/tutorials/getting_started/creating_a_model.md
+++ b/tutorials/getting_started/creating_a_model.md
@@ -13,7 +13,7 @@ In this tutorial we'll also implement a custom PyTorch
 [`Module`](http://pytorch.org/docs/master/nn.html#torch.nn.Module),
 but you won't need to do that in general.
 
-Our [simple tagger](simple-tagger) model
+Our [simple tagger](https://github.com/allenai/allennlp/blob/master/allennlp/models/simple_tagger.py) model
 uses an LSTM to capture dependencies between
 the words in the input sentence, but doesn't have a great way
 to capture dependencies between the _tags_. This can be a problem

--- a/tutorials/getting_started/creating_a_model.md
+++ b/tutorials/getting_started/creating_a_model.md
@@ -13,7 +13,7 @@ In this tutorial we'll also implement a custom PyTorch
 [`Module`](http://pytorch.org/docs/master/nn.html#torch.nn.Module),
 but you won't need to do that in general.
 
-Our [simple tagger](https://github.com/allenai/allennlp/blob/master/allennlp/models/simple_tagger.py) model
+Our [simple tagger](training_and_evaluating.md) model
 uses an LSTM to capture dependencies between
 the words in the input sentence, but doesn't have a great way
 to capture dependencies between the _tags_. This can be a problem


### PR DESCRIPTION
Previous link went to a 404.