### PR TITLE
Ability to Run Elmo on Wikitables

### DIFF
--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -56,7 +56,7 @@ class ModelTestCase(AllenNlpTestCase):
             assert_allclose(model.state_dict()[key].cpu().numpy(),
                             loaded_model.state_dict()[key].cpu().numpy(),
                             err_msg=key)
-        params = Params.from_file(self.param_file)
+        params = Params.from_file(param_file)
         reader = DatasetReader.from_params(params['dataset_reader'])
 
         # Need to duplicate params because Iterator.from_params will consume.

--- a/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_dataset_reader.py
@@ -115,6 +115,8 @@ class WikiTablesDatasetReader(DatasetReader):
         information necessary for reading each instance, which includes the table contents itself.
         This flag tells the reader to include a ``table_metadata`` field that gets read by the
         pre-processing script.
+    max_number_table_tokens : ``int``, optional (default=-1)
+        We use this to truncate the entity tokens in the table.
     """
     def __init__(self,
                  lazy: bool = False,
@@ -130,7 +132,8 @@ class WikiTablesDatasetReader(DatasetReader):
                  nonterminal_indexers: Dict[str, TokenIndexer] = None,
                  terminal_indexers: Dict[str, TokenIndexer] = None,
                  linking_feature_extractors: List[str] = None,
-                 include_table_metadata: bool = False) -> None:
+                 include_table_metadata: bool = False,
+                 max_number_table_tokens: int = -1) -> None:
         super().__init__(lazy=lazy)
         self._tables_directory = tables_directory
         self._dpd_output_directory = dpd_output_directory
@@ -146,6 +149,7 @@ class WikiTablesDatasetReader(DatasetReader):
         self._linking_feature_extractors = linking_feature_extractors
         self._include_table_metadata = include_table_metadata
         self._basic_types = set(str(type_) for type_ in wt_types.BASIC_TYPES)
+        self._max_number_table_tokens = max_number_table_tokens
 
     @overrides
     def _read(self, file_path: str):
@@ -246,7 +250,8 @@ class WikiTablesDatasetReader(DatasetReader):
                                           self._table_token_indexers,
                                           tokenizer=self._tokenizer,
                                           feature_extractors=self._linking_feature_extractors,
-                                          include_in_vocab=self._use_table_for_vocab)
+                                          include_in_vocab=self._use_table_for_vocab,
+                                          max_number_table_tokens=self._max_number_table_tokens)
         world = WikiTablesWorld(table_knowledge_graph)
         world_field = MetadataField(world)
 
@@ -358,6 +363,7 @@ class WikiTablesDatasetReader(DatasetReader):
         use_table_for_vocab = params.pop_bool('use_table_for_vocab', False)
         linking_feature_extracters = params.pop('linking_feature_extractors', None)
         include_table_metadata = params.pop_bool('include_table_metadata', False)
+        max_number_table_tokens = params.pop_int('max_number_table_tokens', -1)
         params.assert_empty(cls.__name__)
         return WikiTablesDatasetReader(lazy=lazy,
                                        tables_directory=tables_directory,
@@ -370,4 +376,5 @@ class WikiTablesDatasetReader(DatasetReader):
                                        table_token_indexers=table_token_indexers,
                                        use_table_for_vocab=use_table_for_vocab,
                                        linking_feature_extractors=linking_feature_extracters,
-                                       include_table_metadata=include_table_metadata)
+                                       include_table_metadata=include_table_metadata,
+                                       max_number_table_tokens=max_number_table_tokens)

--- a/allennlp/data/dataset_readers/wikitables/wikitables_preprocessed_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_preprocessed_dataset_reader.py
@@ -58,6 +58,8 @@ class WikiTablesPreprocessedDatasetReader(DatasetReader):
         TokenCharactersIndexer()}``.  We use this indexer by default because WikiTables has plenty
         of terminals that are unseen at training time, so we need to use a representation for them
         that is not just a vocabulary lookup.
+    max_number_table_tokens : ``int``, optional (default=-1)
+        We use this to truncate the entity tokens in the table.
     """
     def __init__(self,
                  lazy: bool = False,
@@ -65,13 +67,15 @@ class WikiTablesPreprocessedDatasetReader(DatasetReader):
                  table_token_indexers: Dict[str, TokenIndexer] = None,
                  use_table_for_vocab: bool = False,
                  nonterminal_indexers: Dict[str, TokenIndexer] = None,
-                 terminal_indexers: Dict[str, TokenIndexer] = None) -> None:
+                 terminal_indexers: Dict[str, TokenIndexer] = None,
+                 max_number_table_tokens: int = -1) -> None:
         super().__init__(lazy)
         self._question_token_indexers = question_token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._table_token_indexers = table_token_indexers or self._question_token_indexers
         self._use_table_for_vocab = use_table_for_vocab
         self._nonterminal_indexers = nonterminal_indexers or {"tokens": SingleIdTokenIndexer("rule_labels")}
         self._terminal_indexers = terminal_indexers or {"token_characters": TokenCharactersIndexer()}
+        self._max_number_table_tokens = max_number_table_tokens
 
     @overrides
     def _read(self, file_path: str):
@@ -95,7 +99,8 @@ class WikiTablesPreprocessedDatasetReader(DatasetReader):
                                           token_indexers=self._table_token_indexers,
                                           entity_tokens=entity_tokens,
                                           linking_features=json_obj['linking_features'],
-                                          include_in_vocab=self._use_table_for_vocab)
+                                          include_in_vocab=self._use_table_for_vocab,
+                                          max_number_table_tokens=self._max_number_table_tokens)
         world = WikiTablesWorld(table_knowledge_graph)
         world_field = MetadataField(world)
 
@@ -133,8 +138,10 @@ class WikiTablesPreprocessedDatasetReader(DatasetReader):
         question_token_indexers = TokenIndexer.dict_from_params(params.pop('question_token_indexers', {}))
         table_token_indexers = TokenIndexer.dict_from_params(params.pop('table_token_indexers', {}))
         use_table_for_vocab = params.pop('use_table_for_vocab', False)
+        max_number_table_tokens = params.pop_int('max_number_table_tokens', -1)
         params.assert_empty(cls.__name__)
         return WikiTablesPreprocessedDatasetReader(lazy=lazy,
                                                    question_token_indexers=question_token_indexers,
                                                    table_token_indexers=table_token_indexers,
-                                                   use_table_for_vocab=use_table_for_vocab)
+                                                   use_table_for_vocab=use_table_for_vocab,
+                                                   max_number_table_tokens=max_number_table_tokens)

--- a/allennlp/data/dataset_readers/wikitables/wikitables_preprocessed_dataset_reader.py
+++ b/allennlp/data/dataset_readers/wikitables/wikitables_preprocessed_dataset_reader.py
@@ -58,8 +58,11 @@ class WikiTablesPreprocessedDatasetReader(DatasetReader):
         TokenCharactersIndexer()}``.  We use this indexer by default because WikiTables has plenty
         of terminals that are unseen at training time, so we need to use a representation for them
         that is not just a vocabulary lookup.
-    max_number_table_tokens : ``int``, optional (default=-1)
-        We use this to truncate the entity tokens in the table.
+    max_table_tokens : ``int``, optional
+        If given, we will only keep this number of total table tokens.  This bounds the memory
+        usage of the table representations, truncating cells with really long text.  We specify a
+        total number of tokens, not a max cell text length, because the number of table entities
+        varies.
     """
     def __init__(self,
                  lazy: bool = False,
@@ -68,14 +71,14 @@ class WikiTablesPreprocessedDatasetReader(DatasetReader):
                  use_table_for_vocab: bool = False,
                  nonterminal_indexers: Dict[str, TokenIndexer] = None,
                  terminal_indexers: Dict[str, TokenIndexer] = None,
-                 max_number_table_tokens: int = -1) -> None:
+                 max_table_tokens: int = None) -> None:
         super().__init__(lazy)
         self._question_token_indexers = question_token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._table_token_indexers = table_token_indexers or self._question_token_indexers
         self._use_table_for_vocab = use_table_for_vocab
         self._nonterminal_indexers = nonterminal_indexers or {"tokens": SingleIdTokenIndexer("rule_labels")}
         self._terminal_indexers = terminal_indexers or {"token_characters": TokenCharactersIndexer()}
-        self._max_number_table_tokens = max_number_table_tokens
+        self._max_table_tokens = max_table_tokens
 
     @overrides
     def _read(self, file_path: str):
@@ -100,7 +103,7 @@ class WikiTablesPreprocessedDatasetReader(DatasetReader):
                                           entity_tokens=entity_tokens,
                                           linking_features=json_obj['linking_features'],
                                           include_in_vocab=self._use_table_for_vocab,
-                                          max_number_table_tokens=self._max_number_table_tokens)
+                                          max_table_tokens=self._max_table_tokens)
         world = WikiTablesWorld(table_knowledge_graph)
         world_field = MetadataField(world)
 
@@ -138,10 +141,10 @@ class WikiTablesPreprocessedDatasetReader(DatasetReader):
         question_token_indexers = TokenIndexer.dict_from_params(params.pop('question_token_indexers', {}))
         table_token_indexers = TokenIndexer.dict_from_params(params.pop('table_token_indexers', {}))
         use_table_for_vocab = params.pop('use_table_for_vocab', False)
-        max_number_table_tokens = params.pop_int('max_number_table_tokens', -1)
+        max_table_tokens = params.pop_int('max_table_tokens', None)
         params.assert_empty(cls.__name__)
         return WikiTablesPreprocessedDatasetReader(lazy=lazy,
                                                    question_token_indexers=question_token_indexers,
                                                    table_token_indexers=table_token_indexers,
                                                    use_table_for_vocab=use_table_for_vocab,
-                                                   max_number_table_tokens=max_number_table_tokens)
+                                                   max_table_tokens=max_table_tokens)

--- a/allennlp/data/fields/knowledge_graph_field.py
+++ b/allennlp/data/fields/knowledge_graph_field.py
@@ -77,6 +77,8 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
         entity text from the vocabulary computation.  You might want to do this if you have a lot
         of rare entities in your tables, and you see the same table in multiple training instances,
         so your vocabulary counts get skewed and include too many rare entities.
+    max_number_table_tokens : ``int``, optional (default=-1)
+        We use this to truncate the entity tokens in the table.
     """
     def __init__(self,
                  knowledge_graph: KnowledgeGraph,
@@ -86,7 +88,9 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
                  feature_extractors: List[str] = None,
                  entity_tokens: List[List[Token]] = None,
                  linking_features: List[List[List[float]]] = None,
-                 include_in_vocab: bool = True) -> None:
+                 include_in_vocab: bool = True,
+                 # TODO(rajas): should max_number_table_tokens default to high value?
+                 max_number_table_tokens: int = -1) -> None:
         self.knowledge_graph = knowledge_graph
         if not entity_tokens:
             entity_texts = [knowledge_graph.entity_text[entity].lower()
@@ -104,6 +108,7 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
         self._token_indexers: Dict[str, TokenIndexer] = token_indexers
         self._include_in_vocab = include_in_vocab
         self._indexed_entity_texts: Dict[str, TokenList] = None
+        self._max_number_table_tokens = max_number_table_tokens
 
         feature_extractors = feature_extractors or [
                 'exact_token_match',
@@ -159,9 +164,19 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:
-        padding_lengths = {'num_entities': len(self.entity_texts),
+        num_entities = len(self.entity_texts)
+        num_entity_tokens = max(len(entity_text) for entity_text in self.entity_texts)
+
+        # This enables us the truncate the number of entity tokens used, enabling the larger
+        # tables(which can have thousands of entities or more than 50 tokens each) to fit in
+        # memory, particularly when using Elmo.
+        if self._max_number_table_tokens != -1:
+            if num_entities * num_entity_tokens > self._max_number_table_tokens:
+                num_entity_tokens = int(self._max_number_table_tokens / num_entities)
+
+        padding_lengths = {'num_entities': num_entities,
                            'num_utterance_tokens': len(self.utterance_tokens)}
-        padding_lengths['num_entity_tokens'] = max(len(entity_text) for entity_text in self.entity_texts)
+        padding_lengths['num_entity_tokens'] = num_entity_tokens
         lengths = []
         assert self._indexed_entity_texts is not None, ("This field is not indexed yet. Call "
                                                         ".index(vocab) before determining padding "

--- a/allennlp/models/encoder_decoders/wikitables/wikitables_semantic_parser.py
+++ b/allennlp/models/encoder_decoders/wikitables/wikitables_semantic_parser.py
@@ -112,8 +112,6 @@ class WikiTablesSemanticParser(Model):
 
         self.num_entity_types = 4  # TODO(mattg): get this in a more principled way somehow?
 
-        # The entity_encoder's output dim is used instead of question_embedder's output dim since
-        # the question_embedder output will get projected down for Elmo.
         self._embedding_dim = question_embedder.get_output_dim()
         check_dimensions_match(entity_encoder.get_output_dim(), question_embedder.get_output_dim(),
                                "entity word average embedding dim", "question embedding dim")

--- a/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-elmo-no-features.json
+++ b/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-elmo-no-features.json
@@ -2,21 +2,30 @@
   "dataset_reader": {
     "type": "wikitables",
     "tables_directory": "tests/fixtures/data/wikitables/",
-    "dpd_output_directory": "tests/fixtures/data/wikitables/dpd_output/"
+    "dpd_output_directory": "tests/fixtures/data/wikitables/dpd_output/",
+    "question_token_indexers": {
+      "elmo": {
+       "type": "elmo_characters"
+      }
+    },
+    "max_number_table_tokens": 200
   },
   "vocabulary": {
-    "non_padded_namespaces": ["actions"]
+    "non_padded_namespaces": ["actions"],
+    "min_count": {"tokens": 1}
   },
   "train_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
   "validation_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
   "model": {
     "type": "wikitables_parser",
     "question_embedder": {
-      "tokens": {
-        "type": "embedding",
-        "embedding_dim": 25,
-        "trainable": true
-      }
+      "elmo":{
+       "type": "elmo_token_embedder",
+       "options_file": "tests/fixtures/elmo/options.json",
+       "weight_file": "tests/fixtures/elmo/lm_weights.hdf5",
+       "do_layer_norm": false,
+       "dropout": 0.5
+     }
     },
     "action_embedding_dim": 50,
     "encoder": {

--- a/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-elmo-no-features.json
+++ b/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-elmo-no-features.json
@@ -30,13 +30,13 @@
     "action_embedding_dim": 50,
     "encoder": {
       "type": "lstm",
-      "input_size": 50,
+      "input_size": 64,
       "hidden_size": 10,
       "num_layers": 1
     },
     "entity_encoder": {
       "type": "boe",
-      "embedding_dim": 25,
+      "embedding_dim": 32,
       "averaged": true
     },
     "decoder_beam_search": {

--- a/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-elmo-no-features.json
+++ b/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-elmo-no-features.json
@@ -8,10 +8,9 @@
        "type": "elmo_characters"
       }
     },
-    "max_number_table_tokens": 200
+    "max_table_tokens": 200
   },
   "vocabulary": {
-    "non_padded_namespaces": ["actions"],
     "min_count": {"tokens": 1}
   },
   "train_data_path": "tests/fixtures/data/wikitables/sample_data.examples",

--- a/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-mixture.json
+++ b/tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-mixture.json
@@ -4,9 +4,6 @@
     "tables_directory": "tests/fixtures/data/wikitables/",
     "dpd_output_directory": "tests/fixtures/data/wikitables/dpd_output/"
   },
-  "vocabulary": {
-    "non_padded_namespaces": ["actions"]
-  },
   "train_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
   "validation_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
   "model": {

--- a/tests/models/encoder_decoders/wikitables/wikitables_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/wikitables/wikitables_semantic_parser_test.py
@@ -20,14 +20,9 @@ class WikiTablesSemanticParserTest(ModelTestCase):
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)
 
-    @flaky
-    def test_mixture_feedforward_model_can_train_save_and_load(self):
+    def test_elmo_mixture_no_features_model_can_train_save_and_load(self):
         # pylint: disable=line-too-long
-        self.ensure_model_can_train_save_and_load('tests/fixtures/encoder_decoder/wikitables_semantic_parser_with_mixture_feedforward/experiment.json')
-
-    def test_model_no_features_can_train_save_and_load(self):
-        # pylint: disable=line-too-long
-        self.ensure_model_can_train_save_and_load("tests/fixtures/encoder_decoder/wikitables_semantic_parser_no_features/experiment.json")
+        self.ensure_model_can_train_save_and_load('tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-mixture.json')
 
     def test_get_neighbor_indices(self):
         worlds, num_entities = self.get_fake_worlds()
@@ -200,3 +195,16 @@ class WikiTablesSemanticParserTest(ModelTestCase):
                 (2, 1): 8,
                 (2, 2): 9,
                 }
+
+class WikiTablesSemanticParserElmoNoFeaturesTest(ModelTestCase):
+    """
+    This needs to be a separate class since the set_up_model forces the model to expect key
+    'tokens' for the embedder but elmo has key 'elmo'.
+    """
+    def setUp(self):
+        super(WikiTablesSemanticParserElmoNoFeaturesTest, self).setUp()
+        self.set_up_model("tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-elmo-no-features.json",
+                          "tests/fixtures/data/wikitables/sample_data.examples")
+
+    def test_model_can_train_save_and_load(self):
+        self.ensure_model_can_train_save_and_load(self.param_file)

--- a/tests/models/encoder_decoders/wikitables/wikitables_semantic_parser_test.py
+++ b/tests/models/encoder_decoders/wikitables/wikitables_semantic_parser_test.py
@@ -13,7 +13,8 @@ from allennlp.models import Model, WikiTablesSemanticParser
 class WikiTablesSemanticParserTest(ModelTestCase):
     def setUp(self):
         super(WikiTablesSemanticParserTest, self).setUp()
-        self.set_up_model("tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment.json",
+        self.fixture_dir = 'tests/fixtures/encoder_decoder/wikitables_semantic_parser'
+        self.set_up_model(f"{self.fixture_dir}/experiment.json",
                           "tests/fixtures/data/wikitables/sample_data.examples")
 
     @flaky
@@ -21,8 +22,10 @@ class WikiTablesSemanticParserTest(ModelTestCase):
         self.ensure_model_can_train_save_and_load(self.param_file)
 
     def test_elmo_mixture_no_features_model_can_train_save_and_load(self):
-        # pylint: disable=line-too-long
-        self.ensure_model_can_train_save_and_load('tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-mixture.json')
+        self.ensure_model_can_train_save_and_load(f'{self.fixture_dir}/experiment-mixture.json')
+
+    def test_elmo_no_features_can_train_save_and_load(self):
+        self.ensure_model_can_train_save_and_load(f'{self.fixture_dir}/experiment-elmo-no-features.json')
 
     def test_get_neighbor_indices(self):
         worlds, num_entities = self.get_fake_worlds()
@@ -195,16 +198,3 @@ class WikiTablesSemanticParserTest(ModelTestCase):
                 (2, 1): 8,
                 (2, 2): 9,
                 }
-
-class WikiTablesSemanticParserElmoNoFeaturesTest(ModelTestCase):
-    """
-    This needs to be a separate class since the set_up_model forces the model to expect key
-    'tokens' for the embedder but elmo has key 'elmo'.
-    """
-    def setUp(self):
-        super(WikiTablesSemanticParserElmoNoFeaturesTest, self).setUp()
-        self.set_up_model("tests/fixtures/encoder_decoder/wikitables_semantic_parser/experiment-elmo-no-features.json",
-                          "tests/fixtures/data/wikitables/sample_data.examples")
-
-    def test_model_can_train_save_and_load(self):
-        self.ensure_model_can_train_save_and_load(self.param_file)


### PR DESCRIPTION
The main changes are elmo projection, cosine similarity, and table truncation. I replaced dividing by embedding dim with cosine similarity since it performs around 2 percent better. 