### PR TITLE
Add ability to add tokens to vocabulary namespaces

### DIFF
--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -155,13 +155,17 @@ class Vocabulary:
         regardless of their count, depending on the value of ``only_include_pretrained_words``.
         Words which appear in the pretrained embedding file but not in the data are NOT included
         in the Vocabulary.
-    only_include_pretrained_words : bool, optional (default = False)
+    only_include_pretrained_words : ``bool``, optional (default=False)
         This defines the stategy for using any pretrained embedding files which may have been
         specified in ``pretrained_files``. If False, an inclusive stategy is used: and words
         which are in the ``counter`` and in the pretrained file are added to the ``Vocabulary``,
         regardless of whether their count exceeds ``min_count`` or not. If True, we use an
         exclusive strategy: words are only included in the Vocabulary if they are in the pretrained
         embedding file (their count must still be at least ``min_count``).
+    tokens_to_add : ``Dict[str, List[str]]``, optional (default=None)
+        If given, this is a list of tokens to add to the vocabulary, keyed by the namespace to add
+        the tokens to.  This is a way to be sure that certain items appear in your vocabulary,
+        regardless of any other vocabulary computation.
     """
     def __init__(self,
                  counter: Dict[str, Dict[str, int]] = None,

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -4,7 +4,7 @@ out-of-vocabulary token.
 """
 
 from collections import defaultdict
-from typing import Any, Callable, Dict, Union, Sequence, Set, Optional, Iterable
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Union
 import codecs
 import logging
 import os
@@ -169,7 +169,8 @@ class Vocabulary:
                  max_vocab_size: Union[int, Dict[str, int]] = None,
                  non_padded_namespaces: Sequence[str] = DEFAULT_NON_PADDED_NAMESPACES,
                  pretrained_files: Optional[Dict[str, str]] = None,
-                 only_include_pretrained_words: bool = False) -> None:
+                 only_include_pretrained_words: bool = False,
+                 tokens_to_add: Dict[str, List[str]] = None) -> None:
         self._padding_token = DEFAULT_PADDING_TOKEN
         self._oov_token = DEFAULT_OOV_TOKEN
         if not isinstance(max_vocab_size, dict):
@@ -204,6 +205,11 @@ class Vocabulary:
                             self.add_token_to_namespace(token, namespace)
                     elif count >= min_count.get(namespace, 1):
                         self.add_token_to_namespace(token, namespace)
+
+        if tokens_to_add:
+            for namespace, tokens in tokens_to_add.items():
+                for token in tokens:
+                    self.add_token_to_namespace(token, namespace)
 
     def save_to_files(self, directory: str) -> None:
         """
@@ -320,7 +326,8 @@ class Vocabulary:
                        max_vocab_size: Union[int, Dict[str, int]] = None,
                        non_padded_namespaces: Sequence[str] = DEFAULT_NON_PADDED_NAMESPACES,
                        pretrained_files: Optional[Dict[str, str]] = None,
-                       only_include_pretrained_words: bool = False) -> 'Vocabulary':
+                       only_include_pretrained_words: bool = False,
+                       tokens_to_add: Dict[str, List[str]] = None) -> 'Vocabulary':
         """
         Constructs a vocabulary given a collection of `Instances` and some parameters.
         We count all of the vocabulary items in the instances, then pass those counts
@@ -337,7 +344,8 @@ class Vocabulary:
                           max_vocab_size=max_vocab_size,
                           non_padded_namespaces=non_padded_namespaces,
                           pretrained_files=pretrained_files,
-                          only_include_pretrained_words=only_include_pretrained_words)
+                          only_include_pretrained_words=only_include_pretrained_words,
+                          tokens_to_add=tokens_to_add)
 
     @classmethod
     def from_params(cls, params: Params, instances: Iterable['adi.Instance'] = None):
@@ -375,13 +383,15 @@ class Vocabulary:
         non_padded_namespaces = params.pop("non_padded_namespaces", DEFAULT_NON_PADDED_NAMESPACES)
         pretrained_files = params.pop("pretrained_files", {})
         only_include_pretrained_words = params.pop_bool("only_include_pretrained_words", False)
+        tokens_to_add = params.pop("tokens_to_add", None)
         params.assert_empty("Vocabulary - from dataset")
         return Vocabulary.from_instances(instances=instances,
                                          min_count=min_count,
                                          max_vocab_size=max_vocab_size,
                                          non_padded_namespaces=non_padded_namespaces,
                                          pretrained_files=pretrained_files,
-                                         only_include_pretrained_words=only_include_pretrained_words)
+                                         only_include_pretrained_words=only_include_pretrained_words,
+                                         tokens_to_add=tokens_to_add)
 
     def is_padded(self, namespace: str) -> bool:
         """

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -300,6 +300,13 @@ class TestVocabulary(AllenNlpTestCase):
         with pytest.raises(ConfigurationError):
             _ = Vocabulary.from_params(Params({"directory_path": vocab_dir, "min_count": {'tokens': 2}}))
 
+    def test_from_params_adds_tokens_to_vocab(self):
+        vocab = Vocabulary.from_params(Params({'tokens_to_add': {'tokens': ['q', 'x', 'z']}}), self.dataset)
+        assert vocab.get_index_to_token_vocabulary("tokens") == {0: '@@PADDING@@',
+                                                                 1: '@@UNKNOWN@@',
+                                                                 2: 'a', 3: 'c', 4: 'b',
+                                                                 5: 'q', 6: 'x', 7: 'z'}
+
     def test_vocab_can_print(self):
         vocab = Vocabulary(non_padded_namespaces=["a", "c"])
         vocab.add_token_to_namespace("a0", namespace="a")

--- a/training_config/wikitables_parser.json
+++ b/training_config/wikitables_parser.json
@@ -19,7 +19,8 @@
     "keep_if_no_dpd": true
   },
   "vocabulary": {
-    "min_count": {"tokens": 3}
+    "min_count": {"tokens": 3},
+    "tokens_to_add": {"tokens": ["-1", "0", "1"]}
   },
   "train_data_path": "/wikitables_preprocessed/train.jsonl",
   "validation_data_path": "/wikitables_preprocessed/validation.jsonl",


### PR DESCRIPTION
There are a few tokens that I needed to be added to the wikitables parser vocabulary, and I couldn't figure out a cleaner way to do it than to just add them directly to the vocab in the configuration.  Ideally I'd want the model code to specify this, not the configuration file, but I don't know how to do that in a nice way.

This seems like something people might want to do in other circumstances, too.