### PR TITLE
eliminate or make private most of the new Vocabulary methods

### DIFF
--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -500,11 +500,6 @@ class Vocabulary:
                      only_include_pretrained_words=only_include_pretrained_words,
                      tokens_to_add=tokens_to_add)
 
-    def _add_non_padded_namespaces(self, non_padded_namespaces: Set[str]):
-        self._token_to_index.add_non_padded_namespaces(non_padded_namespaces)
-        self._index_to_token.add_non_padded_namespaces(non_padded_namespaces)
-        self._non_padded_namespaces.update(non_padded_namespaces)
-
     def is_padded(self, namespace: str) -> bool:
         """
         Returns whether or not there are padding and OOV tokens added to the given namepsace.

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -196,13 +196,13 @@ class Vocabulary:
                                                         self._padding_token,
                                                         self._oov_token)
         # Made an empty vocabulary, now extend it.
-        self.extend(counter,
-                    min_count,
-                    max_vocab_size,
-                    non_padded_namespaces,
-                    pretrained_files,
-                    only_include_pretrained_words,
-                    tokens_to_add)
+        self._extend(counter,
+                     min_count,
+                     max_vocab_size,
+                     non_padded_namespaces,
+                     pretrained_files,
+                     only_include_pretrained_words,
+                     tokens_to_add)
 
     def save_to_files(self, directory: str) -> None:
         """
@@ -406,14 +406,14 @@ class Vocabulary:
                                          only_include_pretrained_words=only_include_pretrained_words,
                                          tokens_to_add=tokens_to_add)
 
-    def extend(self,
-               counter: Dict[str, Dict[str, int]] = None,
-               min_count: Dict[str, int] = None,
-               max_vocab_size: Union[int, Dict[str, int]] = None,
-               non_padded_namespaces: Iterable[str] = DEFAULT_NON_PADDED_NAMESPACES,
-               pretrained_files: Optional[Dict[str, str]] = None,
-               only_include_pretrained_words: bool = False,
-               tokens_to_add: Dict[str, List[str]] = None) -> None:
+    def _extend(self,
+                counter: Dict[str, Dict[str, int]] = None,
+                min_count: Dict[str, int] = None,
+                max_vocab_size: Union[int, Dict[str, int]] = None,
+                non_padded_namespaces: Iterable[str] = DEFAULT_NON_PADDED_NAMESPACES,
+                pretrained_files: Optional[Dict[str, str]] = None,
+                only_include_pretrained_words: bool = False,
+                tokens_to_add: Dict[str, List[str]] = None) -> None:
         """
         This method can be used for extending already generated vocabulary.
         It takes same parameters as Vocabulary initializer. The token2index
@@ -430,8 +430,10 @@ class Vocabulary:
         tokens_to_add = tokens_to_add or {}
 
         # Make sure vocabulary extension is safe.
+        current_namespaces = {*self._token_to_index}
         extension_namespaces = {*counter, *tokens_to_add}
-        for namespace in extension_namespaces & self.get_all_namespaces():
+
+        for namespace in current_namespaces & extension_namespaces:
             # if new namespace was already present
             # Either both should be padded or none should be.
             original_padded = not any(namespace_match(pattern, namespace)
@@ -442,8 +444,11 @@ class Vocabulary:
                 raise ConfigurationError("Common namespace {} has conflicting ".format(namespace)+
                                          "setting of padded = True/False. "+
                                          "Hence extension cannot be done.")
+
         # Add new non-padded namespaces for extension
-        self.add_non_padded_namespaces(non_padded_namespaces)
+        self._token_to_index.add_non_padded_namespaces(non_padded_namespaces)
+        self._index_to_token.add_non_padded_namespaces(non_padded_namespaces)
+        self._non_padded_namespaces.update(non_padded_namespaces)
 
         for namespace in counter:
             if namespace in pretrained_files:
@@ -473,8 +478,7 @@ class Vocabulary:
                               params: Params,
                               instances: Iterable['adi.Instance'] = ()) -> None:
         """
-        This method can be used for extending already generated vocabulary
-        from collection of instances. It is a wrapped around ``extend`` method.
+        Extends an already generated vocabulary using a collection of instances.
         """
         min_count = params.pop("min_count", None)
         max_vocab_size = params.pop_int("max_vocab_size", None)
@@ -488,30 +492,18 @@ class Vocabulary:
         namespace_token_counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
         for instance in Tqdm.tqdm(instances):
             instance.count_vocab_items(namespace_token_counts)
-        self.extend(counter=namespace_token_counts,
-                    min_count=min_count,
-                    max_vocab_size=max_vocab_size,
-                    non_padded_namespaces=non_padded_namespaces,
-                    pretrained_files=pretrained_files,
-                    only_include_pretrained_words=only_include_pretrained_words,
-                    tokens_to_add=tokens_to_add)
+        self._extend(counter=namespace_token_counts,
+                     min_count=min_count,
+                     max_vocab_size=max_vocab_size,
+                     non_padded_namespaces=non_padded_namespaces,
+                     pretrained_files=pretrained_files,
+                     only_include_pretrained_words=only_include_pretrained_words,
+                     tokens_to_add=tokens_to_add)
 
-    def add_non_padded_namespaces(self, non_padded_namespaces: Set[str]):
+    def _add_non_padded_namespaces(self, non_padded_namespaces: Set[str]):
         self._token_to_index.add_non_padded_namespaces(non_padded_namespaces)
         self._index_to_token.add_non_padded_namespaces(non_padded_namespaces)
         self._non_padded_namespaces.update(non_padded_namespaces)
-
-    def get_all_namespaces(self) -> Set[str]:
-        return set(self._token_to_index.keys())
-
-    def get_non_padded_namespaces(self) -> Set[str]:
-        return self._non_padded_namespaces
-
-    def get_token_to_index(self) -> Dict[str, Dict[str, int]]:
-        return self._token_to_index
-
-    def get_index_to_token(self) -> Dict[str, Dict[int, str]]:
-        return self._index_to_token
 
     def is_padded(self, namespace: str) -> bool:
         """


### PR DESCRIPTION
the code to add `Vocabulary.extend_from_instances` introduced a lot of functions that no one other than a `Vocabulary` instance (or its tests) needs to call. this PR eliminates them or makes them private.

FYI @HarshTrivedi 