### PR TITLE
Add a multilabel field

### DIFF
--- a/allennlp/data/fields/__init__.py
+++ b/allennlp/data/fields/__init__.py
@@ -7,6 +7,7 @@ from allennlp.data.fields.field import Field
 from allennlp.data.fields.array_field import ArrayField
 from allennlp.data.fields.index_field import IndexField
 from allennlp.data.fields.label_field import LabelField
+from allennlp.data.fields.multilabel_field import MultiLabelField
 from allennlp.data.fields.list_field import ListField
 from allennlp.data.fields.metadata_field import MetadataField
 from allennlp.data.fields.sequence_field import SequenceField

--- a/allennlp/data/fields/multilabel_field.py
+++ b/allennlp/data/fields/multilabel_field.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, Sequence, Set, Optional
+from typing import Dict, Union, Sequence, Set, Optional, cast
 import logging
 
 from overrides import overrides
@@ -68,7 +68,7 @@ class MultiLabelField(Field[torch.Tensor]):
             if not num_labels:
                 raise ConfigurationError("In order to skip indexing, num_labels can't be None.")
 
-            if not all(label < num_labels for label in labels):
+            if not all(cast(int, label) < num_labels for label in labels):
                 raise ConfigurationError("All labels should be < num_labels. "
                                          "Found num_labels = {} and labels = {} ".format(num_labels, labels))
 

--- a/allennlp/data/fields/multilabel_field.py
+++ b/allennlp/data/fields/multilabel_field.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, Sequence, Set
+from typing import Dict, Union, Sequence, Set, cast
 import logging
 
 from collections import defaultdict
@@ -63,7 +63,7 @@ class MultiLabelField(Field[torch.Tensor]):
                 raise ConfigurationError("In order to skip indexing, your labels must be integers. "
                                          "Found labels = {}".format(labels))
             # vocabulary size = largest label id
-            largest_label_id = max(labels)
+            largest_label_id: int = cast(int, max(labels))
             MultiLabelField._vocab_size[self._label_namespace] = \
                     max(largest_label_id + 1, MultiLabelField._vocab_size[self._label_namespace])
 

--- a/allennlp/data/fields/multilabel_field.py
+++ b/allennlp/data/fields/multilabel_field.py
@@ -1,0 +1,129 @@
+from typing import Dict, Union, Set
+import logging
+
+from collections import defaultdict
+from overrides import overrides
+import torch
+from torch.autograd import Variable
+
+from allennlp.data.fields.field import Field
+from allennlp.data.vocabulary import Vocabulary
+from allennlp.common.checks import ConfigurationError
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class MultiLabelField(Field[torch.Tensor]):
+    """
+    A ``MultiLabelField`` is an extension of the :class:`LabelField` that allows for multiple labels.
+    It is particularly useful in multi-label classification where more than one label can be correct.
+    As with the :class:`LabelField`, labels are either strings of text or 0-indexed integers (if you wish
+    to skip indexing by passing skip_indexing=True).
+    If the labels need indexing, we will use a :class:`Vocabulary` to convert the string labels
+    into integers.
+
+    This field will get converted into a vector of length equals the vocabulary size with
+    one hot encoding for the labels (all zeros, and ones for the labels).
+
+    Parameters
+    ----------
+    labels : ``Set[Union[str, int]]``
+    label_namespace : ``str``, optional (default="labels")
+        The namespace to use for converting label strings into integers.  We map label strings to
+        integers for you (e.g., "entailment" and "contradiction" get converted to 0, 1, ...),
+        and this namespace tells the ``Vocabulary`` object which mapping from strings to integers
+        to use (so "entailment" as a label doesn't get the same integer id as "entailment" as a
+        word).  If you have multiple different label fields in your data, you should make sure you
+        use different namespaces for each one, always using the suffix "labels" (e.g.,
+        "passage_labels" and "question_labels").
+    skip_indexing : ``bool``, optional (default=False)
+        If your labels are 0-indexed integers, you can pass in this flag, and we'll skip the indexing
+        step.  If this is ``False`` and your labels are not strings, this throws a ``ConfigurationError``.
+    """
+    # It is possible that users want to use this field with a namespace which uses OOV/PAD tokens.
+    # This warning will be repeated for every instantiation of this class (i.e for every data
+    # instance), spewing a lot of warnings so this class variable is used to only log a single
+    # warning per namespace.
+    _already_warned_namespaces: Set[str] = set()
+
+    # Dictionary from a vocab namespace to size. Need the vocab size to map labels to a tensor
+    _vocab_size: Dict[str, int] = defaultdict(int)
+
+    def __init__(self,
+                 labels: Set[Union[str, int]],
+                 label_namespace: str = 'labels',
+                 skip_indexing: bool = False) -> None:
+        self.labels = labels
+        self._label_namespace = label_namespace
+        self._label_ids = None
+        self._maybe_warn_for_namespace(label_namespace)
+
+        if skip_indexing:
+            for label in labels:
+                if not isinstance(label, int):
+                    raise ConfigurationError("In order to skip indexing, your labels must be integers. "
+                                             "Found label = {}".format(label))
+                # vocabulary size = largest label id
+                MultiLabelField._vocab_size[self._label_namespace] = \
+                    max(label + 1, MultiLabelField._vocab_size[self._label_namespace])
+
+            self._label_ids = labels
+        else:
+            for label in labels:
+                if not isinstance(label, str):
+                    raise ConfigurationError("MultiLabelFields expects string labels if skip_indexing=False. "
+                                             "Found label: {} with type: {}.".format(label, type(label)))
+
+    def _maybe_warn_for_namespace(self, label_namespace: str) -> None:
+        if not (self._label_namespace.endswith("labels") or self._label_namespace.endswith("tags")):
+            if label_namespace not in self._already_warned_namespaces:
+                logger.warning("Your label namespace was '%s'. We recommend you use a namespace "
+                               "ending with 'labels' or 'tags', so we don't add UNK and PAD tokens by "
+                               "default to your vocabulary.  See documentation for "
+                               "`non_padded_namespaces` parameter in Vocabulary.",
+                               self._label_namespace)
+                self._already_warned_namespaces.add(label_namespace)
+
+    @overrides
+    def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
+        if self._label_ids is None:
+            for label in self.labels:
+                counter[self._label_namespace][label] += 1  # type: ignore
+
+    @overrides
+    def index(self, vocab: Vocabulary):
+        if self._label_ids is None:
+            self._label_ids = [vocab.get_token_index(label, self._label_namespace)  # type: ignore
+                               for label in self.labels]
+
+        # This is called after the full vocabulary has been built
+        if MultiLabelField._vocab_size[self._label_namespace]:
+            assert MultiLabelField._vocab_size[self._label_namespace] == vocab.get_vocab_size(
+                    self._label_namespace), "Vocabulary size shouldn't change here."
+        else:
+            MultiLabelField._vocab_size[self._label_namespace] = vocab.get_vocab_size(self._label_namespace)
+
+    @overrides
+    def get_padding_lengths(self) -> Dict[str, int]:  # pylint: disable=no-self-use
+        return {}
+
+    @overrides
+    def as_tensor(self,
+                  padding_lengths: Dict[str, int],
+                  cuda_device: int = -1,
+                  for_training: bool = True) -> torch.Tensor:
+        # pylint: disable=unused-argument
+
+        values = torch.zeros(MultiLabelField._vocab_size[self._label_namespace])  # vector of zeros
+        if self._label_ids:
+            values.scatter_(0, torch.LongTensor(self._label_ids), 1)
+
+        tensor = Variable(values, volatile=not for_training)
+        return tensor if cuda_device == -1 else tensor.cuda(cuda_device)
+
+    @overrides
+    def empty_field(self):
+        return MultiLabelField([], self._label_namespace, skip_indexing=True)
+
+    def __str__(self) -> str:
+        return f"MultiLabelField with labels: {self.labels} in namespace: '{self._label_namespace}'.'"

--- a/doc/api/allennlp.data.fields.rst
+++ b/doc/api/allennlp.data.fields.rst
@@ -10,6 +10,7 @@ allennlp.data.fields
 * :ref:`IndexField<index-field>`
 * :ref:`SpanField<span-field>`
 * :ref:`LabelField<label-field>`
+* :ref:`MultiLabelField<label-field>`
 * :ref:`ListField<list-field>`
 * :ref:`MetadataField<metadata-field>`
 * :ref:`SequenceField<sequence-field>`
@@ -37,6 +38,12 @@ allennlp.data.fields
 
 .. _label-field:
 .. automodule:: allennlp.data.fields.label_field
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _multilabel-field:
+.. automodule:: allennlp.data.fields.multilabel_field
    :members:
    :undoc-members:
    :show-inheritance:

--- a/tests/data/fields/multilabel_field_test.py
+++ b/tests/data/fields/multilabel_field_test.py
@@ -1,0 +1,69 @@
+# pylint: disable=no-self-use,invalid-name
+import numpy
+import pytest
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.fields import MultiLabelField
+from allennlp.data.vocabulary import Vocabulary
+
+
+class TestMultiLabelField(AllenNlpTestCase):
+    def test_as_tensor_returns_integer_tensor(self):
+        f = MultiLabelField([5], skip_indexing=True, label_namespace="test1")
+        tensor = f.as_tensor(f.get_padding_lengths()).data.cpu().numpy()
+        numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 0, 0, 0, 0, 1]))
+
+        f = MultiLabelField([3], skip_indexing=True, label_namespace="test1")
+        tensor = f.as_tensor(f.get_padding_lengths()).data.cpu().numpy()
+        numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 0, 0, 1, 0, 0]))
+
+    def test_multilabel_field_can_index_with_vocab(self):
+        vocab = Vocabulary()
+        vocab.add_token_to_namespace("rel0", namespace="rel_labels")
+        vocab.add_token_to_namespace("rel1", namespace="rel_labels")
+        vocab.add_token_to_namespace("rel2", namespace="rel_labels")
+
+        f = MultiLabelField(["rel1", "rel0"], label_namespace="rel_labels")
+        f.index(vocab)
+        tensor = f.as_tensor(f.get_padding_lengths()).data.cpu().numpy()
+        numpy.testing.assert_array_almost_equal(tensor, numpy.array([1, 1, 0]))
+
+    def test_multilabel_field_raises_with_non_integer_labels_and_no_indexing(self):
+        with pytest.raises(ConfigurationError):
+            _ = MultiLabelField(["non integer field"], skip_indexing=True)
+
+    def test_multilabel_field_raises_with_incorrect_label_type(self):
+        with pytest.raises(ConfigurationError):
+            _ = MultiLabelField([1, 2], skip_indexing=False)
+
+    def test_multilabel_field_empty_field_works(self):
+        vocab = Vocabulary()
+        vocab.add_token_to_namespace("label1", namespace="test_empty_labels")
+        vocab.add_token_to_namespace("label2", namespace="test_empty_labels")
+
+        f = MultiLabelField([], label_namespace="test_empty_labels")
+        f.index(vocab)
+        tensor = f.as_tensor(f.get_padding_lengths()).data.cpu().numpy()
+        numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 0]))
+
+    def test_class_variables_for_namespace_warnings_work_correctly(self):
+        # pylint: disable=protected-access
+        assert "text" not in MultiLabelField._already_warned_namespaces
+        with self.assertLogs(logger="allennlp.data.fields.multilabel_field", level="WARNING"):
+            _ = MultiLabelField(["test"], label_namespace="text")
+
+        # We've warned once, so we should have set the class variable to False.
+        assert "text" in MultiLabelField._already_warned_namespaces
+        with pytest.raises(AssertionError):
+            with self.assertLogs(logger="allennlp.data.fields.multilabel_field", level="WARNING"):
+                _ = MultiLabelField(["test2"], label_namespace="text")
+
+        # ... but a new namespace should still log a warning.
+        assert "text2" not in MultiLabelField._already_warned_namespaces
+        with self.assertLogs(logger="allennlp.data.fields.multilabel_field", level="WARNING"):
+            _ = MultiLabelField(["test"], label_namespace="text2")
+
+    def test_printing_doesnt_crash(self):
+        field = MultiLabelField(["label"], label_namespace="namespace")
+        print(field)

--- a/tests/data/fields/multilabel_field_test.py
+++ b/tests/data/fields/multilabel_field_test.py
@@ -10,13 +10,9 @@ from allennlp.data.vocabulary import Vocabulary
 
 class TestMultiLabelField(AllenNlpTestCase):
     def test_as_tensor_returns_integer_tensor(self):
-        f = MultiLabelField([5], skip_indexing=True, label_namespace="test1")
+        f = MultiLabelField([2, 3], skip_indexing=True, label_namespace="test1", num_labels=5)
         tensor = f.as_tensor(f.get_padding_lengths()).data.cpu().numpy()
-        numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 0, 0, 0, 0, 1]))
-
-        f = MultiLabelField([3], skip_indexing=True, label_namespace="test1")
-        tensor = f.as_tensor(f.get_padding_lengths()).data.cpu().numpy()
-        numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 0, 0, 1, 0, 0]))
+        numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 0, 1, 1, 0]))
 
     def test_multilabel_field_can_index_with_vocab(self):
         vocab = Vocabulary()
@@ -33,9 +29,21 @@ class TestMultiLabelField(AllenNlpTestCase):
         with pytest.raises(ConfigurationError):
             _ = MultiLabelField(["non integer field"], skip_indexing=True)
 
+    def test_multilabel_field_raises_with_no_indexing_and_missing_num_labels(self):
+        with pytest.raises(ConfigurationError):
+            _ = MultiLabelField([0, 2], skip_indexing=True, num_labels=None)
+
+    def test_multilabel_field_raises_with_no_indexing_and_wrong_num_labels(self):
+        with pytest.raises(ConfigurationError):
+            _ = MultiLabelField([0, 2, 4], skip_indexing=True, num_labels=3)
+
     def test_multilabel_field_raises_with_incorrect_label_type(self):
         with pytest.raises(ConfigurationError):
             _ = MultiLabelField([1, 2], skip_indexing=False)
+
+    def test_multilabel_field_raises_with_given_num_labels(self):
+        with pytest.raises(ConfigurationError):
+            _ = MultiLabelField([1, 2], skip_indexing=False, num_labels=4)
 
     def test_multilabel_field_empty_field_works(self):
         vocab = Vocabulary()


### PR DESCRIPTION
Adding a multilabel field which is useful for multi-label multi-class classification. 
Notes:
- I don't like how I am reading the vocabulary size, but I didn't find a better way. I am open to better suggestions. 
- The `as_tensor` function returns a dense vector of zeros and ones. It would have been more efficient to work with a list of indices instead, but that's not supported by torch.nn.BCEWithLogitsLoss