### PR TITLE
remove RegistrableVocabulary

### DIFF
--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -46,7 +46,7 @@ from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError, check_for_gpu
 from allennlp.common import Params
 from allennlp.common.util import prepare_environment, prepare_global_logging
-from allennlp.data import RegistrableVocabulary
+from allennlp.data import Vocabulary
 from allennlp.data.instance import Instance
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.iterators.data_iterator import DataIterator
@@ -268,8 +268,8 @@ def train_model(params: Params,
             raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {dataset}")
 
     logger.info("Creating a vocabulary using %s data.", ", ".join(datasets_for_vocab_creation))
-    vocab = RegistrableVocabulary.from_params(
-            params.pop("vocabulary", {"type": "vocabulary"}),
+    vocab = Vocabulary.from_params(
+            params.pop("vocabulary", {}),
             (instance for key, dataset in all_datasets.items()
              for instance in dataset
              if key in datasets_for_vocab_creation)

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -6,7 +6,7 @@ import torch
 from allennlp.commands.train import train_model_from_file
 from allennlp.common import Params
 from allennlp.common.testing.test_case import AllenNlpTestCase
-from allennlp.data import DataIterator, DatasetReader, Vocabulary, RegistrableVocabulary
+from allennlp.data import DataIterator, DatasetReader, Vocabulary
 from allennlp.data.dataset import Batch
 from allennlp.models import Model, load_archive
 
@@ -27,7 +27,7 @@ class ModelTestCase(AllenNlpTestCase):
         # "non_padded_namespaces", "min_count" etc. can be set if needed.
         if 'vocabulary' in params:
             vocab_params = params['vocabulary']
-            vocab = RegistrableVocabulary.from_params(params=vocab_params, instances=instances)
+            vocab = Vocabulary.from_params(params=vocab_params, instances=instances)
         else:
             vocab = Vocabulary.from_instances(instances)
         self.vocab = vocab

--- a/allennlp/data/__init__.py
+++ b/allennlp/data/__init__.py
@@ -5,4 +5,4 @@ from allennlp.data.iterators.data_iterator import DataIterator
 from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
 from allennlp.data.tokenizers.token import Token
 from allennlp.data.tokenizers.tokenizer import Tokenizer
-from allennlp.data.vocabulary import Vocabulary, RegistrableVocabulary
+from allennlp.data.vocabulary import Vocabulary

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -368,6 +368,11 @@ class Vocabulary(Registrable):
         -------
         A ``Vocabulary``.
         """
+        # Vocabulary is ``Registrable`` so that you can configure a custom subclass,
+        # but (unlike most of our registrables) almost everyone will want to use the
+        # base implementation. So instead of having an abstract ``VocabularyBase`` or
+        # such, we just add the logic for instantiating a registered subclass here,
+        # so that most users can continue doing what they were doing.
         vocab_type = params.pop("type", None)
         if vocab_type is not None:
             return cls.by_name(vocab_type).from_params(params=params, instances=instances)

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -113,17 +113,7 @@ def _read_pretrained_tokens(embeddings_file_uri: str) -> Set[str]:
     return tokens
 
 
-class RegistrableVocabulary(Registrable):
-    default_implementation = "vocabulary"
-
-    @classmethod
-    def from_params(cls, params: Params, instances: Iterable['adi.Instance'] = None):
-        choice = params.pop_choice('type', cls.list_available(), default_to_first_choice=True)
-        return cls.by_name(choice).from_params(params, instances)
-
-
-@RegistrableVocabulary.register("vocabulary")
-class Vocabulary(RegistrableVocabulary):
+class Vocabulary(Registrable):
     """
     A Vocabulary maps strings to integers, allowing for strings to be mapped to an
     out-of-vocabulary token.
@@ -378,6 +368,10 @@ class Vocabulary(RegistrableVocabulary):
         -------
         A ``Vocabulary``.
         """
+        vocab_type = params.pop("type", None)
+        if vocab_type is not None:
+            return cls.by_name(vocab_type).from_params(params=params, instances=instances)
+
         extend = params.pop("extend", False)
         vocabulary_directory = params.pop("directory_path", None)
         if not vocabulary_directory and not instances:

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -647,7 +647,7 @@ class TestVocabulary(AllenNlpTestCase):
         class MyVocabulary:
             @classmethod
             def from_params(cls, params, instances=None):
-                # pylint: disable=unused-arguments
+                # pylint: disable=unused-argument
                 return MyVocabulary()
 
 

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -640,3 +640,21 @@ class TestVocabulary(AllenNlpTestCase):
         assert 'a' in words
         assert 'b' in words
         assert 'c' not in words
+
+    def test_registrability(self):
+
+        @Vocabulary.register('my-vocabulary')
+        class MyVocabulary:
+            @classmethod
+            def from_params(cls, params, instances=None):
+                # pylint: disable=unused-arguments
+                return MyVocabulary()
+
+
+        params = Params({'type': 'my-vocabulary'})
+
+        instance = Instance(fields={})
+
+        vocab = Vocabulary.from_params(params=params, instances=[instance])
+
+        assert isinstance(vocab, MyVocabulary)


### PR DESCRIPTION
I think this is a cleaner solution, it allows you to override with a custom vocabulary without having to think of the usual vocabulary as a "type" of vocabulary

@matt-peters this means your code will need to use `@Vocabulary.register(...)`