### PR TITLE
cached iterator

### DIFF
--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -85,7 +85,7 @@ class LabelField(Field[torch.Tensor]):
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:  # pylint: disable=no-self-use
-        return {}
+        return {'label_id': self._label_id}
 
     @overrides
     def as_tensor(self,

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -85,7 +85,7 @@ class LabelField(Field[torch.Tensor]):
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:  # pylint: disable=no-self-use
-        return {'label_id': self._label_id}
+        return {}
 
     @overrides
     def as_tensor(self,

--- a/allennlp/data/iterators/__init__.py
+++ b/allennlp/data/iterators/__init__.py
@@ -4,6 +4,7 @@ can be used to iterate over datasets with different batching and padding schemes
 """
 
 from allennlp.data.iterators.data_iterator import DataIterator
+from allennlp.data.iterators.cached_iterator import CachedIterator
 from allennlp.data.iterators.adaptive_iterator import AdaptiveIterator
 from allennlp.data.iterators.basic_iterator import BasicIterator
 from allennlp.data.iterators.bucket_iterator import BucketIterator

--- a/allennlp/data/iterators/cached_iterator.py
+++ b/allennlp/data/iterators/cached_iterator.py
@@ -19,10 +19,6 @@ class CachedIterator(BucketIterator):
     Using this iterator saves run time but costs more memory to store the cached batches. It should
     be used only if the dataset can fit in memory. This iterator shouldn't be used with the lazy
     mode.
-
-    Parameters:
-    ----------
-        See :class:`BucketIterator`.
     """
 
     def __init__(self, *args, **kwargs):

--- a/allennlp/data/iterators/cached_iterator.py
+++ b/allennlp/data/iterators/cached_iterator.py
@@ -1,0 +1,45 @@
+import logging
+import random
+from typing import Iterable, Dict, List
+from overrides import overrides
+from allennlp.data.instance import Instance
+from allennlp.data.iterators.bucket_iterator import BucketIterator
+from allennlp.data.iterators.data_iterator import DataIterator
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+@DataIterator.register("cached")
+class CachedIterator(BucketIterator):
+    """
+    An extension of the `BucketIterator` that caches its batches between epochs. Batches are built
+    only once during the first epoch, then the same batches are used again in consecutive epochs.
+    Using this iterator saves run time but costs more memory to store the cached batches. It should
+    be used only if the dataset can fit in memory. This iterator shouldn't be used with the lazy
+    mode.
+
+    Parameters:
+    ----------
+        See :class:`BucketIterator`.
+    """
+
+    @overrides
+    def _yield_one_epoch(self, instances: Iterable[Instance], shuffle: bool, cuda_device: int, for_training: bool):
+        if not hasattr(self, 'cached_batches'):
+            # instances id -> list[batches]
+            self.cached_batches: Dict[int, List] = {}  # pylint: disable=attribute-defined-outside-init
+
+        instances_id = id(instances)
+        if instances_id in self.cached_batches:
+            logger.info('returning cached batches of instances id: %d', instances_id)
+            batches = self.cached_batches[instances_id]
+            if shuffle:
+                random.shuffle(batches)  # shuffle the list of batches but not each batch
+            for batch in batches:
+                yield batch
+        else:
+            self.cached_batches[instances_id] = []
+            logger.info('caching batches of instances id: %d', instances_id)
+            for batch in super()._yield_one_epoch(instances, shuffle, cuda_device, for_training):
+                self.cached_batches[instances_id].append(batch)
+                yield batch

--- a/allennlp/data/iterators/cached_iterator.py
+++ b/allennlp/data/iterators/cached_iterator.py
@@ -31,6 +31,8 @@ class CachedIterator(BucketIterator):
 
     @classmethod
     def _move_to_gpu(cls, batch: Dict, cuda_device: int):
+        if cuda_device == -1:
+            return batch
         gpu_batch = dict()
         for k, val in batch.items():
             if isinstance(val, dict):
@@ -58,6 +60,4 @@ class CachedIterator(BucketIterator):
             logger.info('caching batches of instances id: %d', instances_id)
             for batch in super()._yield_one_epoch(instances, shuffle, -1, for_training):  # batches in cpu ram
                 self.cached_batches[instances_id].append(batch)
-                if cuda_device != -1:
-                    batch = self._move_to_gpu(batch, cuda_device)  # if cuda device, move batch to gpu
-                yield batch
+                yield self._move_to_gpu(batch, cuda_device)  # if cuda device, move batch to gpu

--- a/doc/api/allennlp.data.iterators.rst
+++ b/doc/api/allennlp.data.iterators.rst
@@ -11,6 +11,7 @@ allennlp.data.iterators
 * :ref:`BasicIterator<basic-iterator>`
 * :ref:`BucketIterator<bucket-iterator>`
 * :ref:`EpochTrackingBucketIterator<epoch-tracking-bucket-iterator>`
+* :ref:`CachedIterator<cached-iterator>`
 
 .. _data-iterator:
 .. automodule:: allennlp.data.iterators.data_iterator
@@ -38,6 +39,12 @@ allennlp.data.iterators
 
 .. _epoch-tracking-bucket-iterator:
 .. automodule:: allennlp.data.iterators.epoch_tracking_bucket_iterator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _cached-iterator:
+.. automodule:: allennlp.data.iterators.cached_iterator
    :members:
    :undoc-members:
    :show-inheritance:

--- a/tests/data/iterators/cached_iterator_test.py
+++ b/tests/data/iterators/cached_iterator_test.py
@@ -48,6 +48,6 @@ class TestCachedIterator(IteratorTest):
 
         batches4 = [x for x in iterator(self.instances, shuffle=True, num_epochs=2)]
         ids4 = [id(x) for x in batches4]
+        assert ids4[:3] != ids4[3:]
         ids1 = [id(x) for x in batches]
-        assert ids4 != ids1
         assert sorted(ids4) == sorted(ids1)

--- a/tests/data/iterators/cached_iterator_test.py
+++ b/tests/data/iterators/cached_iterator_test.py
@@ -1,0 +1,53 @@
+# pylint: disable=no-self-use,invalid-name
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.data.iterators import CachedIterator
+from tests.data.iterators.basic_iterator_test import IteratorTest
+
+
+class TestCachedIterator(IteratorTest):
+    # pylint: disable=protected-access
+    def test_configuration_error_with_max_instances_in_memory(self):
+        try:
+            CachedIterator(batch_size=2, padding_noise=0, sorting_keys=[('text', 'num_tokens')],
+                           max_instances_in_memory=3)
+        except ConfigurationError:
+            return
+        assert False
+
+    def test_configuration_error_with_lazy(self):
+        try:
+            iterator = CachedIterator(batch_size=2, padding_noise=0, sorting_keys=[('text', 'num_tokens')])
+            [x for x in iterator(self.lazy_instances, num_epochs=2)] # pylint: disable=expression-not-assigned
+            assert False
+        except ConfigurationError:
+            return
+        assert False
+
+    def test_caching(self):
+        iterator = CachedIterator(batch_size=2, padding_noise=0, sorting_keys=[('text', 'num_tokens')])
+        assert not iterator.cached_batches
+
+        batches = [x for x in iterator(self.instances, shuffle=False, num_epochs=2)]
+        assert len(iterator.cached_batches) == 1
+        assert id(batches[0]) == id(batches[3])
+        assert id(batches[1]) == id(batches[4])
+        assert id(batches[2]) == id(batches[5])
+
+        batches2 = [x for x in iterator(self.instances, shuffle=False, num_epochs=1)]
+        assert len(iterator.cached_batches) == 1
+        assert id(batches[0]) == id(batches2[0])
+        assert id(batches[1]) == id(batches2[1])
+        assert id(batches[2]) == id(batches2[2])
+
+        batches3 = [x for x in iterator(self.instances[:], shuffle=False, num_epochs=1)]
+        assert len(iterator.cached_batches) == 2
+        assert id(batches[0]) != id(batches3[0])
+        assert id(batches[1]) != id(batches3[1])
+        assert id(batches[2]) != id(batches3[2])
+
+        batches4 = [x for x in iterator(self.instances, shuffle=True, num_epochs=2)]
+        ids4 = [id(x) for x in batches4]
+        ids1 = [id(x) for x in batches]
+        assert ids4 != ids1
+        assert sorted(ids4) == sorted(ids1)

--- a/tests/data/iterators/cached_iterator_test.py
+++ b/tests/data/iterators/cached_iterator_test.py
@@ -46,8 +46,13 @@ class TestCachedIterator(IteratorTest):
         assert id(batches[1]) != id(batches3[1])
         assert id(batches[2]) != id(batches3[2])
 
-        batches4 = [x for x in iterator(self.instances, shuffle=True, num_epochs=2)]
-        ids4 = [id(x) for x in batches4]
-        assert ids4[:3] != ids4[3:]
-        ids1 = [id(x) for x in batches]
-        assert sorted(ids4) == sorted(ids1)
+        passed = False
+        for _ in range(50):  # make sure it shuffles. If it doesn't shuffle, try again
+            batches4 = [x for x in iterator(self.instances, shuffle=True, num_epochs=2)]
+            ids4 = [id(x) for x in batches4]
+            ids1 = [id(x) for x in batches]
+            if ids1 != ids4:
+                passed = True
+                break
+            assert sorted(ids4) == sorted(ids1)
+        assert passed


### PR DESCRIPTION
A solution for this issue: https://github.com/allenai/allennlp/issues/1128

I implemented it as a subclass of `BucketIterator` just to avoid messing up other stuff. However, it is better to be implemented as an additional option in `BasicIterator` where it is only enabled when `dataset_reader` is not lazy and `max_instances_in_memory is None`. 
