### PR TITLE
Make tqdm description ignore metrics starting with _

### DIFF
--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -43,7 +43,8 @@ class Model(torch.nn.Module, Registrable):
 
     Finally, you can optionally implement :func:`Model.get_metrics` in order to make use
     of early stopping and best-model serialization based on a validation metric in
-    :class:`~allennlp.training.Trainer`.
+    :class:`~allennlp.training.Trainer`. Metrics that begin with "_" will not be logged
+    to the progress bar by :class:`~allennlp.training.Trainer`.
     """
     def __init__(self,
                  vocab: Vocabulary,

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -310,6 +310,7 @@ class Trainer:
             self._tensorboard = TensorboardWriter(train_log, validation_log)
         else:
             self._tensorboard = TensorboardWriter()
+        self._warned_tqdm_ignores_underscores = False
 
     def _enable_gradient_clipping(self) -> None:
         if self._grad_clipping is not None:
@@ -756,7 +757,10 @@ class Trainer:
             return this_epoch_val_metric > max(validation_metric_per_epoch)
 
     def _description_from_metrics(self, metrics: Dict[str, float]) -> str:
-        # pylint: disable=no-self-use
+        if not self._warned_tqdm_ignores_underscores and any(itemA.startswith("_")):
+            logger.warning("Metrics with names beginning with \"_\" will "
+                           "not be logged to the tqdm progress bar.")
+            self._warned_tqdm_ignores_underscores = True
         return ', '.join(["%s: %.4f" % (name, value) for name, value in
                           metrics.items() if not name.startswith("_")]) + " ||"
 

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -757,7 +757,8 @@ class Trainer:
 
     def _description_from_metrics(self, metrics: Dict[str, float]) -> str:
         # pylint: disable=no-self-use
-        return ', '.join(["%s: %.4f" % (name, value) for name, value in metrics.items()]) + " ||"
+        return ', '.join(["%s: %.4f" % (name, value) for name, value in
+                          metrics.items() if not name.startswith("_")]) + " ||"
 
     def _save_checkpoint(self,
                          epoch: Union[int, str],

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -757,7 +757,8 @@ class Trainer:
             return this_epoch_val_metric > max(validation_metric_per_epoch)
 
     def _description_from_metrics(self, metrics: Dict[str, float]) -> str:
-        if not self._warned_tqdm_ignores_underscores and any(itemA.startswith("_")):
+        if (not self._warned_tqdm_ignores_underscores and
+                any(metric_name.startswith("_") for metric_name in metrics)):
             logger.warning("Metrics with names beginning with \"_\" will "
                            "not be logged to the tqdm progress bar.")
             self._warned_tqdm_ignores_underscores = True

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -758,7 +758,7 @@ class Trainer:
 
     def _description_from_metrics(self, metrics: Dict[str, float]) -> str:
         if (not self._warned_tqdm_ignores_underscores and
-                any(metric_name.startswith("_") for metric_name in metrics)):
+                    any(metric_name.startswith("_") for metric_name in metrics)):
             logger.warning("Metrics with names beginning with \"_\" will "
                            "not be logged to the tqdm progress bar.")
             self._warned_tqdm_ignores_underscores = True


### PR DESCRIPTION
tqdm currently doesn't handle long descriptions very gracefully (image below)

![screen shot 2018-06-25 at 5 32 34 pm](https://user-images.githubusercontent.com/7272031/41882458-d5cd1f56-789d-11e8-9a4e-38caf84120d6.png)

This PR makes the tqdm description ignore metrics with a name that begins with `_`.