### PR TITLE
Add support for configurable vocabulary extension

### DIFF
--- a/allennlp/commands/fine_tune.py
+++ b/allennlp/commands/fine_tune.py
@@ -21,7 +21,6 @@ from allennlp.models import load_archive, archive_model
 from allennlp.models.archival import CONFIG_NAME
 from allennlp.models.model import Model, _DEFAULT_WEIGHTS
 from allennlp.training.trainer import Trainer
-from allennlp.data import Vocabulary
 from allennlp.common.checks import ConfigurationError
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -166,11 +165,11 @@ def fine_tune_model(model: Model,
             raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {dataset}")
 
     logger.info("Extending model vocabulary using %s data.", ", ".join(datasets_for_vocab_creation))
-    vocab = Vocabulary.from_params(vocabulary_params,
-                                   (instance for key, dataset in all_datasets.items()
-                                    for instance in dataset
-                                    if key in datasets_for_vocab_creation),
-                                   model.vocab)
+    vocab = model.vocab
+    vocab.extend_from_instances(vocabulary_params,
+                                (instance for key, dataset in all_datasets.items()
+                                 for instance in dataset
+                                 if key in datasets_for_vocab_creation))
     vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
 
     iterator = DataIterator.from_params(params.pop("iterator"))

--- a/allennlp/commands/fine_tune.py
+++ b/allennlp/commands/fine_tune.py
@@ -21,6 +21,8 @@ from allennlp.models import load_archive, archive_model
 from allennlp.models.archival import CONFIG_NAME
 from allennlp.models.model import Model, _DEFAULT_WEIGHTS
 from allennlp.training.trainer import Trainer
+from allennlp.data import Vocabulary
+from allennlp.common.checks import ConfigurationError
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -149,17 +151,30 @@ def fine_tune_model(model: Model,
         logger.warning("You passed parameters for the model in your configuration file, but we "
                        "are ignoring them, using instead the model parameters in the archive.")
 
-    if params.pop('vocabulary', None):
-        logger.warning("You passed parameters for the vocabulary in your configuration file, but "
-                       "we are ignoring them, using instead the vocabulary from the saved model.")
+    vocabulary_params = params.pop('vocabulary', {})
+    if vocabulary_params.get('directory_path', None):
+        logger.warning("You passed `directory_path` in parameters for the vocabulary in "
+                       "your configuration file, but it will be ignored. "
+                       "Vocabulary from the saved model will be extended with current data.")
 
-    vocab = model.vocab
+    all_datasets = datasets_from_params(params)
+
+    datasets_for_vocab_creation = set(params.pop("datasets_for_vocab_creation", all_datasets))
+
+    for dataset in datasets_for_vocab_creation:
+        if dataset not in all_datasets:
+            raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {dataset}")
+
+    logger.info("Extending model vocabulary using %s data.", ", ".join(datasets_for_vocab_creation))
+    vocab = Vocabulary.from_params(vocabulary_params,
+                                   (instance for key, dataset in all_datasets.items()
+                                    for instance in dataset
+                                    if key in datasets_for_vocab_creation),
+                                   model.vocab)
     vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
 
     iterator = DataIterator.from_params(params.pop("iterator"))
     iterator.index_with(vocab)
-
-    all_datasets = datasets_from_params(params)
 
     train_data = all_datasets['train']
     validation_data = all_datasets.get('validation')

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -429,14 +429,13 @@ class Vocabulary:
 
         if counter is not None:
             # Make sure vocabulary extension is safe.
-            # Common named namespaces must have same setting for padded=True/False
-            tob_added_namespaces = list(counter.keys())
-            existing_namespaces = self.get_all_namespaces()
-            for namespace in tob_added_namespaces:
-                if namespace in existing_namespaces:
-                    existing_namespace_padded = namespace in self._non_padded_namespaces
-                    tob_added_namespace_padded = namespace in non_padded_namespaces
-                    if existing_namespace_padded != tob_added_namespace_padded:
+            for namespace in counter:
+                if namespace in self.get_all_namespaces():
+                    # if new namespace was already present
+                    # Either both should be padded or none should be.
+                    original_padded = namespace not in self._non_padded_namespaces
+                    extension_padded = namespace not in non_padded_namespaces
+                    if original_padded != extension_padded:
                         raise ConfigurationError("Common namespace {} has conflicting ".format(namespace)+
                                                  "setting of padded = True/False. "+
                                                  "Hence extension cannot be done.")

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -47,8 +47,8 @@ class _NamespaceDependentDefaultDict(defaultdict):
     Parameters
     ----------
     non_padded_namespaces : ``Iterable[str]``
-        A set of strings describing which namespaces are not padded.  If a namespace (key)
-        is missing from this dictionary, we will use :func:`namespace_match` to see whether
+        A set / list / tuple of strings describing which namespaces are not padded.  If a namespace
+        (key) is missing from this dictionary, we will use :func:`namespace_match` to see whether
         the namespace should be padded.  If the given namespace matches any of the strings in this
         list, we will use ``non_padded_function`` to initialize the value for that namespace, and
         we will use ``padded_function`` otherwise.

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -76,8 +76,9 @@ class _NamespaceDependentDefaultDict(defaultdict):
         dict.__setitem__(self, key, value)
         return value
 
-    def add_non_padded_namespaces(self, namespaces: Sequence[str]):
-        self._non_padded_namespaces.extend(namespaces)
+    def add_non_padded_namespaces(self, non_padded_namespaces: Sequence[str]):
+        # add non_padded_namespaces which weren't already present
+        self._non_padded_namespaces.extend(non_padded_namespaces)
         self._non_padded_namespaces = list(set(self._non_padded_namespaces))
 
 class _TokenToIndexDefaultDict(_NamespaceDependentDefaultDict):
@@ -177,13 +178,6 @@ class Vocabulary:
         If given, this is a list of tokens to add to the vocabulary, keyed by the namespace to add
         the tokens to.  This is a way to be sure that certain items appear in your vocabulary,
         regardless of any other vocabulary computation.
-    extend_vocab : Vocabulary, optional
-        If ``extend_vocab`` is passed, ``counter`` and ``tokens_to_add`` dictionary will be used to
-        extend the ``extend_vocab`` and that will be returned vocabaulary. If ``counter`` is None
-        and ``extend_vocab`` is passed, ``extend_vocab`` with extension of ``tokens_to_add`` will be
-        returned vocabulary. If ``counter`` and ``tokens_to_add`` are None and ``extend_vocab`` is
-        passed, only ``extend_vocab`` will be returned vocabulary. If ``extend_vocab`` is None,
-        vocabulary will be build out of ``counter`` and ``tokens_to_add``.
     """
     def __init__(self,
                  counter: Dict[str, Dict[str, int]] = None,
@@ -192,72 +186,24 @@ class Vocabulary:
                  non_padded_namespaces: Sequence[str] = DEFAULT_NON_PADDED_NAMESPACES,
                  pretrained_files: Optional[Dict[str, str]] = None,
                  only_include_pretrained_words: bool = False,
-                 tokens_to_add: Dict[str, List[str]] = None,
-                 extend_vocab=None) -> None:
-                 # extend_vocab: Vocabulary = None doest not work. Suggestions?
+                 tokens_to_add: Dict[str, List[str]] = None) -> None:
         self._padding_token = DEFAULT_PADDING_TOKEN
         self._oov_token = DEFAULT_OOV_TOKEN
-        if not isinstance(max_vocab_size, dict):
-            int_max_vocab_size = max_vocab_size
-            max_vocab_size = defaultdict(lambda: int_max_vocab_size)  # type: ignore
-        if not extend_vocab:
-            self._non_padded_namespaces = non_padded_namespaces
-            self._token_to_index = _TokenToIndexDefaultDict(non_padded_namespaces,
-                                                            self._padding_token,
-                                                            self._oov_token)
-            self._index_to_token = _IndexToTokenDefaultDict(non_padded_namespaces,
-                                                            self._padding_token,
-                                                            self._oov_token)
-        else:
-            incompatible_padding_or_oov_token = self._padding_token != extend_vocab.get_padding_token() \
-                                                or self._oov_token != extend_vocab.get_oov_token()
-            if incompatible_padding_or_oov_token:
-                raise ConfigurationError("Incompatible padding and/or oov_token")
-            dataset_namespaces = list(counter.keys())
-            extend_vocab_namespaces = extend_vocab.get_all_namespaces()
-            for namespace in extend_vocab_namespaces:
-                if namespace in dataset_namespaces:
-                    instances_padding = namespace in non_padded_namespaces
-                    extend_vocab_padding = namespace in extend_vocab.get_non_padded_namespaces()
-                    namespace_padding_combatible = (instances_padding == extend_vocab_padding)
-                    if not namespace_padding_combatible:
-                        raise ConfigurationError("For {} namespace extend_vocab has ".format(namespace)+
-                                                 "padding: {} but dataset instances ".format(extend_vocab_padding)+
-                                                 "have padding: {}. ".format(instances_padding)+
-                                                 "For extension compatibility both should be same.")
-            self._non_padded_namespaces = list(set(list(extend_vocab.get_non_padded_namespaces())
-                                                   +list(non_padded_namespaces)))
-            self._token_to_index = extend_vocab.get_token_to_index()
-            self._index_to_token = extend_vocab.get_index_to_token()
-            self._token_to_index.add_non_padded_namespaces(non_padded_namespaces)
-            self._index_to_token.add_non_padded_namespaces(non_padded_namespaces)
-        min_count = min_count or {}
-        pretrained_files = pretrained_files or {}
-        if counter is not None:
-            for namespace in counter:
-                if namespace in pretrained_files:
-                    pretrained_list = _read_pretrained_tokens(pretrained_files[namespace])
-                else:
-                    pretrained_list = None
-                token_counts = list(counter[namespace].items())
-                token_counts.sort(key=lambda x: x[1], reverse=True)
-                max_vocab = max_vocab_size[namespace]
-                if max_vocab:
-                    token_counts = token_counts[:max_vocab]
-                for token, count in token_counts:
-                    if pretrained_list is not None:
-                        if only_include_pretrained_words:
-                            if token in pretrained_list and count >= min_count.get(namespace, 1):
-                                self.add_token_to_namespace(token, namespace)
-                        elif token in pretrained_list or count >= min_count.get(namespace, 1):
-                            self.add_token_to_namespace(token, namespace)
-                    elif count >= min_count.get(namespace, 1):
-                        self.add_token_to_namespace(token, namespace)
-
-        if tokens_to_add:
-            for namespace, tokens in tokens_to_add.items():
-                for token in tokens:
-                    self.add_token_to_namespace(token, namespace)
+        self._non_padded_namespaces = list(non_padded_namespaces)
+        self._token_to_index = _TokenToIndexDefaultDict(non_padded_namespaces,
+                                                        self._padding_token,
+                                                        self._oov_token)
+        self._index_to_token = _IndexToTokenDefaultDict(non_padded_namespaces,
+                                                        self._padding_token,
+                                                        self._oov_token)
+        # Made an empty vocabulary, now extend it.
+        self.extend(counter,
+                    min_count,
+                    max_vocab_size,
+                    non_padded_namespaces,
+                    pretrained_files,
+                    only_include_pretrained_words,
+                    tokens_to_add)
 
     def save_to_files(self, directory: str) -> None:
         """
@@ -375,8 +321,7 @@ class Vocabulary:
                        non_padded_namespaces: Sequence[str] = DEFAULT_NON_PADDED_NAMESPACES,
                        pretrained_files: Optional[Dict[str, str]] = None,
                        only_include_pretrained_words: bool = False,
-                       tokens_to_add: Dict[str, List[str]] = None,
-                       extend_vocab=None) -> 'Vocabulary':
+                       tokens_to_add: Dict[str, List[str]] = None) -> 'Vocabulary':
         """
         Constructs a vocabulary given a collection of `Instances` and some parameters.
         We count all of the vocabulary items in the instances, then pass those counts
@@ -387,27 +332,25 @@ class Vocabulary:
         namespace_token_counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
         for instance in Tqdm.tqdm(instances):
             instance.count_vocab_items(namespace_token_counts)
+
         return Vocabulary(counter=namespace_token_counts,
                           min_count=min_count,
                           max_vocab_size=max_vocab_size,
                           non_padded_namespaces=non_padded_namespaces,
                           pretrained_files=pretrained_files,
                           only_include_pretrained_words=only_include_pretrained_words,
-                          tokens_to_add=tokens_to_add,
-                          extend_vocab=extend_vocab)
+                          tokens_to_add=tokens_to_add)
 
     @classmethod
-    def from_params(cls,
-                    params: Params,
-                    instances: Iterable['adi.Instance'] = None,
-                    extend_vocab=None):
-                   # extend_vocab: Vocabulary = None doest not work. Suggestions?
+    def from_params(cls, params: Params, instances: Iterable['adi.Instance'] = None):
         """
         There are two possible ways to build a vocabulary; from a
         collection of instances, using :func:`Vocabulary.from_instances`, or
         from a pre-saved vocabulary, using :func:`Vocabulary.from_files`.
-        This method wraps both of these options, allowing their specification
-        from a ``Params`` object, generated from a JSON configuration file.
+        You can also extend pre-saved vocabulary with collection of instances
+        using this method. This method wraps these options, allowing their
+        specification from a ``Params`` object, generated from a JSON
+        configuration file.
 
         Parameters
         ----------
@@ -420,37 +363,35 @@ class Vocabulary:
             one loaded from ``directory_path``. If ``extend`` key is set True,
             dataset instances will be used to extend the vocabulary loaded
             from ``directory_path`` and that will be final vocabulary used.
-        extend_vocab: Vocabulary, optional
-            If ``extend_vocab`` is passed, dataset instances will be used to
-            extend the ``extend_vocab`` and that will be final vocabaulary
-            used. If ``directory_path`` key is present in ``params`` it will
-            be ignored. ``extend_vocab`` overrides it.
+
         Returns
         -------
         A ``Vocabulary``.
         """
-        if not extend_vocab:
-            vocabulary_directory = params.pop("directory_path", None)
-            extend = params.pop("extend", False)
-            vocab = None
-            if not vocabulary_directory and not instances:
-                raise ConfigurationError("You must provide either a Params object containing a "
-                                         "vocab_directory key or a Dataset to build a vocabulary from.")
-            if extend and not instances:
-                raise ConfigurationError("extend is true but there are not instances passed to extend to")
-            if extend and not vocabulary_directory:
-                raise ConfigurationError("extend is true but there is not directory_path to extend from")
-            if vocabulary_directory and instances:
-                if not extend:
-                    logger.info("Loading Vocab from files instead of dataset.")
-                else:
-                    logger.info("Loading Vocab from files and extending with dataset.")
-            if vocabulary_directory:
-                vocab = Vocabulary.from_files(vocabulary_directory)
-                if not extend:
-                    params.assert_empty("Vocabulary - from files")
-                    return vocab
-                extend_vocab = vocab
+        extend = params.pop("extend", False)
+        vocabulary_directory = params.pop("directory_path", None)
+        if not vocabulary_directory and not instances:
+            raise ConfigurationError("You must provide either a Params object containing a "
+                                     "vocab_directory key or a Dataset to build a vocabulary from.")
+        if extend and not instances:
+            raise ConfigurationError("'extend' is true but there are not instances passed to extend.")
+        if extend and not vocabulary_directory:
+            raise ConfigurationError("'extend' is true but there is not 'directory_path' to extend from.")
+
+        if vocabulary_directory and instances:
+            if extend:
+                logger.info("Loading Vocab from files and extending it with dataset.")
+            else:
+                logger.info("Loading Vocab from files instead of dataset.")
+
+        if vocabulary_directory:
+            vocab = Vocabulary.from_files(vocabulary_directory)
+            if not extend:
+                params.assert_empty("Vocabulary - from files")
+                return vocab
+        if extend:
+            vocab.extend_from_instances(params, instances=instances)
+            return vocab
         min_count = params.pop("min_count", None)
         max_vocab_size = params.pop_int("max_vocab_size", None)
         non_padded_namespaces = params.pop("non_padded_namespaces", DEFAULT_NON_PADDED_NAMESPACES)
@@ -464,8 +405,113 @@ class Vocabulary:
                                          non_padded_namespaces=non_padded_namespaces,
                                          pretrained_files=pretrained_files,
                                          only_include_pretrained_words=only_include_pretrained_words,
-                                         tokens_to_add=tokens_to_add,
-                                         extend_vocab=extend_vocab)
+                                         tokens_to_add=tokens_to_add)
+
+    def extend(self,
+               counter: Dict[str, Dict[str, int]] = None,
+               min_count: Dict[str, int] = None,
+               max_vocab_size: Union[int, Dict[str, int]] = None,
+               non_padded_namespaces: Sequence[str] = DEFAULT_NON_PADDED_NAMESPACES,
+               pretrained_files: Optional[Dict[str, str]] = None,
+               only_include_pretrained_words: bool = False,
+               tokens_to_add: Dict[str, List[str]] = None) -> None:
+        """
+        This method can be used for extending already generated vocabulary.
+        It takes same parameters as Vocabulary initializer. The token2index
+        and indextotoken mappings of calling vocabulary will be retained.
+        It is an inplace operation so None will be returned.
+        """
+        if not isinstance(max_vocab_size, dict):
+            int_max_vocab_size = max_vocab_size
+            max_vocab_size = defaultdict(lambda: int_max_vocab_size)  # type: ignore
+        min_count = min_count or {}
+        pretrained_files = pretrained_files or {}
+
+        if counter is not None:
+            # Make sure vocabulary extension is safe.
+            # Common named namespaces must have same setting for padded=True/False
+            tob_added_namespaces = list(counter.keys())
+            existing_namespaces = self.get_all_namespaces()
+            for namespace in tob_added_namespaces:
+                if namespace in existing_namespaces:
+                    existing_namespace_padded = namespace in self._non_padded_namespaces
+                    tob_added_namespace_padded = namespace in non_padded_namespaces
+                    if existing_namespace_padded != tob_added_namespace_padded:
+                        raise ConfigurationError("Common namespace {} has conflicting ".format(namespace)+
+                                                 "setting of padded = True/False. "+
+                                                 "Hence extension cannot be done.")
+            # Add new non-padded namespaces for extension
+            self.add_non_padded_namespaces(non_padded_namespaces)
+
+            for namespace in counter:
+                if namespace in pretrained_files:
+                    pretrained_list = _read_pretrained_tokens(pretrained_files[namespace])
+                else:
+                    pretrained_list = None
+                token_counts = list(counter[namespace].items())
+                token_counts.sort(key=lambda x: x[1], reverse=True)
+                max_vocab = max_vocab_size[namespace]
+                if max_vocab:
+                    token_counts = token_counts[:max_vocab]
+                for token, count in token_counts:
+                    if pretrained_list is not None:
+                        if only_include_pretrained_words:
+                            if token in pretrained_list and count >= min_count.get(namespace, 1):
+                                self.add_token_to_namespace(token, namespace)
+                        elif token in pretrained_list or count >= min_count.get(namespace, 1):
+                            self.add_token_to_namespace(token, namespace)
+                    elif count >= min_count.get(namespace, 1):
+                        self.add_token_to_namespace(token, namespace)
+
+        if tokens_to_add:
+            for namespace, tokens in tokens_to_add.items():
+                for token in tokens:
+                    self.add_token_to_namespace(token, namespace)
+
+    def extend_from_instances(self,
+                              params: Params,
+                              instances: Iterable['adi.Instance'] = ()) -> None:
+        """
+        This method can be used for extending already generated vocabulary
+        from collection of instances. It is a wrapped around ``extend`` method.
+        """
+        min_count = params.pop("min_count", None)
+        max_vocab_size = params.pop_int("max_vocab_size", None)
+        non_padded_namespaces = params.pop("non_padded_namespaces", DEFAULT_NON_PADDED_NAMESPACES)
+        pretrained_files = params.pop("pretrained_files", {})
+        only_include_pretrained_words = params.pop_bool("only_include_pretrained_words", False)
+        tokens_to_add = params.pop("tokens_to_add", None)
+        params.assert_empty("Vocabulary - from dataset")
+
+        logger.info("Fitting token dictionary from dataset.")
+        namespace_token_counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        for instance in Tqdm.tqdm(instances):
+            instance.count_vocab_items(namespace_token_counts)
+        self.extend(counter=namespace_token_counts,
+                    min_count=min_count,
+                    max_vocab_size=max_vocab_size,
+                    non_padded_namespaces=non_padded_namespaces,
+                    pretrained_files=pretrained_files,
+                    only_include_pretrained_words=only_include_pretrained_words,
+                    tokens_to_add=tokens_to_add)
+
+    def add_non_padded_namespaces(self, non_padded_namespaces: Sequence[str]):
+        self._token_to_index.add_non_padded_namespaces(non_padded_namespaces)
+        self._index_to_token.add_non_padded_namespaces(non_padded_namespaces)
+        self._non_padded_namespaces.extend(non_padded_namespaces)
+        self._non_padded_namespaces = list(set(self._non_padded_namespaces))
+
+    def get_all_namespaces(self) -> List[str]:
+        return list(self._token_to_index.keys())
+
+    def get_non_padded_namespaces(self) -> List[str]:
+        return list(self._non_padded_namespaces)
+
+    def get_token_to_index(self) -> Dict[str, Dict[str, int]]:
+        return self._token_to_index
+
+    def get_index_to_token(self) -> Dict[str, Dict[int, str]]:
+        return self._index_to_token
 
     def is_padded(self, namespace: str) -> bool:
         """
@@ -511,24 +557,6 @@ class Vocabulary:
 
     def get_vocab_size(self, namespace: str = 'tokens') -> int:
         return len(self._token_to_index[namespace])
-
-    def get_non_padded_namespaces(self) -> List[str]:
-        return list(self._non_padded_namespaces)
-
-    def get_all_namespaces(self) -> List[str]:
-        return list(self._token_to_index.keys())
-
-    def get_token_to_index(self) -> Dict[str, Dict[str, int]]:
-        return self._token_to_index
-
-    def get_index_to_token(self) -> Dict[str, Dict[int, str]]:
-        return self._index_to_token
-
-    def get_oov_token(self) -> str:
-        return self._oov_token
-
-    def get_padding_token(self) -> str:
-        return self._padding_token
 
     def __eq__(self, other):
         if isinstance(self, other.__class__):

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -177,6 +177,13 @@ class Vocabulary:
         If given, this is a list of tokens to add to the vocabulary, keyed by the namespace to add
         the tokens to.  This is a way to be sure that certain items appear in your vocabulary,
         regardless of any other vocabulary computation.
+    extend_vocab : Vocabulary, optional
+        If ``extend_vocab`` is passed, ``counter`` and ``tokens_to_add`` dictionary will be used to
+        extend the ``extend_vocab`` and that will be returned vocabaulary. If ``counter`` is None
+        and ``extend_vocab`` is passed, ``extend_vocab`` with extension of ``tokens_to_add`` will be
+        returned vocabulary. If ``counter`` and ``tokens_to_add`` are None and ``extend_vocab`` is
+        passed, only ``extend_vocab`` will be returned vocabulary. If ``extend_vocab`` is None,
+        vocabulary will be build out of ``counter`` and ``tokens_to_add``.
     """
     def __init__(self,
                  counter: Dict[str, Dict[str, int]] = None,
@@ -210,11 +217,14 @@ class Vocabulary:
             extend_vocab_namespaces = extend_vocab.get_all_namespaces()
             for namespace in extend_vocab_namespaces:
                 if namespace in dataset_namespaces:
-                    namespace_padding_combatible = (namespace in non_padded_namespaces) \
-                                                    == (namespace in extend_vocab.get_non_padded_namespaces())
+                    instances_padding = namespace in non_padded_namespaces
+                    extend_vocab_padding = namespace in extend_vocab.get_non_padded_namespaces()
+                    namespace_padding_combatible = (instances_padding == extend_vocab_padding)
                     if not namespace_padding_combatible:
-                        raise ConfigurationError("Padding (padded/non-padded) setting is not compatible"
-                                                 " for {} namespace".format(namespace))
+                        raise ConfigurationError("For {} namespace extend_vocab has ".format(namespace)+
+                                                 "padding: {} but dataset instances ".format(extend_vocab_padding)+
+                                                 "have padding: {}. ".format(instances_padding)+
+                                                 "For extension compatibility both should be same.")
             self._non_padded_namespaces = list(set(list(extend_vocab.get_non_padded_namespaces())
                                                    +list(non_padded_namespaces)))
             self._token_to_index = extend_vocab.get_token_to_index()

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -439,8 +439,10 @@ class Vocabulary:
                 if namespace in self.get_all_namespaces():
                     # if new namespace was already present
                     # Either both should be padded or none should be.
-                    original_padded = namespace not in self._non_padded_namespaces
-                    extension_padded = namespace not in non_padded_namespaces
+                    original_padded = not any(namespace_match(pattern, namespace)
+                                              for pattern in self._non_padded_namespaces)
+                    extension_padded = not any(namespace_match(pattern, namespace)
+                                               for pattern in non_padded_namespaces)
                     if original_padded != extension_padded:
                         raise ConfigurationError("Common namespace {} has conflicting ".format(namespace)+
                                                  "setting of padded = True/False. "+

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -310,6 +310,198 @@ class TestVocabulary(AllenNlpTestCase):
                                                                  2: 'a', 3: 'c', 4: 'b',
                                                                  5: 'q', 6: 'x', 7: 'z'}
 
+    def test_from_params_extend_config_and_direct_extend_vocab(self):
+
+        vocab_dir = self.TEST_DIR / 'vocab_save'
+        original_vocab = Vocabulary(non_padded_namespaces=["tokens"])
+        original_vocab.add_token_to_namespace("a", namespace="tokens")
+        original_vocab.save_to_files(vocab_dir)
+
+        text_field = TextField([Token(t) for t in ["a", "b"]],
+                               {"tokens": SingleIdTokenIndexer("tokens")})
+        instances = Batch([Instance({"text": text_field})])
+
+        # If you ask to extend vocab from `directory_path`, instances must be passed
+        # in Vocabulary constructor, or else there is nothing to extend to.
+        params = Params({"directory_path": vocab_dir, "extend": True})
+        with pytest.raises(ConfigurationError):
+            _ = Vocabulary.from_params(params)
+
+        # If you ask to extend vocab, `directory_path` key must be present in params,
+        # rr else there is nothing to extend from.
+        params = Params({"extend": True})
+        with pytest.raises(ConfigurationError):
+            _ = Vocabulary.from_params(params, instances)
+
+        original_vocab = Vocabulary()
+        original_vocab.add_token_to_namespace("d", namespace="tokens") # index2
+        original_vocab.add_token_to_namespace("a", namespace="tokens") # index3
+        original_vocab.add_token_to_namespace("b", namespace="tokens") # index4
+
+        text_field = TextField([Token(t) for t in ["a", "d", "c", "e"]],
+                               {"tokens": SingleIdTokenIndexer("tokens")})
+        instances = Batch([Instance({"text": text_field})])
+
+        extended_vocab = Vocabulary.from_params(Params({}), instances, original_vocab)
+
+        assert extended_vocab.get_token_index("d", "tokens") == 2
+        assert extended_vocab.get_token_index("a", "tokens") == 3
+        assert extended_vocab.get_token_index("b", "tokens") == 4
+        assert extended_vocab.get_vocab_size("tokens") == 7 # 5+oov+pad
+
+    def test_from_params_vocab_extension(self):
+        ## Tests for Invalid Vocab Extension:
+        vocab_dir = self.TEST_DIR / 'vocab_save'
+        original_vocab = Vocabulary(non_padded_namespaces=["tokens1"])
+        original_vocab.add_token_to_namespace("a", namespace="tokens1")
+        original_vocab.add_token_to_namespace("b", namespace="tokens1")
+        original_vocab.add_token_to_namespace("p", namespace="tokens2")
+        original_vocab.save_to_files(vocab_dir)
+
+        text_field1 = TextField([Token(t) for t in ["a" "c"]],
+                                {"tokens1": SingleIdTokenIndexer("tokens1")})
+        text_field2 = TextField([Token(t) for t in ["p", "q", "r"]],
+                                {"tokens2": SingleIdTokenIndexer("tokens2")})
+        instances = Batch([Instance({"text1": text_field1, "text2": text_field2})])
+
+        # Following should give error: token1 is non-padded in original_vocab but not in instances
+        params = Params({"directory_path": vocab_dir, "extend": True,
+                         "non_padded_namespaces": []})
+        with pytest.raises(ConfigurationError):
+            _ = Vocabulary.from_params(params, instances)
+
+        # Following should not give error: overlapping namespaces have same padding behaviour
+        params = Params({"directory_path": vocab_dir, "extend": True,
+                         "non_padded_namespaces": ["tokens1"]})
+        Vocabulary.from_params(params, instances)
+
+        # # Following should give error: token1 is padded in instances but not in original_vocab
+        params = Params({"directory_path": vocab_dir, "extend": True,
+                         "non_padded_namespaces": ["tokens1", "tokens2"]})
+        with pytest.raises(ConfigurationError):
+            _ = Vocabulary.from_params(params, instances)
+
+        ## Tests for Valid Vocab Extension:
+        # Vocab extension is valid when overlapping namespaces have same padding behaviour (padded/non-padded)
+        # Summary of namespace paddings in this test
+        # original_vocab namespaces
+        #     tokens0     padded
+        #     tokens1     non-padded
+        #     tokens2     padded
+        #     tokens3     non-padded
+        # instances namespaces
+        #     tokens0     padded
+        #     tokens1     non-padded
+        #     tokens4     padded
+        #     tokens5     non-padded
+        #
+        # TypicalExtention example: (of tokens1 namespace)
+        # -> original_vocab index2token
+        #    apple          #0->apple
+        #    bat            #1->bat
+        #    cat            #2->cat
+        #
+        # -> Token to be extended with: cat, an, apple, banana, atom, bat
+        #
+        # -> extended_vocab: index2token
+        #    apple           #0->apple
+        #    bat             #1->bat
+        #    cat             #2->cat
+        #    an              #3->an
+        #    atom            #4->atom
+        #    banana          #5->banana
+
+        vocab_dir = self.TEST_DIR / 'vocab_save'
+        original_vocab = Vocabulary(non_padded_namespaces=["tokens1", "tokens3"])
+        original_vocab.add_token_to_namespace("apple", namespace="tokens0") # index:2
+        original_vocab.add_token_to_namespace("bat", namespace="tokens0")   # index:3
+        original_vocab.add_token_to_namespace("cat", namespace="tokens0")   # index:4
+
+        original_vocab.add_token_to_namespace("apple", namespace="tokens1") # index:0
+        original_vocab.add_token_to_namespace("bat", namespace="tokens1")   # index:1
+        original_vocab.add_token_to_namespace("cat", namespace="tokens1")   # index:2
+
+        original_vocab.add_token_to_namespace("a", namespace="tokens2") # index:0
+        original_vocab.add_token_to_namespace("b", namespace="tokens2") # index:1
+        original_vocab.add_token_to_namespace("c", namespace="tokens2") # index:2
+
+        original_vocab.add_token_to_namespace("p", namespace="tokens3") # index:0
+        original_vocab.add_token_to_namespace("q", namespace="tokens3") # index:1
+
+        original_vocab.save_to_files(vocab_dir)
+
+        text_field0 = TextField([Token(t) for t in ["cat", "an", "apple", "banana", "atom", "bat"]],
+                                {"tokens0": SingleIdTokenIndexer("tokens0")})
+        text_field1 = TextField([Token(t) for t in ["cat", "an", "apple", "banana", "atom", "bat"]],
+                                {"tokens1": SingleIdTokenIndexer("tokens1")})
+        text_field4 = TextField([Token(t) for t in ["l", "m", "n", "o"]],
+                                {"tokens4": SingleIdTokenIndexer("tokens4")})
+        text_field5 = TextField([Token(t) for t in ["x", "y", "z"]],
+                                {"tokens5": SingleIdTokenIndexer("tokens5")})
+        instances = Batch([Instance({"text0": text_field0, "text1": text_field1,
+                                     "text4": text_field4, "text5": text_field5})])
+
+        params = Params({"directory_path": vocab_dir,
+                         "extend": True,
+                         "non_padded_namespaces": ["tokens1", "tokens5"]})
+        extended_vocab = Vocabulary.from_params(params, instances)
+
+        # namespaces: tokens0, tokens1 is common.
+        # tokens2, tokens3 only vocab has. tokens4, tokens5 only instances
+        assert set(extended_vocab.get_token_to_index().keys()) \
+                   == set(["tokens{}".format(i) for i in range(6)])
+
+        # # Check that _non_padded_namespaces list is consistent after extension
+        assert set(extended_vocab.get_non_padded_namespaces()) \
+                   == set(["tokens1", "tokens3", "tokens5"])
+
+        # # original_vocab["tokens1"] has 3 tokens, instances of "tokens1" ns has 5 tokens. 2 overlapping
+        assert extended_vocab.get_vocab_size("tokens1") == 6
+        assert extended_vocab.get_vocab_size("tokens0") == 8 # 2 extra overlapping because padded
+
+        # namespace tokens3, tokens4 was only in original_vocab,
+        # and its token count should be same in extended_vocab
+        assert extended_vocab.get_vocab_size("tokens2") == original_vocab.get_vocab_size("tokens2")
+        assert extended_vocab.get_vocab_size("tokens3") == original_vocab.get_vocab_size("tokens3")
+
+        # namespace tokens2 was only in instances,
+        # and its token count should be same in extended_vocab
+        assert extended_vocab.get_vocab_size("tokens4") == 6 # l,m,n,o + oov + padding
+        assert extended_vocab.get_vocab_size("tokens5") == 3 # x,y,z
+
+        # Word2index mapping of all words in all namespaces of original_vocab
+        # should be maintained in extended_vocab
+        for namespace, token2index in original_vocab.get_token_to_index().items():
+            for token, _ in token2index.items():
+                vocab_index = original_vocab.get_token_index(token, namespace)
+                extended_vocab_index = extended_vocab.get_token_index(token, namespace)
+                assert vocab_index == extended_vocab_index
+        # And same for Index2Word mapping
+        for namespace, index2token in original_vocab.get_index_to_token().items():
+            for index, _ in index2token.items():
+                vocab_token = original_vocab.get_token_from_index(index, namespace)
+                extended_vocab_token = extended_vocab.get_token_from_index(index, namespace)
+                assert vocab_token == extended_vocab_token
+
+        # Manual Print Check
+        # original_vocab._token_to_index :>
+        # {
+        #   "tokens0": {"@@PADDING@@":0,"@@UNKNOWN@@":1,"apple":2,"bat":3,"cat":4},
+        #   "tokens1": {"apple": 0,"bat":1,"cat":2},
+        #   "tokens2": {"@@PADDING@@":0,"@@UNKNOWN@@":1,"a":2,"b":3,"c": 4},
+        #   "tokens3": {"p":0,"q":1}
+        # }
+        # extended_vocab._token_to_index :>
+        # {
+        #   "tokens0": {"@@PADDING@@": 0,"@@UNKNOWN@@": 1,
+        #               "apple": 2,"bat": 3,"cat": 4,"an": 5,"banana": 6,"atom": 7},
+        #   "tokens1": {"apple": 0,"bat": 1,"cat": 2,"an": 3,"banana": 4,"atom": 5},
+        #   "tokens2": {"@@PADDING@@": 0,"@@UNKNOWN@@": 1,"a": 2,"b": 3,"c": 4},
+        #   "tokens3": {"p": 0,"q": 1},
+        #   "tokens4": {"@@PADDING@@": 0,"@@UNKNOWN@@": 1,"l": 2,"m": 3,"n": 4,"o": 5},
+        #   "tokens5": {"x": 0,"y": 1,"z": 2}
+        # }
+
     def test_vocab_can_print(self):
         vocab = Vocabulary(non_padded_namespaces=["a", "c"])
         vocab.add_token_to_namespace("a0", namespace="a")

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -227,7 +227,7 @@ class TestVocabulary(AllenNlpTestCase):
         vocab.save_to_files(vocab_dir)
         vocab2 = Vocabulary.from_files(vocab_dir)
 
-        assert vocab2._non_padded_namespaces == ["a", "c"]
+        assert vocab2._non_padded_namespaces == {"a", "c"}
 
         # Check namespace a.
         assert vocab2.get_vocab_size(namespace='a') == 3
@@ -508,12 +508,12 @@ class TestVocabulary(AllenNlpTestCase):
 
         # namespaces: tokens0, tokens1 is common.
         # tokens2, tokens3 only vocab has. tokens4, tokens5 only instances
-        assert set(extended_vocab.get_all_namespaces()) \
-                   == set(["tokens{}".format(i) for i in range(6)])
+        assert extended_vocab.get_all_namespaces() \
+                   == {"tokens{}".format(i) for i in range(6)}
 
         # # Check that _non_padded_namespaces list is consistent after extension
-        assert set(extended_vocab.get_non_padded_namespaces()) \
-                   == set(["tokens1", "tokens3", "tokens5"])
+        assert extended_vocab.get_non_padded_namespaces() \
+                   == {"tokens1", "tokens3", "tokens5"}
 
         # # original_vocab["tokens1"] has 3 tokens, instances of "tokens1" ns has 5 tokens. 2 overlapping
         assert extended_vocab.get_vocab_size("tokens1") == 6


### PR DESCRIPTION
Add full support for configurable vocabulary extension

1. Add general configurable support for vocabulary extension (essential for transfer learning scenarios, fine tuning).
2. Make fine-tune command extend the saved-model-vocabulary with current dataset instances by default rather than only banking on saved-model-vocabulary.
3. Add extensive test cases for new API. Check test-cases for more example usages.

## General Vocab Extension Support:
Api now allows toggle `extend` in vocabulary params to configure whether to use `directory_path` for extending vocabulary, or use it alone and ignore the the dataset. The current API only allows either to load vocabulary from directory or load from dataset instances. However, vocabulary extension is important for undertaking any kind of transfer learning, fine tuning etc.

**Example Usage:**

In the following case, vocabulary will be first loaded from `directory_path`, then all the tokens read by relevant datasetreader from dataset in this config file will be added onto this vocabulary. Index2word and word2index mapping of tokens in `directory_path` vocabulary will be retained in the extended final vocabulary. Hence models trained using `directory_path` vocabulary will continue to work with extended vocabulary as well. This setting can be used in `train` or even in `make-vocab` command.
```
"vocabulary": {
    "directory_path": "vocabulary_dir_path"
    "extend": true
}
```
In the following case, vocabulary will be first loaded from `directory_path`, and all the tokens read from dataset mentioned in experiment config file will be ignored. Note: Only this behavior was supported earlier. Since `extend` is by default False, it is fully backward compatible.
```
"vocabulary": {
    "directory_path": "vocabulary_dir_path"
    "extend": false
}
```
Vocab extension feature is very much essential for doing any kind of transfer learning properly. Generally one wants to fine-tune or transfer model parts to train on different dataset. Ideally, tokens from this dataset must contribute to vocabulary. Moreover, index mappings of original vocab must be retained in extended vocab because transferred modules were learning with those mappings.

With this feature in place and prevent-initialization support (#1405), one can easily handle wide range of transfer learning kind of scenarios with `train` command itself - what is supported by fine-tune being the simplest case. Will discuss this in separate issue/pr.

## Add vocab extension support in make-vocab and make it default 

Apart of allowing to pass `"extend": false/true` in vocab_params, this PR adds extra optional argument in Vocab.from_params: `extend_vocab: Vocabulary = None`. If `extend_vocab` is explicitly passed, then `extend_vocab` will be taken as starting vocabulary and words/tokens read by datasetreader will be added on to it. The word2index and index2token of mappings of tokens in `extend_vocab` will be retained in final `extended_vocab` output.

**Example Usage:**
```python
extended_vocab = Vocabulary.from_params(Params({}), instances, original_vocab)
```
This feature was specifically added to have vocab extension in `fine-tune` command. Instead of ignoring the tokens from dataset on which tuning is being done, it starts from `saved_model.vocab` and adds on newer dataset words/tokens without disrupting the index2token and token2index mappings. Retaining these mappings in extended vocabulary is essential for `saved_model` to work.

## Vocabulary extension details and examples:

If `original_vocab` is to be extended by tokens in `instances`, for each namespace:
1. If the namespace is in `original_vocab` and not in `instances`, then that namespace will be same in `extended_vocab` as `original_vocab`.
2. If the namespace is not in `original_vocab` and in `instances`, then that namespace will be created from `instances` as usual.
3. if the namespace is common between `original_vocab` and `instances`, then its padded / non-padded setting should be same for it to be extendable. Below is an example for a common namespace (non-padded):

**Example**:
```
#original_vocab index2token
apple           #0->apple
bat             #1->bat
cat             #2->cat
```
Token to be extended with: `cat, an, apple, banana, atom, bat` in same namespace.
```
#extended_vocab: index2token
apple           #0->apple
bat             #1->bat
cat             #2->cat
an              #3->an
atom            #4->atom
banana          #5->banana
```