### PR TITLE
Insteall psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ flask-cors==3.0.3
 gevent==1.2.2
 
 # Talk to postgres demo database
-psycopg2
+psycopg2-binary
 
 # Used by semantic parsing code to strip diacritics from unicode strings.
 unidecode


### PR DESCRIPTION
This is in response to the following message when running `allennlp`:

```
/Users/michaels/miniconda3/envs/cleaner/lib/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```