### PR TITLE
instantiate default activation functions in constructor

### DIFF
--- a/allennlp/modules/attention/bilinear_attention.py
+++ b/allennlp/modules/attention/bilinear_attention.py
@@ -33,12 +33,12 @@ class BilinearAttention(Attention):
     def __init__(self,
                  vector_dim: int,
                  matrix_dim: int,
-                 activation: Activation = Activation.by_name('linear')(),
+                 activation: Activation = None,
                  normalize: bool = True) -> None:
         super().__init__(normalize)
         self._weight_matrix = Parameter(torch.Tensor(vector_dim, matrix_dim))
         self._bias = Parameter(torch.Tensor(1))
-        self._activation = activation
+        self._activation = activation or Activation.by_name('linear')()
         self.reset_parameters()
 
     def reset_parameters(self):

--- a/allennlp/modules/attention/linear_attention.py
+++ b/allennlp/modules/attention/linear_attention.py
@@ -47,14 +47,14 @@ class LinearAttention(Attention):
                  tensor_1_dim: int,
                  tensor_2_dim: int,
                  combination: str = 'x,y',
-                 activation: Activation = Activation.by_name('linear')(),
+                 activation: Activation = None,
                  normalize: bool = True) -> None:
         super().__init__(normalize)
         self._combination = combination
         combined_dim = util.get_combined_dim(combination, [tensor_1_dim, tensor_2_dim])
         self._weight_vector = Parameter(torch.Tensor(combined_dim))
         self._bias = Parameter(torch.Tensor(1))
-        self._activation = activation
+        self._activation = activation or Activation.by_name('linear')()
         self.reset_parameters()
 
     def reset_parameters(self):

--- a/allennlp/modules/matrix_attention/bilinear_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/bilinear_matrix_attention.py
@@ -30,11 +30,11 @@ class BilinearMatrixAttention(MatrixAttention):
     def __init__(self,
                  matrix_1_dim: int,
                  matrix_2_dim: int,
-                 activation: Activation = Activation.by_name('linear')()) -> None:
+                 activation: Activation = None) -> None:
         super().__init__()
         self._weight_matrix = Parameter(torch.Tensor(matrix_1_dim, matrix_2_dim))
         self._bias = Parameter(torch.Tensor(1))
-        self._activation = activation
+        self._activation = activation or Activation.by_name('linear')()
         self.reset_parameters()
 
     def reset_parameters(self):

--- a/allennlp/modules/matrix_attention/linear_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/linear_matrix_attention.py
@@ -49,13 +49,13 @@ class LinearMatrixAttention(MatrixAttention):
                  tensor_1_dim: int,
                  tensor_2_dim: int,
                  combination: str = 'x,y',
-                 activation: Activation = Activation.by_name('linear')()) -> None:
+                 activation: Activation = None) -> None:
         super().__init__()
         self._combination = combination
         combined_dim = util.get_combined_dim(combination, [tensor_1_dim, tensor_2_dim])
         self._weight_vector = Parameter(torch.Tensor(combined_dim))
         self._bias = Parameter(torch.Tensor(1))
-        self._activation = activation
+        self._activation = activation or Activation.by_name('linear')()
         self.reset_parameters()
 
     def reset_parameters(self):

--- a/allennlp/modules/seq2vec_encoders/cnn_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/cnn_encoder.py
@@ -51,13 +51,13 @@ class CnnEncoder(Seq2VecEncoder):
                  embedding_dim: int,
                  num_filters: int,
                  ngram_filter_sizes: Tuple[int, ...] = (2, 3, 4, 5),  # pylint: disable=bad-whitespace
-                 conv_layer_activation: Activation = Activation.by_name('relu')(),
+                 conv_layer_activation: Activation = None,
                  output_dim: Optional[int] = None) -> None:
         super(CnnEncoder, self).__init__()
         self._embedding_dim = embedding_dim
         self._num_filters = num_filters
         self._ngram_filter_sizes = ngram_filter_sizes
-        self._activation = conv_layer_activation
+        self._activation = conv_layer_activation or Activation.by_name('relu')()
         self._output_dim = output_dim
 
         self._convolution_layers = [Conv1d(in_channels=self._embedding_dim,

--- a/allennlp/modules/similarity_functions/bilinear.py
+++ b/allennlp/modules/similarity_functions/bilinear.py
@@ -30,11 +30,11 @@ class BilinearSimilarity(SimilarityFunction):
     def __init__(self,
                  tensor_1_dim: int,
                  tensor_2_dim: int,
-                 activation: Activation = Activation.by_name('linear')()) -> None:
+                 activation: Activation = None) -> None:
         super(BilinearSimilarity, self).__init__()
         self._weight_matrix = Parameter(torch.Tensor(tensor_1_dim, tensor_2_dim))
         self._bias = Parameter(torch.Tensor(1))
-        self._activation = activation
+        self._activation = activation or Activation.by_name('linear')()
         self.reset_parameters()
 
     def reset_parameters(self):

--- a/allennlp/modules/similarity_functions/linear.py
+++ b/allennlp/modules/similarity_functions/linear.py
@@ -46,13 +46,13 @@ class LinearSimilarity(SimilarityFunction):
                  tensor_1_dim: int,
                  tensor_2_dim: int,
                  combination: str = 'x,y',
-                 activation: Activation = Activation.by_name('linear')()) -> None:
+                 activation: Activation = None) -> None:
         super(LinearSimilarity, self).__init__()
         self._combination = combination
         combined_dim = util.get_combined_dim(combination, [tensor_1_dim, tensor_2_dim])
         self._weight_vector = Parameter(torch.Tensor(combined_dim))
         self._bias = Parameter(torch.Tensor(1))
-        self._activation = activation
+        self._activation = activation or Activation.by_name('linear')()
         self.reset_parameters()
 
     def reset_parameters(self):


### PR DESCRIPTION
fixes #1477 

basically, when `Activation.by_name` was called as a default parameter, it was run at [python] module load time, resulting in a bunch of "hey, Activation.from_params got called" log lines before the training code even started running.

using `None` as a default value and moving the call inside the constructor makes it so the logging only happens if the corresponding [pytorch] module actually gets instantiated

(I also considered instantiating the functions directly e.g.

```
activation: Activation = lambda x: x
```

but the thing is that Activation isn't the "real" type of activation functions (it's just a construct to allow from_params), so that doesn't actually typecheck.