### PR TITLE
Allow ablation where linking features are removed

### DIFF
--- a/allennlp/data/fields/knowledge_graph_field.py
+++ b/allennlp/data/fields/knowledge_graph_field.py
@@ -112,7 +112,7 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
         self._indexed_entity_texts: Dict[str, TokenList] = None
         self._max_table_tokens = max_table_tokens
 
-        feature_extractors = feature_extractors or [
+        feature_extractors = feature_extractors if feature_extractors is not None else [
                 'exact_token_match',
                 'contains_exact_token_match',
                 'lemma_match',

--- a/tests/fixtures/semantic_parsing/wikitables/experiment-elmo-no-features.json
+++ b/tests/fixtures/semantic_parsing/wikitables/experiment-elmo-no-features.json
@@ -43,7 +43,8 @@
     },
     "max_decoding_steps": 200,
     "attention_function": {"type": "dot_product"},
-    "num_linking_features": 0
+    "num_linking_features": 0,
+    "use_neighbor_similarity_for_linking": true
   },
   "iterator": {
     "type": "bucket",


### PR DESCRIPTION
Previously, if you wanted to ablate the linking features, we would always try one of Rajas's experiments to replace the linking features.  This makes the replacement optional, so you can actually ablate the linking features.