### PR TITLE
Move imports to inside of CACHE_MODELS=true condition

### DIFF
--- a/scripts/cache_models.py
+++ b/scripts/cache_models.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 
 import os
-import sys
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir))))
-from allennlp.commands.serve import DEFAULT_MODELS
-from allennlp.common.file_utils import cached_path
 
 value = os.environ.get('CACHE_MODELS', 'false')
 if value.lower() == "true":
+    import sys
+    sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir))))
+    from allennlp.commands.serve import DEFAULT_MODELS
+    from allennlp.common.file_utils import cached_path
     models = DEFAULT_MODELS.items()
     print("CACHE_MODELS is '%s'.  Downloading %i models." % (value, len(models)))
     for i, (model, url) in enumerate(models):


### PR DESCRIPTION
Importing `allennlp` is, unfortunately, slow, and causes several seconds of pointless waiting when `CACHE_MODELS=false`.  This removes the unnecessary wait by moving the imports inside the condition where `CACHE_MODELS=true`.