### PR TITLE
Add Stanford Sentiment Treebank dataset reader

### DIFF
--- a/allennlp/data/dataset_readers/__init__.py
+++ b/allennlp/data/dataset_readers/__init__.py
@@ -16,3 +16,5 @@ from allennlp.data.dataset_readers.semantic_role_labeling import SrlReader
 from allennlp.data.dataset_readers.seq2seq import Seq2SeqDatasetReader
 from allennlp.data.dataset_readers.coreference_resolution import ConllCorefReader, WinobiasReader
 from allennlp.data.dataset_readers.penn_tree_bank import PennTreeBankConstituencySpanDatasetReader
+from allennlp.data.dataset_readers.stanford_sentiment_tree_bank import (
+        StanfordSentimentTreeBankTokensDatasetReader)

--- a/allennlp/data/dataset_readers/__init__.py
+++ b/allennlp/data/dataset_readers/__init__.py
@@ -17,4 +17,4 @@ from allennlp.data.dataset_readers.seq2seq import Seq2SeqDatasetReader
 from allennlp.data.dataset_readers.coreference_resolution import ConllCorefReader, WinobiasReader
 from allennlp.data.dataset_readers.penn_tree_bank import PennTreeBankConstituencySpanDatasetReader
 from allennlp.data.dataset_readers.stanford_sentiment_tree_bank import (
-        StanfordSentimentTreeBankTokensDatasetReader)
+        StanfordSentimentTreeBankDatasetReader)

--- a/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
@@ -22,27 +22,34 @@ class StanfordSentimentTreeBankTokensDatasetReader(DatasetReader):
     """
     Reads tokens and their sentiment labels from the Stanford Sentiment Treebank.
 
+    The Stanford Sentiment Treebank comes with labels
+    from 0 to 4. ``"5-class"`` uses these labels as is. ``"3-class"`` converts the
+    problem into one of identifying whether a sentence is negative, positive, or
+    neutral sentiment. In this case, 0 and 1 are grouped as label 0 (negative sentiment),
+    2 is converted to label 1 (neutral sentiment) and 3 and 4 are grouped as label 2
+    (positive sentiment). ``"2-class"`` turns it into a binary classification problem
+    between positive and negative sentiment. 0 and 1 are grouped as the label 0
+    (negative sentiment), 2 (neutral) is discarded, and 3 and 4 are grouped as the label 1
+    (positive sentiment).
+
+    Expected format for each input line: a linearized tree, where nodes are labeled
+    by their sentiment.
+
+    The output of ``read`` is a list of ``Instance`` s with the fields:
+        tokens: ``TextField`` and
+        label: ``LabelField``
+
     Parameters
     ----------
     token_indexers : ``Dict[str, TokenIndexer]``, optional (default=``{"tokens": SingleIdTokenIndexer()}``)
         We use this to define the input representation for the text.  See :class:`TokenIndexer`.
-        Note that the `output` tags will always correspond to single token IDs based on how they
-        are pre-tokenised in the data file.
     use_subtrees : ``bool``, optional, (default = ``False``)
         Whether or not to use sentiment-tagged subtrees.
     granularity : ``str``, optional (default = ``"5-class"``)
         One of ``"5-class"``, ``"3-class"``, or ``"2-class"``, indicating the number
-        of sentiment labels to use. The Stanford Sentiment Treebank comes with labels
-        from 0 to 4. ``"5-class"`` uses these labels as is. ``"3-class"`` converts the
-        problem into one of identifying whether a sentence is negative, positive, or
-        neutral sentiment. In this case, 0 and 1 are grouped as label 0 (negative sentiment),
-        2 is converted to label 1 (neutral sentiment) and 3 and 4 are grouped as label 2
-        (positive sentiment). ``"2-class"`` turns it into a binary classification problem
-        between positive and negative sentiment. 0 and 1 are grouped as the label 0
-        (negative sentiment), 2 (neutral) is discarded, and 3 and 4 are grouped as the label 1
-        (positive sentiment).
+        of sentiment labels to use.
     lazy : ``bool``, optional, (default = ``False``)
-        Whether or not instances can be consumed lazily.
+        Whether or not instances can be read lazily.
     """
     def __init__(self,
                  token_indexers: Dict[str, TokenIndexer] = None,

--- a/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
@@ -32,7 +32,7 @@ class StanfordSentimentTreeBankTokensDatasetReader(DatasetReader):
         Whether or not to use sentiment-tagged subtrees.
     granularity : ``str``, optional (default = ``"5-class"``)
         One of ``"5-class"``, ``"3-class"``, or ``"2-class"``, indicating the number
-        sentiment labels to use.
+        of sentiment labels to use.
     lazy : ``bool``, optional, (default = ``False``)
         Whether or not instances can be consumed lazily.
     """

--- a/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
@@ -62,7 +62,7 @@ class StanfordSentimentTreeBankTokensDatasetReader(DatasetReader):
     def _read(self, file_path):
         with open(cached_path(file_path), "r") as data_file:
             logger.info("Reading instances from lines in file at: %s", file_path)
-            for line in tqdm.tqdm(data_file.readlines()):
+            for line in data_file.readlines():
                 line = line.strip("\n")
                 if not line:
                     continue

--- a/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
@@ -3,7 +3,6 @@ import logging
 
 from overrides import overrides
 from nltk.tree import Tree
-import tqdm
 
 from allennlp.common import Params
 from allennlp.common.file_utils import cached_path
@@ -132,13 +131,13 @@ class StanfordSentimentTreeBankDatasetReader(DatasetReader):
         return Instance(fields)
 
     @classmethod
-    def from_params(cls, params: Params) -> 'StanfordSentimentTreeBankTokensDatasetReader':
+    def from_params(cls, params: Params) -> 'StanfordSentimentTreeBankDatasetReader':
         token_indexers = TokenIndexer.dict_from_params(params.pop('token_indexers', {}))
         use_subtrees = params.pop('use_subtrees', False)
         granularity = params.pop_choice('granularity', ["5-class", "3-class", "2-class"], True)
         lazy = params.pop('lazy', False)
         params.assert_empty(cls.__name__)
-        return StanfordSentimentTreeBankTokensDatasetReader(
+        return StanfordSentimentTreeBankDatasetReader(
                 token_indexers=token_indexers,
                 use_subtrees=use_subtrees,
                 granularity=granularity,

--- a/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 @DatasetReader.register("sst_tokens")
-class StanfordSentimentTreeBankTokensDatasetReader(DatasetReader):
+class StanfordSentimentTreeBankDatasetReader(DatasetReader):
     """
     Reads tokens and their sentiment labels from the Stanford Sentiment Treebank.
 

--- a/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
@@ -32,7 +32,15 @@ class StanfordSentimentTreeBankTokensDatasetReader(DatasetReader):
         Whether or not to use sentiment-tagged subtrees.
     granularity : ``str``, optional (default = ``"5-class"``)
         One of ``"5-class"``, ``"3-class"``, or ``"2-class"``, indicating the number
-        of sentiment labels to use.
+        of sentiment labels to use. The Stanford Sentiment Treebank comes with labels
+        from 0 to 4. ``"5-class"`` uses these labels as is. ``"3-class"`` converts the
+        problem into one of identifying whether a sentence is negative, positive, or
+        neutral sentiment. In this case, 0 and 1 are grouped as label 0 (negative sentiment),
+        2 is converted to label 1 (neutral sentiment) and 3 and 4 are grouped as label 2
+        (positive sentiment). ``"2-class"`` turns it into a binary classification problem
+        between positive and negative sentiment. 0 and 1 are grouped as the label 0
+        (negative sentiment), 2 (neutral) is discarded, and 3 and 4 are grouped as the label 1
+        (positive sentiment).
     lazy : ``bool``, optional, (default = ``False``)
         Whether or not instances can be consumed lazily.
     """
@@ -62,14 +70,12 @@ class StanfordSentimentTreeBankTokensDatasetReader(DatasetReader):
                 if self._use_subtrees:
                     for subtree in parsed_line.subtrees():
                         instance = self.text_to_instance(subtree.leaves(), subtree.label())
-                        if instance is None:
-                            continue
-                        yield instance
+                        if instance is not None:
+                            yield instance
                 else:
                     instance = self.text_to_instance(parsed_line.leaves(), parsed_line.label())
-                    if instance is None:
-                        continue
-                    yield instance
+                    if instance is not None:
+                            yield instance
 
     @overrides
     def text_to_instance(self, tokens: List[str], sentiment: str = None) -> Instance:  # type: ignore
@@ -95,7 +101,12 @@ class StanfordSentimentTreeBankTokensDatasetReader(DatasetReader):
         text_field = TextField([Token(x) for x in tokens], token_indexers=self._token_indexers)
         fields: Dict[str, Field] = {"tokens": text_field}
         if sentiment is not None:
-            # Convert to 3-class.
+            # 0 and 1 are negative sentiment, 2 is neutral, and 3 and 4 are positive sentiment
+            # In 5-class, we use labels as is.
+            # 3-class reduces the granularity, and only asks the model to predict
+            # negative, neutral, or positive.
+            # 2-class further reduces the granularity by only asking the model to
+            # predict whether an instance is negative or positive.
             if self._granularity == "3-class":
                 if int(sentiment) < 2:
                     sentiment = "0"

--- a/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
@@ -1,0 +1,125 @@
+from typing import Dict, List
+import logging
+
+from overrides import overrides
+from nltk.tree import Tree
+import tqdm
+
+from allennlp.common import Params
+from allennlp.common.file_utils import cached_path
+from allennlp.data.dataset_readers.dataset_reader import DatasetReader
+from allennlp.data.fields import LabelField, TextField, Field
+from allennlp.data.instance import Instance
+from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
+from allennlp.data.tokenizers import Token
+from allennlp.common.checks import ConfigurationError
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+@DatasetReader.register("sst_tokens")
+class StanfordSentimentTreeBankTokensDatasetReader(DatasetReader):
+    """
+    Reads tokens and their sentiment labels from the Stanford Sentiment Treebank.
+
+    Parameters
+    ----------
+    token_indexers : ``Dict[str, TokenIndexer]``, optional (default=``{"tokens": SingleIdTokenIndexer()}``)
+        We use this to define the input representation for the text.  See :class:`TokenIndexer`.
+        Note that the `output` tags will always correspond to single token IDs based on how they
+        are pre-tokenised in the data file.
+    use_subtrees : ``bool``, optional, (default = ``False``)
+        Whether or not to use sentiment-tagged subtrees.
+    granularity : ``str``, optional (default = ``"5-class"``)
+        One of ``"5-class"``, ``"3-class"``, or ``"2-class"``, indicating the number
+        sentiment labels to use.
+    lazy : ``bool``, optional, (default = ``False``)
+        Whether or not instances can be consumed lazily.
+    """
+    def __init__(self,
+                 token_indexers: Dict[str, TokenIndexer] = None,
+                 use_subtrees: bool = False,
+                 granularity: str = "5-class",
+                 lazy: bool = False) -> None:
+        super().__init__(lazy=lazy)
+        self._token_indexers = token_indexers or {'tokens': SingleIdTokenIndexer()}
+        self._use_subtrees = use_subtrees
+        allowed_granularities = ["5-class", "3-class", "2-class"]
+        if granularity not in allowed_granularities:
+            raise ConfigurationError("granularity is {}, but expected one of: {}".format(
+                    granularity, allowed_granularities))
+        self._granularity = granularity
+
+    @overrides
+    def _read(self, file_path):
+        with open(cached_path(file_path), "r") as data_file:
+            logger.info("Reading instances from lines in file at: %s", file_path)
+            for line in tqdm.tqdm(data_file.readlines()):
+                line = line.strip("\n")
+                if not line:
+                    continue
+                parsed_line = Tree.fromstring(line)
+                if self._use_subtrees:
+                    for subtree in parsed_line.subtrees():
+                        instance = self.text_to_instance(subtree.leaves(), subtree.label())
+                        if instance is None:
+                            continue
+                        yield instance
+                else:
+                    instance = self.text_to_instance(parsed_line.leaves(), parsed_line.label())
+                    if instance is None:
+                        continue
+                    yield instance
+
+    @overrides
+    def text_to_instance(self, tokens: List[str], sentiment: str = None) -> Instance:  # type: ignore
+        """
+        We take `pre-tokenized` input here, because we don't have a tokenizer in this class.
+
+        Parameters
+        ----------
+        tokens : ``List[str]``, required.
+            The tokens in a given sentence.
+        sentiment ``str``, optional, (default = None).
+            The sentiment for this sentence.
+
+        Returns
+        -------
+        An ``Instance`` containing the following fields:
+            tokens : ``TextField``
+                The tokens in the sentence or phrase.
+            label : ``LabelField``
+                The sentiment label of the sentence or phrase.
+        """
+        # pylint: disable=arguments-differ
+        text_field = TextField([Token(x) for x in tokens], token_indexers=self._token_indexers)
+        fields: Dict[str, Field] = {"tokens": text_field}
+        if sentiment is not None:
+            # Convert to 3-class.
+            if self._granularity == "3-class":
+                if int(sentiment) < 2:
+                    sentiment = "0"
+                elif int(sentiment) == 2:
+                    sentiment = "1"
+                else:
+                    sentiment = "2"
+            elif self._granularity == "2-class":
+                if int(sentiment) < 2:
+                    sentiment = "0"
+                elif int(sentiment) == 2:
+                    return None
+                else:
+                    sentiment = "1"
+            fields['label'] = LabelField(sentiment)
+        return Instance(fields)
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'StanfordSentimentTreeBankTokensDatasetReader':
+        token_indexers = TokenIndexer.dict_from_params(params.pop('token_indexers', {}))
+        use_subtrees = params.pop('use_subtrees', False)
+        granularity = params.pop_choice('granularity', ["5-class", "3-class", "2-class"], True)
+        lazy = params.pop('lazy', False)
+        params.assert_empty(cls.__name__)
+        return StanfordSentimentTreeBankTokensDatasetReader(
+                token_indexers=token_indexers, use_subtrees=use_subtrees,
+                granularity=granularity, lazy=lazy)

--- a/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
@@ -75,7 +75,7 @@ class StanfordSentimentTreeBankTokensDatasetReader(DatasetReader):
                 else:
                     instance = self.text_to_instance(parsed_line.leaves(), parsed_line.label())
                     if instance is not None:
-                            yield instance
+                        yield instance
 
     @overrides
     def text_to_instance(self, tokens: List[str], sentiment: str = None) -> Instance:  # type: ignore
@@ -132,5 +132,7 @@ class StanfordSentimentTreeBankTokensDatasetReader(DatasetReader):
         lazy = params.pop('lazy', False)
         params.assert_empty(cls.__name__)
         return StanfordSentimentTreeBankTokensDatasetReader(
-                token_indexers=token_indexers, use_subtrees=use_subtrees,
-                granularity=granularity, lazy=lazy)
+                token_indexers=token_indexers,
+                use_subtrees=use_subtrees,
+                granularity=granularity,
+                lazy=lazy)

--- a/doc/api/allennlp.data.dataset_readers.rst
+++ b/doc/api/allennlp.data.dataset_readers.rst
@@ -17,5 +17,6 @@ allennlp.data.dataset_readers
   allennlp.data.dataset_readers.seq2seq
   allennlp.data.dataset_readers.sequence_tagging
   allennlp.data.dataset_readers.snli
+  allennlp.data.dataset_readers.stanford_sentiment_tree_bank
   allennlp.data.dataset_readers.penn_tree_bank
   allennlp.data.dataset_readers.dataset_utils

--- a/doc/api/allennlp.data.dataset_readers.stanford_sentiment_tree_bank.rst
+++ b/doc/api/allennlp.data.dataset_readers.stanford_sentiment_tree_bank.rst
@@ -1,0 +1,7 @@
+allennlp.data.dataset_readers.stanford_sentiment_tree_bank
+==========================================================
+
+.. automodule:: allennlp.data.dataset_readers.stanford_sentiment_tree_bank
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/data/dataset_readers/stanford_sentiment_tree_bank_test.py
+++ b/tests/data/dataset_readers/stanford_sentiment_tree_bank_test.py
@@ -1,0 +1,95 @@
+# pylint: disable=no-self-use,invalid-name
+import pytest
+
+from allennlp.data.dataset_readers import (
+        StanfordSentimentTreeBankTokensDatasetReader)
+from allennlp.common.util import ensure_list
+
+class TestStanfordSentimentTreebankReader():
+    @pytest.mark.parametrize("lazy", (True, False))
+    def test_read_from_file(self, lazy):
+        reader = StanfordSentimentTreeBankTokensDatasetReader(lazy=lazy)
+        instances = reader.read('tests/fixtures/data/sst.txt')
+        instances = ensure_list(instances)
+
+        instance1 = {"tokens": ["The", "actors", "are", "fantastic", "."],
+                     "label": "4"}
+        instance2 = {"tokens": ["It", "was", "terrible", "."],
+                     "label": "0"}
+        instance3 = {"tokens": ["Chomp", "chomp", "!"],
+                     "label": "2"}
+
+        assert len(instances) == 3
+        fields = instances[0].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance1["tokens"]
+        assert fields["label"].label == instance1["label"]
+        fields = instances[1].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance2["tokens"]
+        assert fields["label"].label == instance2["label"]
+        fields = instances[2].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance3["tokens"]
+        assert fields["label"].label == instance3["label"]
+
+    def test_use_subtrees(self):
+        reader = StanfordSentimentTreeBankTokensDatasetReader(use_subtrees=True)
+        instances = reader.read('tests/fixtures/data/sst.txt')
+        instances = ensure_list(instances)
+
+        instance1 = {"tokens": ["The", "actors", "are", "fantastic", "."],
+                     "label": "4"}
+        instance2 = {"tokens": ["The", "actors"],
+                     "label": "2"}
+        instance3 = {"tokens": ["The"],
+                     "label": "2"}
+
+        assert len(instances) == 21
+        fields = instances[0].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance1["tokens"]
+        assert fields["label"].label == instance1["label"]
+        fields = instances[1].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance2["tokens"]
+        assert fields["label"].label == instance2["label"]
+        fields = instances[2].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance3["tokens"]
+        assert fields["label"].label == instance3["label"]
+
+    def test_3_class(self):
+        reader = StanfordSentimentTreeBankTokensDatasetReader(granularity="3-class")
+        instances = reader.read('tests/fixtures/data/sst.txt')
+        instances = ensure_list(instances)
+
+        instance1 = {"tokens": ["The", "actors", "are", "fantastic", "."],
+                     "label": "2"}
+        instance2 = {"tokens": ["It", "was", "terrible", "."],
+                     "label": "0"}
+        instance3 = {"tokens": ["Chomp", "chomp", "!"],
+                     "label": "1"}
+
+        assert len(instances) == 3
+        fields = instances[0].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance1["tokens"]
+        assert fields["label"].label == instance1["label"]
+        fields = instances[1].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance2["tokens"]
+        assert fields["label"].label == instance2["label"]
+        fields = instances[2].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance3["tokens"]
+        assert fields["label"].label == instance3["label"]
+
+    def test_2_class(self):
+        reader = StanfordSentimentTreeBankTokensDatasetReader(granularity="2-class")
+        instances = reader.read('tests/fixtures/data/sst.txt')
+        instances = ensure_list(instances)
+
+        instance1 = {"tokens": ["The", "actors", "are", "fantastic", "."],
+                     "label": "1"}
+        instance2 = {"tokens": ["It", "was", "terrible", "."],
+                     "label": "0"}
+
+        assert len(instances) == 2
+        fields = instances[0].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance1["tokens"]
+        assert fields["label"].label == instance1["label"]
+        fields = instances[1].fields
+        assert [t.text for t in fields["tokens"].tokens] == instance2["tokens"]
+        assert fields["label"].label == instance2["label"]

--- a/tests/data/dataset_readers/stanford_sentiment_tree_bank_test.py
+++ b/tests/data/dataset_readers/stanford_sentiment_tree_bank_test.py
@@ -2,6 +2,7 @@
 import pytest
 
 from allennlp.data.dataset_readers import StanfordSentimentTreeBankDatasetReader
+from allennlp.common import Params
 from allennlp.common.util import ensure_list
 
 class TestStanfordSentimentTreebankReader():
@@ -92,3 +93,9 @@ class TestStanfordSentimentTreebankReader():
         fields = instances[1].fields
         assert [t.text for t in fields["tokens"].tokens] == instance2["tokens"]
         assert fields["label"].label == instance2["label"]
+
+    def test_from_params(self):
+        params = Params({"use_subtrees": True, "granularity": "5-class"})
+        reader = StanfordSentimentTreeBankDatasetReader.from_params(params)
+        assert reader._use_subtrees is True
+        assert reader._granularity == "5-class"

--- a/tests/data/dataset_readers/stanford_sentiment_tree_bank_test.py
+++ b/tests/data/dataset_readers/stanford_sentiment_tree_bank_test.py
@@ -95,6 +95,7 @@ class TestStanfordSentimentTreebankReader():
         assert fields["label"].label == instance2["label"]
 
     def test_from_params(self):
+        # pylint: disable=protected-access
         params = Params({"use_subtrees": True, "granularity": "5-class"})
         reader = StanfordSentimentTreeBankDatasetReader.from_params(params)
         assert reader._use_subtrees is True

--- a/tests/data/dataset_readers/stanford_sentiment_tree_bank_test.py
+++ b/tests/data/dataset_readers/stanford_sentiment_tree_bank_test.py
@@ -1,8 +1,7 @@
 # pylint: disable=no-self-use,invalid-name
 import pytest
 
-from allennlp.data.dataset_readers import (
-        StanfordSentimentTreeBankTokensDatasetReader)
+from allennlp.data.dataset_readers import StanfordSentimentTreeBankTokensDatasetReader
 from allennlp.common.util import ensure_list
 
 class TestStanfordSentimentTreebankReader():

--- a/tests/data/dataset_readers/stanford_sentiment_tree_bank_test.py
+++ b/tests/data/dataset_readers/stanford_sentiment_tree_bank_test.py
@@ -1,13 +1,13 @@
 # pylint: disable=no-self-use,invalid-name
 import pytest
 
-from allennlp.data.dataset_readers import StanfordSentimentTreeBankTokensDatasetReader
+from allennlp.data.dataset_readers import StanfordSentimentTreeBankDatasetReader
 from allennlp.common.util import ensure_list
 
 class TestStanfordSentimentTreebankReader():
     @pytest.mark.parametrize("lazy", (True, False))
     def test_read_from_file(self, lazy):
-        reader = StanfordSentimentTreeBankTokensDatasetReader(lazy=lazy)
+        reader = StanfordSentimentTreeBankDatasetReader(lazy=lazy)
         instances = reader.read('tests/fixtures/data/sst.txt')
         instances = ensure_list(instances)
 
@@ -30,7 +30,7 @@ class TestStanfordSentimentTreebankReader():
         assert fields["label"].label == instance3["label"]
 
     def test_use_subtrees(self):
-        reader = StanfordSentimentTreeBankTokensDatasetReader(use_subtrees=True)
+        reader = StanfordSentimentTreeBankDatasetReader(use_subtrees=True)
         instances = reader.read('tests/fixtures/data/sst.txt')
         instances = ensure_list(instances)
 
@@ -53,7 +53,7 @@ class TestStanfordSentimentTreebankReader():
         assert fields["label"].label == instance3["label"]
 
     def test_3_class(self):
-        reader = StanfordSentimentTreeBankTokensDatasetReader(granularity="3-class")
+        reader = StanfordSentimentTreeBankDatasetReader(granularity="3-class")
         instances = reader.read('tests/fixtures/data/sst.txt')
         instances = ensure_list(instances)
 
@@ -76,7 +76,7 @@ class TestStanfordSentimentTreebankReader():
         assert fields["label"].label == instance3["label"]
 
     def test_2_class(self):
-        reader = StanfordSentimentTreeBankTokensDatasetReader(granularity="2-class")
+        reader = StanfordSentimentTreeBankDatasetReader(granularity="2-class")
         instances = reader.read('tests/fixtures/data/sst.txt')
         instances = ensure_list(instances)
 

--- a/tests/fixtures/data/sst.txt
+++ b/tests/fixtures/data/sst.txt
@@ -1,0 +1,3 @@
+(4 (2 (2 The) (2 actors)) (3 (4 (2 are) (3 fantastic)) (2 .)))
+(0 (2 It) (0 (0 (2 was) (0 terrible)) (2 .)))
+(2 (2 Chomp) (2 (2 chomp) (2 !)))


### PR DESCRIPTION
This PR adds a reader for the StanfordSentimentTreebank tokens and labels, for 5/3/2-class text classification. It also optionally lets you pick whether or not to make examples from labeled subtrees, or whether to just use the sentences.