### PR TITLE
allow tests to run in parallel

### DIFF
--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -30,7 +30,7 @@ class AllenNlpTestCase(TestCase):  # pylint: disable=too-many-public-methods
         logging.getLogger('allennlp.modules.token_embedders.embedding').setLevel(logging.INFO)
         log_pytorch_version_info()
 
-        self.TEST_DIR = pathlib.Path("/tmp/allennlp_tests/")
+        self.TEST_DIR = pathlib.Path(f"/tmp/allennlp_tests/{os.getpid()}/")
 
         os.makedirs(self.TEST_DIR, exist_ok=True)
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,8 @@
 #### TESTING-RELATED PACKAGES ####
 
+# Allows running tests in parallel
+pytest-xdist==1.22.2
+
 # Checks style, syntax, and other useful errors.
 pylint==1.8.1
 


### PR DESCRIPTION
in order to do this I needed to make AllenNLPTestCase.TEST_DIR depend on os.getpid(), so that different processes have different TEST_DIRs, otherwise they clobber each other.

on my macbook:

```
$ time pytest -n 8

real	2m35.736s
user	5m14.864s
sys	0m28.034s
```

vs

```
$ time pytest

real	3m47.364s
user	3m47.823s
sys	0m19.338s
```

so that shaves more than a minute off the wall-clock time