### PR TITLE
Ignore tests in coverage metrics

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,4 +10,6 @@ coverage:
         threshold: 1%
     changes: false
 comment: false
-ignore: allennlp/custom_extensions
+ignore:
+  - "allennlp/custom_extensions"
+  - "allennlp/tests"


### PR DESCRIPTION
Our coverage jumped up from 92% to 95% after the tests were moved under `allennlp`...