### PR TITLE
Fix an edge case for incompatible vocabulary extension.

### DIFF
--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -427,23 +427,24 @@ class Vocabulary:
         pretrained_files = pretrained_files or {}
         non_padded_namespaces = set(non_padded_namespaces)
 
-        if counter is not None:
-            # Make sure vocabulary extension is safe.
-            for namespace in counter:
-                if namespace in self.get_all_namespaces():
-                    # if new namespace was already present
-                    # Either both should be padded or none should be.
-                    original_padded = not any(namespace_match(pattern, namespace)
-                                              for pattern in self._non_padded_namespaces)
-                    extension_padded = not any(namespace_match(pattern, namespace)
-                                               for pattern in non_padded_namespaces)
-                    if original_padded != extension_padded:
-                        raise ConfigurationError("Common namespace {} has conflicting ".format(namespace)+
-                                                 "setting of padded = True/False. "+
-                                                 "Hence extension cannot be done.")
-            # Add new non-padded namespaces for extension
-            self.add_non_padded_namespaces(non_padded_namespaces)
+        # Make sure vocabulary extension is safe.
+        extension_namespaces = list((counter or {}).keys()) + list((tokens_to_add or {}).keys())
+        for namespace in extension_namespaces:
+            if namespace in self.get_all_namespaces():
+                # if new namespace was already present
+                # Either both should be padded or none should be.
+                original_padded = not any(namespace_match(pattern, namespace)
+                                          for pattern in self._non_padded_namespaces)
+                extension_padded = not any(namespace_match(pattern, namespace)
+                                           for pattern in non_padded_namespaces)
+                if original_padded != extension_padded:
+                    raise ConfigurationError("Common namespace {} has conflicting ".format(namespace)+
+                                             "setting of padded = True/False. "+
+                                             "Hence extension cannot be done.")
+        # Add new non-padded namespaces for extension
+        self.add_non_padded_namespaces(non_padded_namespaces)
 
+        if counter is not None:
             for namespace in counter:
                 if namespace in pretrained_files:
                     pretrained_list = _read_pretrained_tokens(pretrained_files[namespace])

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -426,49 +426,48 @@ class Vocabulary:
         min_count = min_count or {}
         pretrained_files = pretrained_files or {}
         non_padded_namespaces = set(non_padded_namespaces)
+        counter = counter or {}
+        tokens_to_add = tokens_to_add or {}
 
         # Make sure vocabulary extension is safe.
-        extension_namespaces = list((counter or {}).keys()) + list((tokens_to_add or {}).keys())
-        for namespace in extension_namespaces:
-            if namespace in self.get_all_namespaces():
-                # if new namespace was already present
-                # Either both should be padded or none should be.
-                original_padded = not any(namespace_match(pattern, namespace)
-                                          for pattern in self._non_padded_namespaces)
-                extension_padded = not any(namespace_match(pattern, namespace)
-                                           for pattern in non_padded_namespaces)
-                if original_padded != extension_padded:
-                    raise ConfigurationError("Common namespace {} has conflicting ".format(namespace)+
-                                             "setting of padded = True/False. "+
-                                             "Hence extension cannot be done.")
+        extension_namespaces = {*counter, *tokens_to_add}
+        for namespace in extension_namespaces & self.get_all_namespaces():
+            # if new namespace was already present
+            # Either both should be padded or none should be.
+            original_padded = not any(namespace_match(pattern, namespace)
+                                      for pattern in self._non_padded_namespaces)
+            extension_padded = not any(namespace_match(pattern, namespace)
+                                       for pattern in non_padded_namespaces)
+            if original_padded != extension_padded:
+                raise ConfigurationError("Common namespace {} has conflicting ".format(namespace)+
+                                         "setting of padded = True/False. "+
+                                         "Hence extension cannot be done.")
         # Add new non-padded namespaces for extension
         self.add_non_padded_namespaces(non_padded_namespaces)
 
-        if counter is not None:
-            for namespace in counter:
-                if namespace in pretrained_files:
-                    pretrained_list = _read_pretrained_tokens(pretrained_files[namespace])
-                else:
-                    pretrained_list = None
-                token_counts = list(counter[namespace].items())
-                token_counts.sort(key=lambda x: x[1], reverse=True)
-                max_vocab = max_vocab_size[namespace]
-                if max_vocab:
-                    token_counts = token_counts[:max_vocab]
-                for token, count in token_counts:
-                    if pretrained_list is not None:
-                        if only_include_pretrained_words:
-                            if token in pretrained_list and count >= min_count.get(namespace, 1):
-                                self.add_token_to_namespace(token, namespace)
-                        elif token in pretrained_list or count >= min_count.get(namespace, 1):
+        for namespace in counter:
+            if namespace in pretrained_files:
+                pretrained_list = _read_pretrained_tokens(pretrained_files[namespace])
+            else:
+                pretrained_list = None
+            token_counts = list(counter[namespace].items())
+            token_counts.sort(key=lambda x: x[1], reverse=True)
+            max_vocab = max_vocab_size[namespace]
+            if max_vocab:
+                token_counts = token_counts[:max_vocab]
+            for token, count in token_counts:
+                if pretrained_list is not None:
+                    if only_include_pretrained_words:
+                        if token in pretrained_list and count >= min_count.get(namespace, 1):
                             self.add_token_to_namespace(token, namespace)
-                    elif count >= min_count.get(namespace, 1):
+                    elif token in pretrained_list or count >= min_count.get(namespace, 1):
                         self.add_token_to_namespace(token, namespace)
-
-        if tokens_to_add:
-            for namespace, tokens in tokens_to_add.items():
-                for token in tokens:
+                elif count >= min_count.get(namespace, 1):
                     self.add_token_to_namespace(token, namespace)
+
+        for namespace, tokens in tokens_to_add.items():
+            for token in tokens:
+                self.add_token_to_namespace(token, namespace)
 
     def extend_from_instances(self,
                               params: Params,

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -399,6 +399,10 @@ class TestVocabulary(AllenNlpTestCase):
             extended_vocab = copy.copy(original_vocab)
             params = Params({"non_padded_namespaces": []})
             extended_vocab.extend_from_instances(params, instances)
+        with pytest.raises(ConfigurationError):
+            extended_vocab = copy.copy(original_vocab)
+            extended_vocab.extend(non_padded_namespaces=[],
+                                  tokens_to_add={"tokens1": ["a"], "tokens2": ["p"]})
 
         # Following 2 should not give error: overlapping namespaces have same padding setting
         params = Params({"directory_path": vocab_dir, "extend": True,
@@ -407,6 +411,9 @@ class TestVocabulary(AllenNlpTestCase):
         extended_vocab = copy.copy(original_vocab)
         params = Params({"non_padded_namespaces": ["tokens1"]})
         extended_vocab.extend_from_instances(params, instances)
+        extended_vocab = copy.copy(original_vocab)
+        extended_vocab.extend(non_padded_namespaces=["tokens1"],
+                              tokens_to_add={"tokens1": ["a"], "tokens2": ["p"]})
 
         # Following 2 should give error: token1 is padded in instances but not in original_vocab
         params = Params({"directory_path": vocab_dir, "extend": True,
@@ -417,6 +424,10 @@ class TestVocabulary(AllenNlpTestCase):
             extended_vocab = copy.copy(original_vocab)
             params = Params({"non_padded_namespaces": ["tokens1", "tokens2"]})
             extended_vocab.extend_from_instances(params, instances)
+        with pytest.raises(ConfigurationError):
+            extended_vocab = copy.copy(original_vocab)
+            extended_vocab.extend(non_padded_namespaces=["tokens1", "tokens2"],
+                                  tokens_to_add={"tokens1": ["a"], "tokens2": ["p"]})
 
     def test_from_params_extend_config(self):
 


### PR DESCRIPTION
Continuation of (#1416) missed edge case.

@joelgrus I found an unhandled edgecase in `extend` function. If one tries to add new tokens for existing namespace it must always use same padding setting or err. Case A and B do give error, but C does not.


```python
# In original vocab "tokens" is padded namespace
vocab = Vocabulary(non_padded_namespaces=[])
vocab.add_token_to_namespace("a", namespace="tokens")
```

So in A, B, C: asking for "tokens" to be padded should give error:

A. Following gives error appropriately:
```python
vocab.extend(counter={"tokens": {"a":100}}, non_padded_namespaces=["tokens"])
# allennlp.common.checks.ConfigurationError:
# Common namespace tokens has conflicting setting of padded = True/False. Hence extension cannot be done.
```

B. Following does aswell:
```python
text_field = TextField([Token("a")], {"tokens": SingleIdTokenIndexer("tokens")})
vocab.extend_from_instances(Params({"non_padded_namespaces": ["tokens"]}),
                            Batch([Instance({"text": text_field})]) )
# allennlp.common.checks.ConfigurationError:
# Common namespace tokens has conflicting setting of padded = True/False. Hence extension cannot be done.
```

C. Following should but did not give error:
```python
vocab.extend(non_padded_namespaces=["tokens"], tokens_to_add={"tokens":["a"]})
# {0: '@@PADDING@@', 1: '@@UNKNOWN@@', 2: 'a'}
```

This PR fixes this and adds additional tests for the same.