### PR TITLE
hack to stop tqdm hanging

### DIFF
--- a/allennlp/common/tqdm.py
+++ b/allennlp/common/tqdm.py
@@ -4,6 +4,13 @@ global defaults for certain tqdm parameters.
 """
 
 from tqdm import tqdm as _tqdm
+# This is neccesary to stop tqdm from hanging
+# when exceptions are raised inside iterators.
+# It should have been fixed in 4.2.1, but it still
+# occurs.
+# TODO(Mark): Remove this once tqdm cleans up after itself properly.
+# https://github.com/tqdm/tqdm/issues/469
+_tqdm.monitor_interval = 0
 
 class Tqdm:
     # These defaults are the same as the argument defaults in tqdm.


### PR DESCRIPTION
This was causing serious grief in Beaker - if an exception was raised inside any code wrapped in a tqdm progress bar, it would hang after raising the exception. @schmmd we might need to release again after this, so that people can upgrade.