### PR TITLE
Reading glove embeddings: strip() --> rstrip()

### DIFF
--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -231,7 +231,7 @@ def _read_pretrained_word2vec_format_embedding_file(embeddings_filename: str, # 
     logger.info("Reading embeddings from file")
     with gzip.open(cached_path(embeddings_filename), 'rb') as embeddings_file:
         for line in embeddings_file:
-            fields = line.decode('utf-8').strip().split(' ')
+            fields = line.decode('utf-8').rstrip().split(' ')
             if len(fields) - 1 != embedding_dim:
                 # Sometimes there are funny unicode parsing problems that lead to different
                 # fields lengths (e.g., a word with a unicode space character that splits

--- a/tests/modules/token_embedders/embedding_test.py
+++ b/tests/modules/token_embedders/embedding_test.py
@@ -51,10 +51,12 @@ class TestEmbedding(AllenNlpTestCase):
         vocab = Vocabulary()
         vocab.add_token_to_namespace("word")
         vocab.add_token_to_namespace("word2")
+        unicode_space = "\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0"
+        vocab.add_token_to_namespace(unicode_space)
         embeddings_filename = self.TEST_DIR + "embeddings.gz"
         with gzip.open(embeddings_filename, 'wb') as embeddings_file:
             embeddings_file.write("word 1.0 2.3 -1.0\n".encode('utf-8'))
-            embeddings_file.write("\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0 3.4 3.3 5.0\n".encode('utf-8'))
+            embeddings_file.write(f"{unicode_space} 3.4 3.3 5.0\n".encode('utf-8'))
         params = Params({
                 'pretrained_file': embeddings_filename,
                 'embedding_dim': 3,
@@ -62,7 +64,7 @@ class TestEmbedding(AllenNlpTestCase):
         embedding_layer = Embedding.from_params(vocab, params)
         word_vector = embedding_layer.weight.data[vocab.get_token_index("word")]
         assert numpy.allclose(word_vector.numpy(), numpy.array([1.0, 2.3, -1.0]))
-        word_vector = embedding_layer.weight.data[vocab.get_token_index("\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0".encode("utf-8"))]
+        word_vector = embedding_layer.weight.data[vocab.get_token_index(unicode_space)]
         assert numpy.allclose(word_vector.numpy(), numpy.array([3.4, 3.3, 5.0]))
         word_vector = embedding_layer.weight.data[vocab.get_token_index("word2")]
         assert not numpy.allclose(word_vector.numpy(), numpy.array([1.0, 2.3, -1.0]))

--- a/tests/modules/token_embedders/embedding_test.py
+++ b/tests/modules/token_embedders/embedding_test.py
@@ -54,6 +54,7 @@ class TestEmbedding(AllenNlpTestCase):
         embeddings_filename = self.TEST_DIR + "embeddings.gz"
         with gzip.open(embeddings_filename, 'wb') as embeddings_file:
             embeddings_file.write("word 1.0 2.3 -1.0\n".encode('utf-8'))
+            embeddings_file.write("\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0 3.4 3.3 5.0\n".encode('utf-8'))
         params = Params({
                 'pretrained_file': embeddings_filename,
                 'embedding_dim': 3,
@@ -61,6 +62,8 @@ class TestEmbedding(AllenNlpTestCase):
         embedding_layer = Embedding.from_params(vocab, params)
         word_vector = embedding_layer.weight.data[vocab.get_token_index("word")]
         assert numpy.allclose(word_vector.numpy(), numpy.array([1.0, 2.3, -1.0]))
+        word_vector = embedding_layer.weight.data[vocab.get_token_index("\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0".encode("utf-8"))]
+        assert numpy.allclose(word_vector.numpy(), numpy.array([3.4, 3.3, 5.0]))
         word_vector = embedding_layer.weight.data[vocab.get_token_index("word2")]
         assert not numpy.allclose(word_vector.numpy(), numpy.array([1.0, 2.3, -1.0]))
 


### PR DESCRIPTION
Applying `strip()` on the line leads to incorrect reading of certain words in the `glove.840B.300d` file. More precisely, it deletes the word (interpreting it as whitespace), considers the first dimension of the embedding as the word, and consequently finds only 299 dimensions. Sample log message 

`2018-03-30 15:06:35,244 - WARNING - allennlp.modules.token_embedders.embedding - Found line with wrong number of dimensions (expected 300, was 299): b'\xc2\xa0\xc2\xa0\xc2\xa0\xc2\xa0\xc2\xa0\xc2\xa0\xc2\xa0\xc2\xa0 0.59759 -0.64012 0.32797 -0.40237 -0.96606 0.059478 -0.21576 0.16216 -0.32797 -1.6323 0.68522 -0.073292 0.21555 1.3283 -0.031215 -0.53429 0.49431 -1.1694 0.24104 -0.33426 0.58275 0.38341 0.55435 0.48166 -0.52648 0.064375 -0.8332 0.36364 0.41019 -0.72814 0.37718 0.12334 0.65675 0.24793 -0.18758 0.14272 0.62822 0.29398 -0.38322 0.1577 0.61929 0.13675 0.58332 0.19871 0.25006 -0.81523 -0.45037 0.079187 -0.35683 1.014 0.56923 0.011635 0.73754 -0.16272 0.16946 -0.85107 0.28715 -0.040366 -0.47167 0.64212 -0.17451 -0.03211 1.2196 -0.77149 -0.83482 -0.26648 0.52057 0.027308 -0.30045 0.052085 0.5338 -0.34966 -0.15528 -1.1164 -0.30006 0.4234 -0.81019 0.50919 -0.46411 0.043904 -0.50195 0.081817 0.51933 0.12137 -0.21922 0.010013 0.76642 0.39335 -0.16865 -0.45341 -0.76879 -0.15407 -0.68731 -0.12682 0.03759 0.78558 -0.10268 -0.98331 0.35893 -0.066734 -0.43872 0.5072 0.61228 0.99948 -0.59586 -0.83491 0.13185 -0.5546 -1.0491 0.010842 0.14695 0.10353 0.15564 0.062978 0.36645 0.097292 -0.34948 0.44568 -0.11599 0.64676 -0.97452 0.1114 -0.092003 0.31164 -0.70877 -0.33556 -0.47921 0.49446 -0.55879 0.15302 -0.27326 0.012649 0.20556 -0.19405 0.26573 -0.2673 0.63431 -0.36549 0.32918 -0.79218 1.0017 -0.12909 -0.62981 0.73703 -1.0183 -0.16428 0.50129 0.31386 -0.75925 -0.18461 -0.31729 0.74761 -0.74921 0.66782 0.60203 0.68145 -0.25125 -0.038851 0.059788 -0.36312 0.20819 0.32061 1.1507 -0.11093 0.64951 0.23964 -0.3711 0.54309 -0.61297 0.59027 0.04426 0.32154 0.45133 0.2978 0.45305 -0.17236 -0.98148 0.19651 -0.54731 -0.42562 0.38961 -0.56711 0.79143 0.14931 0.70015 0.55543 0.02439 0.11753 -0.083093 -0.14134 0.53873 0.64715 0.70151 -1.2352 0.51635 0.08466 0.99562 0.16819 -0.45894 -0.43009 -0.041268 0.85343 0.59703 0.03857 -0.75895 0.38059 0.011928 0.15895 -0.49433 0.31188 0.55795 0.489 0.28439 0.5521 -0.29506 -0.24759 -0.38424 0.53704 0.73393 -0.10952 0.33085 -0.30816 0.53731 -0.22865 -0.63114 -0.61012 0.61583 -0.45295 -1.226 -0.90847 0.4904 0.089766 -0.3157 -0.27985 -0.65357 0.92423 0.71765 -0.41399 -1.0852 0.37901 -0.10546 0.52884 0.65648 -0.64929 -0.86047 0.49595 0.73634 1.0105 -0.12911 0.157 0.067726 0.15838 0.18021 0.97215 0.1298 -0.068941 0.38541 0.42544 0.17778 0.39474 -0.16531 -0.5659 0.1885 0.45535 -0.10229 0.077971 -0.044195 -0.26739 -0.48962 -0.27334 -0.13136 -0.22749 0.074986 0.44992 -0.16366 -0.036424 0.45594 0.29928 -0.11101 -0.54998 -0.68498 0.6914 -0.026335 0.44588 0.17025 0.64951 0.045954 1.3128 -0.91445 0.29611 0.25968 -0.331 -0.60079 -0.49182 0.74319 -0.22999 -0.10779 -0.45078 -0.34475 -0.56342\n' `