### PR TITLE
Top-K for Constituency Parser

### DIFF
--- a/allennlp/models/constituency_parser.py
+++ b/allennlp/models/constituency_parser.py
@@ -435,7 +435,6 @@ class SpanConstituencyParser(Model):
         exclusive_end_spans[:, :, -1] += 1
 
         trees: List[List[Tree]] = []
-        predictions_np = predictions.cpu().numpy()
         for batch_index in range(len(sentences)):
             span_to_index = {}
             for span_index in range(num_spans[batch_index]):
@@ -444,7 +443,7 @@ class SpanConstituencyParser(Model):
                 span_to_index[span] = span_index
             top_k_trees, _ = self.compute_k_best(sentences[batch_index],
                                                          pos_tags[batch_index],
-                                                         predictions_np[batch_index, :, :],
+                                                         predictions[batch_index, :, :],
                                                          span_to_index,
                                                          num_trees=num_trees)
             trees.append(top_k_trees)

--- a/allennlp/models/constituency_parser.py
+++ b/allennlp/models/constituency_parser.py
@@ -225,12 +225,13 @@ class SpanConstituencyParser(Model):
         if all(batch_gold_trees) and self._evalb_score is not None and not self.training:
             gold_pos_tags: List[List[str]] = [list(zip(*tree.pos()))[1]
                                               for tree in batch_gold_trees]
-            predicted_trees = self.construct_trees(class_probabilities.cpu().data,
+            predicted_top1_trees = self.construct_topk_trees(class_probabilities.cpu().data,
                                                    spans.cpu().data,
                                                    num_spans.data,
                                                    output_dict["tokens"],
-                                                   gold_pos_tags)
-            self._evalb_score(predicted_trees, batch_gold_trees)
+                                                   gold_pos_tags,
+                                                        num_trees=1)
+            self._evalb_score([trees[0] for tree in predicted_top1_trees], batch_gold_trees)
 
         return output_dict
 
@@ -256,16 +257,15 @@ class SpanConstituencyParser(Model):
         output_dict["spans"] = [all_spans[i, :num_spans[i]] for i in range(batch_size)]
         output_dict["class_probabilities"] = [all_predictions[i, :num_spans[i], :] for i in range(batch_size)]
 
-        output_dict["trees"] = self.construct_trees(all_predictions,
-                                                    all_spans,
-                                                    num_spans,
-                                                    all_sentences,
-                                                    all_pos_tags)
-        output_dict['top_k_trees'] = self.construct_topk_trees(all_predictions,
-                                                               all_spans,
-                                                               num_spans,
-                                                               all_sentences,
-                                                               all_pos_tags)
+        top_k_trees = self.construct_topk_trees(num_trees=16,
+                                                predictions=all_predictions,
+                                                all_spans=all_spans,
+                                                num_spans=num_spans,
+                                                sentences=all_sentences,
+                                                pos_tags=all_pos_tags)
+
+        output_dict["trees"] = [trees[0] for trees in top_k_trees]
+        output_dict['top_k_trees'] = top_k_trees
         return output_dict
 
     def compute_k_best(self,
@@ -396,7 +396,8 @@ class SpanConstituencyParser(Model):
                         all_spans: torch.LongTensor,
                         num_spans: torch.LongTensor,
                         sentences: List[List[str]],
-                        pos_tags: List[List[str]] = None) -> List[Tree]:
+                        pos_tags: List[List[str]],
+                             num_trees: int,) -> List[Tree]:
         """
         Construct ``nltk.Tree``'s for each batch element by greedily nesting spans.
         The trees use exclusive end indices, which contrasts with how spans are
@@ -418,10 +419,16 @@ class SpanConstituencyParser(Model):
         pos_tags : ``List[List[str]]``, optional (default = None).
             A list of POS tags for each word in the sentence for each element
             in the batch.
+        num_trees: ``int``, required.
+            The number of trees to be returned for each sentence.
 
         Returns
         -------
         A ``List[Tree]`` containing the decoded trees for each element in the batch.
+        :param sentences:
+        :param predictions:
+        :param all_spans:
+        :param num_trees:
         """
         # Switch to using exclusive end spans.
         exclusive_end_spans = all_spans.clone().cpu().numpy()
@@ -439,199 +446,9 @@ class SpanConstituencyParser(Model):
                                                          pos_tags[batch_index],
                                                          predictions_np[batch_index, :, :],
                                                          span_to_index,
-                                                         num_trees=16)
+                                                         num_trees=num_trees)
             trees.append(top_k_trees)
         return trees
-
-    def construct_trees(self,
-                        predictions: torch.FloatTensor,
-                        all_spans: torch.LongTensor,
-                        num_spans: torch.LongTensor,
-                        sentences: List[List[str]],
-                        pos_tags: List[List[str]] = None) -> List[Tree]:
-        """
-        Construct ``nltk.Tree``'s for each batch element by greedily nesting spans.
-        The trees use exclusive end indices, which contrasts with how spans are
-        represented in the rest of the model.
-
-        Parameters
-        ----------
-        predictions : ``torch.FloatTensor``, required.
-            A tensor of shape ``(batch_size, num_spans, span_label_vocab_size)``
-            representing a distribution over the label classes per span.
-        all_spans : ``torch.LongTensor``, required.
-            A tensor of shape (batch_size, num_spans, 2), representing the span
-            indices we scored.
-        num_spans : ``torch.LongTensor``, required.
-            A tensor of shape (batch_size), representing the lengths of non-padded spans
-            in ``enumerated_spans``.
-        sentences : ``List[List[str]]``, required.
-            A list of tokens in the sentence for each element in the batch.
-        pos_tags : ``List[List[str]]``, optional (default = None).
-            A list of POS tags for each word in the sentence for each element
-            in the batch.
-
-        Returns
-        -------
-        A ``List[Tree]`` containing the decoded trees for each element in the batch.
-        """
-        # Switch to using exclusive end spans.
-        exclusive_end_spans = all_spans.clone()
-        exclusive_end_spans[:, :, -1] += 1
-        no_label_id = self.vocab.get_token_index("NO-LABEL", "labels")
-
-        trees: List[Tree] = []
-        for batch_index, (scored_spans, spans, sentence) in enumerate(zip(predictions,
-                                                                          exclusive_end_spans,
-                                                                          sentences)):
-            selected_spans = []
-            for prediction, span in zip(scored_spans[:num_spans[batch_index]],
-                                        spans[:num_spans[batch_index]]):
-                start, end = span
-                no_label_prob = prediction[no_label_id]
-                label_prob, label_index = torch.max(prediction, -1)
-
-                # Does the span have a label != NO-LABEL or is it the root node?
-                # If so, include it in the spans that we consider.
-                if int(label_index) != no_label_id or (start == 0 and end == len(sentence)):
-                    # TODO(Mark): Remove this once pylint sorts out named tuples.
-                    # https://github.com/PyCQA/pylint/issues/1418
-                    selected_spans.append(SpanInformation(start=int(start), # pylint: disable=no-value-for-parameter
-                                                          end=int(end),
-                                                          label_prob=float(label_prob),
-                                                          no_label_prob=float(no_label_prob),
-                                                          label_index=int(label_index)))
-
-            # The spans we've selected might overlap, which causes problems when we try
-            # to construct the tree as they won't nest properly.
-            consistent_spans = self.resolve_overlap_conflicts_greedily(selected_spans)
-
-            spans_to_labels = {(span.start, span.end):
-                               self.vocab.get_token_from_index(span.label_index, "labels")
-                               for span in consistent_spans}
-            sentence_pos = pos_tags[batch_index] if pos_tags is not None else None
-            trees.append(self.construct_tree_from_spans(spans_to_labels, sentence, sentence_pos))
-
-        return trees
-
-    @staticmethod
-    def resolve_overlap_conflicts_greedily(spans: List[SpanInformation]) -> List[SpanInformation]:
-        """
-        Given a set of spans, removes spans which overlap by evaluating the difference
-        in probability between one being labeled and the other explicitly having no label
-        and vice-versa. The worst case time complexity of this method is ``O(k * n^4)`` where ``n``
-        is the length of the sentence that the spans were enumerated from (and therefore
-        ``k * m^2`` complexity with respect to the number of spans ``m``) and ``k`` is the
-        number of conflicts. However, in practice, there are very few conflicts. Hopefully.
-
-        This function modifies ``spans`` to remove overlapping spans.
-
-        Parameters
-        ----------
-        spans: ``List[SpanInformation]``, required.
-            A list of spans, where each span is a ``namedtuple`` containing the
-            following attributes:
-
-        start : ``int``
-            The start index of the span.
-        end : ``int``
-            The exclusive end index of the span.
-        no_label_prob : ``float``
-            The probability of this span being assigned the ``NO-LABEL`` label.
-        label_prob : ``float``
-            The probability of the most likely label.
-
-        Returns
-        -------
-        A modified list of ``spans``, with the conflicts resolved by considering local
-        differences between pairs of spans and removing one of the two spans.
-        """
-        conflicts_exist = True
-        while conflicts_exist:
-            conflicts_exist = False
-            for span1_index, span1 in enumerate(spans):
-                for span2_index, span2 in list(enumerate(spans))[span1_index + 1:]:
-                    if (span1.start < span2.start < span1.end < span2.end or
-                                span2.start < span1.start < span2.end < span1.end):
-                        # The spans overlap.
-                        conflicts_exist = True
-                        # What's the more likely situation: that span2 was labeled
-                        # and span1 was unlabled, or that span1 was labeled and span2
-                        # was unlabled? In the first case, we delete span2 from the
-                        # set of spans to form the tree - in the second case, we delete
-                        # span1.
-                        if (span1.no_label_prob * span2.label_prob <
-                                    span2.no_label_prob * span1.label_prob):
-                            spans.pop(span2_index)
-                        else:
-                            spans.pop(span1_index)
-                        break
-        return spans
-
-    @staticmethod
-    def construct_tree_from_spans(spans_to_labels: Dict[Tuple[int, int], str],
-                                  sentence: List[str],
-                                  pos_tags: List[str] = None) -> Tree:
-        """
-        Parameters
-        ----------
-        spans_to_labels : ``Dict[Tuple[int, int], str]``, required.
-            A mapping from spans to constituency labels.
-        sentence : ``List[str]``, required.
-            A list of tokens forming the sentence to be parsed.
-        pos_tags : ``List[str]``, optional (default = None)
-            A list of the pos tags for the words in the sentence, if they
-            were either predicted or taken as input to the model.
-
-        Returns
-        -------
-        An ``nltk.Tree`` constructed from the labelled spans.
-        """
-        def assemble_subtree(start: int, end: int):
-            if (start, end) in spans_to_labels:
-                # Some labels contain nested spans, e.g S-VP.
-                # We actually want to create (S (VP ...)) nodes
-                # for these labels, so we split them up here.
-                labels: List[str] = spans_to_labels[(start, end)].split("-")
-            else:
-                labels = None
-
-            # This node is a leaf.
-            if end - start == 1:
-                word = sentence[start]
-                pos_tag = pos_tags[start] if pos_tags is not None else "XX"
-                tree = Tree(pos_tag, [word])
-                if labels is not None and pos_tags is not None:
-                    # If POS tags were passed explicitly,
-                    # they are added as pre-terminal nodes.
-                    while labels:
-                        tree = Tree(labels.pop(), [tree])
-                elif labels is not None:
-                    # Otherwise, we didn't want POS tags
-                    # at all.
-                    tree = Tree(labels.pop(), [word])
-                    while labels:
-                        tree = Tree(labels.pop(), [tree])
-                return [tree]
-
-            argmax_split = start + 1
-            # Find the next largest subspan such that
-            # the left hand side is a constituent.
-            for split in range(end - 1, start, -1):
-                if (start, split) in spans_to_labels:
-                    argmax_split = split
-                    break
-
-            left_trees = assemble_subtree(start, argmax_split)
-            right_trees = assemble_subtree(argmax_split, end)
-            children = left_trees + right_trees
-            if labels is not None:
-                while labels:
-                    children = [Tree(labels.pop(), children)]
-            return children
-
-        tree = assemble_subtree(0, len(sentence))
-        return tree[0]
 
     @overrides
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:

--- a/allennlp/models/constituency_parser.py
+++ b/allennlp/models/constituency_parser.py
@@ -269,16 +269,16 @@ class SpanConstituencyParser(Model):
         return output_dict
 
     def compute_k_best(self,
-                       sentence,
-                       pos_tags,
-                       label_probabilities_np,
-                       span_to_index,
-                       num_trees,
-                       distinguish_between_labels=False):
+                       sentence: List[str],
+                       pos_tags: List[str],
+                       label_probabilities: torch.TensorFloat,
+                       span_to_index: Dict[(int, int), int],
+                       num_trees: List[int],
+                       distinguish_between_labels: bool = False):
         """
         :param sentence: The sentence for which top-k parses are being computed.
         :param pos_tags: Part of speech tags for every token in the input sentence.
-        :param label_probabilities_np: A numpy array of shape (num_spans, num_labels)
+        :param label_probabilities: A numpy array of shape (num_spans, num_labels)
         :param span_to_index: A dictionary mapping span indices to column indices in
         label_log_probabilities.
         :param no_label_id: The id of the empty label.
@@ -290,7 +290,7 @@ class SpanConstituencyParser(Model):
         empty_label_index = self.vocab.get_token_index("NO-LABEL", "labels")
         all_labels = [self.vocab.get_token_from_index(index, "labels").split("-") for index in
                   range(self.vocab.get_vocab_size("labels"))]
-
+        label_probabilities_np = label_probabilities.data().cpu().numpy()
         if not distinguish_between_labels:
             temp = np.zeros((len(span_to_index), 2))
             temp[:, 0] = label_probabilities_np[:, empty_label_index]

--- a/allennlp/models/constituency_parser.py
+++ b/allennlp/models/constituency_parser.py
@@ -271,8 +271,8 @@ class SpanConstituencyParser(Model):
     def compute_k_best(self,
                        sentence: List[str],
                        pos_tags: List[str],
-                       label_probabilities: torch.TensorFloat,
-                       span_to_index: Dict[(int, int), int],
+                       label_probabilities: torch.FloatTensor,
+                       span_to_index: Dict[Tuple[int, int], int],
                        num_trees: List[int],
                        distinguish_between_labels: bool = False):
         """

--- a/allennlp/models/constituency_parser.py
+++ b/allennlp/models/constituency_parser.py
@@ -18,7 +18,7 @@ from allennlp.nn.util import last_dim_softmax, get_lengths_from_binary_sequence_
 from allennlp.training.metrics import CategoricalAccuracy
 from allennlp.training.metrics import EvalbBracketingScorer
 from allennlp.common.checks import ConfigurationError
-import numpy as np
+import numpy
 from sortedcontainers import SortedList
 
 class SpanInformation(NamedTuple):
@@ -290,9 +290,9 @@ class SpanConstituencyParser(Model):
         empty_label_index = self.vocab.get_token_index("NO-LABEL", "labels")
         all_labels = [self.vocab.get_token_from_index(index, "labels").split("-") for index in
                   range(self.vocab.get_vocab_size("labels"))]
-        label_probabilities_np = label_probabilities.data().cpu().numpy()
+        label_probabilities_np = label_probabilities.cpu().numpy()
         if not distinguish_between_labels:
-            temp = np.zeros((len(span_to_index), 2))
+            temp = numpy.zeros((len(span_to_index), 2))
             temp[:, 0] = label_probabilities_np[:, empty_label_index]
             temp[:, 1] = 1 - label_probabilities_np[:, empty_label_index]
 
@@ -307,8 +307,8 @@ class SpanConstituencyParser(Model):
             empty_label_index = 0
 
 
-        label_log_probabilities_np = np.log(label_probabilities_np)
-        correction_term = np.sum(label_log_probabilities_np[:, empty_label_index])
+        label_log_probabilities_np = numpy.log(label_probabilities_np + 10 ** -5)
+        correction_term = numpy.sum(label_log_probabilities_np[:, empty_label_index])
         label_log_probabilities_np -= label_log_probabilities_np[:, empty_label_index]\
             .reshape((len(span_to_index), 1))
         cache = {}

--- a/allennlp/service/predictors/constituency_parser.py
+++ b/allennlp/service/predictors/constituency_parser.py
@@ -86,6 +86,8 @@ class ConstituencyParserPredictor(Predictor):
         tree = return_dict.pop("trees")
         return_dict["hierplane_tree"] = self._build_hierplane_tree(tree, 0, is_root=True)
         return_dict["trees"] = tree.pformat(margin=1000000)
+        return_dict["top_k_trees"] = \
+            [tree.pformat(margin=1000000) for tree in return_dict["top_k_trees"]]
         return sanitize(return_dict)
 
     @overrides
@@ -97,7 +99,8 @@ class ConstituencyParserPredictor(Predictor):
             # format the NLTK tree as a string on a single line.
             tree = return_dict.pop("trees")
             return_dict["hierplane_tree"] = self._build_hierplane_tree(tree, 0, is_root=True)
-            return_dict["trees"] = tree.pformat(margin=1000000)
+            return_dict["top_k_trees"] = \
+                [tree.pformat(margin=1000000) for tree in return_dict["top_k_trees"]]
         return sanitize(return_dicts)
 
 


### PR DESCRIPTION
Adds `top_k_trees` to the output of the constituency parser. Fixes minor bug in `resolve_overlap_conflicts_greedily`.