### PR TITLE
Add custom extensions to distribution and install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
 include README.md
 include requirements.txt
 include bin/allennlp
-recursive-include scripts *
-recursive-include tutorials *
+graft allennlp
+graft scripts
+graft tutorials
+graft tests
 recursive-include training_config *.json
-recursive-include tests *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include requirements.txt
 include bin/allennlp
 recursive-include allennlp *
 recursive-include scripts *
-recursive-include training_config *.json
 recursive-include tests *
+recursive-include training_config *.json
 recursive-include tutorials *
 recursive-exclude * __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include requirements.txt
 include bin/allennlp
 recursive-include allennlp *
 recursive-include scripts *
-recursive-include tutorials *
-recursive-include tests *
 recursive-include training_config *.json
+recursive-include tests *
+recursive-include tutorials *
 recursive-exclude * __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,9 @@
 include README.md
 include requirements.txt
 include bin/allennlp
-graft allennlp
-graft scripts
-graft tutorials
-graft tests
+recursive-include allennlp *
+recursive-include scripts *
+recursive-include tutorials *
+recursive-include tests *
 recursive-include training_config *.json
+recursive-exclude * __pycache__


### PR DESCRIPTION
The custom extensions were previously not being packaged, since they didn't end in `.py`. I just added all files in the `allennlp` module, removing `__pycache__`s.