### PR TITLE
don't call create_kwargs  for a class that has no constructor

### DIFF
--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -251,7 +251,7 @@ class FromParams:
                 # This class does not have an explicit constructor, so don't give it any kwargs.
                 # Without this logic, create_kwargs will look at object.__init__ and see that
                 # it takes *args and **kwargs and look for those.
-                kwargs = {}
+                kwargs: Dict[str, Any] = {}
             else:
                 # This class has a constructor, so create kwargs for it.
                 kwargs = create_kwargs(cls, params, **extras)

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -246,5 +246,14 @@ class FromParams:
             return subclass.from_params(params=params, **extras)
         else:
             # This is not a base class, so convert our params and extras into a dict of kwargs.
-            kwargs = create_kwargs(cls, params, **extras)
+
+            if cls.__init__ == object.__init__:
+                # This class does not have an explicit constructor, so don't give it any kwargs.
+                # Without this logic, create_kwargs will look at object.__init__ and see that
+                # it takes *args and **kwargs and look for those.
+                kwargs = {}
+            else:
+                # This class has a constructor, so create kwargs for it.
+                kwargs = create_kwargs(cls, params, **extras)
+
             return cls(**kwargs)  # type: ignore

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 from allennlp.common import Params
 from allennlp.common.from_params import FromParams, takes_arg, remove_optional, create_kwargs
 from allennlp.common.testing import AllenNlpTestCase
-
+from allennlp.data.tokenizers.word_splitter import WordSplitter
 
 class MyClass(FromParams):
     def __init__(self, my_int: int, my_bool: bool = False) -> None:
@@ -125,3 +125,8 @@ class TestFromParams(AllenNlpTestCase):
 
         assert c.name == "extra_c"
         assert c.size == 20
+
+    def test_no_constructor(self):
+        params = Params({"type": "just_spaces"})
+
+        WordSplitter.from_params(params)


### PR DESCRIPTION
fixes #1480

also add a test that would have caught this case.

I'm not entirely thrilled with this solution, but it was cleaner than the other ways I thought of.