### PR TITLE
add an initial string representation to fields and instances

### DIFF
--- a/allennlp/data/fields/array_field.py
+++ b/allennlp/data/fields/array_field.py
@@ -48,3 +48,7 @@ class ArrayField(Field[numpy.ndarray]):
         # Pass the padding_value, so that any outer field, e.g., `ListField[ArrayField]` uses the
         # same padding_value in the padded ArrayFields
         return ArrayField(numpy.array([], dtype="float32"), padding_value=self.padding_value)
+
+
+    def __str__(self) -> str:
+        return f"ArrayField with shape: {self.array.shape}."

--- a/allennlp/data/fields/index_field.py
+++ b/allennlp/data/fields/index_field.py
@@ -54,4 +54,4 @@ class IndexField(Field[torch.Tensor]):
         return IndexField(-1, self.sequence_field.empty_field())
 
     def __str__(self) -> str:
-        return f"IndexField with index: {self.sequence_index}"
+        return f"IndexField with index: {self.sequence_index}."

--- a/allennlp/data/fields/index_field.py
+++ b/allennlp/data/fields/index_field.py
@@ -52,3 +52,6 @@ class IndexField(Field[torch.Tensor]):
     @overrides
     def empty_field(self):
         return IndexField(-1, self.sequence_field.empty_field())
+
+    def __str__(self) -> str:
+        return f"IndexField with index: {self.sequence_index}"

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -98,3 +98,6 @@ class LabelField(Field[torch.Tensor]):
     @overrides
     def empty_field(self):
         return LabelField(-1, self._label_namespace, skip_indexing=True)
+
+    def __str__(self) -> str:
+        return f"LabelField with label: {self.label} in namespace {self._label_namespace}"

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -100,4 +100,4 @@ class LabelField(Field[torch.Tensor]):
         return LabelField(-1, self._label_namespace, skip_indexing=True)
 
     def __str__(self) -> str:
-        return f"LabelField with label: {self.label} in namespace {self._label_namespace}"
+        return f"LabelField with label: {self.label} in namespace: '{self._label_namespace}'.'"

--- a/allennlp/data/fields/list_field.py
+++ b/allennlp/data/fields/list_field.py
@@ -96,3 +96,8 @@ class ListField(SequenceField[DataArray]):
     def batch_tensors(self, tensor_list: List[DataArray]) -> DataArray:
         # We defer to the class we're wrapping in a list to handle the batching.
         return self.field_list[0].batch_tensors(tensor_list)
+
+    def __str__(self) -> str:
+        field_class = self.field_list[0].__class__.__name__
+        base_string = f"ListField of {len(self.field_list)} {field_class}s : \n"
+        return " ".join([base_string] + [f"\t {field} \n" for field in self.field_list])

--- a/allennlp/data/fields/metadata_field.py
+++ b/allennlp/data/fields/metadata_field.py
@@ -50,4 +50,4 @@ class MetadataField(Field[DataArray]):
 
 
     def __str__(self) -> str:
-        return f"MetadataField (print field.metadata to see specific information.)"
+        return f"MetadataField (print field.metadata to see specific information)."

--- a/allennlp/data/fields/metadata_field.py
+++ b/allennlp/data/fields/metadata_field.py
@@ -47,3 +47,7 @@ class MetadataField(Field[DataArray]):
     @overrides
     def batch_tensors(cls, tensor_list: List[DataArray]) -> DataArray:  # type: ignore
         return tensor_list  # type: ignore
+
+
+    def __str__(self) -> str:
+        return f"MetadataField with metadata: {self.metadata}"

--- a/allennlp/data/fields/metadata_field.py
+++ b/allennlp/data/fields/metadata_field.py
@@ -50,5 +50,4 @@ class MetadataField(Field[DataArray]):
 
 
     def __str__(self) -> str:
-        # If you print a Metadata Field, we'll just assume it has a string representation.
-        return f"MetadataField with metadata: {self.metadata}" # type: ignore
+        return f"MetadataField (print field.metadata to see specific information.)"

--- a/allennlp/data/fields/metadata_field.py
+++ b/allennlp/data/fields/metadata_field.py
@@ -50,4 +50,5 @@ class MetadataField(Field[DataArray]):
 
 
     def __str__(self) -> str:
-        return f"MetadataField with metadata: {self.metadata}"
+        # If you print a Metadata Field, we'll just assume it has a string representation.
+        return f"MetadataField with metadata: {self.metadata}" # type: ignore

--- a/allennlp/data/fields/sequence_label_field.py
+++ b/allennlp/data/fields/sequence_label_field.py
@@ -114,4 +114,4 @@ class SequenceLabelField(Field[torch.Tensor]):
         formatted_labels = "".join(["\t\t" + labels + "\n"
                                     for labels in textwrap.wrap(repr(self.labels), 100)])
         return f"SequenceLabelField of length {length} with " \
-               f"labels {formatted_labels} \t\tin namespace {self._label_namespace}."
+               f"labels:\n {formatted_labels} \t\tin namespace {self._label_namespace}."

--- a/allennlp/data/fields/sequence_label_field.py
+++ b/allennlp/data/fields/sequence_label_field.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Union, Set
 import logging
+import textwrap
 
 from overrides import overrides
 import torch
@@ -107,3 +108,10 @@ class SequenceLabelField(Field[torch.Tensor]):
         sequence_label_field = SequenceLabelField([], self.sequence_field.empty_field())
         sequence_label_field._indexed_labels = []
         return sequence_label_field
+
+    def __str__(self) -> str:
+        length = self.sequence_field.sequence_length()
+        formatted_labels = "".join(["\t\t" + labels + "\n"
+                                    for labels in textwrap.wrap(repr(self.labels), 100)])
+        return f"SequenceLabelField of length {length} with " \
+               f"labels {formatted_labels} \t\tin namespace {self._label_namespace}."

--- a/allennlp/data/fields/sequence_label_field.py
+++ b/allennlp/data/fields/sequence_label_field.py
@@ -114,4 +114,4 @@ class SequenceLabelField(Field[torch.Tensor]):
         formatted_labels = "".join(["\t\t" + labels + "\n"
                                     for labels in textwrap.wrap(repr(self.labels), 100)])
         return f"SequenceLabelField of length {length} with " \
-               f"labels:\n {formatted_labels} \t\tin namespace {self._label_namespace}."
+               f"labels:\n {formatted_labels} \t\tin namespace: '{self._label_namespace}'."

--- a/allennlp/data/fields/span_field.py
+++ b/allennlp/data/fields/span_field.py
@@ -59,3 +59,6 @@ class SpanField(Field[torch.Tensor]):
     @overrides
     def empty_field(self):
         return SpanField(-1, -1, self.sequence_field.empty_field())
+
+    def __str__(self) -> str:
+        return f"SpanField with spans: ({self.span_start}, {self.span_end})"

--- a/allennlp/data/fields/span_field.py
+++ b/allennlp/data/fields/span_field.py
@@ -61,4 +61,4 @@ class SpanField(Field[torch.Tensor]):
         return SpanField(-1, -1, self.sequence_field.empty_field())
 
     def __str__(self) -> str:
-        return f"SpanField with spans: ({self.span_start}, {self.span_end})"
+        return f"SpanField with spans: ({self.span_start}, {self.span_end})."

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -3,6 +3,7 @@ A ``TextField`` represents a string of text, the kind that you might want to rep
 standard word vectors, or pass through an LSTM.
 """
 from typing import Dict, List, Optional
+import textwrap
 
 from overrides import overrides
 from spacy.tokens import Token as SpacyToken
@@ -135,3 +136,12 @@ class TextField(SequenceField[Dict[str, torch.Tensor]]):
         # This is creating a dict of {token_indexer_key: batch_tensor} for each token indexer used
         # to index this field.
         return util.batch_tensor_dicts(tensor_list)
+
+    def __str__(self) -> str:
+        indexers = {name: indexer.__class__.__name__ for name, indexer in self._token_indexers.items()}
+
+        # Double tab to indent under the header.
+        formatted_text = "".join(["\t\t" + text + "\n"
+                                  for text in textwrap.wrap(repr(self.tokens), 100)])
+        return f"TextField of length {self.sequence_length()} with " \
+               f"text: \n {formatted_text} \t\tand TokenIndexers : {indexers}"

--- a/allennlp/data/instance.py
+++ b/allennlp/data/instance.py
@@ -78,3 +78,9 @@ class Instance:
                                                   cuda_device=cuda_device,
                                                   for_training=for_training)
         return tensors
+
+
+    def __str__(self) -> str:
+        base_string = f"Instance with fields:\n"
+        return " ".join([base_string] + [f"\t {name}: {field} \n"
+                                         for name, field in self.fields.items()])

--- a/tests/data/fields/array_field_test.py
+++ b/tests/data/fields/array_field_test.py
@@ -53,3 +53,7 @@ class TestArrayField(AllenNlpTestCase):
                                       [[-1., -1., -1., -1., -1.],
                                        [-1., -1., -1., -1., -1.]]])
         numpy.testing.assert_array_equal(returned_tensor, correct_tensor)
+
+    def test_printing_doesnt_crash(self):
+        array = ArrayField(numpy.ones([2, 3]), padding_value=-1)
+        print(array)

--- a/tests/data/fields/index_field_test.py
+++ b/tests/data/fields/index_field_test.py
@@ -27,3 +27,6 @@ class TestIndexField(AllenNlpTestCase):
         index_field = IndexField(4, self.text)
         empty_index = index_field.empty_field()
         assert empty_index.sequence_index == -1
+
+    def test_printing_doesnt_crash(self):
+        print(self.text)

--- a/tests/data/fields/label_field_test.py
+++ b/tests/data/fields/label_field_test.py
@@ -54,3 +54,8 @@ class TestLabelField(AllenNlpTestCase):
         assert "text2" not in LabelField._already_warned_namespaces
         with self.assertLogs(logger="allennlp.data.fields.label_field", level="WARNING"):
             _ = LabelField("test", label_namespace="text2")
+
+    def test_printing_doesnt_crash(self):
+        label = LabelField("label", label_namespace="namespace")
+        print(label)
+ 

--- a/tests/data/fields/list_field_test.py
+++ b/tests/data/fields/list_field_test.py
@@ -177,3 +177,7 @@ class TestListField(AllenNlpTestCase):
                                                                             [1, 0, 0, 0, 0, 0, 0, 0, 0],
                                                                             [1, 1, 1, 1, 3, 1, 3, 4, 5],
                                                                             [2, 3, 4, 5, 3, 4, 6, 3, 0]]))
+
+    def test_printing_doesnt_crash(self):
+        list_field = ListField([self.field1, self.field2])
+        print(list_field)

--- a/tests/data/fields/sequence_label_field_test.py
+++ b/tests/data/fields/sequence_label_field_test.py
@@ -83,3 +83,8 @@ class TestSequenceLabelField(AllenNlpTestCase):
         assert "text2" not in SequenceLabelField._already_warned_namespaces
         with self.assertLogs(logger="allennlp.data.fields.sequence_label_field", level="WARNING"):
             _ = SequenceLabelField(tags, self.text, label_namespace="text2")
+
+    def test_printing_doesnt_crash(self):
+        tags = ["B", "I", "O", "O", "O"]
+        sequence_label_field = SequenceLabelField(tags, self.text, label_namespace="labels")
+        print(sequence_label_field)

--- a/tests/data/fields/span_field_test.py
+++ b/tests/data/fields/span_field_test.py
@@ -35,3 +35,7 @@ class TestSpanField(AllenNlpTestCase):
         empty_span = span_field.empty_field()
         assert empty_span.span_start == -1
         assert empty_span.span_end == -1
+
+    def test_printing_doesnt_crash(self):
+        span_field = SpanField(2, 3, self.text)
+        print(span_field)

--- a/tests/data/fields/text_field_test.py
+++ b/tests/data/fields/text_field_test.py
@@ -188,3 +188,8 @@ class TestTextField(AllenNlpTestCase):
                                                              [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                                              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                                              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]))
+
+    def test_printing_doesnt_crash(self):
+        field = TextField([Token(t) for t in ["A", "sentence"]],
+                          {"words": SingleIdTokenIndexer(namespace="words")})
+        print(field)


### PR DESCRIPTION
Here's an initial pass at making it easier to see what's happening inside the data pieces. I'm sure there's many things we can add/improve but already I can see that this would help me check things when building a model.

SNLI:
```
>>> print(instance)
Instance with fields:
         premise: TextField of length 12 with text:
                [A, person, on, a, horse, jumps, over, a, broken, down, airplane, .]
                and TokenIndexers : {'tokens': 'SingleIdTokenIndexer'}
         hypothesis: TextField of length 10 with text:
                [A, person, is, training, his, horse, for, a, competition, .]
                and TokenIndexers : {'tokens': 'SingleIdTokenIndexer'}
         label: LabelField with label: neutral in namespace labels
```

Squad:
```
>>> print(instance)
Instance with fields:
         passage: TextField with text:
                [Architecturally, ,, the, school, has, a, Catholic, character, ., Atop, the, Main, Building, 's,
                gold, dome, is, a, golden, statue, of, the, Virgin, Mary, ., Immediately, in, front, of, the, Main,
                Building, and, facing, it, ,, is, a, copper, statue, of, Christ, with, arms, upraised, with, the,
                legend, ", Venite, Ad, Me, Omnes, ", ., Next, to, the, Main, Building, is, the, Basilica, of, the,
                Sacred, Heart, ., Immediately, behind, the, basilica, is, the, Grotto, ,, a, Marian, place, of,
                prayer, and, reflection, ., It, is, a, replica, of, the, grotto, at, Lourdes, ,, France, where, the,
                Virgin, Mary, reputedly, appeared, to, Saint, Bernadette, Soubirous, in, 1858, ., At, the, end, of,
                the, main, drive, (, and, in, a, direct, line, that, connects, through, 3, statues, and, the, Gold,
                Dome, ), ,, is, a, simple, ,, modern, stone, statue, of, Mary, .]
                and token indexers : {'tokens': 'SingleIdTokenIndexer'}
         question: TextField with text:
                [To, whom, did, the, Virgin, Mary, allegedly, appear, in, 1858, in, Lourdes, France, ?]
                and token indexers : {'tokens': 'SingleIdTokenIndexer'}
         span_start: IndexField with index: 102
         span_end: IndexField with index: 104
```

SRL
```
>>> print(instance)
Instance with fields:
         tokens: TextField of length 11 with text:
                [Mali, government, officials, say, the, woman, 's, confession, was, forced, .]
                and TokenIndexers : {'tokens': 'SingleIdTokenIndexer'}
         verb_indicator: SequenceLabelField of length 11 with labels:
                [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]
                in namespace labels.
         tags: SequenceLabelField of length 11 with labels:
                ['B-ARG0', 'I-ARG0', 'I-ARG0', 'B-V', 'B-ARG1', 'I-ARG1', 'I-ARG1', 'I-ARG1', 'I-ARG1', 'I-ARG1',
                'O']
                in namespace labels.

```

It gets a bit crazy with the coref and parsing instances, because we're enumerating spans, but it's still very useful.


