### PR TITLE
Adding the decoding framework from the wikitables branch

### DIFF
--- a/allennlp/nn/decoding/__init__.py
+++ b/allennlp/nn/decoding/__init__.py
@@ -1,18 +1,17 @@
 """
-This module contains code for transition-based decoding.  If you want to do decoding for a
-vocabulary-based model, where the allowable outputs are the same at every timestep of decoding,
-this code is not what you are looking for, and it will be quite inefficient compared to other
-things you could do.
+This module contains code for transition-based decoding.  "Transition-based decoding" is where you
+start in some state, iteratively transition between states, and have some kind of supervision
+signal that tells you which end states, or which transition sequences, are "good".
 
-This code assumes you have a transition-based model, where you start in some state, iteratively
-transition between states, and have some kind of supervision signal that tells you which end
-states, or which transition sequences, are "good".
+If you want to do decoding for a vocabulary-based model, where the allowable outputs are the same
+at every timestep of decoding, this code is not what you are looking for, and it will be quite
+inefficient compared to other things you could do.
 
 The key abstractions in this code are the following:
 
     - ``DecoderState`` represents the current state of decoding, containing a list of all of the
       actions taken so far, and a current score for the state.  It also has methods around
-      determining whether the state is "finished", for combining states for batched computation.
+      determining whether the state is "finished" and for combining states for batched computation.
     - ``DecoderStep`` is a ``torch.nn.Module`` that models the transition function between states.
       Its main method is ``take_step``, which generates a ranked list of next states given a
       current state.

--- a/allennlp/nn/decoding/__init__.py
+++ b/allennlp/nn/decoding/__init__.py
@@ -1,0 +1,36 @@
+"""
+This module contains code for transition-based decoding.  If you want to do decoding for a
+vocabulary-based model, where the allowable outputs are the same at every timestep of decoding,
+this code is not what you are looking for, and it will be quite inefficient compared to other
+things you could do.
+
+This code assumes you have a transition-based model, where you start in some state, iteratively
+transition between states, and have some kind of supervision signal that tells you which end
+states, or which transition sequences, are "good".
+
+The key abstractions in this code are the following:
+
+    - ``DecoderState`` represents the current state of decoding, containing a list of all of the
+      actions taken so far, and a current score for the state.  It also has methods around
+      determining whether the state is "finished", for combining states for batched computation.
+    - ``DecoderStep`` is a ``torch.nn.Module`` that models the transition function between states.
+      Its main method is ``take_step``, which generates a ranked list of next states given a
+      current state.
+    - ``DecoderTrainer`` is an algorithm for training the transition function with some kind of
+      supervision signal.  There are many options for training algorithms and supervision signals;
+      this is an abstract class that is generic over the type of the supervision signal.
+
+The module also has some classes to help represent the ``DecoderState``, including ``RnnState``,
+which you can use to keep track of a decoder RNN's internal state, and ``GrammarState``, which
+keeps track of what actions are allowed at each timestep of decoding, if your outputs are
+production rules from a grammar.
+
+There is also a generic ``BeamSearch`` class for finding the ``k`` highest-scoring transition
+sequences given a trained ``DecoderStep`` and an initial ``DecoderState``.
+"""
+from allennlp.nn.decoding.beam_search import BeamSearch
+from allennlp.nn.decoding.decoder_state import DecoderState
+from allennlp.nn.decoding.decoder_step import DecoderStep
+from allennlp.nn.decoding.decoder_trainers.decoder_trainer import DecoderTrainer
+from allennlp.nn.decoding.grammar_state import GrammarState
+from allennlp.nn.decoding.rnn_state import RnnState

--- a/allennlp/nn/decoding/beam_search.py
+++ b/allennlp/nn/decoding/beam_search.py
@@ -1,0 +1,83 @@
+from collections import defaultdict
+from typing import Dict, List
+
+from allennlp.common import Params
+from allennlp.nn.decoding.decoder_step import DecoderStep
+from allennlp.nn.decoding.decoder_state import DecoderState
+
+
+class BeamSearch:
+    """
+    This class implements beam search over transition sequences given an initial ``DecoderState``
+    and a ``DecoderStep``, returning the highest scoring final states found by the beam (the states
+    will keep track of the transition sequence themselves).
+
+    The initial ``DecoderState`` is assumed to be `batched`.  The value we return from the search
+    is a dictionary from batch indices to ranked finished states.
+    """
+    def __init__(self, beam_size: int) -> None:
+        self._beam_size = beam_size
+
+    def search(self,
+               num_steps: int,
+               initial_state: DecoderState,
+               decoder_step: DecoderStep,
+               keep_final_unfinished_states: bool = True) -> Dict[int, List[DecoderState]]:
+        """
+        Parameters
+        ----------
+        num_steps : ``int``
+            How many steps should we take in our search?  This is an upper bound, as it's possible
+            for the search to run out of valid actions before hitting this number, or for all
+            states on the beam to finish.
+        initial_state : ``DecoderState``
+            The starting state of our search.  This is assumed to be `batched`, and our beam search
+            is batch-aware - we'll keep ``beam_size`` states around for each instance in the batch.
+        decoder_step : ``DecoderStep``
+            The ``DecoderStep`` object that defines and scores transitions from one state to the
+            next.
+        keep_final_unfinished_states : ``bool``, optional (default=True)
+            If we run out of steps before a state is "finished", should we return that state in our
+            search results?
+
+        Returns
+        -------
+        best_states : ``Dict[int, List[DecoderState]]``
+            This is a mapping from batch index to the top states for that instance.
+        """
+        finished_states: Dict[int, List[DecoderState]] = defaultdict(list)
+        states = [initial_state]
+        step_num = 1
+        while states and step_num <= num_steps:
+            next_states: Dict[int, List[DecoderState]] = defaultdict(list)
+            grouped_state = states[0].combine_states(states)
+            for next_state in decoder_step.take_step(grouped_state, max_actions=self._beam_size):
+                # NOTE: we're doing state.batch_indices[0] here (and similar things below),
+                # hard-coding a group size of 1.  But, our use of `next_state.is_finished()`
+                # already checks for that, as it crashes if the group size is not 1.
+                batch_index = next_state.batch_indices[0]
+                if next_state.is_finished():
+                    finished_states[batch_index].append(next_state)
+                else:
+                    if step_num == num_steps and keep_final_unfinished_states:
+                        finished_states[batch_index].append(next_state)
+                    next_states[batch_index].append(next_state)
+            states = []
+            for batch_index, batch_states in next_states.items():
+                # The states from the generator are already sorted, so we can just take the first
+                # ones here, without an additional sort.
+                states.extend(batch_states[:self._beam_size])
+            step_num += 1
+        best_states: Dict[int, List[DecoderState]] = {}
+        for batch_index, batch_states in finished_states.items():
+            # The time this sort takes is pretty negligible, no particular need to optimize this
+            # yet.  Maybe with a larger beam size...
+            finished_to_sort = [(-state.score[0].data[0], state) for state in batch_states]
+            finished_to_sort.sort(key=lambda x: x[0])
+            best_states[batch_index] = [state[1] for state in finished_to_sort[:self._beam_size]]
+        return best_states
+
+    @classmethod
+    def from_params(cls, params: Params) -> 'BeamSearch':
+        beam_size = params.pop('beam_size')
+        return cls(beam_size=beam_size)

--- a/allennlp/nn/decoding/beam_search.py
+++ b/allennlp/nn/decoding/beam_search.py
@@ -14,6 +14,11 @@ class BeamSearch:
 
     The initial ``DecoderState`` is assumed to be `batched`.  The value we return from the search
     is a dictionary from batch indices to ranked finished states.
+
+    IMPORTANT: We assume that the ``DecoderStep`` that you are using returns possible next states
+    in sorted order, so we do not do an additional sort inside of ``BeamSearch.search()``.  If
+    you're implementing your own ``DecoderStep``, you must ensure that you've sorted the states
+    that you return.
     """
     def __init__(self, beam_size: int) -> None:
         self._beam_size = beam_size
@@ -66,6 +71,7 @@ class BeamSearch:
             for batch_index, batch_states in next_states.items():
                 # The states from the generator are already sorted, so we can just take the first
                 # ones here, without an additional sort.
+                print(batch_index, batch_states)
                 states.extend(batch_states[:self._beam_size])
             step_num += 1
         best_states: Dict[int, List[DecoderState]] = {}
@@ -74,6 +80,7 @@ class BeamSearch:
             # yet.  Maybe with a larger beam size...
             finished_to_sort = [(-state.score[0].data[0], state) for state in batch_states]
             finished_to_sort.sort(key=lambda x: x[0])
+            print(finished_to_sort)
             best_states[batch_index] = [state[1] for state in finished_to_sort[:self._beam_size]]
         return best_states
 

--- a/allennlp/nn/decoding/beam_search.py
+++ b/allennlp/nn/decoding/beam_search.py
@@ -71,7 +71,6 @@ class BeamSearch:
             for batch_index, batch_states in next_states.items():
                 # The states from the generator are already sorted, so we can just take the first
                 # ones here, without an additional sort.
-                print(batch_index, batch_states)
                 states.extend(batch_states[:self._beam_size])
             step_num += 1
         best_states: Dict[int, List[DecoderState]] = {}
@@ -80,7 +79,6 @@ class BeamSearch:
             # yet.  Maybe with a larger beam size...
             finished_to_sort = [(-state.score[0].data[0], state) for state in batch_states]
             finished_to_sort.sort(key=lambda x: x[0])
-            print(finished_to_sort)
             best_states[batch_index] = [state[1] for state in finished_to_sort[:self._beam_size]]
         return best_states
 

--- a/allennlp/nn/decoding/decoder_state.py
+++ b/allennlp/nn/decoding/decoder_state.py
@@ -28,6 +28,9 @@ class DecoderState(Generic[T]):
     Parameters
     ----------
     batch_indices : ``List[int]``
+        A ``group_size``-length list, where each element specifies which ``batch_index`` that group
+        element came from.
+
         Our internal variables (like scores, action histories, hidden states, whatever) are
         `grouped`, and our ``group_size`` is likely different from the original ``batch_size``.
         This variable keeps track of which batch instance each group element came from (e.g., to
@@ -35,15 +38,10 @@ class DecoderState(Generic[T]):
     action_history : ``List[List[int]]``
         The list of actions taken so far in this state.  This is also grouped, so each state in the
         group has a list of actions.
-
-        The type annotation says this is an ``int``, but none of the training logic relies on this
-        being an ``int``.  In some cases, items from this list will get passed as inputs to
-        ``DecodeStep``, so this must return items that are compatible with inputs to your
-        ``DecodeStep`` class.
     score : ``List[torch.autograd.Variable]``
         This state's score.  It's a variable, because typically we'll be computing a loss based on
-        this score, and using it for backprop during training.  Like the other variables here, it's
-        grouped.
+        this score, and using it for backprop during training.  Like the other variables here, this
+        is a ``group_size``-length list.
     """
     def __init__(self,
                  batch_indices: List[int],

--- a/allennlp/nn/decoding/decoder_state.py
+++ b/allennlp/nn/decoding/decoder_state.py
@@ -1,0 +1,69 @@
+from typing import Generic, List, TypeVar
+
+import torch
+
+# Note that the bound here is `DecoderState` itself.  This is what lets us have methods that take
+# lists of a `DecoderState` subclass and output structures with the subclass.  Really ugly that we
+# have to do this generic typing _for our own class_, but it makes mypy happy and gives us good
+# type checking in a few important methods.
+T = TypeVar('T', bound='DecoderState')
+
+class DecoderState(Generic[T]):
+    """
+    Represents the (batched) state of a transition-based decoder.
+
+    There are two different kinds of batching we need to distinguish here.  First, there's the
+    batch of training instances passed to ``model.forward()``.  We'll use "batch" and
+    ``batch_size`` to refer to this through the docs and code.  We additionally batch together
+    computation for several states at the same time, where each state could be from the same
+    training instance in the original batch, or different instances.  We use "group" and
+    ``group_size`` in the docs and code to refer to this kind of batching, to distinguish it from
+    the batch of training instances.
+
+    So, using this terminology, a single ``DecoderState`` object represents a `grouped` collection
+    of states.  Because different states in this group might finish at different timesteps, we have
+    methods and member variables to handle some bookkeeping around this, to split and regroup
+    things.
+
+    Parameters
+    ----------
+    batch_indices : ``List[int]``
+        Our internal variables (like scores, action histories, hidden states, whatever) are
+        `grouped`, and our ``group_size`` is likely different from the original ``batch_size``.
+        This variable keeps track of which batch instance each group element came from (e.g., to
+        know what the correct action sequences are, or which encoder outputs to use).
+    action_history : ``List[List[int]]``
+        The list of actions taken so far in this state.  This is also grouped, so each state in the
+        group has a list of actions.
+
+        The type annotation says this is an ``int``, but none of the training logic relies on this
+        being an ``int``.  In some cases, items from this list will get passed as inputs to
+        ``DecodeStep``, so this must return items that are compatible with inputs to your
+        ``DecodeStep`` class.
+    score : ``List[torch.autograd.Variable]``
+        This state's score.  It's a variable, because typically we'll be computing a loss based on
+        this score, and using it for backprop during training.  Like the other variables here, it's
+        grouped.
+    """
+    def __init__(self,
+                 batch_indices: List[int],
+                 action_history: List[List[int]],
+                 score: List[torch.autograd.Variable]) -> None:
+        self.batch_indices = batch_indices
+        self.action_history = action_history
+        self.score = score
+
+    def is_finished(self) -> bool:
+        """
+        If this state has a ``group_size`` of 1, this returns whether the single action sequence in
+        this state is finished or not.  If this state has a ``group_size`` other than 1, this
+        method raises an error.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def combine_states(cls, states: List[T]) -> T:
+        """
+        Combines a list of states, each with their own group size, into a single state.
+        """
+        raise NotImplementedError

--- a/allennlp/nn/decoding/decoder_step.py
+++ b/allennlp/nn/decoding/decoder_step.py
@@ -1,0 +1,73 @@
+from typing import Generic, List, Set, TypeVar
+
+import torch
+
+from allennlp.nn.decoding.decoder_state import DecoderState
+
+StateType = TypeVar('StateType', bound=DecoderState)  # pylint: disable=invalid-name
+
+
+class DecoderStep(torch.nn.Module, Generic[StateType]):
+    """
+    A ``DecoderStep`` is a module that assigns scores to state transitions in a transition-based
+    decoder.
+
+    The ``DecoderStep`` takes a ``DecoderState`` and outputs a ranked list of next states, ordered
+    by the state's score.
+
+    The intention with this class is that a model will implement a subclass of ``DecoderStep`` that
+    defines how exactly you want to handle the input and what computations get done at each step of
+    decoding, and how states are scored.  This subclass then gets passed to a ``DecoderTrainer`` to
+    have its parameters trained.
+    """
+    def take_step(self,
+                  state: StateType,
+                  max_actions: int = None,
+                  allowed_actions: List[Set] = None) -> List[StateType]:
+        """
+        The main method in the ``DecoderStep`` API.  This function defines the computation done at
+        each step of decoding and returns a ranked list of next states.
+
+        The input state is `grouped`, to allow for efficient computation, but the output states
+        should all have a ``group_size`` of 1, to make things easier on the decoding algorithm.
+        They will get regrouped later as needed.
+
+        Because of the way we handle grouping in the decoder states, constructing a new state is
+        actually a relatively expensive operation.  If you know a priori that only some of the
+        states will be needed (either because you have a set of gold action sequences, or you have
+        a fixed beam size), passing that information into this function will keep us from
+        constructing more states than we need, which will greatly speed up your computation.
+
+        Parameters
+        ----------
+        state : ``DecoderState``
+            The current state of the decoder, which we will take a step `from`.  We may be grouping
+            together computation for several states here.  Because we can have several states for
+            each instance in the original batch being evaluated at the same time, we use
+            ``group_size`` for this kind of batching, and ``batch_size`` for the `original` batch
+            in ``model.forward.``
+        max_actions : ``int``, optional
+            If you know that you will only need a certain number of states out of this (e.g., in a
+            beam search), you can pass in the max number of actions that you need, and we will only
+            construct that many states (for each `batch` instance - `not` for each `group`
+            instance!).  This can save a whole lot of computation if you have an action space
+            that's much larger than your beam size.
+        allowed_actions : ``List[Set]``, optional
+            If the ``DecoderTrainer`` has constraints on which actions need to be evaluated (e.g.,
+            maximum marginal likelihood only needs to evaluate action sequences in a given set),
+            you can pass those constraints here, to avoid constructing state objects unnecessarily.
+            If there are no constraints from the trainer, passing a value of ``None`` here will
+            allow all actions to be considered.
+
+            This is a list because it is `batched` - every instance in the batch has a set of
+            allowed actions.  Note that the size of this list is the ``group_size`` in the
+            ``DecoderState``, `not` the ``batch_size`` of ``model.forward``.  The training
+            algorithm needs to convert from the `batched` allowed action sequences that it has to a
+            `grouped` allowed action sequence list.
+
+        Returns
+        -------
+        next_states : ``List[DecoderState]``
+            A list of next states, ordered by score.
+        """
+        raise NotImplementedError

--- a/allennlp/nn/decoding/decoder_step.py
+++ b/allennlp/nn/decoding/decoder_step.py
@@ -38,6 +38,10 @@ class DecoderStep(torch.nn.Module, Generic[StateType]):
         a fixed beam size), passing that information into this function will keep us from
         constructing more states than we need, which will greatly speed up your computation.
 
+        IMPORTANT: This method `must` returns states already sorted by their score, otherwise
+        ``BeamSearch`` and other methods will break.  For efficiency, we do not perform an
+        additional sort in those methods.
+
         Parameters
         ----------
         state : ``DecoderState``

--- a/allennlp/nn/decoding/decoder_trainers/__init__.py
+++ b/allennlp/nn/decoding/decoder_trainers/__init__.py
@@ -1,0 +1,2 @@
+from allennlp.nn.decoding.decoder_trainers.expected_risk_minimization import ExpectedRiskMinimization
+from allennlp.nn.decoding.decoder_trainers.maximum_marginal_likelihood import MaximumMarginalLikelihood

--- a/allennlp/nn/decoding/decoder_trainers/decoder_trainer.py
+++ b/allennlp/nn/decoding/decoder_trainers/decoder_trainer.py
@@ -17,8 +17,9 @@ class DecoderTrainer(Generic[SupervisionType]):
 
     Concrete implementations of this abstract base class could do things like maximum marginal
     likelihood, SEARN, LaSO, or other structured learning algorithms.  If you're just trying to
-    maximize the probability of a single target sequence, there are way more efficient ways to do
-    that than using this API.
+    maximize the probability of a single target sequence where the possible outputs are the same
+    for each timestep (as in, e.g., typical machine translation training regimes), there are way
+    more efficient ways to do that than using this API.
     """
     def decode(self,
                initial_state: DecoderState,
@@ -28,6 +29,9 @@ class DecoderTrainer(Generic[SupervisionType]):
         Takes an initial state object, a means of transitioning from state to state, and a
         supervision signal, and uses the supervision to train the transition function to pick
         "good" states.
+
+        This function should typically return a ``loss`` key during training, which the ``Model``
+        will use as its loss.
 
         Parameters
         ----------

--- a/allennlp/nn/decoding/decoder_trainers/decoder_trainer.py
+++ b/allennlp/nn/decoding/decoder_trainers/decoder_trainer.py
@@ -1,0 +1,48 @@
+from typing import Dict, Generic, TypeVar
+
+import torch
+
+from allennlp.nn.decoding.decoder_step import DecoderStep
+from allennlp.nn.decoding.decoder_state import DecoderState
+
+SupervisionType = TypeVar('SupervisionType')  # pylint: disable=invalid-name
+
+class DecoderTrainer(Generic[SupervisionType]):
+    """
+    ``DecoderTrainers`` define a training regime for transition-based decoders.  A
+    ``DecoderTrainer`` assumes an initial ``DecoderState``, a ``DecoderStep`` function that can
+    traverse the state space, and some supervision signal.  Given these things, the
+    ``DecoderTrainer`` trains the ``DecoderStep`` function to traverse the state space to end up at
+    good end states.
+
+    Concrete implementations of this abstract base class could do things like maximum marginal
+    likelihood, SEARN, LaSO, or other structured learning algorithms.  If you're just trying to
+    maximize the probability of a single target sequence, there are way more efficient ways to do
+    that than using this API.
+    """
+    def decode(self,
+               initial_state: DecoderState,
+               decode_step: DecoderStep,
+               supervision: SupervisionType) -> Dict[str, torch.Tensor]:
+        """
+        Takes an initial state object, a means of transitioning from state to state, and a
+        supervision signal, and uses the supervision to train the transition function to pick
+        "good" states.
+
+        Parameters
+        ----------
+        initial_state : ``DecoderState``
+            This is the initial state for decoding, typically initialized after running some kind
+            of encoder on some inputs.
+        decode_step : ``DecoderStep``
+            This is the transition function that scores all possible actions that can be taken in a
+            given state, and returns a ranked list of next states at each step of decoding.
+        supervision : ``SupervisionType``
+            This is the supervision that is used to train the ``decode_step`` function to pick
+            "good" states.  You can use whatever kind of supervision you want (e.g., a single
+            "gold" action sequence, a set of possible "gold" action sequences, a reward function,
+            etc.).  We use ``typing.Generics`` to make sure that our static type checker is happy
+            with how you've matched the supervision that you provide in the model to the
+            ``DecoderTrainer`` that you want to use.
+        """
+        raise NotImplementedError

--- a/allennlp/nn/decoding/decoder_trainers/expected_risk_minimization.py
+++ b/allennlp/nn/decoding/decoder_trainers/expected_risk_minimization.py
@@ -1,0 +1,140 @@
+from typing import Callable, Dict, List, TypeVar
+from collections import defaultdict
+
+import torch
+from torch.autograd import Variable
+
+from allennlp.nn.decoding.decoder_step import DecoderStep
+from allennlp.nn.decoding.decoder_state import DecoderState
+from allennlp.nn.decoding.decoder_trainers.decoder_trainer import DecoderTrainer
+from allennlp.nn import util as nn_util
+
+StateType = TypeVar('StateType', bound=DecoderState)  # pylint: disable=invalid-name
+
+
+class ExpectedRiskMinimization(DecoderTrainer[Callable[[StateType], torch.Tensor]]):
+    """
+    This class implements a trainer that minimizes the expected value of a cost function over the
+    space of some candidate sequences produced by a decoder. We generate the candidate sequences by
+    performing beam search (which is one of the two popular ways of getting these sequences, the
+    other one being sampling; see "Classical Structured Prediction Losses for Sequence to Sequence
+    Learning" by Edunov et al., 2017 for more details).
+    Note that we do not have a notion of targets here, so we're breaking the API of DecoderTrainer
+    a bit.
+
+    Parameters
+    ----------
+    beam_size : ``int``
+    noramlize_by_length : ``bool``
+        Should the log probabilities be normalized by length before renormalizing them? Edunov et
+        al. do this in their work.
+    max_decoding_steps : ``int``
+        The maximum number of steps we should take during decoding.
+    """
+    def __init__(self, beam_size: int, normalize_by_length: bool, max_decoding_steps: int) -> None:
+        self._beam_size = beam_size
+        self._normalize_by_length = normalize_by_length
+        self.max_decoding_steps = max_decoding_steps
+
+    def decode(self,
+               initial_state: DecoderState,
+               decode_step: DecoderStep,
+               supervision: Callable[[StateType], torch.Tensor]) -> Dict[str, torch.Tensor]:
+        cost_function = supervision
+        finished_states = self._get_finished_states(initial_state, decode_step)
+        loss = nn_util.new_variable_with_data(initial_state.score[0], torch.Tensor([0.0]))
+        finished_model_scores = self._get_model_scores_by_batch(finished_states)
+        finished_costs = self._get_costs_by_batch(finished_states, cost_function)
+        for batch_index in finished_model_scores:
+            # Finished model scores are log-probabilities of the predicted sequences. We convert
+            # log probabilities into probabilities and re-normalize them to compute expected cost under
+            # the distribution approximated by the beam search.
+            costs = torch.cat(finished_costs[batch_index])
+            logprobs = torch.cat(finished_model_scores[batch_index])
+            # Unmasked softmax of log probabilities will convert them into probabilities and
+            # renormalize them.
+            renormalized_probs = nn_util.masked_softmax(logprobs, None)
+            loss += renormalized_probs.dot(costs)
+        mean_loss = loss / len(finished_model_scores)
+        return {'loss': mean_loss,
+                'best_action_sequence': self._get_best_action_sequences(finished_states)}
+
+    def _get_finished_states(self,
+                             initial_state: DecoderState,
+                             decode_step: DecoderStep) -> List[StateType]:
+        finished_states = []
+        states = [initial_state]
+        num_steps = 0
+        while states and num_steps < self.max_decoding_steps:
+            next_states = []
+            grouped_state = states[0].combine_states(states)
+            # These states already come sorted.
+            for next_state in decode_step.take_step(grouped_state):
+                if next_state.is_finished():
+                    finished_states.append(next_state)
+                else:
+                    next_states.append(next_state)
+
+            states = self._prune_beam(next_states)
+            num_steps += 1
+        return finished_states
+
+    def _get_model_scores_by_batch(self, states: List[StateType]) -> Dict[int, List[Variable]]:
+        batch_scores: Dict[int, List[Variable]] = defaultdict(list)
+        for state in states:
+            for batch_index, model_score, history in zip(state.batch_indices,
+                                                         state.score,
+                                                         state.action_history):
+                if self._normalize_by_length:
+                    path_length = nn_util.new_variable_with_data(model_score,
+                                                                 torch.Tensor([len(history)]))
+                    model_score = model_score / path_length
+                batch_scores[batch_index].append(model_score)
+        return batch_scores
+
+    @staticmethod
+    def _get_costs_by_batch(states: List[StateType],
+                            cost_function: Callable[[StateType], torch.Tensor]) -> Dict[int, List[Variable]]:
+        batch_costs: Dict[int, List[Variable]] = defaultdict(list)
+        for state in states:
+            cost = cost_function(state)
+            # Since this is a finished state, its group size is 1, and we just take the only batch
+            # index.
+            batch_index = state.batch_indices[0]
+            batch_costs[batch_index].append(cost)
+        return batch_costs
+
+    def _get_best_action_sequences(self, finished_states: List[StateType]) -> Dict[int, List[int]]:
+        """
+        Returns the best action sequences for each item based on model scores.
+        """
+        batch_action_histories: Dict[int, List[List[int]]] = defaultdict(list)
+        for state in finished_states:
+            for batch_index, action_history in zip(state.batch_indices,
+                                                   state.action_history):
+                batch_action_histories[batch_index].append(action_history)
+
+        batch_scores = self._get_model_scores_by_batch(finished_states)
+        best_action_sequences: Dict[int, List[int]] = {}
+        for batch_index, scores in batch_scores.items():
+            _, sorted_indices = torch.cat(scores).sort(-1, descending=True)
+            cpu_indices = [int(index) for index in sorted_indices.data.cpu().numpy()]
+            best_action_sequence = batch_action_histories[batch_index][cpu_indices[0]]
+            best_action_sequences[batch_index] = best_action_sequence
+        return best_action_sequences
+
+    def _prune_beam(self, states: List[DecoderState]) -> List[DecoderState]:
+        """
+        Prunes a beam, and keeps at most ``self._beam_size`` states per instance. We
+        assume that the ``states`` are grouped, with a group size of 1, and that they're already
+        sorted.
+        """
+        num_states_per_instance: Dict[int, int] = defaultdict(int)
+        pruned_states = []
+        for state in states:
+            assert len(state.batch_indices) == 1
+            batch_index = state.batch_indices[0]
+            if num_states_per_instance[batch_index] < self._beam_size:
+                pruned_states.append(state)
+                num_states_per_instance[batch_index] += 1
+        return pruned_states

--- a/allennlp/nn/decoding/decoder_trainers/maximum_marginal_likelihood.py
+++ b/allennlp/nn/decoding/decoder_trainers/maximum_marginal_likelihood.py
@@ -118,7 +118,7 @@ class MaximumMarginalLikelihood(DecoderTrainer[Tuple[torch.Tensor, torch.Tensor]
             action_history = grouped_state.action_history[i]
             for allowed_action in allowed_actions[i]:
                 expected_histories.add((batch_index, tuple(action_history + [allowed_action])))
-        assert action_histories == expected_histories
+        assert action_histories == expected_histories, f'Expected: {expected_histories}'
 
     @staticmethod
     def _get_allowed_actions(state: DecoderState,

--- a/allennlp/nn/decoding/decoder_trainers/maximum_marginal_likelihood.py
+++ b/allennlp/nn/decoding/decoder_trainers/maximum_marginal_likelihood.py
@@ -1,0 +1,148 @@
+from collections import defaultdict
+import logging
+from typing import Dict, List, Optional, Set, Tuple, Union
+
+import torch
+from torch.autograd import Variable
+
+from allennlp.nn import util
+from allennlp.nn.decoding.decoder_step import DecoderStep
+from allennlp.nn.decoding.decoder_state import DecoderState
+from allennlp.nn.decoding.decoder_trainers.decoder_trainer import DecoderTrainer
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class MaximumMarginalLikelihood(DecoderTrainer[Tuple[torch.Tensor, torch.Tensor]]):
+    """
+    This class trains a decoder by maximizing the marginal likelihood of the targets.  That is,
+    during training, we are given a `set` of acceptable or possible target sequences, and we
+    optimize the `sum` of the probability the model assigns to each item in the set.  This allows
+    the model to distribute its probability mass over the set however it chooses, without forcing
+    `all` of the given target sequences to have high probability.  This is helpful, for example, if
+    you have good reason to expect that the correct target sequence is in the set, but aren't sure
+    `which` of the sequences is actually correct.
+
+    This implementation of maximum marginal likelihood requires the model you use to be `locally
+    normalized`; that is, at each decoding timestep, we assume that the model creates a normalized
+    probability distribution over actions.  This assumption is necessary, because we do no explicit
+    normalization in our loss function, we just sum the probabilities assigned to all correct
+    target sequences, relying on the local normalization at each time step to push probability mass
+    from bad actions to good ones.
+    """
+    def decode(self,
+               initial_state: DecoderState,
+               decode_step: DecoderStep,
+               supervision: Tuple[torch.Tensor, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        targets, target_mask = supervision
+        allowed_transitions = self._create_allowed_transitions(targets, target_mask)
+        finished_states = []
+        states = [initial_state]
+        step_num = 0
+        while states:
+            step_num += 1
+            next_states = []
+            # We group together all current states to get more efficient (batched) computation.
+            grouped_state = states[0].combine_states(states)
+            allowed_actions = self._get_allowed_actions(grouped_state, allowed_transitions)
+            # This will store a set of (batch_index, action_history) tuples, and we'll check it
+            # against the allowed actions to make sure we're actually scoring all of the actions we
+            # are supposed to.
+            actions_taken: Set[Tuple[int, Tuple[int, ...]]] = set()
+            for next_state in decode_step.take_step(grouped_state, allowed_actions=allowed_actions):
+                actions_taken.add((next_state.batch_indices[0], tuple(next_state.action_history[0])))
+                if next_state.is_finished():
+                    finished_states.append(next_state)
+                else:
+                    next_states.append(next_state)
+            states = next_states
+            self._check_all_actions_taken(actions_taken, grouped_state, allowed_actions)
+
+        # This is a dictionary of lists - for each batch instance, we want the score of all
+        # finished states.  So this has shape (batch_size, num_target_action_sequences), though
+        # it's not actually a tensor, because different batch instance might have different numbers
+        # of finished states.
+        batch_scores = self._group_scores_by_batch(finished_states)
+        loss = 0
+        for scores in batch_scores.values():  # we don't care about the batch index, just the scores
+            loss += -util.logsumexp(torch.cat(scores))
+        return {'loss': loss / len(batch_scores)}
+
+    @staticmethod
+    def _create_allowed_transitions(targets: Union[torch.Tensor, List[List[List[int]]]],
+                                    target_mask: Optional[torch.Tensor] = None) -> List[Dict[Tuple[int, ...],
+                                                                                             Set[int]]]:
+        """
+        Takes a list of valid target action sequences and creates a mapping from all possible
+        (valid) action prefixes to allowed actions given that prefix.  ``targets`` is assumed to be
+        a tensor of shape ``(batch_size, num_valid_sequences, sequence_length)``.  If the mask is
+        not ``None``, it is assumed to have the same shape, and we will ignore any value in
+        ``targets`` that has a value of ``0`` in the corresponding position in the mask.  We assume
+        that the mask has the format 1*0* for each item in ``targets`` - that is, once we see our
+        first zero, we stop processing that target.
+
+        For example, if ``targets`` is the following tensor: ``[[1, 2, 3], [1, 4, 5]]``, the return
+        value will be: ``{(): set([1]), (1,): set([2, 4]), (1, 2): set([3]), (1, 4): set([5])}``.
+
+        We use this to prune the set of actions we consider during decoding, because we only need
+        to score the sequences in ``targets``.
+        """
+        batched_allowed_transitions: List[Dict[Tuple[int, ...], Set[int]]] = []
+
+        if not isinstance(targets, list):
+            assert targets.dim() == 3, "targets tensor needs to be batched!"
+            targets = targets.data.cpu().numpy().tolist()
+        if target_mask is not None:
+            target_mask = target_mask.data.cpu().numpy().tolist()
+        else:
+            target_mask = [None for _ in targets]
+
+        for instance_targets, instance_mask in zip(targets, target_mask):
+            allowed_transitions: Dict[Tuple[int, ...], Set[int]] = defaultdict(set)
+            for i, target_sequence in enumerate(instance_targets):
+                history: Tuple[int, ...] = ()
+                for j, action in enumerate(target_sequence):
+                    if instance_mask and instance_mask[i][j] == 0:
+                        break
+                    allowed_transitions[history].add(action)
+                    history = history + (action,)
+            batched_allowed_transitions.append(allowed_transitions)
+        return batched_allowed_transitions
+
+    @staticmethod
+    def _check_all_actions_taken(action_histories: Set[Tuple[int, Tuple[int, ...]]],
+                                 grouped_state: DecoderState,
+                                 allowed_actions: List[Set[int]]) -> None:
+        expected_histories = set()
+        for i, batch_index in enumerate(grouped_state.batch_indices):
+            action_history = grouped_state.action_history[i]
+            for allowed_action in allowed_actions[i]:
+                expected_histories.add((batch_index, tuple(action_history + [allowed_action])))
+        assert action_histories == expected_histories
+
+    @staticmethod
+    def _get_allowed_actions(state: DecoderState,
+                             allowed_transitions: List[Dict[Tuple[int, ...], Set[int]]]) -> List[Set[int]]:
+        """
+        Takes a list of allowed transitions for each element of a batch, and a decoder state that
+        contains the current action history for each `group` element, and returns a list of allowed
+        actions in the current state, also for each `group` element.
+        """
+        allowed_actions = []
+        for batch_index, action_history in zip(state.batch_indices, state.action_history):
+            allowed_actions.append(allowed_transitions[batch_index][tuple(action_history)])
+        return allowed_actions
+
+    @staticmethod
+    def _group_scores_by_batch(finished_states: List[DecoderState]) -> Dict[int, List[Variable]]:
+        """
+        Takes a list of finished states and groups all final scores for each batch element into a
+        list.  This is not trivial because the instances in the batch all might "finish" at
+        different times, so we re-batch them during the training process.  We need to recover the
+        original batch grouping so we can compute the loss correctly.
+        """
+        batch_scores: Dict[int, List[Variable]] = defaultdict(list)
+        for state in finished_states:
+            for score, batch_index in zip(state.score, state.batch_indices):
+                batch_scores[batch_index].append(score)
+        return batch_scores

--- a/allennlp/nn/decoding/grammar_state.py
+++ b/allennlp/nn/decoding/grammar_state.py
@@ -1,0 +1,155 @@
+from copy import deepcopy
+from typing import Callable, Dict, List, Tuple
+
+
+class GrammarState:
+    """
+    A ``GrammarState`` specifies the currently valid actions at every step of decoding.
+
+    If we had a global context-free grammar, this would not be necessary - the currently valid
+    actions would always be the same, and we would not need to represent the current state.
+    However, our grammar is not context free (we have lambda expressions that introduce
+    context-dependent production rules), and it is not global (each instance can have its own
+    entities of a particular type, or its own functions).
+
+    We thus recognize three different sources of valid actions.  The first are actions that come
+    from the type declaration; these are defined once by the model and shared across all
+    ``GrammarStates`` produced by that model.  The second are actions that come from the current
+    instance; these are defined by the ``World`` that corresponds to each instance, and are shared
+    across all decoding states for that instance.  The last are actions that come from the current
+    state of the decoder; these are updated after every action taken by the decoder, though only
+    some actions initiate changes.
+
+    In practice, we use the ``World`` class to get the first two sources of valid actions at the
+    same time, and we take as input a ``valid_actions`` dictionary that is computed by the
+    ``World``.  These will not change during the course of decoding.  The ``GrammarState`` object
+    itself maintains the context-dependent valid actions.
+
+    Parameters
+    ----------
+    nonterminal_stack : ``List[str]``
+        Holds the list of non-terminals that still need to be expanded.  This starts out as
+        [START_SYMBOL], and decoding ends when this is empty.  Every time we take an action, we
+        update the non-terminal stack and the context-dependent valid actions, and we use what's on
+        the stack to decide which actions are valid in the current state.
+    lambda_stacks : ``Dict[Tuple[str, str], List[str]]``
+        The lambda stack keeps track of when we're in the scope of a lambda function.  The
+        dictionary is keyed by the production rule we are adding (like "r -> x", separated into
+        left hand side and right hand side, where the LHS is the type of the lambda variable and
+        the RHS is the variable itself), and the value is a nonterminal stack much like
+        ``nonterminal_stack``.  When the stack becomes empty, we remove the lambda entry.
+    valid_actions : ``Dict[str, List[int]]``
+        A mapping from non-terminals (represented as strings) to all valid (global and
+        instance-specific) productions from that non-terminal (represented as a list of integers).
+    action_indices : ``Dict[str, int]``
+        We use integers to represent productions in the ``valid_actions`` dictionary for efficiency
+        reasons in the decoder.  This means we need a way to map from the production rule strings
+        that we generate for lambda variables back to the integer used to represent it.
+    is_nonterminal : ``Callable[[str], bool]``
+        A function that is used to determine whether each piece of the RHS of the action string is
+        a non-terminal that needs to be added to the non-terminal stack.  You can use
+        ``type_declaraction.is_nonterminal`` here, or write your own function if that one doesn't
+        work for your domain.
+    """
+    def __init__(self,
+                 nonterminal_stack: List[str],
+                 lambda_stacks: Dict[Tuple[str, str], List[str]],
+                 valid_actions: Dict[str, List[int]],
+                 action_indices: Dict[str, int],
+                 is_nonterminal: Callable[[str], bool]) -> None:
+        self._nonterminal_stack = nonterminal_stack
+        self._lambda_stacks = lambda_stacks
+        self._valid_actions = valid_actions
+        self._action_indices = action_indices
+        self._is_nonterminal = is_nonterminal
+
+    def is_finished(self) -> bool:
+        """
+        Have we finished producing our logical form?  We have finished producing the logical form
+        if and only if there are no more non-terminals on the stack.
+        """
+        return not self._nonterminal_stack
+
+    def get_valid_actions(self) -> List[int]:
+        """
+        Returns a list of valid actions (represented as integers)
+        """
+        actions = self._valid_actions[self._nonterminal_stack[-1]]
+        for type_, variable in self._lambda_stacks:
+            if self._nonterminal_stack[-1] == type_:
+                production_string = f"{type_} -> {variable}"
+                actions = actions + [self._action_indices[production_string]]
+        return actions
+
+    def take_action(self, production_rule: str) -> 'GrammarState':
+        """
+        Takes an action in the current grammar state, returning a new grammar state with whatever
+        updates are necessary.  The production rule is assumed to be formatted as "LHS -> RHS".
+
+        This will update the non-terminal stack and the context-dependent actions.  Updating the
+        non-terminal stack involves popping the non-terminal that was expanded off of the stack,
+        then pushing on any non-terminals in the production rule back on the stack.  We push the
+        non-terminals on in `reverse` order, so that the first non-terminal in the production rule
+        gets popped off the stack first.
+
+        For example, if our current ``nonterminal_stack`` is ``["r", "<e,r>", "d"]``, and
+        ``action`` is ``d -> [<e,d>, e]``, the resulting stack will be ``["r", "<e,r>", "e",
+        "<e,d>"]``.
+        """
+        left_side, right_side = production_rule.split(' -> ')
+        assert self._nonterminal_stack[-1] == left_side, (f"Tried to expand {self._nonterminal_stack[-1]}"
+                                                          "but got rule f{left_side}->f{right_side}")
+        new_stack = self._nonterminal_stack[:-1]
+        new_lambda_stacks = deepcopy(self._lambda_stacks)
+        for key, lambda_stack in new_lambda_stacks.items():
+            assert lambda_stack[-1] == left_side
+            lambda_stack.pop()  # pop to modify the value in the dictionary
+
+        productions = self._get_productions_from_string(right_side)
+        if 'lambda' in productions[0]:
+            production = productions[0]
+            if production[0] == "'" and production[-1] == "'":
+                # The production rule with a lambda is typically "<t,d> -> ['lambda x', d]".  We
+                # need to strip the quotes.
+                production = production[1:-1]
+            lambda_variable = production.split(' ')[1]
+            # The left side must be formatted as "<t,d>", where "t" is the type of the lambda
+            # variable, and "d" is the return type of the lambda function.  We need to pull out the
+            # "t" here.  TODO(mattg): this is pretty limiting, but I'm not sure how general we
+            # should make this.
+            if len(left_side) != 5:
+                raise NotImplementedError("Can't handle this type yet:", left_side)
+            lambda_type = left_side[1]
+            new_lambda_stacks[(lambda_type, lambda_variable)] = []
+
+        for production in reversed(productions):
+            if self._is_nonterminal(production):
+                new_stack.append(production)
+                for lambda_stack in new_lambda_stacks.values():
+                    lambda_stack.append(production)
+
+        # If any of the lambda stacks have now become empty, we remove them from our dictionary.
+        finished_lambdas = set()
+        for key, lambda_stack in new_lambda_stacks.items():
+            if not lambda_stack:
+                finished_lambdas.add(key)
+        for finished_lambda in finished_lambdas:
+            del new_lambda_stacks[finished_lambda]
+
+        return GrammarState(nonterminal_stack=new_stack,
+                            lambda_stacks=new_lambda_stacks,
+                            valid_actions=self._valid_actions,
+                            action_indices=self._action_indices,
+                            is_nonterminal=self._is_nonterminal)
+
+    @staticmethod
+    def _get_productions_from_string(production_string: str) -> List[str]:
+        """
+        Takes a string like '[<d,d>, d]' and parses it into a list like ['<d,d>', 'd'].  For
+        production strings that are not lists, like '<e,d>', we return a single-element list:
+        ['<e,d>'].
+        """
+        if production_string[0] == '[':
+            return production_string[1:-1].split(', ')
+        else:
+            return [production_string]

--- a/allennlp/nn/decoding/rnn_state.py
+++ b/allennlp/nn/decoding/rnn_state.py
@@ -1,0 +1,56 @@
+from typing import List
+
+import torch
+
+
+class RnnState:
+    """
+    This class keeps track of all of decoder-RNN-related variables that you need during decoding.
+    This includes things like the current decoder hidden state, the memory cell (for LSTM
+    decoders), the encoder output that you need for computing attentions, and so on.
+
+    This is intended to be used `inside` a ``DecoderState``, which likely has other things it has
+    to keep track of for doing constrained decoding.
+
+    Parameters
+    ----------
+    hidden_state : ``torch.Tensor``
+        This holds the LSTM hidden state, with shape ``(decoder_output_dim,)``.
+    memory_cell : ``torch.Tensor``
+        This holds the LSTM memory cell, with shape ``(decoder_output_dim,)``.
+    previous_action_embedding : ``torch.Tensor``
+        This holds the embedding for the action we took at the last timestep (which gets input to
+        the decoder).  Has shape ``(action_embedding_dim,)``.
+    attended_input : ``torch.Tensor``
+        This holds the attention-weighted sum over the input representations that we computed in
+        the previous timestep.  We keep this as part of the state because we use the previous
+        attention as part of our decoder cell update.  Has shape ``(encoder_output_dim,)``.
+    encoder_outputs : ``List[torch.Tensor]``
+        A list of variables, each of shape ``(input_sequence_length, encoder_output_dim)``,
+        containing the encoder outputs at each timestep.  The list is over batch elements, and we
+        do the input this way so we can easily do a ``torch.cat`` on a list of indices into this
+        batched list.
+
+        Note that all of the above parameters are single tensors, while the encoder outputs and
+        mask are lists of length ``batch_size``.  We always pass around the encoder outputs and
+        mask unmodified, regardless of what's in the grouping for this state.  We'll use the
+        ``batch_indices`` for the group to pull pieces out of these lists when we're ready to
+        actually do some computation.
+    encoder_output_mask : ``List[torch.Tensor]``
+        A list of variables, each of shape ``(input_sequence_length,)``, containing a mask over
+        question tokens for each batch instance.  This is a list over batch elements, for the same
+        reasons as above.
+    """
+    def __init__(self,
+                 hidden_state: torch.Tensor,
+                 memory_cell: torch.Tensor,
+                 previous_action_embedding: torch.Tensor,
+                 attended_input: torch.Tensor,
+                 encoder_outputs: List[torch.Tensor],
+                 encoder_output_mask: List[torch.Tensor]) -> None:
+        self.hidden_state = hidden_state
+        self.memory_cell = memory_cell
+        self.previous_action_embedding = previous_action_embedding
+        self.attended_input = attended_input
+        self.encoder_outputs = encoder_outputs
+        self.encoder_output_mask = encoder_output_mask

--- a/doc/api/allennlp.nn.decoding.decoder_trainers.rst
+++ b/doc/api/allennlp.nn.decoding.decoder_trainers.rst
@@ -1,0 +1,17 @@
+allennlp.nn.decoding.decoder_trainers
+=====================================
+
+.. automodule:: allennlp.nn.decoding.decoder_trainers.decoder_trainer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: allennlp.nn.decoding.decoder_trainers.maximum_marginal_likelihood
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: allennlp.nn.decoding.decoder_trainers.expected_risk_minimization
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.nn.decoding.rst
+++ b/doc/api/allennlp.nn.decoding.rst
@@ -1,0 +1,36 @@
+allennlp.nn.decoding
+====================
+
+.. automodule:: allennlp.nn.decoding
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: allennlp.nn.decoding.decoder_step
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: allennlp.nn.decoding.decoder_state
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: allennlp.nn.decoding.rnn_state
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: allennlp.nn.decoding.grammar_state
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: allennlp.nn.decoding.beam_search
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. toctree::
+
+  allennlp.nn.decoding.decoder_trainers

--- a/doc/api/allennlp.nn.rst
+++ b/doc/api/allennlp.nn.rst
@@ -7,6 +7,7 @@ for working with PyTorch neural networks.
 .. toctree::
 
    allennlp.nn.activations
+   allennlp.nn.decoding
    allennlp.nn.initializers
    allennlp.nn.regularizers
    allennlp.nn.util

--- a/tests/nn/decoding/beam_search_test.py
+++ b/tests/nn/decoding/beam_search_test.py
@@ -1,0 +1,30 @@
+# pylint: disable=invalid-name,no-self-use,protected-access
+import torch
+from torch.autograd import Variable
+
+from allennlp.common import Params
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.nn.decoding import BeamSearch
+from .simple_transition_system import SimpleDecoderState, SimpleDecoderStep
+
+
+class TestBeamSearch(AllenNlpTestCase):
+    def test_search(self):
+        beam_search = BeamSearch.from_params(Params({'beam_size': 4}))
+        initial_state = SimpleDecoderState([0, 1, 2, 3],
+                                           [[], []],
+                                           [Variable(torch.Tensor([0.0])), Variable(torch.Tensor([0.0]))],
+                                           [-3, 1, -20, 5])
+        decoder_step = SimpleDecoderStep(include_value_in_score=True)
+        best_states = beam_search.search(5,
+                                         initial_state,
+                                         decoder_step,
+                                         keep_final_unfinished_states=False)
+
+        # Instance with batch index 2 needed too many steps to finish, and batch index 3 had no
+        # path to get to a finished state.  (See the simple transition system definitely; goal is
+        # to end up at 4, actions are either add one or two to starting value.)
+        assert len(best_states) == 2
+        print(list((x.action_history[0], x.score) for x in best_states[0]))
+        assert best_states[0][0].action_history[0] == [-1, 1, 3, 4]
+        assert best_states[1][0].action_history[0] == [3, 4]

--- a/tests/nn/decoding/decoder_trainers/expected_risk_minimization_test.py
+++ b/tests/nn/decoding/decoder_trainers/expected_risk_minimization_test.py
@@ -1,0 +1,113 @@
+"""
+We define a simple deterministic decoder here, that takes steps to add integers to list. At
+each step, the decoder takes the last integer in the list, and adds either 1 or 2 to produce the
+next element that will be added to the list. We initialize the list to contain one element, 0 and
+we say that a sequence is finished when the last element is 4. We define the score of a state as the
+negative of the number of elements (excluding 0) in the action history, and the cost of a finished
+state as the number of odd numbers in the list.
+"""
+
+
+# pylint: disable=no-self-use,protected-access
+from typing import List, Set, Dict
+from collections import defaultdict
+
+from overrides import overrides
+import torch
+from torch.autograd import Variable
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.nn.decoding.decoder_state import DecoderState
+from allennlp.nn.decoding.decoder_step import DecoderStep
+from allennlp.nn.decoding.decoder_trainers import ExpectedRiskMinimization
+
+
+class SimpleDecoderState(DecoderState['SimpleDecoderState']):
+    def is_finished(self) -> bool:
+        return self.action_history[0][-1] == 4
+
+    @classmethod
+    def combine_states(cls, states) -> 'SimpleDecoderState':
+        batch_indices = [batch_index for state in states for batch_index in state.batch_indices]
+        action_histories = [action_history for state in states for action_history in
+                            state.action_history]
+        scores = [score for state in states for score in state.score]
+        return SimpleDecoderState(batch_indices, action_histories, scores)
+
+
+class SimpleDecoderStep(DecoderStep[SimpleDecoderState]):
+    @overrides
+    def take_step(self,
+                  state: SimpleDecoderState,
+                  max_actions: int = None,
+                  allowed_actions: List[Set] = None) -> List[SimpleDecoderState]:
+        if allowed_actions is None:
+            # For each element in the group, the allowed actions are adding 1 or 2 to the last
+            # element.
+            allowed_actions = [{1, 2} for _ in state.batch_indices]
+        indexed_next_states: Dict[int, List[SimpleDecoderState]] = defaultdict(list)
+        for batch_index, action_history, score, actions in zip(state.batch_indices,
+                                                               state.action_history,
+                                                               state.score,
+                                                               allowed_actions):
+
+            for action in actions:
+                next_item = action_history[-1] + action
+                new_history = action_history + [next_item]
+                # For every action taken, we reduce the score by 1.
+                new_score = score - 1
+                new_state = SimpleDecoderState([batch_index],
+                                               [new_history],
+                                               [new_score])
+                indexed_next_states[batch_index].append(new_state)
+        next_states: List[SimpleDecoderState] = []
+        for batch_next_states in indexed_next_states.values():
+            if max_actions is not None:
+                batch_next_states = batch_next_states[:max_actions]
+            next_states.extend(batch_next_states)
+        return next_states
+
+
+class TestExpectedRiskMinimization(AllenNlpTestCase):
+    def setUp(self):
+        super(TestExpectedRiskMinimization, self).setUp()
+        self.initial_state = SimpleDecoderState([0], [[0]], [Variable(torch.Tensor([0.0]))])
+        self.decoder_step = SimpleDecoderStep()
+        # Cost is the number of odd elements in the action history.
+        self.supervision = lambda state: Variable(torch.Tensor([sum([x%2 != 0 for x in
+                                                                     state.action_history[0]])]))
+        # High beam size ensures exhaustive search.
+        self.trainer = ExpectedRiskMinimization(beam_size=100,
+                                                normalize_by_length=False,
+                                                max_decoding_steps=10)
+
+    def test_get_finished_states(self):
+        finished_states = self.trainer._get_finished_states(self.initial_state, self.decoder_step)
+        state_info = [(state.action_history[0], int(state.score[0].data)) for state in finished_states]
+        # There will be exactly five finished states with the following paths. Each score is the
+        # negative of one less than the number of elements in the action history.
+        assert len(finished_states) == 5
+        assert ([0, 2, 4], -2) in state_info
+        assert ([0, 1, 2, 4], -3) in state_info
+        assert ([0, 1, 3, 4], -3) in state_info
+        assert ([0, 2, 3, 4], -3) in state_info
+        assert ([0, 1, 2, 3, 4], -4) in state_info
+
+    def test_decode(self):
+        decoded_info = self.trainer.decode(self.initial_state, self.decoder_step, self.supervision)
+        # The best state corresponds to the shortest path.
+        assert decoded_info['best_action_sequence'][0] == [0, 2, 4]
+        # The scores and costs corresponding to the finished states will be
+        # [0, 2, 4] : -2, 0
+        # [0, 1, 2, 4] : -3, 1
+        # [0, 1, 3, 4] : -3, 2
+        # [0, 2, 3, 4] : -3, 1
+        # [0, 1, 2, 3, 4] : -4, 2
+
+        # This is the normalization factor while re-normalizing probabilities on the beam
+        partition = np.exp(-2) + np.exp(-3) + np.exp(-3) + np.exp(-3) + np.exp(-4)
+        expected_loss = ((np.exp(-2) * 0) + (np.exp(-3) * 1) + (np.exp(-3) * 2) +
+                         (np.exp(-3) *1) + (np.exp(-4) * 2)) / partition
+        assert_almost_equal(decoded_info['loss'].data.numpy(), expected_loss)

--- a/tests/nn/decoding/decoder_trainers/expected_risk_minimization_test.py
+++ b/tests/nn/decoding/decoder_trainers/expected_risk_minimization_test.py
@@ -1,78 +1,17 @@
-"""
-We define a simple deterministic decoder here, that takes steps to add integers to list. At
-each step, the decoder takes the last integer in the list, and adds either 1 or 2 to produce the
-next element that will be added to the list. We initialize the list to contain one element, 0 and
-we say that a sequence is finished when the last element is 4. We define the score of a state as the
-negative of the number of elements (excluding 0) in the action history, and the cost of a finished
-state as the number of odd numbers in the list.
-"""
-
-
 # pylint: disable=no-self-use,protected-access
-from typing import List, Set, Dict
-from collections import defaultdict
-
-from overrides import overrides
 import torch
 from torch.autograd import Variable
 import numpy as np
 from numpy.testing import assert_almost_equal
 
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.nn.decoding.decoder_state import DecoderState
-from allennlp.nn.decoding.decoder_step import DecoderStep
 from allennlp.nn.decoding.decoder_trainers import ExpectedRiskMinimization
-
-
-class SimpleDecoderState(DecoderState['SimpleDecoderState']):
-    def is_finished(self) -> bool:
-        return self.action_history[0][-1] == 4
-
-    @classmethod
-    def combine_states(cls, states) -> 'SimpleDecoderState':
-        batch_indices = [batch_index for state in states for batch_index in state.batch_indices]
-        action_histories = [action_history for state in states for action_history in
-                            state.action_history]
-        scores = [score for state in states for score in state.score]
-        return SimpleDecoderState(batch_indices, action_histories, scores)
-
-
-class SimpleDecoderStep(DecoderStep[SimpleDecoderState]):
-    @overrides
-    def take_step(self,
-                  state: SimpleDecoderState,
-                  max_actions: int = None,
-                  allowed_actions: List[Set] = None) -> List[SimpleDecoderState]:
-        if allowed_actions is None:
-            # For each element in the group, the allowed actions are adding 1 or 2 to the last
-            # element.
-            allowed_actions = [{1, 2} for _ in state.batch_indices]
-        indexed_next_states: Dict[int, List[SimpleDecoderState]] = defaultdict(list)
-        for batch_index, action_history, score, actions in zip(state.batch_indices,
-                                                               state.action_history,
-                                                               state.score,
-                                                               allowed_actions):
-
-            for action in actions:
-                next_item = action_history[-1] + action
-                new_history = action_history + [next_item]
-                # For every action taken, we reduce the score by 1.
-                new_score = score - 1
-                new_state = SimpleDecoderState([batch_index],
-                                               [new_history],
-                                               [new_score])
-                indexed_next_states[batch_index].append(new_state)
-        next_states: List[SimpleDecoderState] = []
-        for batch_next_states in indexed_next_states.values():
-            if max_actions is not None:
-                batch_next_states = batch_next_states[:max_actions]
-            next_states.extend(batch_next_states)
-        return next_states
+from ..simple_transition_system import SimpleDecoderState, SimpleDecoderStep
 
 
 class TestExpectedRiskMinimization(AllenNlpTestCase):
     def setUp(self):
-        super(TestExpectedRiskMinimization, self).setUp()
+        super().setUp()
         self.initial_state = SimpleDecoderState([0], [[0]], [Variable(torch.Tensor([0.0]))])
         self.decoder_step = SimpleDecoderStep()
         # Cost is the number of odd elements in the action history.
@@ -109,5 +48,5 @@ class TestExpectedRiskMinimization(AllenNlpTestCase):
         # This is the normalization factor while re-normalizing probabilities on the beam
         partition = np.exp(-2) + np.exp(-3) + np.exp(-3) + np.exp(-3) + np.exp(-4)
         expected_loss = ((np.exp(-2) * 0) + (np.exp(-3) * 1) + (np.exp(-3) * 2) +
-                         (np.exp(-3) *1) + (np.exp(-4) * 2)) / partition
+                         (np.exp(-3) * 1) + (np.exp(-4) * 2)) / partition
         assert_almost_equal(decoded_info['loss'].data.numpy(), expected_loss)

--- a/tests/nn/decoding/decoder_trainers/maximum_marginal_likelihood_test.py
+++ b/tests/nn/decoding/decoder_trainers/maximum_marginal_likelihood_test.py
@@ -1,41 +1,66 @@
-# pylint: disable=invalid-name, no-self-use,too-many-public-methods
+# pylint: disable=invalid-name,no-self-use,protected-access
+import math
+
+from numpy.testing import assert_almost_equal
 import torch
+from torch.autograd import Variable
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.nn.decoding import DecoderState
 from allennlp.nn.decoding.decoder_trainers import MaximumMarginalLikelihood
+from ..simple_transition_system import SimpleDecoderState, SimpleDecoderStep
 
 
 class TestMaximumMarginalLikelihood(AllenNlpTestCase):
+    def setUp(self):
+        super().setUp()
+        self.initial_state = SimpleDecoderState([0, 1],
+                                                [[], []],
+                                                [Variable(torch.Tensor([0.0])), Variable(torch.Tensor([0.0]))],
+                                                [0, 1])
+        self.decoder_step = SimpleDecoderStep()
+        self.targets = torch.autograd.Variable(torch.Tensor([[[2, 3, 4], [1, 3, 4], [1, 2, 4]],
+                                                             [[3, 4, 0], [2, 3, 4], [0, 0, 0]]]))
+        self.target_mask = torch.autograd.Variable(torch.Tensor([[[1, 1, 1], [1, 1, 1], [1, 1, 1]],
+                                                                 [[1, 1, 0], [1, 1, 1], [0, 0, 0]]]))
+
+        self.supervision = (self.targets, self.target_mask)
+        # High beam size ensures exhaustive search.
+        self.trainer = MaximumMarginalLikelihood()
+
+    def test_decode(self):
+        decoded_info = self.trainer.decode(self.initial_state, self.decoder_step, self.supervision)
+
+        # Our loss is the negative log sum of the scores from each target sequence.  The score for
+        # each sequence in our simple transition system is just `-sequence_length`.
+        instance0_loss = math.log(math.exp(-3) * 3)  # all three sequences have length 3
+        instance1_loss = math.log(math.exp(-2) + math.exp(-3))  # one has length 2, one has length 3
+        expected_loss = -(instance0_loss + instance1_loss) / 2
+        assert_almost_equal(decoded_info['loss'].data.numpy(), expected_loss)
+
     def test_create_allowed_transitions(self):
-        # pylint: disable=protected-access
-        # `1` is our "start symbol" here - the first index is always assumed to be the start symbol
-        # and is ignored.  This is due to how the data processing for seq2seq data works.  If that
-        # logic changes, we can revisit this.
-        targets = torch.autograd.Variable(torch.Tensor([[[1, 2, 3], [1, 4, 5], [1, 2, 7]],
-                                                        [[1, 9, 10], [1, 3, 5], [1, 3, 3]]]))
-        target_mask = torch.autograd.Variable(torch.Tensor([[[1, 1, 1], [1, 1, 1], [1, 1, 0]],
-                                                            [[0, 0, 0], [1, 1, 1], [1, 1, 1]]]))
-        result = MaximumMarginalLikelihood._create_allowed_transitions(targets, target_mask)
+        result = self.trainer._create_allowed_transitions(self.targets, self.target_mask)
         # There were two instances in this batch.
         assert len(result) == 2
 
-        # The first instance had four valid action sequence prefixes.
-        assert len(result[0]) == 4
-        assert result[0][()] == set([1])
-        assert result[0][(1,)] == set([2, 4])
-        assert result[0][(1, 2)] == set([3])  # note that 7 is not in here; it was masked
-        assert result[0][(1, 4)] == set([5])
+        # The first instance had six valid action sequence prefixes.
+        assert len(result[0]) == 6
+        assert result[0][()] == {1, 2}
+        assert result[0][(1,)] == {2, 3}
+        assert result[0][(1, 2)] == {4}
+        assert result[0][(1, 3)] == {4}
+        assert result[0][(2,)] == {3}
+        assert result[0][(2, 3)] == {4}
 
-        # The second instance had two valid action sequence prefixes.
-        assert len(result[1]) == 3
-        assert result[1][()] == set([1])
-        assert result[1][(1,)] == set([3])  # note that 9 is not in here; it was masked
-        assert result[1][(1, 3)] == set([3, 5])
+        # The second instance had four valid action sequence prefixes.
+        assert len(result[1]) == 4
+        assert result[1][()] == {2, 3}
+        assert result[1][(2,)] == {3}
+        assert result[1][(2, 3)] == {4}
+        assert result[1][(3,)] == {4}
 
     def test_get_allowed_actions(self):
-        # pylint: disable=protected-access
         state = DecoderState([0, 1, 0], [[1], [0], []], [])
         allowed_transitions = [{(1,): {2}, (): {3}}, {(0,): {4, 5}}]
-        allowed_actions = MaximumMarginalLikelihood._get_allowed_actions(state, allowed_transitions)
+        allowed_actions = self.trainer._get_allowed_actions(state, allowed_transitions)
         assert allowed_actions == [{2}, {4, 5}, {3}]

--- a/tests/nn/decoding/decoder_trainers/maximum_marginal_likelihood_test.py
+++ b/tests/nn/decoding/decoder_trainers/maximum_marginal_likelihood_test.py
@@ -1,0 +1,41 @@
+# pylint: disable=invalid-name, no-self-use,too-many-public-methods
+import torch
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.nn.decoding import DecoderState
+from allennlp.nn.decoding.decoder_trainers import MaximumMarginalLikelihood
+
+
+class TestMaximumMarginalLikelihood(AllenNlpTestCase):
+    def test_create_allowed_transitions(self):
+        # pylint: disable=protected-access
+        # `1` is our "start symbol" here - the first index is always assumed to be the start symbol
+        # and is ignored.  This is due to how the data processing for seq2seq data works.  If that
+        # logic changes, we can revisit this.
+        targets = torch.autograd.Variable(torch.Tensor([[[1, 2, 3], [1, 4, 5], [1, 2, 7]],
+                                                        [[1, 9, 10], [1, 3, 5], [1, 3, 3]]]))
+        target_mask = torch.autograd.Variable(torch.Tensor([[[1, 1, 1], [1, 1, 1], [1, 1, 0]],
+                                                            [[0, 0, 0], [1, 1, 1], [1, 1, 1]]]))
+        result = MaximumMarginalLikelihood._create_allowed_transitions(targets, target_mask)
+        # There were two instances in this batch.
+        assert len(result) == 2
+
+        # The first instance had four valid action sequence prefixes.
+        assert len(result[0]) == 4
+        assert result[0][()] == set([1])
+        assert result[0][(1,)] == set([2, 4])
+        assert result[0][(1, 2)] == set([3])  # note that 7 is not in here; it was masked
+        assert result[0][(1, 4)] == set([5])
+
+        # The second instance had two valid action sequence prefixes.
+        assert len(result[1]) == 3
+        assert result[1][()] == set([1])
+        assert result[1][(1,)] == set([3])  # note that 9 is not in here; it was masked
+        assert result[1][(1, 3)] == set([3, 5])
+
+    def test_get_allowed_actions(self):
+        # pylint: disable=protected-access
+        state = DecoderState([0, 1, 0], [[1], [0], []], [])
+        allowed_transitions = [{(1,): {2}, (): {3}}, {(0,): {4, 5}}]
+        allowed_actions = MaximumMarginalLikelihood._get_allowed_actions(state, allowed_transitions)
+        assert allowed_actions == [{2}, {4, 5}, {3}]

--- a/tests/nn/decoding/grammar_state_test.py
+++ b/tests/nn/decoding/grammar_state_test.py
@@ -1,0 +1,118 @@
+# pylint: disable=no-self-use,invalid-name
+import pytest
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.nn.decoding import GrammarState
+
+def is_nonterminal(symbol: str) -> bool:
+    if symbol == 'identity':
+        return False
+    if 'lambda ' in symbol:
+        return False
+    if symbol in {'x', 'y', 'z'}:
+        return False
+    return True
+
+
+class TestGrammarState(AllenNlpTestCase):
+    def test_is_finished_just_uses_nonterminal_stack(self):
+        state = GrammarState(['s'], {}, {}, {}, is_nonterminal)
+        assert not state.is_finished()
+        state = GrammarState([], {}, {}, {}, is_nonterminal)
+        assert state.is_finished()
+
+    def test_get_valid_actions_uses_top_of_stack(self):
+        state = GrammarState(['s'], {}, {'s': [1, 2], 't': [3, 4]}, {}, is_nonterminal)
+        assert state.get_valid_actions() == [1, 2]
+        state = GrammarState(['t'], {}, {'s': [1, 2], 't': [3, 4]}, {}, is_nonterminal)
+        assert state.get_valid_actions() == [3, 4]
+        state = GrammarState(['e'], {}, {'s': [1, 2], 't': [3, 4], 'e': []}, {}, is_nonterminal)
+        assert state.get_valid_actions() == []
+
+    def test_get_valid_actions_adds_lambda_productions(self):
+        state = GrammarState(['s'], {('s', 'x'): ['s']}, {'s': [1, 2]}, {'s -> x': 5}, is_nonterminal)
+        assert state.get_valid_actions() == [1, 2, 5]
+        # We're doing this assert twice to make sure we haven't accidentally modified the state.
+        assert state.get_valid_actions() == [1, 2, 5]
+
+    def test_get_valid_actions_adds_lambda_productions_only_for_correct_type(self):
+        state = GrammarState(['t'],
+                             {('s', 'x'): ['t']},
+                             {'s': [1, 2], 't': [3, 4]},
+                             {'s -> x': 5},
+                             is_nonterminal)
+        assert state.get_valid_actions() == [3, 4]
+        # We're doing this assert twice to make sure we haven't accidentally modified the state.
+        assert state.get_valid_actions() == [3, 4]
+
+    def test_take_action_gives_correct_next_states_with_non_lambda_productions(self):
+        # state.take_action() doesn't read or change these objects, it just passes them through, so
+        # we'll use some sentinels to be sure of that.
+        valid_actions = object()
+        action_indices = object()
+
+        state = GrammarState(['s'], {}, valid_actions, action_indices, is_nonterminal)
+        next_state = state.take_action('s -> [t, r]')
+        expected_next_state = GrammarState(['r', 't'], {}, valid_actions, action_indices, is_nonterminal)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+        state = GrammarState(['r', 't'], {}, valid_actions, action_indices, is_nonterminal)
+        next_state = state.take_action('t -> identity')
+        expected_next_state = GrammarState(['r'], {}, valid_actions, action_indices, is_nonterminal)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+    def test_take_action_crashes_with_mismatched_types(self):
+        with pytest.raises(AssertionError):
+            state = GrammarState(['s'], {}, {}, {}, is_nonterminal)
+            state.take_action('t -> identity')
+
+    def test_take_action_gives_correct_next_states_with_lambda_productions(self):
+        # state.take_action() doesn't read or change these objects, it just passes them through, so
+        # we'll use some sentinels to be sure of that.
+        valid_actions = object()
+        action_indices = object()
+
+        state = GrammarState(['t', '<s,d>'], {}, valid_actions, action_indices, is_nonterminal)
+        next_state = state.take_action('<s,d> -> [lambda x, d]')
+        expected_next_state = GrammarState(['t', 'd'],
+                                           {('s', 'x'): ['d']},
+                                           valid_actions,
+                                           action_indices,
+                                           is_nonterminal)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+        state = expected_next_state
+        next_state = state.take_action('d -> [<s,r>, d]')
+        expected_next_state = GrammarState(['t', 'd', '<s,r>'],
+                                           {('s', 'x'): ['d', '<s,r>']},
+                                           valid_actions,
+                                           action_indices,
+                                           is_nonterminal)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+        state = expected_next_state
+        next_state = state.take_action('<s,r> -> [lambda y, r]')
+        expected_next_state = GrammarState(['t', 'd', 'r'],
+                                           {('s', 'x'): ['d', 'r'], ('s', 'y'): ['r']},
+                                           valid_actions,
+                                           action_indices,
+                                           is_nonterminal)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+        state = expected_next_state
+        next_state = state.take_action('r -> identity')
+        expected_next_state = GrammarState(['t', 'd'],
+                                           {('s', 'x'): ['d']},
+                                           valid_actions,
+                                           action_indices,
+                                           is_nonterminal)
+        assert next_state.__dict__ == expected_next_state.__dict__
+
+        state = expected_next_state
+        next_state = state.take_action('d -> x')
+        expected_next_state = GrammarState(['t'],
+                                           {},
+                                           valid_actions,
+                                           action_indices,
+                                           is_nonterminal)
+        assert next_state.__dict__ == expected_next_state.__dict__

--- a/tests/nn/decoding/simple_transition_system.py
+++ b/tests/nn/decoding/simple_transition_system.py
@@ -1,0 +1,75 @@
+"""
+We define a simple deterministic decoder here, that takes steps to add integers to list. At
+each step, the decoder takes the last integer in the list, and adds either 1 or 2 to produce the
+next element that will be added to the list. We initialize the list with the value 0 (or whatever
+you pick), and we say that a sequence is finished when the last element is 4. We define the score
+of a state as the negative of the number of elements (excluding the initial value) in the action
+history.
+"""
+from collections import defaultdict
+from typing import List, Set, Dict
+
+from overrides import overrides
+import torch
+
+from allennlp.nn.decoding import DecoderState, DecoderStep
+
+class SimpleDecoderState(DecoderState['SimpleDecoderState']):
+    def __init__(self,
+                 batch_indices: List[int],
+                 action_history: List[List[int]],
+                 score: List[torch.autograd.Variable],
+                 start_values: List[int] = None) -> None:
+        super().__init__(batch_indices, action_history, score)
+        self.start_values = start_values or [0] * len(batch_indices)
+
+    def is_finished(self) -> bool:
+        return self.action_history[0][-1] == 4
+
+    @classmethod
+    def combine_states(cls, states) -> 'SimpleDecoderState':
+        batch_indices = [batch_index for state in states for batch_index in state.batch_indices]
+        action_histories = [action_history for state in states for action_history in
+                            state.action_history]
+        scores = [score for state in states for score in state.score]
+        start_values = [start_value for state in states for start_value in state.start_values]
+        return SimpleDecoderState(batch_indices, action_histories, scores, start_values)
+
+
+class SimpleDecoderStep(DecoderStep[SimpleDecoderState]):
+    def __init__(self):
+        # The allowed actions are adding 1 or 2 to the last element.
+        self._valid_actions = {1, 2}
+
+    @overrides
+    def take_step(self,
+                  state: SimpleDecoderState,
+                  max_actions: int = None,
+                  allowed_actions: List[Set] = None) -> List[SimpleDecoderState]:
+        indexed_next_states: Dict[int, List[SimpleDecoderState]] = defaultdict(list)
+        if not allowed_actions:
+            allowed_actions = [None] * len(state.batch_indices)
+        for batch_index, action_history, score, start_value, actions in zip(state.batch_indices,
+                                                                            state.action_history,
+                                                                            state.score,
+                                                                            state.start_values,
+                                                                            allowed_actions):
+
+            prev_action = action_history[-1] if action_history else start_value
+            for action in self._valid_actions:
+                next_item = int(prev_action + action)
+                if actions and next_item not in actions:
+                    continue
+                new_history = action_history + [next_item]
+                # For every action taken, we reduce the score by 1.
+                new_score = score - 1
+                new_state = SimpleDecoderState([batch_index],
+                                               [new_history],
+                                               [new_score])
+                indexed_next_states[batch_index].append(new_state)
+        next_states: List[SimpleDecoderState] = []
+        for batch_next_states in indexed_next_states.values():
+            if max_actions is not None:
+                batch_next_states = batch_next_states[:max_actions]
+            next_states.extend(batch_next_states)
+        return next_states


### PR DESCRIPTION
This PR adds the transition-based decoding framework from the `wikitables` branch.  All of the code here has already been reviewed, so this doesn't need a thorough look at the code (unless you _want_ to go over it in detail!).  What I'm looking for in a review at this point is to make sure that the high-level structure of this module makes sense, and that the documentation is sufficient to know what each piece does and when it should be used.

It might be easiest to browse the code in my fork of the repo, found here: https://github.com/matt-gardner/allennlp/tree/decoding/allennlp/nn/decoding.  Start by looking at the module docstring in `__init__.py`, then look over the class structure, and class docstrings.  If anything isn't clear or could use some more documentation, let me know!