### PR TITLE
Format pytest logging correctly

### DIFF
--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -28,6 +28,7 @@ class AllenNlpTestCase(TestCase):  # pylint: disable=too-many-public-methods
         logging.getLogger('allennlp.common.params').disabled = True
         logging.getLogger('allennlp.nn.initializers').disabled = True
         logging.getLogger('allennlp.modules.token_embedders.embedding').setLevel(logging.INFO)
+        logging.getLogger('urllib3.connectionpool').disabled = True
         log_pytorch_version_info()
 
         self.TEST_DIR = pathlib.Path("/tmp/allennlp_tests/")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 testpaths = allennlp/tests/
+log_format = %(asctime)s - %(levelname)s - %(name)s - %(message)s
+log_level = DEBUG


### PR DESCRIPTION
Fixes #1350.  Well, it kind of fixes it.  I'd prefer to have the logs just interleaved with stderr, like they used to be, because this way it makes it pretty hard to follow some things...  If anyone knows how to get back to that without just pinning to `pytest==3.2`, I'd be happy to hear it.  (I'm also maybe happy to pin to 3.2 instead of this...)