### PR TITLE
Fix a minor typo in docstring causing wrong api docs of vocabulary config

### DIFF
--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -372,7 +372,7 @@ class Vocabulary:
         ----------
         params: Params, required.
         instances: Iterable['adi.Instance'], optional
-            If ``params`` doesn't contain a ``vocabulary_directory`` key,
+            If ``params`` doesn't contain a ``directory_path`` key,
             the ``Vocabulary`` can be built directly from a collection of
             instances (i.e. a dataset).
 

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -299,7 +299,7 @@ class TestVocabulary(AllenNlpTestCase):
             _ = Vocabulary.from_params(Params({}))
 
         # Test from_params raises when there are any other dict keys
-        # present apart from 'vocabulary_directory' and we aren't calling from_dataset.
+        # present apart from 'directory_path' and we aren't calling from_dataset.
         with pytest.raises(ConfigurationError):
             _ = Vocabulary.from_params(Params({"directory_path": vocab_dir, "min_count": {'tokens': 2}}))
 


### PR DESCRIPTION
- Change expected key in docstring from 'vocabulary_directory' to 'directory_path' ([link](https://allenai.github.io/allennlp-docs/api/allennlp.data.vocabulary.html#allennlp.data.vocabulary.Vocabulary.from_params))