### PR TITLE
WIP / experimental: one possible way to refactor iterators

### DIFF
--- a/allennlp/data/iterators/basic_iterator.py
+++ b/allennlp/data/iterators/basic_iterator.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Dict, Iterator, Optional, List
+from typing import Iterable
 import logging
 import math
 import random
@@ -9,6 +9,7 @@ from allennlp.common import Params
 from allennlp.common.util import ensure_list, is_lazy, lazy_groups_of
 from allennlp.data.instance import Instance
 from allennlp.data.iterators.data_iterator import DataIterator
+from allennlp.data.iterators.utils import memory_sized_lists
 from allennlp.data.dataset import Batch
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -35,12 +36,13 @@ class BasicIterator(DataIterator):
     def __init__(self,
                  batch_size: int = 32,
                  instances_per_epoch: int = None,
-                 max_instances_in_memory: int = None) -> None:
+                 max_instances_in_memory: int = None,
+                 cache_instances: bool = False,
+                 track_epoch: bool = False) -> None:
+        super().__init__(cache_instances=cache_instances, track_epoch=track_epoch)
         self._batch_size = batch_size
         self._instances_per_epoch = instances_per_epoch
         self._max_instances_in_memory = max_instances_in_memory
-
-        self._cursors: Dict[int, Iterator[Instance]] = {}
 
     @overrides
     def get_num_batches(self, instances: Iterable[Instance]) -> int:
@@ -53,83 +55,19 @@ class BasicIterator(DataIterator):
             # Not lazy, so can compute the list length.
             return math.ceil(len(ensure_list(instances)) / self._batch_size)
 
-    def _take_instances(self,
-                        instances: Iterable[Instance],
-                        max_instances: Optional[int] = None) -> Iterator[Instance]:
-        """
-        Take the next `max_instances` instances from the given dataset.
-        If `max_instances` is `None`, then just take all instances from the dataset.
-        If `max_instances` is not `None`, each call resumes where the previous one
-        left off, and when you get to the end of the dataset you start again from the beginning.
-        """
-        # If max_instances isn't specified, just iterate once over the whole dataset
-        if max_instances is None:
-            yield from iter(instances)
-        else:
-            # If we don't have a cursor for this dataset, create one. We use ``id()``
-            # for the key because ``instances`` could be a list, which can't be used as a key.
-            key = id(instances)
-            iterator = self._cursors.get(key, iter(instances))
-
-            while max_instances > 0:
-                try:
-                    # If there are instances left on this iterator,
-                    # yield one and decrement max_instances.
-                    yield next(iterator)
-                    max_instances -= 1
-                except StopIteration:
-                    # None left, so start over again at the beginning of the dataset.
-                    iterator = iter(instances)
-
-            # We may have a new iterator, so update the cursor.
-            self._cursors[key] = iterator
-
-    def _memory_sized_lists(self, instances: Iterable[Instance]) -> Iterable[List[Instance]]:
-        """
-        Breaks the dataset into "memory-sized" lists of instances,
-        which it yields up one at a time until it gets through a full epoch.
-
-        For example, if the dataset is already an in-memory list, and each epoch
-        represents one pass through the dataset, it just yields back the dataset.
-        Whereas if the dataset is lazily read from disk and we've specified to
-        load 1000 instances at a time, then it yields lists of 1000 instances each.
-        """
-        lazy = is_lazy(instances)
-
-        # Get an iterator over the next epoch worth of instances.
-        iterator = self._take_instances(instances, self._instances_per_epoch)
-
-        # We have four different cases to deal with:
-
-        # With lazy instances and no guidance about how many to load into memory,
-        # we just load ``batch_size`` instances at a time:
-        if lazy and self._max_instances_in_memory is None:
-            yield from lazy_groups_of(iterator, self._batch_size)
-        # If we specified max instances in memory, lazy or not, we just
-        # load ``max_instances_in_memory`` instances at a time:
-        elif self._max_instances_in_memory is not None:
-            yield from lazy_groups_of(iterator, self._max_instances_in_memory)
-        # If we have non-lazy instances, and we want all instances each epoch,
-        # then we just yield back the list of instances:
-        elif self._instances_per_epoch is None:
-            yield ensure_list(instances)
-        # In the final case we have non-lazy instances, we want a specific number
-        # of instances each epoch, and we didn't specify how to many instances to load
-        # into memory. So we convert the whole iterator to a list:
-        else:
-            yield list(iterator)
-
-
-    @overrides
     def _create_batches(self, instances: Iterable[Instance], shuffle: bool) -> Iterable[Batch]:
         # First break the dataset into memory-sized lists:
-        for instance_list in self._memory_sized_lists(instances):
+        for instance_list in memory_sized_lists(instances,
+                                                self._batch_size,
+                                                self._max_instances_in_memory,
+                                                self._instances_per_epoch):
             if shuffle:
                 random.shuffle(instance_list)
             iterator = iter(instance_list)
             # Then break each memory-sized list into batches.
             for batch_instances in lazy_groups_of(iterator, self._batch_size):
-                yield Batch(batch_instances)
+                batch = Batch(batch_instances)
+                yield batch
 
     @classmethod
     def from_params(cls, params: Params) -> 'BasicIterator':

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import random
 from typing import List, Tuple, Dict, cast, Iterable
 
@@ -6,17 +7,17 @@ from overrides import overrides
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.common import Params
-from allennlp.common.util import add_noise_to_dict_values
+from allennlp.common.util import add_noise_to_dict_values, is_lazy, lazy_groups_of, ensure_list
 from allennlp.data.dataset import Batch
 from allennlp.data.instance import Instance
-from allennlp.data.iterators.basic_iterator import BasicIterator
 from allennlp.data.iterators.data_iterator import DataIterator
+from allennlp.data.iterators.utils import memory_sized_lists, sort_by_padding
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 @DataIterator.register("bucket")
-class BucketIterator(BasicIterator):
+class BucketIterator(DataIterator):
     """
     An iterator which by default, pads batches with respect to the maximum input lengths `per
     batch`. Additionally, you can provide a list of field names and padding keys which the dataset
@@ -62,66 +63,62 @@ class BucketIterator(BasicIterator):
                  biggest_batch_first: bool = False,
                  batch_size: int = 32,
                  instances_per_epoch: int = None,
-                 max_instances_in_memory: int = None) -> None:
+                 max_instances_in_memory: int = None,
+                 cache_instances: bool = False,
+                 track_epoch: bool = False) -> None:
         if not sorting_keys:
             raise ConfigurationError("BucketIterator requires sorting_keys to be specified")
 
+        super().__init__(cache_instances=cache_instances,
+                         track_epoch=track_epoch)
+        self._batch_size = batch_size
+        self._instances_per_epoch = instances_per_epoch
+        self._max_instances_in_memory = max_instances_in_memory
         self._sorting_keys = sorting_keys
         self._padding_noise = padding_noise
         self._biggest_batch_first = biggest_batch_first
-        super(BucketIterator, self).__init__(batch_size=batch_size,
-                                             instances_per_epoch=instances_per_epoch,
-                                             max_instances_in_memory=max_instances_in_memory)
+
+    @overrides
+    def get_num_batches(self, instances: Iterable[Instance]) -> int:
+        if is_lazy(instances) and self._instances_per_epoch is None:
+            # Unable to compute num batches, so just return 1.
+            return 1
+        elif self._instances_per_epoch is not None:
+            return math.ceil(self._instances_per_epoch / self._batch_size)
+        else:
+            # Not lazy, so can compute the list length.
+            return math.ceil(len(ensure_list(instances)) / self._batch_size)
 
     @overrides
     def _create_batches(self, instances: Iterable[Instance], shuffle: bool) -> Iterable[Batch]:
-        for instance_list in self._memory_sized_lists(instances):
-            instance_list = self._sort_by_padding(instance_list,
-                                                  self._sorting_keys,
-                                                  self._padding_noise)
+        for instance_list in memory_sized_lists(instances,
+                                                self._batch_size,
+                                                self._instances_per_epoch,
+                                                self._max_instances_in_memory):
 
-            grouped_instances = list(super()._create_batches(instance_list, shuffle=False))
-            move_to_front = self._biggest_batch_first and len(grouped_instances) > 1
+            instance_list = sort_by_padding(instance_list,
+                                            self._sorting_keys,
+                                            self.vocab,
+                                            self._padding_noise)
+
+            batches = [Batch(batch_instances)
+                       for batch_instances in lazy_groups_of(iter(instance_list), self._batch_size)]
+
+            move_to_front = self._biggest_batch_first and len(batches) > 1
             if move_to_front:
                 # We'll actually pop the last _two_ batches, because the last one might not be full.
-                last_batch = grouped_instances.pop()
-                penultimate_batch = grouped_instances.pop()
+                last_batch = batches.pop()
+                penultimate_batch = batches.pop()
             if shuffle:
-                random.shuffle(grouped_instances)
+                random.shuffle(batches)
             else:
                 logger.warning("shuffle parameter is set to False,"
                                " while bucket iterators by definition change the order of your data.")
             if move_to_front:
-                grouped_instances.insert(0, penultimate_batch)
-                grouped_instances.insert(0, last_batch)
+                batches.insert(0, penultimate_batch)
+                batches.insert(0, last_batch)
 
-            yield from grouped_instances
-
-    def _sort_by_padding(self,
-                         instances: List[Instance],
-                         sorting_keys: List[Tuple[str, str]],  # pylint: disable=invalid-sequence-index
-                         padding_noise: float = 0.0) -> List[Instance]:
-        """
-        Sorts the ``Instances`` in this ``Batch`` by their padding lengths, using the keys in
-        ``sorting_keys`` (in the order in which they are provided).  ``sorting_keys`` is a list of
-        ``(field_name, padding_key)`` tuples.
-        """
-        instances_with_lengths = []
-        for instance in instances:
-            # Make sure instance is indexed before calling .get_padding
-            instance.index_fields(self.vocab)
-            padding_lengths = cast(Dict[str, Dict[str, float]], instance.get_padding_lengths())
-            if padding_noise > 0.0:
-                noisy_lengths = {}
-                for field_name, field_lengths in padding_lengths.items():
-                    noisy_lengths[field_name] = add_noise_to_dict_values(field_lengths, padding_noise)
-                padding_lengths = noisy_lengths
-            instance_with_lengths = ([padding_lengths[field_name][padding_key]
-                                      for (field_name, padding_key) in sorting_keys],
-                                     instance)
-            instances_with_lengths.append(instance_with_lengths)
-        instances_with_lengths.sort(key=lambda x: x[0])
-        return [instance_with_lengths[-1] for instance_with_lengths in instances_with_lengths]
+            yield from batches
 
     @classmethod
     def from_params(cls, params: Params) -> 'BucketIterator':

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -1,34 +1,50 @@
 import logging
-from typing import Dict, Generator, Union, Iterable
+from typing import Dict, Union, Iterable, Iterator, List
+from collections import defaultdict
+import itertools
+import random
 
-import numpy
+import torch
 
 from allennlp.data.dataset import Batch
 from allennlp.data.instance import Instance
+from allennlp.data.iterators.utils import add_epoch_number
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.common import Params
 from allennlp.common.registrable import Registrable
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
+TensorDict = Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]  # pylint: disable=invalid-name
+
 class DataIterator(Registrable):
     """
-    An abstract ``DataIterator`` class. ``DataIterators`` must implement __call__, which yields
-    batched examples.
+    An abstract ``DataIterator`` class. ``DataIterators`` must override ``_create_batches()``.
     """
     default_implementation = 'bucket'
-    vocab: Vocabulary = None
+    def __init__(self,
+                 cache_instances: bool = False,
+                 track_epoch: bool = False):
+        self.vocab: Vocabulary = None
+
+        # We might want to cache the instances in memory.
+        self._cache_instances = cache_instances
+        self._cache: Dict[int, List[TensorDict]] = defaultdict(list)
+
+        # We also might want to add the epoch number to each instance.
+        self._track_epoch = track_epoch
+        self._epochs: Dict[int, int] = defaultdict(int)
 
     def __call__(self,
                  instances: Iterable[Instance],
                  num_epochs: int = None,
                  shuffle: bool = True,
                  cuda_device: int = -1,
-                 for_training: bool = True) -> Generator[Dict[str, Union[numpy.ndarray,
-                                                                         Dict[str, numpy.ndarray]]],
-                                                         None, None]:
+                 for_training: bool = True) -> Iterator[TensorDict]:
         """
-        Returns a generator that yields batches over the given dataset, forever.
+        Returns a generator that yields batches over the given dataset
+        for the given number of epochs. If ``num_epochs`` is not specified,
+        it will yield batches forever.
 
         Parameters
         ----------
@@ -51,36 +67,68 @@ class DataIterator(Registrable):
             which disables gradient computations in the graph.  This makes inference more efficient
             (particularly in memory usage), but is incompatible with training models.
         """
+        # Instances is likely to be a list, which cannot be used as a key,
+        # so we take the object id instead.
+        key = id(instances)
+        starting_epoch = self._epochs[key]
+
         if num_epochs is None:
-            while True:
-                yield from self._yield_one_epoch(instances, shuffle, cuda_device, for_training)
+            epochs: Iterable[int] = itertools.count(starting_epoch)
         else:
-            for _ in range(num_epochs):
-                yield from self._yield_one_epoch(instances, shuffle, cuda_device, for_training)
+            epochs = range(starting_epoch, starting_epoch + num_epochs)
+
+        for epoch in epochs:
+            self._epochs[key] = epoch
+
+            if self._cache_instances and key in self._cache:
+                # Serve the results from the cache.
+                tensor_dicts = self._cache[key]
+
+                if shuffle:
+                    random.shuffle(tensor_dicts)
+                for tensor_dict in tensor_dicts:
+                    if self._track_epoch:
+                        # The tensor_dict already has an "epoch_num" tensor,
+                        # so just fill it with the right value.
+                        tensor_dict['epoch_num'].fill_(epoch)
+                    yield tensor_dict
+            else:
+                batches = self._create_batches(instances, shuffle)
+
+                # Should we add the instances to the cache this epoch?
+                add_to_cache = self._cache_instances and key not in self._cache
+
+                for batch in batches:
+                    if self._track_epoch:
+                        add_epoch_number(batch, epoch)
+
+                    if self.vocab is not None:
+                        batch.index_instances(self.vocab)
+
+                    padding_lengths = batch.get_padding_lengths()
+                    logger.debug("Batch padding lengths: %s", str(padding_lengths))
+                    logger.debug("Batch size: %d", len(batch.instances))
+                    tensor_dict = batch.as_tensor_dict(padding_lengths,
+                                                       cuda_device=cuda_device,
+                                                       for_training=for_training)
+
+                    if add_to_cache:
+                        self._cache[key].append(tensor_dict)
+
+                    yield tensor_dict
 
     def get_num_batches(self, instances: Iterable[Instance]) -> int:
         """
         Returns the number of batches that ``dataset`` will be split into; if you want to track
         progress through the batch with the generator produced by ``__call__``, this could be
-        useful.
+        useful. If you don't override it, it will always return 1.
         """
-        raise NotImplementedError
-
-    def _yield_one_epoch(self, instances: Iterable[Instance], shuffle: bool, cuda_device: int, for_training: bool):
-        batches = self._create_batches(instances, shuffle)
-        for batch in batches:
-            if self.vocab is not None:
-                batch.index_instances(self.vocab)
-            padding_lengths = batch.get_padding_lengths()
-            logger.debug("Batch padding lengths: %s", str(padding_lengths))
-            logger.debug("Batch size: %d", len(batch.instances))
-            yield batch.as_tensor_dict(padding_lengths,
-                                       cuda_device=cuda_device,
-                                       for_training=for_training)
+        # pylint: disable=unused-argument
+        return 1
 
     def _create_batches(self, instances: Iterable[Instance], shuffle: bool) -> Iterable[Batch]:
         """
-        Creates batches of instances. Each batch is a small ``Dataset``.
+        This method should return one epoch worth of batches.
         """
         raise NotImplementedError
 

--- a/allennlp/data/iterators/epoch_tracking_bucket_iterator.py
+++ b/allennlp/data/iterators/epoch_tracking_bucket_iterator.py
@@ -1,12 +1,6 @@
 import logging
-from typing import List, Tuple, Dict, Iterable, Generator, Union
-from collections import defaultdict
+from typing import List, Tuple
 
-from overrides import overrides
-import numpy
-
-from allennlp.data.fields import MetadataField
-from allennlp.data.instance import Instance
 from allennlp.data.iterators.data_iterator import DataIterator
 from allennlp.data.iterators.bucket_iterator import BucketIterator
 
@@ -34,44 +28,10 @@ class EpochTrackingBucketIterator(BucketIterator):
                  batch_size: int = 32,
                  instances_per_epoch: int = None,
                  max_instances_in_memory: int = None) -> None:
-        super(EpochTrackingBucketIterator, self).__init__(sorting_keys=sorting_keys,
-                                                          padding_noise=padding_noise,
-                                                          biggest_batch_first=biggest_batch_first,
-                                                          batch_size=batch_size,
-                                                          instances_per_epoch=instances_per_epoch,
-                                                          max_instances_in_memory=max_instances_in_memory)
-        # Epoch number value per dataset.
-        self._global_epoch_nums: Dict[int, int] = defaultdict(int)
-
-    @overrides
-    def __call__(self,
-                 instances: Iterable[Instance],
-                 num_epochs: int = None,
-                 shuffle: bool = True,
-                 cuda_device: int = -1,
-                 for_training: bool = True) -> Generator[Dict[str, Union[numpy.ndarray,
-                                                                         Dict[str, numpy.ndarray]]],
-                                                         None, None]:
-        """
-        See ``DataIterator.__call__`` for parameters.
-        """
-        dataset_id = id(instances)
-        if num_epochs is None:
-            while True:
-                self._add_epoch_num_to_instances(instances, dataset_id)
-                yield from self._yield_one_epoch(instances, shuffle, cuda_device, for_training)
-                self._global_epoch_nums[dataset_id] += 1
-        else:
-            for _ in range(num_epochs):
-                self._add_epoch_num_to_instances(instances, dataset_id)
-                yield from self._yield_one_epoch(instances, shuffle, cuda_device, for_training)
-                self._global_epoch_nums[dataset_id] += 1
-
-    def _add_epoch_num_to_instances(self,
-                                    instances: Iterable[Instance],
-                                    dataset_id: int) -> None:
-        for instance in instances:
-            # TODO(pradeep): Mypy complains here most probably because ``fields`` is typed as a
-            # ``Mapping``, and not a ``Dict``. Ignoring this for now, but the type of fields
-            # probably needs to be changed.
-            instance.fields["epoch_num"] = MetadataField(self._global_epoch_nums[dataset_id])  #type: ignore
+        super().__init__(sorting_keys=sorting_keys,
+                         padding_noise=padding_noise,
+                         biggest_batch_first=biggest_batch_first,
+                         batch_size=batch_size,
+                         instances_per_epoch=instances_per_epoch,
+                         max_instances_in_memory=max_instances_in_memory,
+                         track_epoch=True)

--- a/allennlp/data/iterators/utils.py
+++ b/allennlp/data/iterators/utils.py
@@ -1,0 +1,116 @@
+"""
+Utilities for creating DataIterators.
+"""
+from typing import Iterable, Optional, List, Iterator, Dict, cast, Tuple
+
+from allennlp.common.util import lazy_groups_of, ensure_list, is_lazy, add_noise_to_dict_values
+from allennlp.data.dataset import Batch
+from allennlp.data.fields import MetadataField
+from allennlp.data.instance import Instance
+from allennlp.data.vocabulary import Vocabulary
+
+# Global variable for tracking cursors.
+_cursors: Dict[int, Iterator[Instance]] = {}
+
+def take_instances(instances: Iterable[Instance],
+                   max_instances: Optional[int] = None) -> Iterator[Instance]:
+    """
+    Take the next `max_instances` instances from the given dataset.
+    If `max_instances` is `None`, then just take all instances from the dataset.
+    If `max_instances` is not `None`, each call resumes where the previous one
+    left off, and when you get to the end of the dataset you start again from the beginning.
+    """
+    # If max_instances isn't specified, just iterate once over the whole dataset
+    if max_instances is None:
+        yield from iter(instances)
+    else:
+        # If we don't have a cursor for this dataset, create one. We use ``id()``
+        # for the key because ``instances`` could be a list, which can't be used as a key.
+        key = id(instances)
+        iterator = _cursors.get(key, iter(instances))
+
+        while max_instances > 0:
+            try:
+                # If there are instances left on this iterator,
+                # yield one and decrement max_instances.
+                yield next(iterator)
+                max_instances -= 1
+            except StopIteration:
+                # None left, so start over again at the beginning of the dataset.
+                iterator = iter(instances)
+
+        # We may have a new iterator, so update the cursor.
+        _cursors[key] = iterator
+
+
+def memory_sized_lists(instances: Iterable[Instance],
+                       batch_size: int,
+                       max_instances_in_memory: Optional[int] = None,
+                       instances_per_epoch: Optional[int] = None) -> Iterable[List[Instance]]:
+    """
+    Breaks the dataset into "memory-sized" lists of instances,
+    which it yields up one at a time until it gets through a full epoch.
+
+    For example, if the dataset is already an in-memory list, and each epoch
+    represents one pass through the dataset, it just yields back the dataset.
+    Whereas if the dataset is lazily read from disk and we've specified to
+    load 1000 instances at a time, then it yields lists of 1000 instances each.
+    """
+    lazy = is_lazy(instances)
+
+    # Get an iterator over the next epoch worth of instances.
+    iterator = take_instances(instances, instances_per_epoch)
+
+    # We have four different cases to deal with:
+
+    # With lazy instances and no guidance about how many to load into memory,
+    # we just load ``batch_size`` instances at a time:
+    if lazy and max_instances_in_memory is None:
+        yield from lazy_groups_of(iterator, batch_size)
+    # If we specified max instances in memory, lazy or not, we just
+    # load ``max_instances_in_memory`` instances at a time:
+    elif max_instances_in_memory is not None:
+        yield from lazy_groups_of(iterator, max_instances_in_memory)
+    # If we have non-lazy instances, and we want all instances each epoch,
+    # then we just yield back the list of instances:
+    elif instances_per_epoch is None:
+        yield ensure_list(instances)
+    # In the final case we have non-lazy instances, we want a specific number
+    # of instances each epoch, and we didn't specify how to many instances to load
+    # into memory. So we convert the whole iterator to a list:
+    else:
+        yield list(iterator)
+
+def add_epoch_number(batch: Batch, epoch: int) -> Batch:
+    """
+    Add the epoch number to the batch instances as a MetadataField.
+    """
+    for instance in batch.instances:
+        instance.fields['epoch_num'] = MetadataField(epoch)
+    return batch
+
+def sort_by_padding(instances: List[Instance],
+                    sorting_keys: List[Tuple[str, str]],  # pylint: disable=invalid-sequence-index
+                    vocab: Vocabulary,
+                    padding_noise: float = 0.0) -> List[Instance]:
+    """
+    Sorts the ``Instances`` in this ``Batch`` by their padding lengths, using the keys in
+    ``sorting_keys`` (in the order in which they are provided).  ``sorting_keys`` is a list of
+    ``(field_name, padding_key)`` tuples.
+    """
+    instances_with_lengths = []
+    for instance in instances:
+        # Make sure instance is indexed before calling .get_padding
+        instance.index_fields(vocab)
+        padding_lengths = cast(Dict[str, Dict[str, float]], instance.get_padding_lengths())
+        if padding_noise > 0.0:
+            noisy_lengths = {}
+            for field_name, field_lengths in padding_lengths.items():
+                noisy_lengths[field_name] = add_noise_to_dict_values(field_lengths, padding_noise)
+            padding_lengths = noisy_lengths
+        instance_with_lengths = ([padding_lengths[field_name][padding_key]
+                                  for (field_name, padding_key) in sorting_keys],
+                                 instance)
+        instances_with_lengths.append(instance_with_lengths)
+    instances_with_lengths.sort(key=lambda x: x[0])
+    return [instance_with_lengths[-1] for instance_with_lengths in instances_with_lengths]

--- a/tests/data/iterators/basic_iterator_test.py
+++ b/tests/data/iterators/basic_iterator_test.py
@@ -5,10 +5,20 @@ from collections import Counter
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Instance, Token, Vocabulary
+from allennlp.data.dataset import Batch
 from allennlp.data.dataset_readers.dataset_reader import _LazyInstances
 from allennlp.data.fields import TextField
 from allennlp.data.iterators import BasicIterator
 from allennlp.data.token_indexers import SingleIdTokenIndexer
+
+def assert_tensor_dict_eq(td1, td2) -> bool:
+    assert td1.keys() == td2.keys()
+
+    for k, v in td1.items():
+        if isinstance(v, dict):
+            assert_tensor_dict_eq(v, td2[k])
+        else:
+            assert v.equal(td2[k])
 
 class IteratorTest(AllenNlpTestCase):
     def setUp(self):


### PR DESCRIPTION
at a high level, here are the changes:

* create `allennlp.data.iterators.utils`, and move shared code there (rather than using inheritance)
* put a lot more logic in `DataIterator.__call__` (and, in particular, have it handle caching and adding epoch numbers)
* get rid of the complex inheritance hierarchy, now we have `BucketIterator(DataIterator)` and so on

some things I don't like about this WIP:

* storing `_cursors` in a global variable in `iterators.utils`. 
* the way `AdaptiveIterator` handles the "fall back to BucketIterator in `biggest_batch_first` case"
* the logic around `take_instances` and `memory_sized_lists` is still too intricate (but possibly there's no way around that)