### PR TITLE
Migrate gevent's wsgi to pywsgi

### DIFF
--- a/allennlp/service/server_flask.py
+++ b/allennlp/service/server_flask.py
@@ -16,7 +16,7 @@ from functools import lru_cache
 
 from flask import Flask, request, Response, jsonify, send_file, send_from_directory
 from flask_cors import CORS
-from gevent.wsgi import WSGIServer
+from gevent.pywsgi import WSGIServer
 
 import psycopg2
 

--- a/allennlp/service/server_simple.py
+++ b/allennlp/service/server_simple.py
@@ -25,7 +25,7 @@ import sys
 
 from flask import Flask, request, Response, jsonify, send_file, send_from_directory
 from flask_cors import CORS
-from gevent.wsgi import WSGIServer
+from gevent.pywsgi import WSGIServer
 
 from allennlp.common import JsonDict
 from allennlp.common.util import import_submodules


### PR DESCRIPTION
Since gevent 1.0a1 was released in 2011, wsgi is just an alias for pywsgi.
In version 1.3 wsgi is completely removed, causing allennlp to break.
For more info check  http://www.gevent.org/api/gevent.wsgi.html

Test plan:
run scripts/verify.py on trunk, all test pass.