### PR TITLE
Add missing import to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ run chmod 600 ./pypirc so only you can read/write.
 
 """
 from setuptools import setup, find_packages
+import sys
 
 # PEP0440 compatible formatted version, see:
 # https://www.python.org/dev/peps/pep-0440/


### PR DESCRIPTION
Fixes https://github.com/allenai/allennlp/commit/70862e09eb9546f849334e4df4893d7597c9f1aa#commitcomment-28975524

Surprised that pylint didn't pick this up, but `python setup.py install` and `python setup.py test` now work on this branch. Sorry for the carelessness!

cc: @jpowerwa 