### PR TITLE
better error for gradient check

### DIFF
--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -133,15 +133,24 @@ class ModelTestCase(AllenNlpTestCase):
         model.zero_grad()
         result = model(**model_batch)
         result["loss"].backward()
-
-        for parameter in model.parameters():
+        has_zero_or_none_grads = {}
+        for name, parameter in model.named_parameters():
             zeros = torch.zeros(parameter.size())
             if parameter.requires_grad:
+
+                if parameter.grad is None:
+                    has_zero_or_none_grads[name] = "No gradient computed (i.e parameter.grad is None)"
                 # Some parameters will only be partially updated,
                 # like embeddings, so we just check that any gradient is non-zero.
-                assert (parameter.grad.data.cpu() != zeros).any()
+                if not (parameter.grad.data.cpu() != zeros).any():
+                    has_zero_or_none_grads[name] = f"zeros with shape ({tuple(parameter.grad.size())})"
             else:
                 assert parameter.grad is None
+
+        if has_zero_or_none_grads:
+            for name, grad in has_zero_or_none_grads.items():
+                print(f"Parameter: {name} had incorrect gradient: {grad}")
+            raise Exception("Incorrect gradients found. See stack trace for info.")
 
     def ensure_batch_predictions_are_consistent(self):
         self.model.eval()

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -150,7 +150,7 @@ class ModelTestCase(AllenNlpTestCase):
         if has_zero_or_none_grads:
             for name, grad in has_zero_or_none_grads.items():
                 print(f"Parameter: {name} had incorrect gradient: {grad}")
-            raise Exception("Incorrect gradients found. See stack trace for info.")
+            raise Exception("Incorrect gradients found. See stdout for more info.")
 
     def ensure_batch_predictions_are_consistent(self):
         self.model.eval()

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -142,7 +142,7 @@ class ModelTestCase(AllenNlpTestCase):
                     has_zero_or_none_grads[name] = "No gradient computed (i.e parameter.grad is None)"
                 # Some parameters will only be partially updated,
                 # like embeddings, so we just check that any gradient is non-zero.
-                if not (parameter.grad.data.cpu() != zeros).any():
+                if (parameter.grad.data.cpu() == zeros).all():
                     has_zero_or_none_grads[name] = f"zeros with shape ({tuple(parameter.grad.size())})"
             else:
                 assert parameter.grad is None


### PR DESCRIPTION
The assert gave a really rubbish error in the case that the gradient was `None`, so this will improve that.