### PR TITLE
Adding an optional projection layer to ElmoTokenEmbedder

### DIFF
--- a/allennlp/modules/__init__.py
+++ b/allennlp/modules/__init__.py
@@ -6,17 +6,18 @@ that are used as components in AllenNLP
 """
 
 from allennlp.modules.attention import Attention
-from allennlp.modules.layer_norm import LayerNorm
 from allennlp.modules.conditional_random_field import ConditionalRandomField
+from allennlp.modules.elmo import Elmo
 from allennlp.modules.feedforward import FeedForward
 from allennlp.modules.highway import Highway
+from allennlp.modules.layer_norm import LayerNorm
 from allennlp.modules.matrix_attention import MatrixAttention
+from allennlp.modules.maxout import Maxout
+from allennlp.modules.scalar_mix import ScalarMix
 from allennlp.modules.seq2seq_encoders import Seq2SeqEncoder
 from allennlp.modules.seq2vec_encoders import Seq2VecEncoder
 from allennlp.modules.similarity_functions import SimilarityFunction
+from allennlp.modules.span_pruner import SpanPruner
 from allennlp.modules.text_field_embedders import TextFieldEmbedder
 from allennlp.modules.time_distributed import TimeDistributed
 from allennlp.modules.token_embedders import TokenEmbedder
-from allennlp.modules.scalar_mix import ScalarMix
-from allennlp.modules.span_pruner import SpanPruner
-from allennlp.modules.maxout import Maxout

--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -87,6 +87,9 @@ class Elmo(torch.nn.Module):
             self.add_module('scalar_mix_{}'.format(k), scalar_mix)
             self._scalar_mixes.append(scalar_mix)
 
+    def get_output_dim(self):
+        return self._elmo_lstm.get_output_dim()
+
     def forward(self,    # pylint: disable=arguments-differ
                 inputs: torch.Tensor) -> Dict[str, Union[torch.Tensor, List[torch.Tensor]]]:
         """
@@ -431,6 +434,9 @@ class _ElmoBiLm(torch.nn.Module):
         self._elmo_lstm.load_weights(weight_file)
         # Number of representation layers including context independent layer
         self.num_layers = options['lstm']['n_layers'] + 1
+
+    def get_output_dim(self):
+        return 2 * self._token_embedder.get_output_dim()
 
     def forward(self,  # pylint: disable=arguments-differ
                 inputs: torch.Tensor) -> Dict[str, Union[torch.Tensor, List[torch.Tensor]]]:

--- a/tests/modules/token_embedders/elmo_token_embedder_test.py
+++ b/tests/modules/token_embedders/elmo_token_embedder_test.py
@@ -4,10 +4,15 @@ import json
 import os
 import tarfile
 
+import torch
+from torch.autograd import Variable
+
 from allennlp.commands.train import train_model
 from allennlp.common import Params
 from allennlp.common.testing import ModelTestCase
 from allennlp.data.dataset import Batch
+from allennlp.modules.token_embedders import ElmoTokenEmbedder
+
 
 class TestElmoTokenEmbedder(ModelTestCase):
     def setUp(self):
@@ -63,3 +68,28 @@ class TestElmoTokenEmbedder(ModelTestCase):
         for key, original_filename in files_to_archive.items():
             new_filename = os.path.join(unarchive_dir, "fta", key)
             assert filecmp.cmp(original_filename, new_filename)
+
+    def test_forward_works_with_projection_layer(self):
+        params = Params({
+                'options_file': 'tests/fixtures/elmo/options.json',
+                'weight_file': 'tests/fixtures/elmo/lm_weights.hdf5',
+                'projection_dim': 20
+                })
+        word1 = [0] * 50
+        word2 = [0] * 50
+        word1[0] = 6
+        word1[1] = 5
+        word1[2] = 4
+        word1[3] = 3
+        word2[0] = 3
+        word2[1] = 2
+        word2[2] = 1
+        word2[3] = 0
+        embedding_layer = ElmoTokenEmbedder.from_params(vocab=None, params=params)
+        input_tensor = Variable(torch.LongTensor([[word1, word2]]))
+        embedded = embedding_layer(input_tensor).data.numpy()
+        assert embedded.shape == (1, 2, 20)
+
+        input_tensor = Variable(torch.LongTensor([[[word1]]]))
+        embedded = embedding_layer(input_tensor).data.numpy()
+        assert embedded.shape == (1, 1, 1, 20)


### PR DESCRIPTION
@matt-peters FYI. @rajasagashe's experiments with the WikiTables parser found that a projection of the ELMo representations was significantly better than just using dropout.  In order to handle the projection cleanly in AllenNLP, it has to be done inside the `ElmoTokenEmbedder`.  This PR adds that.