### PR TITLE
Constituency Parser Demo Reference Update

### DIFF
--- a/demo/src/components/ConstituencyParserComponent.js
+++ b/demo/src/components/ConstituencyParserComponent.js
@@ -22,9 +22,9 @@ const description = (
   <span>
     <span>
       A constituency parse tree breaks a text into sub-phrases, or constituents. Non-terminals in the tree are types of phrases, the terminals are the words in the sentence.
-      This demo is an implementation of a minimal neural model for constituency parsing based on an independent scoring of labels and spans from
+      This demo is an implementation of a minimal neural model for constituency parsing based on an independent scoring of labels and spans described in
     </span>
-    <a href="https://www.semanticscholar.org/paper/A-Minimal-Span-Based-Neural-Constituency-Parser-Stern-Andreas/593e4e749bd2dbcaf8dc25298d830b41d435e435" target="_blank" rel="noopener noreferrer">{' '} a Minimal Span Based Constituency Parser (Stern et al, 2017)</a>
+    <a href="http://arxiv.org/abs/1805.06556" target="_blank" rel="noopener noreferrer">{' '} Extending a Parser to Distant Domains Using a Few Dozen Partially Annotated Examples (Joshi et al, 2018)</a>
     <span>
       . This model uses <a href="https://arxiv.org/abs/1802.05365">ELMo embeddings</a>, which are completely character based and improves single model performance from 92.6 F1 to 94.11 F1 on the Penn Treebank, a 20% relative error reduction.
     </span>


### PR DESCRIPTION
Updates the constituency parser demo to reference *Extending a Parser to Distant Domains Using a Few Dozen Partially Annotated Examples* which is now on arXiv http://arxiv.org/abs/1805.06556