### PR TITLE
Speedup ELMo command by making input tensors volatile

### DIFF
--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -143,7 +143,7 @@ class ElmoEmbedder():
             A tuple of tensors, the first representing activations (batch_size, 3, num_timesteps, 1024) and
         the second a mask (batch_size, num_timesteps).
         """
-        character_ids = batch_to_ids(batch)
+        character_ids = batch_to_ids(batch, for_training=False)
         if self.cuda_device >= 0:
             character_ids = character_ids.cuda(device=self.cuda_device)
 

--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -164,7 +164,8 @@ class Elmo(torch.nn.Module):
                    requires_grad=requires_grad, do_layer_norm=do_layer_norm)
 
 
-def batch_to_ids(batch: List[List[str]]) -> torch.Tensor:
+def batch_to_ids(batch: List[List[str]],
+                 for_training: bool = True) -> torch.Tensor:
     """
     Converts a batch of tokenized sentences to a tensor representing the sentences with encoded characters
     (len(batch), max sentence length, max word length).
@@ -190,7 +191,7 @@ def batch_to_ids(batch: List[List[str]]) -> torch.Tensor:
     dataset = Batch(instances)
     vocab = Vocabulary()
     dataset.index_instances(vocab)
-    return dataset.as_tensor_dict()['elmo']['character_ids']
+    return dataset.as_tensor_dict(for_training=for_training)['elmo']['character_ids']
 
 
 class _ElmoCharacterEncoder(torch.nn.Module):


### PR DESCRIPTION
Maybe I'm missing something here, but it seems like setting `for_training` to `False` when using `allennlp elmo` should not affect the output results while also producing some speedups + memory savings.