### PR TITLE
Fix state scores in WikiTablesDecoderStep

### DIFF
--- a/allennlp/models/semantic_parsing/wikitables/wikitables_decoder_state.py
+++ b/allennlp/models/semantic_parsing/wikitables/wikitables_decoder_state.py
@@ -71,6 +71,14 @@ class WikiTablesDecoderState(DecoderState['WikiTablesDecoderState']):
         self.entity_types = entity_types
         self.debug_info = debug_info
 
+    def print_action_history(self, group_index: int = None) -> None:
+        scores = self.score if group_index is None else [self.score[group_index]]
+        batch_indices = self.batch_indices if group_index is None else [self.batch_indices[group_index]]
+        histories = self.action_history if group_index is None else [self.action_history[group_index]]
+        for score, batch_index, action_history in zip(scores, batch_indices, histories):
+            print('  ', score.data.cpu().numpy()[0],
+                  [self.possible_actions[batch_index][action][0] for action in action_history])
+
     def get_valid_actions(self) -> List[List[int]]:
         """
         Returns a list of valid actions for each element of the group.

--- a/allennlp/models/semantic_parsing/wikitables/wikitables_decoder_step.py
+++ b/allennlp/models/semantic_parsing/wikitables/wikitables_decoder_step.py
@@ -84,7 +84,9 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
         memory_cell = torch.stack([rnn_state.memory_cell for rnn_state in state.rnn_state])
         previous_action_embedding = torch.stack([rnn_state.previous_action_embedding
                                                  for rnn_state in state.rnn_state])
-        score_so_far = torch.stack(state.score)
+
+        # The scores from all prior state transitions until now.  Shape: (group_size, 1).
+        scores_so_far = torch.stack(state.score)
 
         # (group_size, decoder_input_dim)
         decoder_input = self._input_projection_layer(torch.cat([attended_question,
@@ -142,18 +144,25 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
                                                               entity_action_mask.float()) + mix1
                 embedded_action_probs = util.masked_log_softmax(embedded_action_logits,
                                                                 embedded_action_mask.float()) + mix2
-                log_probs = torch.cat([embedded_action_probs, entity_action_probs], dim=1)
+                current_log_probs = torch.cat([embedded_action_probs, entity_action_probs], dim=1)
             else:
                 action_logits = torch.cat([embedded_action_logits, entity_action_logits], dim=1)
                 action_mask = torch.cat([embedded_action_mask, entity_action_mask], dim=1).float()
-                log_probs = util.masked_log_softmax(action_logits, action_mask)
+                current_log_probs = util.masked_log_softmax(action_logits, action_mask)
         else:
             action_logits = embedded_action_logits
             action_mask = embedded_action_mask.float()
-            log_probs = util.masked_log_softmax(action_logits, action_mask)
+            current_log_probs = util.masked_log_softmax(action_logits, action_mask)
+
+        # current_log_probs is shape (group_size, num_actions).  We're broadcasting an addition
+        # here with scores_so_far, which has shape (group_size, 1).  This is now the total score
+        # for each state after taking each action.  We're going to sort by this in
+        # `_compute_new_states`, so it's important that this is the total score, not just the score
+        # for the current action.
+        log_probs = scores_so_far + current_log_probs
 
         return self._compute_new_states(state,
-                                        log_probs + score_so_far,
+                                        log_probs,
                                         hidden_state,
                                         memory_cell,
                                         action_embeddings,

--- a/tests/models/semantic_parsing/wikitables/wikitables_decoder_step_test.py
+++ b/tests/models/semantic_parsing/wikitables/wikitables_decoder_step_test.py
@@ -235,11 +235,10 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         new_state = new_states[0]
         # For batch instance 0, we should have selected action 4 from group index 2.
         assert new_state.batch_indices == [0]
-        # These three have values taken from what's defined in setUp() - the prior action history
-        # (empty in this case), the initial score (2.2), and the nonterminals corresponding to the
-        # action we picked ('j').
+        assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [.3])
+        # These have values taken from what's defined in setUp() - the prior action history
+        # (empty in this case)  and the nonterminals corresponding to the action we picked ('j').
         assert new_state.action_history == [[4]]
-        assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [2.2 + .3])
         assert new_state.grammar_state[0]._nonterminal_stack == ['j']
         # All of these values come from the objects instantiated directly above.
         assert_almost_equal(new_state.rnn_state[0].hidden_state.cpu().numpy().tolist(), [3, 3])
@@ -259,11 +258,10 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         new_state = new_states[1]
         # For batch instance 1, we should have selected action 0 from group index 1.
         assert new_state.batch_indices == [1]
-        # These three have values taken from what's defined in setUp() - the prior action history
-        # ([3, 4]), the initial score (1.1), and the nonterminals corresponding to the action we
-        # picked ('q').
+        assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [.3])
+        # These two have values taken from what's defined in setUp() - the prior action history
+        # ([3, 4]) and the nonterminals corresponding to the action we picked ('q').
         assert new_state.action_history == [[3, 4, 0]]
-        assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [1.1 + .3])
         assert new_state.grammar_state[0]._nonterminal_stack == ['q']
         # All of these values come from the objects instantiated directly above.
         assert_almost_equal(new_state.rnn_state[0].hidden_state.cpu().numpy().tolist(), [2, 2])
@@ -311,11 +309,10 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         new_state = new_states[0]
         # For batch instance 0, we should have selected action 1 from group index 0.
         assert new_state.batch_indices == [0]
-        # These three have values taken from what's defined in setUp() - the prior action history
-        # ([1]), the initial score (0.1), and the nonterminals corresponding to the
-        # action we picked ('j').
+        assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [.9])
+        # These two have values taken from what's defined in setUp() - the prior action history
+        # ([1]) and the nonterminals corresponding to the action we picked ('j').
         assert new_state.action_history == [[1, 1]]
-        assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [0.1 + .9])
         assert new_state.grammar_state[0]._nonterminal_stack == ['g']
         # All of these values come from the objects instantiated directly above.
         assert_almost_equal(new_state.rnn_state[0].hidden_state.cpu().numpy().tolist(), [1, 1])
@@ -335,11 +332,10 @@ class WikiTablesDecoderStepTest(AllenNlpTestCase):
         new_state = new_states[1]
         # For batch instance 0, we should have selected action 0 from group index 1.
         assert new_state.batch_indices == [1]
-        # These three have values taken from what's defined in setUp() - the prior action history
-        # ([3, 4]), the initial score (1.1), and the nonterminals corresponding to the action we
-        # picked ('q').
+        assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [.3])
+        # These have values taken from what's defined in setUp() - the prior action history
+        # ([3, 4]) and the nonterminals corresponding to the action we picked ('q').
         assert new_state.action_history == [[3, 4, 0]]
-        assert_almost_equal(new_state.score[0].data.cpu().numpy().tolist(), [1.1 + .3])
         assert new_state.grammar_state[0]._nonterminal_stack == ['q']
         # All of these values come from the objects instantiated directly above.
         assert_almost_equal(new_state.rnn_state[0].hidden_state.cpu().numpy().tolist(), [2, 2])


### PR DESCRIPTION
I also added a convenience method for printing out the score and action sequence in a WikiTablesDecoderState, which is helpful for examining what's going on during decoding / beam search.