### PR TITLE
gitignore EVALB generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 doc/_build/
 .ipynb_checkpoints
 .pytest_cache/
+scripts/EVALB/evalb.dSYM/
 
 # build artifacts
 allennlp.egg-info/


### PR DESCRIPTION
Whenever I run the tests on my macbook, EVALB generates these unchecked files that don't seem to matter --- i've added to directory to the .gitignore.