### PR TITLE
fix elmo command to use line indices and disallow empty lines

### DIFF
--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -294,6 +294,8 @@ class ElmoEmbedder():
         # Uses the sentence index as the key.
 
         if use_sentence_keys:
+            logger.warning("Using sentences as keys can fail if sentences "
+                           "contain backslashes or colons. Use with caution.")
             embedded_sentences = zip(sentences, self.embed_sentences(split_sentences, batch_size))
         else:
             embedded_sentences = enumerate(self.embed_sentences(split_sentences, batch_size))
@@ -309,7 +311,7 @@ class ElmoEmbedder():
                 if output_format == "all":
                     output = embeddings
                 elif output_format == "top":
-                    output = embeddings[2]
+                    output = embeddings[-1]
                 elif output_format == "average":
                     output = numpy.average(embeddings, axis=0)
 

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -11,7 +11,7 @@ sentence is a size (3, num_tokens, 1024) array with the biLM representations.
 For information, see "Deep contextualized word representations", Peters et al 2018.
 https://arxiv.org/abs/1802.05365
 
-.. code-block:: bash
+.. code-block:: console
 
    $ allennlp elmo --help
    usage: allennlp elmo [-h] (--all | --top | --average)

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -308,7 +308,7 @@ class ElmoEmbedder():
                 if key in fout.keys() and use_sentence_keys:
                     raise ConfigurationError(f"Key already exists in {output_file_path}. "
                                              f"To encode duplicate sentences, do not pass "
-                                             f"the --use_sentence_ids flag.")
+                                             f"the --use-sentence-keys flag.")
 
                 if output_format == "all":
                     output = embeddings

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -44,6 +44,8 @@ https://arxiv.org/abs/1802.05365
                            The batch size to use.
      --cuda-device CUDA_DEVICE
                            The cuda_device to run on.
+     --use-sentence-keys USE_SENTENCE_KEYS
+                           Whether to use line numbers or sentence keys as ids. 
      --include-package INCLUDE_PACKAGE
                            additional packages to include
 """
@@ -112,7 +114,7 @@ class Elmo(Subcommand):
         subparser.add_argument('--batch-size', type=int, default=DEFAULT_BATCH_SIZE, help='The batch size to use.')
         subparser.add_argument('--cuda-device', type=int, default=-1, help='The cuda_device to run on.')
         subparser.add_argument(
-                '--use-sentenc-keys',
+                '--use-sentence-keys',
                 type=bool,
                 default=False,
                 help='Whether to use line numbers or sentence keys as ids.')

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -115,7 +115,7 @@ class Elmo(Subcommand):
         subparser.add_argument('--cuda-device', type=int, default=-1, help='The cuda_device to run on.')
         subparser.add_argument(
                 '--use-sentence-keys',
-                action='store_false',
+                action='store_true',
                 help='Whether to use line numbers or sentence keys as ids.')
 
         subparser.set_defaults(func=elmo_command)
@@ -304,7 +304,7 @@ class ElmoEmbedder():
         logger.info("Processing sentences.")
         with h5py.File(output_file_path, 'w') as fout:
             for key, embeddings in Tqdm.tqdm(embedded_sentences):
-                if key in fout.keys() and use_sentence_keys:
+                if str(key) in fout.keys() and use_sentence_keys:
                     raise ConfigurationError(f"Key already exists in {output_file_path}. "
                                              f"To encode duplicate sentences, do not pass "
                                              f"the --use-sentence-keys flag.")
@@ -324,6 +324,7 @@ class ElmoEmbedder():
         input_file.close()
 
 def elmo_command(args):
+    print(args.use_sentence_keys)
     elmo_embedder = ElmoEmbedder(args.options_file, args.weight_file, args.cuda_device)
     output_format = ""
     if args.all:

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -116,7 +116,7 @@ class Elmo(Subcommand):
         subparser.add_argument(
                 '--use-sentence-keys',
                 type=bool,
-                default=False,
+                action='store_true',
                 help='Whether to use line numbers or sentence keys as ids.')
 
         subparser.set_defaults(func=elmo_command)

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -42,9 +42,7 @@ https://arxiv.org/abs/1802.05365
                            The batch size to use.
    --cuda-device CUDA_DEVICE
                            The cuda_device to run on.
-   --use-sentence-keys   Normally a sentence's line number is used as the HDF5
-                           key for its embedding. If this flag is specified, the
-                           sentence itself will be used as the key.
+   --use-sentence-keys   Normally a sentence's line number is used - instead, use the sentence itself.
    --include-package INCLUDE_PACKAGE
                            additional packages to include
 """

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -45,7 +45,7 @@ https://arxiv.org/abs/1802.05365
      --cuda-device CUDA_DEVICE
                            The cuda_device to run on.
      --use-sentence-keys USE_SENTENCE_KEYS
-                           Whether to use line numbers or sentence keys as ids. 
+                           Whether to use line numbers or sentence keys as ids.
      --include-package INCLUDE_PACKAGE
                            additional packages to include
 """
@@ -115,8 +115,7 @@ class Elmo(Subcommand):
         subparser.add_argument('--cuda-device', type=int, default=-1, help='The cuda_device to run on.')
         subparser.add_argument(
                 '--use-sentence-keys',
-                type=bool,
-                action='store_true',
+                action='store_false',
                 help='Whether to use line numbers or sentence keys as ids.')
 
         subparser.set_defaults(func=elmo_command)

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -288,7 +288,7 @@ class ElmoEmbedder():
         sentences = [line.strip() for line in input_file]
 
         blank_lines = [i for (i, line) in enumerate(sentences) if line == ""]
-        if blank_lines is not None:
+        if blank_lines:
             raise ConfigurationError(f"Your input file contains empty lines at indexes "
                                      f"{blank_lines}. Please remove them.")
         split_sentences = [sentence.split() for sentence in sentences]

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -324,7 +324,6 @@ class ElmoEmbedder():
         input_file.close()
 
 def elmo_command(args):
-    print(args.use_sentence_keys)
     elmo_embedder = ElmoEmbedder(args.options_file, args.weight_file, args.cuda_device)
     output_format = ""
     if args.all:

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -15,40 +15,37 @@ https://arxiv.org/abs/1802.05365
 
    $ allennlp elmo --help
    usage: allennlp elmo [-h] (--all | --top | --average)
-                                      [--vocab-path VOCAB_PATH]
-                                      [--options-file OPTIONS_FILE]
-                                      [--weight-file WEIGHT_FILE]
-                                      [--batch-size BATCH_SIZE]
-                                      [--cuda-device CUDA_DEVICE]
-                                      [--include-package INCLUDE_PACKAGE]
-                                      input_file output_file
+                       [--vocab-path VOCAB_PATH] [--options-file OPTIONS_FILE]
+                       [--weight-file WEIGHT_FILE] [--batch-size BATCH_SIZE]
+                       [--cuda-device CUDA_DEVICE] [--use-sentence-keys]
+                       [--include-package INCLUDE_PACKAGE]
+                       input_file output_file
 
    Create word vectors using ELMo.
 
    positional arguments:
-     input_file            The path to the input file.
-     output_file           The path to the output file.
+   input_file            The path to the input file.
+   output_file           The path to the output file.
 
    optional arguments:
-     -h, --help            show this help message and exit
-     --all                 Output all three ELMo vectors.
-     --top                 Output the top ELMo vector.
-     --average             Output the average of the ELMo vectors.
-     --vocab-path VOCAB_PATH
+   -h, --help            show this help message and exit
+   --all                 Output all three ELMo vectors.
+   --top                 Output the top ELMo vector.
+   --average             Output the average of the ELMo vectors.
+   --vocab-path VOCAB_PATH
                            A path to a vocabulary file to generate.
-     --options-file OPTIONS_FILE
+   --options-file OPTIONS_FILE
                            The path to the ELMo options file.
-     --weight-file WEIGHT_FILE
+   --weight-file WEIGHT_FILE
                            The path to the ELMo weight file.
-     --batch-size BATCH_SIZE
+   --batch-size BATCH_SIZE
                            The batch size to use.
-     --cuda-device CUDA_DEVICE
+   --cuda-device CUDA_DEVICE
                            The cuda_device to run on.
-     --use-sentence-keys USE_SENTENCE_KEYS
-                           Normally a sentence's line number is used as the HDF5
+   --use-sentence-keys   Normally a sentence's line number is used as the HDF5
                            key for its embedding. If this flag is specified, the
                            sentence itself will be used as the key.
-     --include-package INCLUDE_PACKAGE
+   --include-package INCLUDE_PACKAGE
                            additional packages to include
 """
 

--- a/allennlp/tests/commands/elmo_test.py
+++ b/allennlp/tests/commands/elmo_test.py
@@ -9,7 +9,9 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=FutureWarning)
     import h5py
 import numpy
+import pytest
 
+from allennlp.common.checks import ConfigurationError
 from allennlp.commands import main
 from allennlp.commands.elmo import ElmoEmbedder
 from allennlp.tests.modules.elmo_test import ElmoTestCase
@@ -45,9 +47,9 @@ class TestElmoCommand(ElmoTestCase):
         expected_embedding = embedder.embed_sentence(sentence.split())
 
         with h5py.File(self.output_path, 'r') as h5py_file:
-            assert list(h5py_file.keys()) == [sentence]
+            assert list(h5py_file.keys()) == ["0"]
             # The vectors in the test configuration are smaller (32 length)
-            embedding = h5py_file.get(sentence)
+            embedding = h5py_file.get("0")
             assert embedding.shape == (3, len(sentence.split()), 32)
             numpy.testing.assert_allclose(embedding, expected_embedding, rtol=1e-4)
 
@@ -74,9 +76,9 @@ class TestElmoCommand(ElmoTestCase):
         expected_embedding = embedder.embed_sentence(sentence.split())[2]
 
         with h5py.File(self.output_path, 'r') as h5py_file:
-            assert list(h5py_file.keys()) == [sentence]
+            assert list(h5py_file.keys()) == ["0"]
             # The vectors in the test configuration are smaller (32 length)
-            embedding = h5py_file.get(sentence)
+            embedding = h5py_file.get("0")
             assert embedding.shape == (len(sentence.split()), 32)
             numpy.testing.assert_allclose(embedding, expected_embedding, rtol=1e-4)
 
@@ -104,9 +106,9 @@ class TestElmoCommand(ElmoTestCase):
         expected_embedding = (expected_embedding[0] + expected_embedding[1] + expected_embedding[2]) / 3
 
         with h5py.File(self.output_path, 'r') as h5py_file:
-            assert list(h5py_file.keys()) == [sentence]
+            assert list(h5py_file.keys()) == ["0"]
             # The vectors in the test configuration are smaller (32 length)
-            embedding = h5py_file.get(sentence)
+            embedding = h5py_file.get("0")
             assert embedding.shape == (len(sentence.split()), 32)
             numpy.testing.assert_allclose(embedding, expected_embedding, rtol=1e-4)
 
@@ -135,10 +137,10 @@ class TestElmoCommand(ElmoTestCase):
         assert os.path.exists(self.output_path)
 
         with h5py.File(self.output_path, 'r') as h5py_file:
-            assert set(h5py_file.keys()) == set(sentences)
+            assert set(h5py_file.keys()) == {"0", "1"}
             # The vectors in the test configuration are smaller (32 length)
-            for sentence in sentences:
-                assert h5py_file.get(sentence).shape == (3, len(sentence.split()), 32)
+            for sentence_id, sentence in zip(["0", "1"], sentences):
+                assert h5py_file.get(sentence_id).shape == (3, len(sentence.split()), 32)
 
     def test_duplicate_sentences(self):
         sentences = [
@@ -165,13 +167,13 @@ class TestElmoCommand(ElmoTestCase):
         assert os.path.exists(self.output_path)
 
         with h5py.File(self.output_path, 'r') as h5py_file:
-            assert len(h5py_file.keys()) == 1
-            assert set(h5py_file.keys()) == set(sentences)
+            assert len(h5py_file.keys()) == 2
+            assert set(h5py_file.keys()) == {"0", "1"}
             # The vectors in the test configuration are smaller (32 length)
-            for sentence in set(sentences):
-                assert h5py_file.get(sentence).shape == (3, len(sentence.split()), 32)
+            for sentence_id, sentence in zip(["0", "1"], sentences):
+                assert h5py_file.get(sentence_id).shape == (3, len(sentence.split()), 32)
 
-    def test_empty_sentences_are_filtered(self):
+    def test_empty_sentences_raise_errors(self):
         sentences = [
                 "A",
                 "",
@@ -192,14 +194,8 @@ class TestElmoCommand(ElmoTestCase):
                     self.options_file,
                     "--weight-file",
                     self.weight_file]
-
-        main()
-
-        assert os.path.exists(self.output_path)
-
-        with h5py.File(self.output_path, 'r') as h5py_file:
-            assert len(h5py_file.keys()) == 2
-            assert set(h5py_file.keys()) == set(["A", "B"])
+        with pytest.raises(ConfigurationError):
+            main()
 
 
 class TestElmoEmbedder(ElmoTestCase):

--- a/allennlp/tests/commands/elmo_test.py
+++ b/allennlp/tests/commands/elmo_test.py
@@ -142,6 +142,36 @@ class TestElmoCommand(ElmoTestCase):
             for sentence_id, sentence in zip(["0", "1"], sentences):
                 assert h5py_file.get(sentence_id).shape == (3, len(sentence.split()), 32)
 
+    def test_batch_embedding_works_with_sentences_as_keys(self):
+        sentences = [
+                "Michael went to the store to buy some eggs .",
+                "Joel rolled down the street on his skateboard ."
+        ]
+
+        with open(self.sentences_path, 'w') as f:
+            for line in sentences:
+                f.write(line + '\n')
+
+        sys.argv = ["run.py",  # executable
+                    "elmo",  # command
+                    self.sentences_path,
+                    self.output_path,
+                    "--all",
+                    "--options-file",
+                    self.options_file,
+                    "--weight-file",
+                    self.weight_file,
+                    "--use-sentence-keys"]
+        main()
+
+        assert os.path.exists(self.output_path)
+
+        with h5py.File(self.output_path, 'r') as h5py_file:
+            assert set(h5py_file.keys()) == set(sentences)
+            # The vectors in the test configuration are smaller (32 length)
+            for sentence in sentences:
+                assert h5py_file.get(sentence).shape == (3, len(sentence.split()), 32)
+
     def test_duplicate_sentences(self):
         sentences = [
                 "Michael went to the store to buy some eggs .",

--- a/tutorials/how_to/elmo.md
+++ b/tutorials/how_to/elmo.md
@@ -13,7 +13,8 @@ For more detail about ELMo, please see the publication ["Deep contextualized wor
 
 You can write ELMo representations to disk with the `elmo` command.  The `elmo`
 command will write all the biLM individual layer representations for a dataset
-of sentences to an HDF5 file.  Here is an example of using the `elmo` command:
+of sentences to an HDF5 file. The generated hdf5 file will contain line indices
+of the original sentences as keys. Here is an example of using the `elmo` command:
 
 ```bash
 echo "The cryptocurrency space is now figuring out to have the highest search on Google globally ." > sentences.txt


### PR DESCRIPTION
Fixes #1396 Fixes #1257 

- Replaces sentence indexes with integer line indices
- Doesn't ignore duplicate lines in the dataset
- raises an error if your input file contains blank lines, rather than silently creating a dataset which doesn't align with the input file