### PR TITLE
Streamlining the docker build a little bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,16 +48,21 @@ COPY requirements_test.txt .
 COPY scripts/install_requirements.sh scripts/install_requirements.sh
 RUN INSTALL_TEST_REQUIREMENTS="true" ./scripts/install_requirements.sh
 
-# Build demo
-COPY demo/ demo/
-RUN cd demo && npm install && npm run build && cd ..
+# Same idea as above, but for EVALB this time.
+COPY scripts/EVALB scripts/EVALB
 
-COPY scripts/ scripts/
 # Compile EVALB - required for parsing evaluation.
 # EVALB produces scary looking c-level output which we don't
 # care about, so we redirect the output to /dev/null.
-RUN cd scripts/EVALB && make > /dev/null && cd ..
+RUN cd scripts/EVALB && make &> /dev/null && cd ..
 
+# And the demo; `npm install` and `npm run build` are slow, so we skip them if we can.
+COPY demo/ demo/
+COPY scripts/build_demo.py scripts/build_demo.py
+ARG BUILD_DEMO=false
+RUN ./scripts/build_demo.py
+
+COPY scripts/ scripts/
 COPY allennlp/ allennlp/
 COPY tests/ tests/
 COPY pytest.ini pytest.ini
@@ -66,7 +71,8 @@ COPY tutorials/ tutorials/
 COPY training_config training_config/
 COPY setup.py setup.py
 
-# Add model caching
+# Caching models when building the image makes a dockerized server start up faster, but is slow for
+# running tests and things, so we skip it by default.
 ARG CACHE_MODELS=false
 RUN ./scripts/cache_models.py
 

--- a/scripts/build_demo.py
+++ b/scripts/build_demo.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import os
+from subprocess import run
+
+value = os.environ.get('BUILD_DEMO', 'false')
+if value.lower() == "true":
+    run('npm install', shell=True, check=True, cwd='demo')
+    run('npm run build', shell=True, check=True, cwd='demo')
+    print('Demo built')
+else:
+    print("BUILD_DEMO is '%s'.  Not building demo." % value)

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -26,8 +26,6 @@ MODULES_THAT_NEED_NO_DOCS: Set[str] = {
         'allennlp.modules.alternating_highway_lstm',
         # Private base class, no docs needed.
         'allennlp.modules.encoder_base',
-        # TODO(Mark): remove this once the coref model is switched over.
-        'allennlp.models.coreference_resolution.coref_v2'
 }
 
 DOCS_THAT_NEED_NO_MODULES: Set[str] = {


### PR DESCRIPTION
1. Minor tweaks to the order of copies in the dockerfile.
2. Redirecting stderr as well as stdout in the `EVALB` command.
3. Hiding building the demo behind an argument and a script, because it is slow.

It's possible that our tests rely on the demo; CI will tell us that for sure.  If so, I'll try to find a way to make the tests not rely on the demo...

@schmmd, this means that something has to change in the demo build, in the same place where `CACHE_MODELS=true` is specified, wherever that is.