### PR TITLE
Replace slicing with chunk along the last dim

### DIFF
--- a/allennlp/modules/highway.py
+++ b/allennlp/modules/highway.py
@@ -22,8 +22,8 @@ class Highway(torch.nn.Module):
     Parameters
     ----------
     input_dim : ``int``
-        The dimensionality of :math:`x`.  We assume the input has shape ``(batch_size,
-        input_dim)``.
+        The dimensionality of :math:`x`.  We assume the input has shape ``(batch_size, *,
+        input_dim)``, where * is any number of dimensions.
     num_layers : ``int``, optional (default=``1``)
         The number of highway layers to apply to the input.
     activation : ``Callable[[torch.Tensor], torch.Tensor]``, optional (default=``torch.nn.functional.relu``)

--- a/allennlp/modules/highway.py
+++ b/allennlp/modules/highway.py
@@ -22,8 +22,8 @@ class Highway(torch.nn.Module):
     Parameters
     ----------
     input_dim : ``int``
-        The dimensionality of :math:`x`.  We assume the input has shape ``(batch_size, *,
-        input_dim)``, where * is any number of dimensions.
+        The dimensionality of :math:`x`.  We assume the input has shape ``(batch_size, ...,
+        input_dim)``.
     num_layers : ``int``, optional (default=``1``)
         The number of highway layers to apply to the input.
     activation : ``Callable[[torch.Tensor], torch.Tensor]``, optional (default=``torch.nn.functional.relu``)
@@ -41,7 +41,7 @@ class Highway(torch.nn.Module):
         for layer in self._layers:
             # We should bias the highway layer to just carry its input forward.  We do that by
             # setting the bias on `B(x)` to be positive, because that means `g` will be biased to
-            # be high, to we will carry the input forward.  The bias on `B(x)` is the second half
+            # be high, so we will carry the input forward.  The bias on `B(x)` is the second half
             # of the bias vector in each Linear layer.
             layer.bias[input_dim:].data.fill_(1)
 

--- a/allennlp/modules/highway.py
+++ b/allennlp/modules/highway.py
@@ -53,8 +53,7 @@ class Highway(torch.nn.Module):
             linear_part = current_input
             # NOTE: if you modify this, think about whether you should modify the initialization
             # above, too.
-            nonlinear_part = projected_input[:, (0 * self._input_dim):(1 * self._input_dim)]
-            gate = projected_input[:, (1 * self._input_dim):(2 * self._input_dim)]
+            nonlinear_part, gate = projected_input.chunk(2, dim=-1)
             nonlinear_part = self._activation(nonlinear_part)
             gate = torch.nn.functional.sigmoid(gate)
             current_input = gate * linear_part + (1 - gate) * nonlinear_part

--- a/tests/modules/highway_test.py
+++ b/tests/modules/highway_test.py
@@ -20,3 +20,9 @@ class TestHighway(AllenNlpTestCase):
         assert result.shape == (2, 2)
         # This was checked by hand.
         assert_almost_equal(result, [[-0.0394, 0.0197], [1.7527, -0.5550]], decimal=4)
+
+    def test_forward_works_on_nd_input(self):
+        highway = Highway(2, 2)
+        input_tensor = Variable(torch.ones(2, 2, 2))
+        output = highway(input_tensor)
+        assert output.size() == (2, 2, 2)


### PR DESCRIPTION
As per #1211, now the Highway implementation won't require the `TimeDistributed` wrapper to work with n-dimensional input.

I've glanced around the lib and saw that `FeedForward` also has the 2-d input assumption, as well as some other layers (at least in the docs). Since `nn.Linear` accepts n-d input, I believe this can be relaxed. I've used `FeedForward` on `BxTxD` data unknowingly, and everything worked fine.

Fixes #1211.