### PR TITLE
Fix chdir in ModelTestCase breaking downstream models

### DIFF
--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -19,10 +19,6 @@ class ModelTestCase(AllenNlpTestCase):
     """
     def set_up_model(self, param_file, dataset_file):
         # pylint: disable=attribute-defined-outside-init
-        initial_working_dir = os.getcwd()
-        # Change directory to module root.
-        os.chdir(self.MODULE_ROOT)
-
         self.param_file = param_file
         params = Params.from_file(self.param_file)
 
@@ -44,17 +40,10 @@ class ModelTestCase(AllenNlpTestCase):
         self.dataset = Batch(self.instances)
         self.dataset.index_instances(self.vocab)
 
-        # Change directory back to what it was initially
-        os.chdir(initial_working_dir)
-
     def ensure_model_can_train_save_and_load(self,
                                              param_file: str,
                                              tolerance: float = 1e-4,
                                              cuda_device: int = -1):
-        initial_working_dir = os.getcwd()
-        # Change directory to module root.
-        os.chdir(self.MODULE_ROOT)
-
         save_dir = self.TEST_DIR / "save_and_load_test"
         archive_file = save_dir / "model.tar.gz"
         model = train_model_from_file(param_file, save_dir)
@@ -119,9 +108,6 @@ class ModelTestCase(AllenNlpTestCase):
                                      loaded_model_predictions[key],
                                      name=key,
                                      tolerance=tolerance)
-
-        # Change directory back to what it was initially
-        os.chdir(initial_working_dir)
 
         return model, loaded_model
 

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -1,5 +1,4 @@
 import copy
-import os
 
 from numpy.testing import assert_allclose
 import torch

--- a/allennlp/tests/commands/fine_tune_test.py
+++ b/allennlp/tests/commands/fine_tune_test.py
@@ -1,6 +1,5 @@
 # pylint: disable=invalid-name,no-self-use
 import argparse
-import os
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.commands.fine_tune import FineTune, fine_tune_model_from_file_paths, fine_tune_model_from_args

--- a/allennlp/tests/commands/fine_tune_test.py
+++ b/allennlp/tests/commands/fine_tune_test.py
@@ -18,21 +18,11 @@ class TestFineTune(AllenNlpTestCase):
 
 
     def test_fine_tune_model_runs_from_file_paths(self):
-        initial_working_dir = os.getcwd()
-        # Change directory to module root.
-        os.chdir(self.MODULE_ROOT)
-
         fine_tune_model_from_file_paths(model_archive_path=self.model_archive,
                                         config_file=self.config_file,
                                         serialization_dir=self.serialization_dir)
-        # Change directory back to what it was initially
-        os.chdir(initial_working_dir)
 
     def test_fine_tune_runs_from_parser_arguments(self):
-        initial_working_dir = os.getcwd()
-        # Change directory to module root.
-        os.chdir(self.MODULE_ROOT)
-
         raw_args = ["fine-tune",
                     "-m", self.model_archive,
                     "-c", self.config_file,
@@ -45,8 +35,6 @@ class TestFineTune(AllenNlpTestCase):
         assert args.config_file == self.config_file
         assert args.serialization_dir == self.serialization_dir
         fine_tune_model_from_args(args)
-        # Change directory back to what it was initially
-        os.chdir(initial_working_dir)
 
     def test_fine_tune_fails_without_required_args(self):
         # Configuration file is required.

--- a/allennlp/tests/common/params_test.py
+++ b/allennlp/tests/common/params_test.py
@@ -186,6 +186,8 @@ class TestParams(AllenNlpTestCase):
 
         del os.environ[key]
 
+    @pytest.mark.xfail(not os.path.exists(AllenNlpTestCase.PROJECT_ROOT / "training_config"),
+                       reason="Training configs not installed with pip")
     def test_known_configs(self):
         configs = os.listdir(self.PROJECT_ROOT / "training_config")
 

--- a/allennlp/tests/fixtures/biattentive_classification_network/broken_experiments/elmo_in_text_field_embedder.json
+++ b/allennlp/tests/fixtures/biattentive_classification_network/broken_experiments/elmo_in_text_field_embedder.json
@@ -14,8 +14,8 @@
       }
     }
   },
-  "train_data_path": "tests/fixtures/data/sst.txt",
-  "validation_data_path": "tests/fixtures/data/sst.txt",
+  "train_data_path": "allennlp/tests/fixtures/data/sst.txt",
+  "validation_data_path": "allennlp/tests/fixtures/data/sst.txt",
   "model": {
     "type": "bcn",
     "text_field_embedder": {
@@ -27,8 +27,8 @@
       # in their text_field_embedder
       "elmo": {
         "type": "elmo_token_embedder",
-        "options_file": "tests/fixtures/elmo/options.json",
-        "weight_file": "tests/fixtures/elmo/lm_weights.hdf5",
+        "options_file": "allennlp/tests/fixtures/elmo/options.json",
+        "weight_file": "allennlp/tests/fixtures/elmo/lm_weights.hdf5",
         "do_layer_norm": false,
         "dropout": 0.5
       }
@@ -55,8 +55,8 @@
     },
     "integrator_dropout": 0.2,
     "elmo": {
-      "options_file": "tests/fixtures/elmo/options.json",
-      "weight_file": "tests/fixtures/elmo/lm_weights.hdf5",
+      "options_file": "allennlp/tests/fixtures/elmo/options.json",
+      "weight_file": "allennlp/tests/fixtures/elmo/lm_weights.hdf5",
       "num_output_representations": 2,
       "do_layer_norm": false
     },

--- a/allennlp/tests/fixtures/biattentive_classification_network/broken_experiments/no_elmo_tokenizer_for_elmo.json
+++ b/allennlp/tests/fixtures/biattentive_classification_network/broken_experiments/no_elmo_tokenizer_for_elmo.json
@@ -15,8 +15,8 @@
     #   }
     # }
   },
-  "train_data_path": "tests/fixtures/data/sst.txt",
-  "validation_data_path": "tests/fixtures/data/sst.txt",
+  "train_data_path": "allennlp/tests/fixtures/data/sst.txt",
+  "validation_data_path": "allennlp/tests/fixtures/data/sst.txt",
   "model": {
     "type": "bcn",
     "text_field_embedder": {
@@ -47,8 +47,8 @@
     },
     "integrator_dropout": 0.2,
     "elmo": {
-      "options_file": "tests/fixtures/elmo/options.json",
-      "weight_file": "tests/fixtures/elmo/lm_weights.hdf5",
+      "options_file": "allennlp/tests/fixtures/elmo/options.json",
+      "weight_file": "allennlp/tests/fixtures/elmo/lm_weights.hdf5",
       "num_output_representations": 2,
       "do_layer_norm": false
     },

--- a/allennlp/tests/fixtures/biattentive_classification_network/elmo_experiment.json
+++ b/allennlp/tests/fixtures/biattentive_classification_network/elmo_experiment.json
@@ -12,8 +12,8 @@
       }
     }
   },
-  "train_data_path": "tests/fixtures/data/sst.txt",
-  "validation_data_path": "tests/fixtures/data/sst.txt",
+  "train_data_path": "allennlp/tests/fixtures/data/sst.txt",
+  "validation_data_path": "allennlp/tests/fixtures/data/sst.txt",
   "model": {
     "type": "bcn",
     "text_field_embedder": {
@@ -44,8 +44,8 @@
     },
     "integrator_dropout": 0.2,
     "elmo": {
-      "options_file": "tests/fixtures/elmo/options.json",
-      "weight_file": "tests/fixtures/elmo/lm_weights.hdf5",
+      "options_file": "allennlp/tests/fixtures/elmo/options.json",
+      "weight_file": "allennlp/tests/fixtures/elmo/lm_weights.hdf5",
       "num_output_representations": 2,
       "do_layer_norm": false
     },

--- a/allennlp/tests/fixtures/biattentive_classification_network/experiment.json
+++ b/allennlp/tests/fixtures/biattentive_classification_network/experiment.json
@@ -4,8 +4,8 @@
       "use_subtrees": true,
       "granularity": "5-class"
   },
-  "train_data_path": "tests/fixtures/data/sst.txt",
-  "validation_data_path": "tests/fixtures/data/sst.txt",
+  "train_data_path": "allennlp/tests/fixtures/data/sst.txt",
+  "validation_data_path": "allennlp/tests/fixtures/data/sst.txt",
   "model": {
     "type": "bcn",
     "text_field_embedder": {

--- a/allennlp/tests/fixtures/biattentive_classification_network/feedforward_experiment.json
+++ b/allennlp/tests/fixtures/biattentive_classification_network/feedforward_experiment.json
@@ -4,8 +4,8 @@
       "use_subtrees": true,
       "granularity": "5-class"
   },
-  "train_data_path": "tests/fixtures/data/sst.txt",
-  "validation_data_path": "tests/fixtures/data/sst.txt",
+  "train_data_path": "allennlp/tests/fixtures/data/sst.txt",
+  "validation_data_path": "allennlp/tests/fixtures/data/sst.txt",
   "model": {
     "type": "bcn",
     "text_field_embedder": {

--- a/allennlp/tests/fixtures/biattentive_classification_network/output_only_elmo_experiment.json
+++ b/allennlp/tests/fixtures/biattentive_classification_network/output_only_elmo_experiment.json
@@ -12,8 +12,8 @@
       }
     }
   },
-  "train_data_path": "tests/fixtures/data/sst.txt",
-  "validation_data_path": "tests/fixtures/data/sst.txt",
+  "train_data_path": "allennlp/tests/fixtures/data/sst.txt",
+  "validation_data_path": "allennlp/tests/fixtures/data/sst.txt",
   "model": {
     "type": "bcn",
     "text_field_embedder": {
@@ -44,8 +44,8 @@
     },
     "integrator_dropout": 0.2,
     "elmo": {
-      "options_file": "tests/fixtures/elmo/options.json",
-      "weight_file": "tests/fixtures/elmo/lm_weights.hdf5",
+      "options_file": "allennlp/tests/fixtures/elmo/options.json",
+      "weight_file": "allennlp/tests/fixtures/elmo/lm_weights.hdf5",
       "num_output_representations": 1,
       "do_layer_norm": false
     },

--- a/allennlp/tests/fixtures/bidaf/experiment.json
+++ b/allennlp/tests/fixtures/bidaf/experiment.json
@@ -14,8 +14,8 @@
       }
     }
   },
-  "train_data_path": "tests/fixtures/data/squad.json",
-  "validation_data_path": "tests/fixtures/data/squad.json",
+  "train_data_path": "allennlp/tests/fixtures/data/squad.json",
+  "validation_data_path": "allennlp/tests/fixtures/data/squad.json",
   "model": {
     "type": "bidaf",
     "text_field_embedder": {

--- a/allennlp/tests/fixtures/constituency_parser/constituency_parser.json
+++ b/allennlp/tests/fixtures/constituency_parser/constituency_parser.json
@@ -3,8 +3,8 @@
         "type":"ptb_trees",
         "use_pos_tags": true
     },
-    "train_data_path": "tests/fixtures/data/example_ptb.trees",
-    "validation_data_path": "tests/fixtures/data/example_ptb.trees",
+    "train_data_path": "allennlp/tests/fixtures/data/example_ptb.trees",
+    "validation_data_path": "allennlp/tests/fixtures/data/example_ptb.trees",
     "model": {
       "type": "constituency_parser",
       "text_field_embedder": {

--- a/allennlp/tests/fixtures/constituency_parser/experiment.json
+++ b/allennlp/tests/fixtures/constituency_parser/experiment.json
@@ -3,8 +3,8 @@
         "type":"ptb_trees",
         "use_pos_tags": false
     },
-    "train_data_path": "tests/fixtures/data/example_ptb.trees",
-    "validation_data_path": "tests/fixtures/data/example_ptb.trees",
+    "train_data_path": "allennlp/tests/fixtures/data/example_ptb.trees",
+    "validation_data_path": "allennlp/tests/fixtures/data/example_ptb.trees",
     "model": {
       "type": "constituency_parser",
       "text_field_embedder": {

--- a/allennlp/tests/fixtures/coref/experiment.json
+++ b/allennlp/tests/fixtures/coref/experiment.json
@@ -15,8 +15,8 @@
     },
     "max_span_width": 5
   },
-  "train_data_path": "tests/fixtures/coref/coref.gold_conll",
-  "validation_data_path": "tests/fixtures/coref/coref.gold_conll",
+  "train_data_path": "allennlp/tests/fixtures/coref/coref.gold_conll",
+  "validation_data_path": "allennlp/tests/fixtures/coref/coref.gold_conll",
   "model": {
     "type": "coref",
     "text_field_embedder": {

--- a/allennlp/tests/fixtures/crf_tagger/experiment.json
+++ b/allennlp/tests/fixtures/crf_tagger/experiment.json
@@ -12,8 +12,8 @@
         }
       }
     },
-    "train_data_path": "tests/fixtures/data/conll2003.txt",
-    "validation_data_path": "tests/fixtures/data/conll2003.txt",
+    "train_data_path": "allennlp/tests/fixtures/data/conll2003.txt",
+    "validation_data_path": "allennlp/tests/fixtures/data/conll2003.txt",
     "model": {
       "type": "crf_tagger",
       "text_field_embedder": {

--- a/allennlp/tests/fixtures/decomposable_attention/experiment.json
+++ b/allennlp/tests/fixtures/decomposable_attention/experiment.json
@@ -8,15 +8,15 @@
       }
     }
   },
-  "train_data_path": "tests/fixtures/data/snli.jsonl",
-  "validation_data_path": "tests/fixtures/data/snli.jsonl",
+  "train_data_path": "allennlp/tests/fixtures/data/snli.jsonl",
+  "validation_data_path": "allennlp/tests/fixtures/data/snli.jsonl",
   "model": {
     "type": "decomposable_attention",
     "text_field_embedder": {
       "tokens": {
         "type": "embedding",
         "projection_dim": 2,
-        "pretrained_file": "tests/fixtures/embeddings/glove.6B.300d.sample.txt.gz",
+        "pretrained_file": "allennlp/tests/fixtures/embeddings/glove.6B.300d.sample.txt.gz",
         "embedding_dim": 300,
         "trainable": false
       }

--- a/allennlp/tests/fixtures/elmo/config/characters_token_embedder.json
+++ b/allennlp/tests/fixtures/elmo/config/characters_token_embedder.json
@@ -12,8 +12,8 @@
         }
       }
     },
-    "train_data_path": "tests/fixtures/data/conll2003.txt",
-    "validation_data_path": "tests/fixtures/data/conll2003.txt",
+    "train_data_path": "allennlp/tests/fixtures/data/conll2003.txt",
+    "validation_data_path": "allennlp/tests/fixtures/data/conll2003.txt",
     "model": {
       "type": "crf_tagger",
       "text_field_embedder": {
@@ -23,8 +23,8 @@
               },
               "elmo": {
                 "type": "elmo_token_embedder",
-                "options_file": "tests/fixtures/elmo/options.json",
-                "weight_file": "tests/fixtures/elmo/lm_weights.hdf5",
+                "options_file": "allennlp/tests/fixtures/elmo/options.json",
+                "weight_file": "allennlp/tests/fixtures/elmo/lm_weights.hdf5",
               },
       },
       "encoder": {

--- a/allennlp/tests/fixtures/encoder_decoder/simple_seq2seq/experiment.json
+++ b/allennlp/tests/fixtures/encoder_decoder/simple_seq2seq/experiment.json
@@ -37,8 +37,8 @@
       }
     }
   },
-  "train_data_path": "tests/fixtures/data/seq2seq_copy.tsv",
-  "validation_data_path": "tests/fixtures/data/seq2seq_copy.tsv",
+  "train_data_path": "allennlp/tests/fixtures/data/seq2seq_copy.tsv",
+  "validation_data_path": "allennlp/tests/fixtures/data/seq2seq_copy.tsv",
   "model": {
     "type": "simple_seq2seq",
     "source_embedder": {

--- a/allennlp/tests/fixtures/encoder_decoder/simple_seq2seq/experiment_with_attention.json
+++ b/allennlp/tests/fixtures/encoder_decoder/simple_seq2seq/experiment_with_attention.json
@@ -4,8 +4,8 @@
     "source_token_indexers":{"tokens": {"namespace": "source_tokens"}},
     "target_token_indexers":{"tokens": {"namespace": "target_tokens"}}
   },
-  "train_data_path": "tests/fixtures/data/seq2seq_copy.tsv",
-  "validation_data_path": "tests/fixtures/data/seq2seq_copy.tsv",
+  "train_data_path": "allennlp/tests/fixtures/data/seq2seq_copy.tsv",
+  "validation_data_path": "allennlp/tests/fixtures/data/seq2seq_copy.tsv",
   "model": {
     "type": "simple_seq2seq",
     "source_embedder": {

--- a/allennlp/tests/fixtures/semantic_parsing/nlvr_coverage_semantic_parser/experiment.json
+++ b/allennlp/tests/fixtures/semantic_parsing/nlvr_coverage_semantic_parser/experiment.json
@@ -6,8 +6,8 @@
   "vocabulary": {
     "non_padded_namespaces": ["denotations", "rule_labels"]
   },
-  "train_data_path": "tests/fixtures/data/nlvr/sample_grouped_data.jsonl",
-  "validation_data_path": "tests/fixtures/data/nlvr/sample_grouped_data.jsonl",
+  "train_data_path": "allennlp/tests/fixtures/data/nlvr/sample_grouped_data.jsonl",
+  "validation_data_path": "allennlp/tests/fixtures/data/nlvr/sample_grouped_data.jsonl",
   "model": {
     "type": "nlvr_coverage_parser",
     "sentence_embedder": {

--- a/allennlp/tests/fixtures/semantic_parsing/nlvr_coverage_semantic_parser/mml_init_experiment.json
+++ b/allennlp/tests/fixtures/semantic_parsing/nlvr_coverage_semantic_parser/mml_init_experiment.json
@@ -6,8 +6,8 @@
   "vocabulary": {
     "non_padded_namespaces": ["denotations", "rule_labels"]
   },
-  "train_data_path": "tests/fixtures/data/nlvr/sample_grouped_data.jsonl",
-  "validation_data_path": "tests/fixtures/data/nlvr/sample_grouped_data.jsonl",
+  "train_data_path": "allennlp/tests/fixtures/data/nlvr/sample_grouped_data.jsonl",
+  "validation_data_path": "allennlp/tests/fixtures/data/nlvr/sample_grouped_data.jsonl",
   "model": {
     "type": "nlvr_coverage_parser",
     "sentence_embedder": {
@@ -33,7 +33,7 @@
       "rate": 0.1
     },
     "penalize_non_agenda_actions": true,
-    "initial_mml_model_file": "tests/fixtures/semantic_parsing/nlvr_direct_semantic_parser/serialization/model.tar.gz"
+    "initial_mml_model_file": "allennlp/tests/fixtures/semantic_parsing/nlvr_direct_semantic_parser/serialization/model.tar.gz"
   },
   "iterator": {
     "type": "epoch_tracking_bucket",

--- a/allennlp/tests/fixtures/semantic_parsing/nlvr_coverage_semantic_parser/ungrouped_experiment.json
+++ b/allennlp/tests/fixtures/semantic_parsing/nlvr_coverage_semantic_parser/ungrouped_experiment.json
@@ -6,8 +6,8 @@
   "vocabulary": {
     "non_padded_namespaces": ["rule_labels", "denotations"]
   },
-  "train_data_path": "tests/fixtures/data/nlvr/sample_ungrouped_data.jsonl",
-  "validation_data_path": "tests/fixtures/data/nlvr/sample_ungrouped_data.jsonl",
+  "train_data_path": "allennlp/tests/fixtures/data/nlvr/sample_ungrouped_data.jsonl",
+  "validation_data_path": "allennlp/tests/fixtures/data/nlvr/sample_ungrouped_data.jsonl",
   "model": {
     "type": "nlvr_coverage_parser",
     "sentence_embedder": {

--- a/allennlp/tests/fixtures/semantic_parsing/nlvr_direct_semantic_parser/experiment.json
+++ b/allennlp/tests/fixtures/semantic_parsing/nlvr_direct_semantic_parser/experiment.json
@@ -6,8 +6,8 @@
   "vocabulary": {
     "non_padded_namespaces": ["denotations", "rule_labels"]
   },
-  "train_data_path": "tests/fixtures/data/nlvr/sample_processed_data.jsonl",
-  "validation_data_path": "tests/fixtures/data/nlvr/sample_processed_data.jsonl",
+  "train_data_path": "allennlp/tests/fixtures/data/nlvr/sample_processed_data.jsonl",
+  "validation_data_path": "allennlp/tests/fixtures/data/nlvr/sample_processed_data.jsonl",
   "model": {
     "type": "nlvr_direct_parser",
     "sentence_embedder": {

--- a/allennlp/tests/fixtures/semantic_parsing/wikitables/experiment-elmo-no-features.json
+++ b/allennlp/tests/fixtures/semantic_parsing/wikitables/experiment-elmo-no-features.json
@@ -1,8 +1,8 @@
 {
   "dataset_reader": {
     "type": "wikitables",
-    "tables_directory": "tests/fixtures/data/wikitables/",
-    "dpd_output_directory": "tests/fixtures/data/wikitables/dpd_output/",
+    "tables_directory": "allennlp/tests/fixtures/data/wikitables/",
+    "dpd_output_directory": "allennlp/tests/fixtures/data/wikitables/dpd_output/",
     "question_token_indexers": {
       "elmo": {
        "type": "elmo_characters"
@@ -13,15 +13,15 @@
   "vocabulary": {
     "min_count": {"tokens": 1}
   },
-  "train_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
-  "validation_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
+  "train_data_path": "allennlp/tests/fixtures/data/wikitables/sample_data.examples",
+  "validation_data_path": "allennlp/tests/fixtures/data/wikitables/sample_data.examples",
   "model": {
     "type": "wikitables_mml_parser",
     "question_embedder": {
       "elmo":{
        "type": "elmo_token_embedder",
-       "options_file": "tests/fixtures/elmo/options.json",
-       "weight_file": "tests/fixtures/elmo/lm_weights.hdf5",
+       "options_file": "allennlp/tests/fixtures/elmo/options.json",
+       "weight_file": "allennlp/tests/fixtures/elmo/lm_weights.hdf5",
        "do_layer_norm": false,
        "dropout": 0.5
      }
@@ -45,7 +45,7 @@
     "attention": {"type": "dot_product"},
     "num_linking_features": 0,
     "use_neighbor_similarity_for_linking": true,
-    "tables_directory": "tests/fixtures/data/wikitables/"
+    "tables_directory": "allennlp/tests/fixtures/data/wikitables/"
   },
   "iterator": {
     "type": "bucket",

--- a/allennlp/tests/fixtures/semantic_parsing/wikitables/experiment-erm.json
+++ b/allennlp/tests/fixtures/semantic_parsing/wikitables/experiment-erm.json
@@ -1,14 +1,14 @@
 {
   "dataset_reader": {
     "type": "wikitables",
-    "tables_directory": "tests/fixtures/data/wikitables/",
+    "tables_directory": "allennlp/tests/fixtures/data/wikitables/",
     "output_agendas": true
   },
-  "train_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
-  "validation_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
+  "train_data_path": "allennlp/tests/fixtures/data/wikitables/sample_data.examples",
+  "validation_data_path": "allennlp/tests/fixtures/data/wikitables/sample_data.examples",
   "model": {
     "type": "wikitables_erm_parser",
-    "tables_directory": "tests/fixtures/data/wikitables/",
+    "tables_directory": "allennlp/tests/fixtures/data/wikitables/",
     "question_embedder": {
       "tokens": {
         "type": "embedding",
@@ -33,7 +33,7 @@
     "decoder_beam_size": 20,
     "decoder_num_finished_states": 200,
     "attention": {"type": "dot_product"},
-    "mml_model_file": "tests/fixtures/semantic_parsing/wikitables/serialization/model.tar.gz"
+    "mml_model_file": "allennlp/tests/fixtures/semantic_parsing/wikitables/serialization/model.tar.gz"
   },
   "iterator": {
     "type": "bucket",

--- a/allennlp/tests/fixtures/semantic_parsing/wikitables/experiment-mixture.json
+++ b/allennlp/tests/fixtures/semantic_parsing/wikitables/experiment-mixture.json
@@ -1,14 +1,14 @@
 {
   "dataset_reader": {
     "type": "wikitables",
-    "tables_directory": "tests/fixtures/data/wikitables/",
-    "dpd_output_directory": "tests/fixtures/data/wikitables/dpd_output/"
+    "tables_directory": "allennlp/tests/fixtures/data/wikitables/",
+    "dpd_output_directory": "allennlp/tests/fixtures/data/wikitables/dpd_output/"
   },
-  "train_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
-  "validation_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
+  "train_data_path": "allennlp/tests/fixtures/data/wikitables/sample_data.examples",
+  "validation_data_path": "allennlp/tests/fixtures/data/wikitables/sample_data.examples",
   "model": {
     "type": "wikitables_mml_parser",
-    "tables_directory": "tests/fixtures/data/wikitables/",
+    "tables_directory": "allennlp/tests/fixtures/data/wikitables/",
     "question_embedder": {
       "tokens": {
         "type": "embedding",

--- a/allennlp/tests/fixtures/semantic_parsing/wikitables/experiment.json
+++ b/allennlp/tests/fixtures/semantic_parsing/wikitables/experiment.json
@@ -1,14 +1,14 @@
 {
   "dataset_reader": {
     "type": "wikitables",
-    "tables_directory": "tests/fixtures/data/wikitables/",
-    "dpd_output_directory": "tests/fixtures/data/wikitables/dpd_output/"
+    "tables_directory": "allennlp/tests/fixtures/data/wikitables/",
+    "dpd_output_directory": "allennlp/tests/fixtures/data/wikitables/dpd_output/"
   },
-  "train_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
-  "validation_data_path": "tests/fixtures/data/wikitables/sample_data.examples",
+  "train_data_path": "allennlp/tests/fixtures/data/wikitables/sample_data.examples",
+  "validation_data_path": "allennlp/tests/fixtures/data/wikitables/sample_data.examples",
   "model": {
     "type": "wikitables_mml_parser",
-    "tables_directory": "tests/fixtures/data/wikitables/",
+    "tables_directory": "allennlp/tests/fixtures/data/wikitables/",
     "question_embedder": {
       "tokens": {
         "type": "embedding",

--- a/allennlp/tests/fixtures/simple_tagger/experiment.json
+++ b/allennlp/tests/fixtures/simple_tagger/experiment.json
@@ -1,14 +1,14 @@
 {
   "dataset_reader":{"type":"sequence_tagging"},
-  "train_data_path": "tests/fixtures/data/sequence_tagging.tsv",
-  "validation_data_path": "tests/fixtures/data/sequence_tagging.tsv",
+  "train_data_path": "allennlp/tests/fixtures/data/sequence_tagging.tsv",
+  "validation_data_path": "allennlp/tests/fixtures/data/sequence_tagging.tsv",
   "model": {
     "type": "simple_tagger",
     "text_field_embedder": {
       "tokens": {
         "type": "embedding",
         "projection_dim": 2,
-        "pretrained_file": "tests/fixtures/embeddings/glove.6B.100d.sample.txt.gz",
+        "pretrained_file": "allennlp/tests/fixtures/embeddings/glove.6B.100d.sample.txt.gz",
         "embedding_dim": 100,
         "trainable": true
       }

--- a/allennlp/tests/fixtures/simple_tagger/experiment_with_regularization.json
+++ b/allennlp/tests/fixtures/simple_tagger/experiment_with_regularization.json
@@ -1,14 +1,14 @@
 {
     "dataset_reader":{"type":"sequence_tagging"},
-    "train_data_path": "tests/fixtures/data/sequence_tagging.tsv",
-    "validation_data_path": "tests/fixtures/data/sequence_tagging.tsv",
+    "train_data_path": "allennlp/tests/fixtures/data/sequence_tagging.tsv",
+    "validation_data_path": "allennlp/tests/fixtures/data/sequence_tagging.tsv",
     "model": {
       "type": "simple_tagger",
       "text_field_embedder": {
         "tokens": {
           "type": "embedding",
           "projection_dim": 2,
-          "pretrained_file": "tests/fixtures/embeddings/glove.6B.100d.sample.txt.gz",
+          "pretrained_file": "allennlp/tests/fixtures/embeddings/glove.6B.100d.sample.txt.gz",
           "embedding_dim": 100,
           "trainable": true
         }

--- a/allennlp/tests/fixtures/srl/experiment.json
+++ b/allennlp/tests/fixtures/srl/experiment.json
@@ -1,13 +1,13 @@
 {
   "dataset_reader":{"type":"srl"},
-  "train_data_path": "tests/fixtures/data/srl",
-  "validation_data_path": "tests/fixtures/data/srl",
+  "train_data_path": "allennlp/tests/fixtures/data/srl",
+  "validation_data_path": "allennlp/tests/fixtures/data/srl",
   "model": {
     "type": "srl",
     "text_field_embedder": {
       "tokens": {
         "type": "embedding",
-        "pretrained_file": "tests/fixtures/embeddings/glove.6B.100d.sample.txt.gz",
+        "pretrained_file": "allennlp/tests/fixtures/embeddings/glove.6B.100d.sample.txt.gz",
         "embedding_dim": 100,
         "trainable": true
       }

--- a/allennlp/tests/models/biattentive_classification_network_test.py
+++ b/allennlp/tests/models/biattentive_classification_network_test.py
@@ -1,6 +1,5 @@
 # pylint: disable=invalid-name,protected-access
 from copy import deepcopy
-import os
 import pytest
 
 

--- a/allennlp/tests/models/biattentive_classification_network_test.py
+++ b/allennlp/tests/models/biattentive_classification_network_test.py
@@ -67,10 +67,6 @@ class BiattentiveClassificationNetworkTest(ModelTestCase):
             Model.from_params(self.vocab, tmp_params.get("model"))
 
     def test_elmo_but_no_set_flags_throws_configuration_error(self):
-        initial_working_dir = os.getcwd()
-        # Change directory to module root.
-        os.chdir(self.MODULE_ROOT)
-
         # pylint: disable=line-too-long
         params = Params.from_file(self.FIXTURES_ROOT / 'biattentive_classification_network' / 'elmo_experiment.json')
         # Elmo is specified in the model, but set both flags to false.
@@ -78,8 +74,6 @@ class BiattentiveClassificationNetworkTest(ModelTestCase):
         params["model"]["use_integrator_output_elmo"] = False
         with pytest.raises(ConfigurationError):
             Model.from_params(self.vocab, params.get("model"))
-        # Change directory back to what it was initially
-        os.chdir(initial_working_dir)
 
     def test_elmo_num_repr_set_flags_mismatch_throws_configuration_error(self):
         # pylint: disable=line-too-long

--- a/allennlp/tests/models/decomposable_attention_test.py
+++ b/allennlp/tests/models/decomposable_attention_test.py
@@ -39,10 +39,6 @@ class TestDecomposableAttention(ModelTestCase):
         assert isinstance(model, DecomposableAttention)
 
     def test_mismatched_dimensions_raise_configuration_errors(self):
-        initial_working_dir = os.getcwd()
-        # Change directory to module root.
-        os.chdir(self.MODULE_ROOT)
-
         params = Params.from_file(self.param_file)
         # Make the input_dim to the first feedforward_layer wrong - it should be 2.
         params["model"]["attend_feedforward"]["input_dim"] = 10
@@ -55,5 +51,3 @@ class TestDecomposableAttention(ModelTestCase):
         params["model"]["aggregate_feedforward"]["output_dim"] = 10
         with pytest.raises(ConfigurationError):
             Model.from_params(self.vocab, params.pop("model"))
-        # Change directory back to what it was initially
-        os.chdir(initial_working_dir)

--- a/allennlp/tests/models/decomposable_attention_test.py
+++ b/allennlp/tests/models/decomposable_attention_test.py
@@ -1,6 +1,4 @@
 # pylint: disable=no-self-use,invalid-name
-import os
-
 from flaky import flaky
 import pytest
 import numpy

--- a/allennlp/tests/models/semantic_role_labeler_test.py
+++ b/allennlp/tests/models/semantic_role_labeler_test.py
@@ -70,16 +70,9 @@ class SemanticRoleLabelerTest(ModelTestCase):
         assert exit_code == 0
 
     def test_mismatching_dimensions_throws_configuration_error(self):
-        initial_working_dir = os.getcwd()
-        # Change directory to module root.
-        os.chdir(self.MODULE_ROOT)
-
         params = Params.from_file(self.param_file)
         # Make the phrase layer wrong - it should be 150 to match
         # the embedding + binary feature dimensions.
         params["model"]["encoder"]["input_size"] = 10
         with pytest.raises(ConfigurationError):
             Model.from_params(self.vocab, params.pop("model"))
-
-        # Change directory back to what it was initially
-        os.chdir(initial_working_dir)

--- a/allennlp/tests/models/simple_tagger_test.py
+++ b/allennlp/tests/models/simple_tagger_test.py
@@ -1,6 +1,4 @@
 # pylint: disable=invalid-name,protected-access
-import os
-
 from flaky import flaky
 import numpy
 import pytest

--- a/allennlp/tests/models/simple_tagger_test.py
+++ b/allennlp/tests/models/simple_tagger_test.py
@@ -35,19 +35,12 @@ class SimpleTaggerTest(ModelTestCase):
         numpy.testing.assert_almost_equal(numpy.sum(class_probs, -1), numpy.array([1, 1, 1, 1]))
 
     def test_mismatching_dimensions_throws_configuration_error(self):
-        initial_working_dir = os.getcwd()
-        # Change directory to module root.
-        os.chdir(self.MODULE_ROOT)
-
         params = Params.from_file(self.param_file)
         # Make the encoder wrong - it should be 2 to match
         # the embedding dimension from the text_field_embedder.
         params["model"]["encoder"]["input_size"] = 10
         with pytest.raises(ConfigurationError):
             Model.from_params(self.vocab, params.pop("model"))
-
-        # Change directory back to what it was initially
-        os.chdir(initial_working_dir)
 
     def test_regularization(self):
         penalty = self.model.get_regularization_penalty()

--- a/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
@@ -39,10 +39,6 @@ class TestElmoTokenEmbedder(ModelTestCase):
 
     def test_file_archiving(self):
         # This happens to be a good place to test auxiliary file archiving.
-        initial_working_dir = os.getcwd()
-        # Change directory to module root.
-        os.chdir(self.MODULE_ROOT)
-
         # Train the model
         params = Params.from_file(self.FIXTURES_ROOT / 'elmo' / 'config' / 'characters_token_embedder.json')
         serialization_dir = os.path.join(self.TEST_DIR, 'serialization')
@@ -73,8 +69,6 @@ class TestElmoTokenEmbedder(ModelTestCase):
         for key, original_filename in files_to_archive.items():
             new_filename = os.path.join(unarchive_dir, "fta", key)
             assert filecmp.cmp(original_filename, new_filename)
-        # Change directory back to what it was initially
-        os.chdir(initial_working_dir)
 
     def test_forward_works_with_projection_layer(self):
         params = Params({

--- a/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
@@ -59,10 +59,10 @@ class TestElmoTokenEmbedder(ModelTestCase):
             files_to_archive = json.loads(fta.read())
 
         assert files_to_archive == {
-                'model.text_field_embedder.elmo.options_file': str(pathlib.Path('allennlp') / 'tests' / 'fixtures' /
-                                                                   'elmo' / 'options.json'),
-                'model.text_field_embedder.elmo.weight_file': str(pathlib.Path('allennlp') / 'tests' / 'fixtures' /
-                                                                  'elmo' / 'lm_weights.hdf5'),
+                'model.text_field_embedder.elmo.options_file': str(pathlib.Path('allennlp') / 'tests' /
+                                                                   'fixtures' / 'elmo' / 'options.json'),
+                'model.text_field_embedder.elmo.weight_file': str(pathlib.Path('allennlp') / 'tests' /
+                                                                  'fixtures' / 'elmo' / 'lm_weights.hdf5'),
         }
 
         # Check that the unarchived contents of those files match the original contents.

--- a/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
@@ -59,9 +59,9 @@ class TestElmoTokenEmbedder(ModelTestCase):
             files_to_archive = json.loads(fta.read())
 
         assert files_to_archive == {
-                'model.text_field_embedder.elmo.options_file': str(pathlib.Path('tests') / 'fixtures' /
+                'model.text_field_embedder.elmo.options_file': str(pathlib.Path('allennlp') / 'tests' / 'fixtures' /
                                                                    'elmo' / 'options.json'),
-                'model.text_field_embedder.elmo.weight_file': str(pathlib.Path('tests') / 'fixtures' /
+                'model.text_field_embedder.elmo.weight_file': str(pathlib.Path('allennlp') / 'tests' / 'fixtures' /
                                                                   'elmo' / 'lm_weights.hdf5'),
         }
 

--- a/tests
+++ b/tests
@@ -1,1 +1,0 @@
-allennlp/tests/

--- a/tests
+++ b/tests
@@ -1,0 +1,1 @@
+allennlp/tests/


### PR DESCRIPTION
ModelTestCase has a few `chdir`s since after we moved the tests into the module, all the relative paths in the test fixtures were broken (since they assumed that we were running the tests in the same directory as the `tests` folder). I got around this by using `os.chdir`, but did not realize that this would break models that import and use `ModelTestCase` (see #1417 ).

I think a reasonable solution to this is to simply remove all the `chdir` calls and add a symbolic link in the project root called `tests` that links to the tests folder (in the module root). This means that the relative paths in the fixtures don't need to be redone and downstream clients using `ModelTestCase` won't deal with issues from `os.chdir`.