### PR TITLE
Tweak TestInstall._get_project_root()

### DIFF
--- a/tests/commands/test_install_test.py
+++ b/tests/commands/test_install_test.py
@@ -9,5 +9,5 @@ class TestTestInstall(AllenNlpTestCase):
     def test_get_project_root(self):
         project_root = _get_project_root()
         assert os.path.exists(os.path.join(project_root, "tests"))
-        assert os.path.exists(os.path.join(project_root, "LICENSE"))
-        assert os.path.exists(os.path.join(project_root, "setup.py"))
+        assert os.path.exists(os.path.join(project_root, "tests",
+                                           "commands", "test_install_test.py"))


### PR DESCRIPTION
I realized that it's a pretty strong assumption for this function to look for `setup.py` and `license` --- all we're really looking for is the `tests` directory. I also added another assert that the test file exists, just as a sanity check that we've got the right tests directory.