### PR TITLE
Changed how checklist balance is used in action prediction

### DIFF
--- a/allennlp/models/semantic_parsing/nlvr/nlvr_decoder_step.py
+++ b/allennlp/models/semantic_parsing/nlvr/nlvr_decoder_step.py
@@ -26,7 +26,7 @@ class NlvrDecoderStep(DecoderStep[NlvrDecoderState]):
     attention_function : ``SimilarityFunction``
     dropout : ``float``
         Dropout to use on decoder outputs and before action prediction.
-    use_coverage : ``bool``
+    use_coverage : ``bool``, optional (default=False)
         Is this DecoderStep being used in a semantic parser trained using coverage? We need to know
         this to define a learned parameter for using checklist balances in action prediction.
     """
@@ -95,7 +95,7 @@ class NlvrDecoderStep(DecoderStep[NlvrDecoderState]):
         # (group_size, decoder_input_dim)
         decoder_input = self._input_projection_layer(torch.cat([attended_sentence,
                                                                 previous_action_embedding], -1))
-
+        decoder_input = torch.nn.functional.tanh(decoder_input)
         hidden_state, memory_cell = self._decoder_cell(decoder_input, (hidden_state, memory_cell))
 
         hidden_state = self._dropout(hidden_state)
@@ -138,7 +138,7 @@ class NlvrDecoderStep(DecoderStep[NlvrDecoderState]):
         action_query = torch.cat([hidden_state, attended_sentence], dim=-1)
         # (group_size, action_embedding_dim)
         predicted_action_embedding = self._output_projection_layer(action_query)
-        predicted_action_embedding = self._dropout(torch.nn.functional.relu(predicted_action_embedding))
+        predicted_action_embedding = self._dropout(torch.nn.functional.tanh(predicted_action_embedding))
         if state.checklist_state[0] is not None:
             embedding_addition = self._get_predicted_embedding_addition(state)
             predicted_action_embedding += self._checklist_embedding_multiplier * embedding_addition

--- a/allennlp/models/semantic_parsing/nlvr/nlvr_decoder_step.py
+++ b/allennlp/models/semantic_parsing/nlvr/nlvr_decoder_step.py
@@ -141,7 +141,8 @@ class NlvrDecoderStep(DecoderStep[NlvrDecoderState]):
         predicted_action_embedding = self._dropout(torch.nn.functional.tanh(predicted_action_embedding))
         if state.checklist_state[0] is not None:
             embedding_addition = self._get_predicted_embedding_addition(state)
-            predicted_action_embedding += self._checklist_embedding_multiplier * embedding_addition
+            addition = embedding_addition * self._checklist_embedding_multiplier
+            predicted_action_embedding = predicted_action_embedding + addition
         # We'll do a batch dot product here with `bmm`.  We want `dot(predicted_action_embedding,
         # action_embedding)` for each `action_embedding`, and we can get that efficiently with
         # `bmm` and some squeezing.

--- a/allennlp/models/semantic_parsing/wikitables/wikitables_decoder_step.py
+++ b/allennlp/models/semantic_parsing/wikitables/wikitables_decoder_step.py
@@ -147,7 +147,8 @@ class WikiTablesDecoderStep(DecoderStep[WikiTablesDecoderState]):
             embedding_addition = self._get_predicted_embedding_addition(state,
                                                                         self._unlinked_terminal_indices,
                                                                         unlinked_balance)
-            predicted_action_embedding += self._unlinked_checklist_multiplier * embedding_addition
+            addition = embedding_addition * self._unlinked_checklist_multiplier
+            predicted_action_embedding = predicted_action_embedding + addition
 
         # We'll do a batch dot product here with `bmm`.  We want `dot(predicted_action_embedding,
         # action_embedding)` for each `action_embedding`, and we can get that efficiently with


### PR DESCRIPTION
Summary of changes:
1) Made the output projection layer the same in both mml and erm parsers for both nlvr and wikitables parsers
2) The checklist balance in nlvr (and unlinked checklist balance in wikitables) is now used to select appropriate action embeddings, the sum of which is added to predicted action embedding.
3) There are now learned scalar parameters that regularize the addition to predicted embedding (in nlvr and wikitables) and action logits (in wikitables). 