### PR TITLE
Fix link to installation instructions

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -4,7 +4,7 @@ These tutorials relate to the version of AllenNLP at the git commit SHA you are 
 
 ## Getting Started
 
-* [Installation](getting_started/installation.md)
+* [Installation](../README.md#installation)
 * [Training and Evaluating Models](getting_started/training_and_evaluating.md)
 * [Configuring Experiments](getting_started/configuration.md)
 * [Creating a Model](getting_started/creating_a_model.md)


### PR DESCRIPTION
The installation tutorial was removed in https://github.com/allenai/allennlp/pull/1261. This PR changes the link on the tutorials site to the `#installation` section of the project `README.md.