### PR TITLE
Fix a typo in embedding_tokens notebook.

### DIFF
--- a/tutorials/notebooks/embedding_tokens.ipynb
+++ b/tutorials/notebooks/embedding_tokens.ipynb
@@ -95,7 +95,7 @@
      "text": [
       "This is the token_ids vocabulary we created: \n",
       "\n",
-      "{0: '@@PADDING@@', 1: '@@UNKNOWN@@'}\n",
+      "{0: '@@PADDING@@', 1: '@@UNKNOWN@@', 2: 'All', 3: 'the', 4: 'cool', 5: 'kids', 6: 'use', 7: 'character', 8: 'embeddings', 9: '.', 10: 'I', 11: 'prefer', 12: 'word2vec', 13: 'though', 14: '...'}\n",
       "This is the character vocabulary we created: \n",
       "\n",
       "{0: '@@PADDING@@', 1: '@@UNKNOWN@@', 2: 'e', 3: 'r', 4: 'h', 5: 'c', 6: 'o', 7: 'd', 8: '.', 9: 'l', 10: 't', 11: 's', 12: 'i', 13: 'u', 14: 'a', 15: 'g', 16: 'A', 17: 'k', 18: 'm', 19: 'b', 20: 'n', 21: 'I', 22: 'p', 23: 'f', 24: 'w', 25: '2', 26: 'v'}\n"
@@ -118,7 +118,7 @@
     "vocab = Vocabulary.from_instances(instances)\n",
     "\n",
     "print(\"This is the token_ids vocabulary we created: \\n\")\n",
-    "print(vocab.get_index_to_token_vocabulary(\"tokens_ids\"))\n",
+    "print(vocab.get_index_to_token_vocabulary(\"token_ids\"))\n",
     "\n",
     "print(\"This is the character vocabulary we created: \\n\")\n",
     "print(vocab.get_index_to_token_vocabulary(\"token_characters\"))\n",


### PR DESCRIPTION
Fix a typo in embedding_tokens notebook : The vocabulary is `token_ids` and not `tokens_ids`.