### PR TITLE
In Trainer, require "patience" to be a positive integer or None (meaning "no early stopping"). Set patience=None by default.

### DIFF
--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -122,6 +122,24 @@ class TestTrainer(AllenNlpTestCase):
         assert new_trainer._should_stop_early([.02, .3, .2, .1, .4, .4])  # pylint: disable=protected-access
         assert not new_trainer._should_stop_early([.3, .3, .2, .1, .4, .5])  # pylint: disable=protected-access
 
+    def test_should_stop_early_with_non_positive_patience(self):
+        new_trainer = Trainer(self.model, self.optimizer, self.iterator, self.instances,
+                              validation_dataset=self.instances, num_epochs=100,
+                              patience=-1, validation_metric="+test")
+        assert not new_trainer._should_stop_early(map(float, reversed(range(50))))  # pylint: disable=protected-access
+
+    def test_should_stop_early_with_patience_equal_to_none(self):
+        new_trainer = Trainer(self.model, self.optimizer, self.iterator, self.instances,
+                              validation_dataset=self.instances, num_epochs=100,
+                              patience=None, validation_metric="+test")
+        assert not new_trainer._should_stop_early(map(float, reversed(range(50))))  # pylint: disable=protected-access
+
+    def test_should_stop_early_with_patience_equal_to_zero(self):
+        with pytest.raises(ValueError):
+            Trainer(self.model, self.optimizer, self.iterator, self.instances,
+                    validation_dataset=self.instances, num_epochs=100,
+                    patience=0, validation_metric="+test")
+
     def test_trainer_can_run_with_lr_scheduler(self):
 
         lr_params = Params({"type": "reduce_on_plateau"})

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -6,6 +6,7 @@ import time
 
 import torch
 import pytest
+from allennlp.common.checks import ConfigurationError
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.training.trainer import Trainer, sparse_clip_norm, is_sparse
@@ -122,23 +123,27 @@ class TestTrainer(AllenNlpTestCase):
         assert new_trainer._should_stop_early([.02, .3, .2, .1, .4, .4])  # pylint: disable=protected-access
         assert not new_trainer._should_stop_early([.3, .3, .2, .1, .4, .5])  # pylint: disable=protected-access
 
-    def test_should_stop_early_with_non_positive_patience(self):
-        new_trainer = Trainer(self.model, self.optimizer, self.iterator, self.instances,
-                              validation_dataset=self.instances, num_epochs=100,
-                              patience=-1, validation_metric="+test")
-        assert not new_trainer._should_stop_early(map(float, reversed(range(50))))  # pylint: disable=protected-access
+    def test_should_stop_early_with_early_stopping_disabled(self):
+        # Increasing metric
+        trainer = Trainer(self.model, self.optimizer, self.iterator, self.instances,
+                          validation_dataset=self.instances, num_epochs=100,
+                          patience=None, validation_metric="+test")
+        decreasing_history = [float(i) for i in reversed(range(20))]
+        assert not trainer._should_stop_early(decreasing_history)  # pylint: disable=protected-access
 
-    def test_should_stop_early_with_patience_equal_to_none(self):
-        new_trainer = Trainer(self.model, self.optimizer, self.iterator, self.instances,
-                              validation_dataset=self.instances, num_epochs=100,
-                              patience=None, validation_metric="+test")
-        assert not new_trainer._should_stop_early(map(float, reversed(range(50))))  # pylint: disable=protected-access
+        # Decreasing metric
+        trainer = Trainer(self.model, self.optimizer, self.iterator, self.instances,
+                          validation_dataset=self.instances, num_epochs=100,
+                          patience=None, validation_metric="-test")
+        increasing_history = [float(i) for i in range(20)]
+        assert not trainer._should_stop_early(increasing_history)  # pylint: disable=protected-access
 
-    def test_should_stop_early_with_patience_equal_to_zero(self):
-        with pytest.raises(ValueError):
-            Trainer(self.model, self.optimizer, self.iterator, self.instances,
-                    validation_dataset=self.instances, num_epochs=100,
-                    patience=0, validation_metric="+test")
+    def test_should_stop_early_with_invalid_patience(self):
+        for patience in [0, -1, -2, 1.5, 'None']:
+            with pytest.raises(ConfigurationError, message='No ConfigurationError for patience={}'.format(patience)):
+                Trainer(self.model, self.optimizer, self.iterator, self.instances,
+                        validation_dataset=self.instances, num_epochs=100,
+                        patience=patience, validation_metric="+test")
 
     def test_trainer_can_run_with_lr_scheduler(self):
 

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -140,7 +140,8 @@ class TestTrainer(AllenNlpTestCase):
 
     def test_should_stop_early_with_invalid_patience(self):
         for patience in [0, -1, -2, 1.5, 'None']:
-            with pytest.raises(ConfigurationError, message='No ConfigurationError for patience={}'.format(patience)):
+            with pytest.raises(ConfigurationError,
+                               message='No ConfigurationError for patience={}'.format(patience)):
                 Trainer(self.model, self.optimizer, self.iterator, self.instances,
                         validation_dataset=self.instances, num_epochs=100,
                         patience=patience, validation_metric="+test")

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -152,7 +152,7 @@ class Trainer:
                  iterator: DataIterator,
                  train_dataset: Iterable[Instance],
                  validation_dataset: Optional[Iterable[Instance]] = None,
-                 patience: Optional[int] = 2,
+                 patience: Optional[int] = None,
                  validation_metric: str = "-loss",
                  num_epochs: int = 20,
                  serialization_dir: Optional[str] = None,
@@ -181,12 +181,10 @@ class Trainer:
             A ``Dataset`` to train on. The dataset should have already been indexed.
         validation_dataset : ``Dataset``, optional, (default = None).
             A ``Dataset`` to evaluate on. The dataset should have already been indexed.
-        patience : int != 0, optional (default=2)
-            If ``patience > 0``, it's the number of epochs to be patient before early stopping:
-            the training is stopped after ``patience`` epochs with no improvement.
-            If ``patience < 0 or patience == None``, early stopping is disabled.
-            Because the behavior for ``patience = 0`` is undefined and prone to misinterpretations,
-            it's required ``patience != 0``.
+        patience : Optional[int] > 0, optional (default=None)
+            Number of epochs to be patient before early stopping: the training is stopped
+            after ``patience`` epochs with no improvement. If given, it must be ``> 0``.
+            If None, early stopping is disabled.
         validation_metric : str, optional (default="loss")
             Validation metric to measure for whether to stop training using patience
             and whether to serialize an ``is_best`` model each epoch. The metric name
@@ -247,12 +245,14 @@ class Trainer:
         self._train_data = train_dataset
         self._validation_data = validation_dataset
 
-        if patience == 0:
-            raise ValueError('0 is not a valid value for patience. If you want to stop the training after '
-                             'the first epoch without improvement, set patience to 1. '
-                             'If you want to disable early stopping, please set patience to a negative '
-                             'number or to None.')
-        self._patience = patience or -1
+        if patience is None:  # no early stopping
+            if validation_dataset:
+                logger.warning('You provided a validation dataset but patience was set to None, '
+                               'meaning that early stopping is disabled')
+        elif (not isinstance(patience, int)) or patience <= 0:
+            raise ConfigurationError('{} is an invalid value for "patience": it must be a positive integer '
+                                     'or None (if you want to disable early stopping)'.format(patience))
+        self._patience = patience
         self._num_epochs = num_epochs
 
         self._serialization_dir = serialization_dir
@@ -370,6 +370,7 @@ class Trainer:
                                   if p.grad is not None]
             return sparse_clip_norm(parameters_to_clip, self._grad_norm)
         return None
+
     def _data_parallel(self, batch):
         """
         Do the forward pass using multiple GPUs.  This is a simplification
@@ -521,7 +522,7 @@ class Trainer:
         """
         uses patience and the validation metric to determine if training should stop early
         """
-        if 0 < self._patience < len(metric_history):
+        if self._patience and self._patience < len(metric_history):
             # Is the best score in the past N epochs worse than the best score overall?
             if self._validation_metric_decreases:
                 return min(metric_history[-self._patience:]) > min(metric_history)
@@ -686,7 +687,7 @@ class Trainer:
                 this_epoch_val_metric = val_metrics[self._validation_metric]
                 validation_metric_per_epoch.append(this_epoch_val_metric)
                 if self._should_stop_early(validation_metric_per_epoch):
-                    logger.info("Ran out of patience.  Stopping training.")
+                    logger.info("Ran out of patience. Stopping training.")
                     break
 
                 # Check validation metric to see if it's the best so far
@@ -897,7 +898,7 @@ class Trainer:
                     validation_data: Optional[Iterable[Instance]],
                     params: Params) -> 'Trainer':
 
-        patience = params.pop_int("patience", 2)
+        patience = params.pop_int("patience", None)
         validation_metric = params.pop("validation_metric", "-loss")
         num_epochs = params.pop_int("num_epochs", 20)
         cuda_device = params.pop_int("cuda_device", -1)

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -523,6 +523,9 @@ class Trainer:
         uses patience and the validation metric to determine if training should stop early
         """
         if self._patience and self._patience < len(metric_history):
+            # Pylint can't figure out that in this branch `self._patience` is an int.
+            # pylint: disable=invalid-unary-operand-type
+
             # Is the best score in the past N epochs worse than the best score overall?
             if self._validation_metric_decreases:
                 return min(metric_history[-self._patience:]) > min(metric_history)


### PR DESCRIPTION
Fixes https://github.com/allenai/allennlp/issues/1267