### PR TITLE
Remove the KeyError catch block in the server

### DIFF
--- a/allennlp/service/server_flask.py
+++ b/allennlp/service/server_flask.py
@@ -173,16 +173,13 @@ def make_app(build_dir: str = None, demo_db: Optional[DemoDatabase] = None) -> F
         # In theory this could result in false positives.
         pre_hits = _caching_prediction.cache_info().hits  # pylint: disable=no-value-for-parameter
 
-        try:
-            if use_cache and cache_size > 0:
-                # lru_cache insists that all function arguments be hashable,
-                # so unfortunately we have to stringify the data.
-                prediction = _caching_prediction(model, json.dumps(data))
-            else:
-                # if cache_size is 0, skip caching altogether
-                prediction = model.predict_json(data)
-        except KeyError as err:
-            raise ServerError("Required JSON field not found: " + err.args[0], status_code=400)
+        if use_cache and cache_size > 0:
+            # lru_cache insists that all function arguments be hashable,
+            # so unfortunately we have to stringify the data.
+            prediction = _caching_prediction(model, json.dumps(data))
+        else:
+            # if cache_size is 0, skip caching altogether
+            prediction = model.predict_json(data)
 
         post_hits = _caching_prediction.cache_info().hits  # pylint: disable=no-value-for-parameter
 


### PR DESCRIPTION
Several times I've run into an issue where I get a really weird error message about some required JSON field being missing, where there was actually a `KeyError` deep in my model code that was being caught at this point and re-branded incorrectly, hiding the original stack trace.  I don't think trying to catch the `KeyError` here is actually useful.