### PR TITLE
Make usage of make-vocab, dry-run consistent with train and allow 'extend' to be used by both

### DIFF
--- a/allennlp/commands/dry_run.py
+++ b/allennlp/commands/dry_run.py
@@ -97,6 +97,9 @@ def dry_run_from_params(params: Params, serialization_dir: str) -> None:
         if dataset not in all_datasets:
             raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {dataset}")
 
+    logger.info("From dataset instances, %s will be considered for vocabulary creation.",
+                ", ".join(datasets_for_vocab_creation))
+
     instances = [instance for key, dataset in all_datasets.items()
                  for instance in dataset
                  if key in datasets_for_vocab_creation]

--- a/allennlp/commands/dry_run.py
+++ b/allennlp/commands/dry_run.py
@@ -87,8 +87,8 @@ def dry_run_from_params(params: Params, serialization_dir: str) -> None:
     vocab_dir = os.path.join(serialization_dir, "vocabulary")
 
     if os.path.isdir(vocab_dir) and os.listdir(vocab_dir) is not None:
-        raise ConfigurationError("The 'vocabulary' directory in serialization"
-                                 " directory that you provided is non-empty")
+        raise ConfigurationError("The 'vocabulary' directory in the provided"
+                                 "serialization directory is non-empty")
 
     all_datasets = datasets_from_params(params)
     datasets_for_vocab_creation = set(params.pop("datasets_for_vocab_creation", all_datasets))

--- a/allennlp/commands/dry_run.py
+++ b/allennlp/commands/dry_run.py
@@ -86,6 +86,10 @@ def dry_run_from_params(params: Params, serialization_dir: str) -> None:
     os.makedirs(serialization_dir, exist_ok=True)
     vocab_dir = os.path.join(serialization_dir, "vocabulary")
 
+    if os.path.isdir(vocab_dir) and os.listdir(vocab_dir) is not None:
+        raise ConfigurationError("The 'vocabulary' directory in serialization"
+                                 " directory that you provided is non-empty")
+
     all_datasets = datasets_from_params(params)
     datasets_for_vocab_creation = set(params.pop("datasets_for_vocab_creation", all_datasets))
 

--- a/allennlp/commands/dry_run.py
+++ b/allennlp/commands/dry_run.py
@@ -26,21 +26,17 @@ a model.
     --include-package INCLUDE_PACKAGE
                             additional packages to include
 """
-from typing import Dict, List
-from collections import defaultdict
 import argparse
 import logging
 import os
-
-import numpy
 
 from allennlp.commands.train import datasets_from_params
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.params import Params
 from allennlp.common.util import prepare_environment
-from allennlp.data.vocabulary import DEFAULT_NON_PADDED_NAMESPACES
-from allennlp.data import Vocabulary, Instance
+from allennlp.data import Vocabulary
+from allennlp.data.dataset import Batch
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -87,14 +83,8 @@ def dry_run_from_params(params: Params, serialization_dir: str) -> None:
     prepare_environment(params)
 
     vocab_params = params.pop("vocabulary", {})
-    vocab_dir = vocab_params.pop('directory_path', None)
-
-    if vocab_dir is not None:
-        logger.info("Found a vocabulary.directory_path parameter in your config. "
-                    "Also saving the vocab we create to that location.")
-        os.makedirs(vocab_dir, exist_ok=True)
-
     os.makedirs(serialization_dir, exist_ok=True)
+    vocab_dir = os.path.join(serialization_dir, "vocabulary")
 
     all_datasets = datasets_from_params(params)
     datasets_for_vocab_creation = set(params.pop("datasets_for_vocab_creation", all_datasets))
@@ -103,100 +93,15 @@ def dry_run_from_params(params: Params, serialization_dir: str) -> None:
         if dataset not in all_datasets:
             raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {dataset}")
 
-    logger.info("Creating a vocabulary using %s data.", ", ".join(datasets_for_vocab_creation))
-
     instances = [instance for key, dataset in all_datasets.items()
                  for instance in dataset
                  if key in datasets_for_vocab_creation]
 
-    vocabulary = verbosely_create_vocabulary(vocab_params, instances)
+    vocab = Vocabulary.from_params(vocab_params, instances)
+    dataset = Batch(instances)
+    dataset.index_instances(vocab)
+    dataset.print_statistics()
+    vocab.print_statistics(ignore_error=True)
 
-    logger.info(f"writing the vocabulary to {serialization_dir}.")
-    vocabulary.save_to_files(os.path.join(serialization_dir, "vocabulary"))
-    if vocab_dir is not None and os.path.exists(vocab_dir) and os.listdir(vocab_dir) is not None:
-        logger.info(f"You passed a vocabulary.directory_path in your config which already exists "
-                    f"and is non-empty. Refusing to overwrite - we saved it to {serialization_dir} instead.")
-    elif vocab_dir is not None:
-        logger.info(f"You passed a vocabulary.directory_path in your config which was empty. Also "
-                    f"writing the vocabulary to {vocab_dir}.")
-        vocabulary.save_to_files(vocab_dir)
-
-
-def verbosely_create_vocabulary(vocab_params: Params, instances: List[Instance]) -> Vocabulary:
-    """
-    Given a parameter config specifying a vocabulary and a list of instances, this function
-    creates a Vocabulary from the instances. Additionally, it logs corpus statistics, prints
-    a random selection of instances and prints vocabulary sizes and namespaces.
-
-    Parameters
-    ----------
-    vocab_params : ``Params``, required
-        The parameters for the Vocabulary we create.
-    instances : ``List[Instance]``, required.
-        The instances to build the vocabulary from.
-
-    Returns
-    -------
-    The created Vocabulary.
-    """
-    # This is exactly the code in Vocabulary.from_params,
-    # but we want to retain access to the counter we use to
-    # index the data so we can compute statistics about the corpus.
-    min_count = vocab_params.pop("min_count", None)
-    max_vocab_size = vocab_params.pop_int("max_vocab_size", None)
-    non_padded_namespaces = vocab_params.pop("non_padded_namespaces", DEFAULT_NON_PADDED_NAMESPACES)
-    pretrained_files = vocab_params.pop("pretrained_files", {})
-    only_include_pretrained_words = vocab_params.pop_bool("only_include_pretrained_words", False)
-    vocab_params.assert_empty("Vocabulary - from dataset")
-
-    logger.info("Fitting token dictionary from dataset.")
-    namespace_token_counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
-    sequence_field_lengths: Dict[str, List] = defaultdict(list)
-
-    for instance in instances:
-        instance.count_vocab_items(namespace_token_counts)
-    vocabulary = Vocabulary(counter=namespace_token_counts,
-                            min_count=min_count,
-                            max_vocab_size=max_vocab_size,
-                            non_padded_namespaces=non_padded_namespaces,
-                            pretrained_files=pretrained_files,
-                            only_include_pretrained_words=only_include_pretrained_words)
-
-    for instance in instances:
-        instance.index_fields(vocabulary)
-        for field, field_padding_lengths in instance.get_padding_lengths().items():
-            for key, value in field_padding_lengths.items():
-                sequence_field_lengths[f"{field}.{key}"].append(value)
-
-    print("\n\n----Dataset Statistics----\n")
-    for name, lengths in sequence_field_lengths.items():
-        print(f"Statistics for {name}:")
-        print(f"\tLengths: Mean: {numpy.mean(lengths)}, Standard Dev: {numpy.std(lengths)}, "
-              f"Max: {numpy.max(lengths)}, Min: {numpy.min(lengths)}")
-
-    print("\n10 Random instances: ")
-    for i in list(numpy.random.randint(len(instances), size=10)):
-        print(f"Instance {i}:")
-        print(f"\t{instances[i]}")
-
-    print("\n\n----Vocabulary Statistics----\n")
-    print(vocabulary)
-
-    for namespace in namespace_token_counts:
-        tokens_with_counts = list(namespace_token_counts[namespace].items())
-        tokens_with_counts.sort(key=lambda x: x[1], reverse=True)
-        print(f"\nTop 10 most frequent tokens in namespace '{namespace}':")
-        for token, freq in tokens_with_counts[:10]:
-            print(f"\tToken: {token}\t\tFrequency: {freq}")
-        # Now sort by token length, not frequency
-        tokens_with_counts.sort(key=lambda x: len(x[0]), reverse=True)
-
-        print(f"\nTop 10 longest tokens in namespace '{namespace}':")
-        for token, freq in tokens_with_counts[:10]:
-            print(f"\tToken: {token}\t\tlength: {len(token)}\tFrequency: {freq}")
-
-        print(f"\nTop 10 shortest tokens in namespace '{namespace}':")
-        for token, freq in reversed(tokens_with_counts[-10:]):
-            print(f"\tToken: {token}\t\tlength: {len(token)}\tFrequency: {freq}")
-
-    return vocabulary
+    logger.info(f"writing the vocabulary to {vocab_dir}.")
+    vocab.save_to_files(vocab_dir)

--- a/allennlp/commands/dry_run.py
+++ b/allennlp/commands/dry_run.py
@@ -29,14 +29,16 @@ a model.
 import argparse
 import logging
 import os
+import re
 
 from allennlp.commands.train import datasets_from_params
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.params import Params
-from allennlp.common.util import prepare_environment
+from allennlp.common.util import prepare_environment, get_frozen_and_tunable_parameter_names
 from allennlp.data import Vocabulary
 from allennlp.data.dataset import Batch
+from allennlp.models import Model
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -112,3 +114,19 @@ def dry_run_from_params(params: Params, serialization_dir: str) -> None:
 
     logger.info(f"writing the vocabulary to {vocab_dir}.")
     vocab.save_to_files(vocab_dir)
+
+    model = Model.from_params(vocab=vocab, params=params.pop('model'))
+    trainer_params = params.pop("trainer")
+    no_grad_regexes = trainer_params.pop("no_grad", ())
+    for name, parameter in model.named_parameters():
+        if any(re.search(regex, name) for regex in no_grad_regexes):
+            parameter.requires_grad_(False)
+
+    frozen_parameter_names, tunable_parameter_names = \
+                   get_frozen_and_tunable_parameter_names(model)
+    logger.info("Following parameters are Frozen  (without gradient):")
+    for name in frozen_parameter_names:
+        logger.info(name)
+    logger.info("Following parameters are Tunable (with gradient):")
+    for name in tunable_parameter_names:
+        logger.info(name)

--- a/allennlp/commands/dry_run.py
+++ b/allennlp/commands/dry_run.py
@@ -87,7 +87,7 @@ def dry_run_from_params(params: Params, serialization_dir: str) -> None:
     vocab_dir = os.path.join(serialization_dir, "vocabulary")
 
     if os.path.isdir(vocab_dir) and os.listdir(vocab_dir) is not None:
-        raise ConfigurationError("The 'vocabulary' directory in the provided"
+        raise ConfigurationError("The 'vocabulary' directory in the provided "
                                  "serialization directory is non-empty")
 
     all_datasets = datasets_from_params(params)
@@ -105,7 +105,7 @@ def dry_run_from_params(params: Params, serialization_dir: str) -> None:
     dataset = Batch(instances)
     dataset.index_instances(vocab)
     dataset.print_statistics()
-    vocab.print_statistics(ignore_error=True)
+    vocab.print_statistics()
 
     logger.info(f"writing the vocabulary to {vocab_dir}.")
     vocab.save_to_files(vocab_dir)

--- a/allennlp/commands/make_vocab.py
+++ b/allennlp/commands/make_vocab.py
@@ -94,6 +94,9 @@ def make_vocab_from_params(params: Params, serialization_dir: str):
         if dataset not in all_datasets:
             raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {dataset}")
 
+    logger.info("From dataset instances, %s will be considered for vocabulary creation.",
+                ", ".join(datasets_for_vocab_creation))
+
     instances = [instance for key, dataset in all_datasets.items()
                  for instance in dataset
                  if key in datasets_for_vocab_creation]

--- a/allennlp/commands/make_vocab.py
+++ b/allennlp/commands/make_vocab.py
@@ -84,7 +84,7 @@ def make_vocab_from_params(params: Params, serialization_dir: str):
     vocab_dir = os.path.join(serialization_dir, "vocabulary")
 
     if os.path.isdir(vocab_dir) and os.listdir(vocab_dir) is not None:
-        raise ConfigurationError("The 'vocabulary' directory in the provided"
+        raise ConfigurationError("The 'vocabulary' directory in the provided "
                                  "serialization directory is non-empty")
 
     all_datasets = datasets_from_params(params)

--- a/allennlp/commands/make_vocab.py
+++ b/allennlp/commands/make_vocab.py
@@ -17,6 +17,8 @@ each training run.
 
     optional arguments:
     -h, --help            show this help message and exit
+   -s SERIALIZATION_DIR, --serialization-dir SERIALIZATION_DIR
+                           directory in which to save the vocabulary directory
     -o OVERRIDES, --overrides OVERRIDES
                           a JSON structure used to override the experiment
                           configuration
@@ -47,6 +49,11 @@ class MakeVocab(Subcommand):
                                type=str,
                                help='path to parameter file describing the model and its inputs')
 
+        subparser.add_argument('-s', '--serialization-dir',
+                               required=True,
+                               type=str,
+                               help='directory in which to save the vocabulary directory')
+
         subparser.add_argument('-o', '--overrides',
                                type=str,
                                default="",
@@ -63,20 +70,17 @@ def make_vocab_from_args(args: argparse.Namespace):
     """
     parameter_path = args.param_path
     overrides = args.overrides
+    serialization_dir = args.serialization_dir
 
     params = Params.from_file(parameter_path, overrides)
+    vocab_dir = os.path.join(serialization_dir, "vocabulary")
 
-    make_vocab_from_params(params)
+    make_vocab_from_params(params, vocab_dir)
 
-def make_vocab_from_params(params: Params):
+def make_vocab_from_params(params: Params, vocab_dir: str):
     prepare_environment(params)
 
     vocab_params = params.pop("vocabulary", {})
-    vocab_dir = vocab_params.pop('directory_path', None)
-    if vocab_dir is None:
-        raise ConfigurationError("To use `make-vocab` your configuration must contain a value "
-                                 "at vocabulary.directory_path")
-
     os.makedirs(vocab_dir, exist_ok=True)
 
     all_datasets = datasets_from_params(params)

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -268,7 +268,8 @@ def train_model(params: Params,
         if dataset not in all_datasets:
             raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {dataset}")
 
-    logger.info("Creating a vocabulary using %s data.", ", ".join(datasets_for_vocab_creation))
+    logger.info("From dataset instances, %s will be considered for vocabulary creation.",
+                ", ".join(datasets_for_vocab_creation))
     vocab = Vocabulary.from_params(
             params.pop("vocabulary", {}),
             (instance for key, dataset in all_datasets.items()

--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -162,10 +162,12 @@ class Batch(Iterable):
         # Make sure if has been indexed first
         sequence_field_lengths: Dict[str, List] = defaultdict(list)
         for instance in self.instances:
+            if not instance.indexed:
+                raise ConfigurationError("Instances must be indexed with vocabulary "
+                                         "before asking to print dataset statistics.")
             for field, field_padding_lengths in instance.get_padding_lengths().items():
                 for key, value in field_padding_lengths.items():
                     sequence_field_lengths[f"{field}.{key}"].append(value)
-
 
         print("\n\n----Dataset Statistics----\n")
         for name, lengths in sequence_field_lengths.items():

--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -7,6 +7,7 @@ import logging
 from collections import defaultdict
 from typing import Dict, List, Union, Iterator, Iterable
 
+import numpy
 import torch
 
 from allennlp.common.checks import ConfigurationError
@@ -156,3 +157,23 @@ class Batch(Iterable):
     def index_instances(self, vocab: Vocabulary) -> None:
         for instance in self.instances:
             instance.index_fields(vocab)
+
+    def print_statistics(self) -> None:
+        # Make sure if has been indexed first
+        sequence_field_lengths: Dict[str, List] = defaultdict(list)
+        for instance in self.instances:
+            for field, field_padding_lengths in instance.get_padding_lengths().items():
+                for key, value in field_padding_lengths.items():
+                    sequence_field_lengths[f"{field}.{key}"].append(value)
+
+
+        print("\n\n----Dataset Statistics----\n")
+        for name, lengths in sequence_field_lengths.items():
+            print(f"Statistics for {name}:")
+            print(f"\tLengths: Mean: {numpy.mean(lengths)}, Standard Dev: {numpy.std(lengths)}, "
+                  f"Max: {numpy.max(lengths)}, Min: {numpy.min(lengths)}")
+
+        print("\n10 Random instances: ")
+        for i in list(numpy.random.randint(len(self.instances), size=10)):
+            print(f"Instance {i}:")
+            print(f"\t{self.instances[i]}")

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -214,6 +214,7 @@ class Vocabulary(Registrable):
         self._index_to_token = _IndexToTokenDefaultDict(self._non_padded_namespaces,
                                                         self._padding_token,
                                                         self._oov_token)
+        self._retained_counter = None
         # Made an empty vocabulary, now extend it.
         self._extend(counter,
                      min_count,
@@ -589,13 +590,13 @@ class Vocabulary(Registrable):
                       for name in self._index_to_token]
         return " ".join([base_string, non_padded_namespaces] + namespaces)
 
-    def print_statistics(self, ignore_error: bool = False) -> None:
+    def print_statistics(self) -> None:
         if self._retained_counter:
-            # Caveat: Printed info is only for part of vocabulary generated from instances. If Vocabulary
-            # is constructed by extending saved vocabulary with dataset instances, then directly loaded
-            # portion won't be considered for statistics. This might be confusing for users. But it
-            # it is impossible to consider that portion since we do not save counter information.
+            logger.info("Printed vocabulary statistics are only for the part of the vocabulary generated " \
+                        "from instances. If vocabulary is constructed by extending saved vocabulary with " \
+                        "dataset instances, the directly loaded portion won't be considered here.")
             print("\n\n----Vocabulary Statistics----\n")
+            # Since we don't saved counter info, it is impossible to consider pre-saved portion.
             for namespace in self._retained_counter:
                 tokens_with_counts = list(self._retained_counter[namespace].items())
                 tokens_with_counts.sort(key=lambda x: x[1], reverse=True)
@@ -613,8 +614,6 @@ class Vocabulary(Registrable):
                 for token, freq in reversed(tokens_with_counts[-10:]):
                     print(f"\tToken: {token}\t\tlength: {len(token)}\tFrequency: {freq}")
         else:
-            # _retained_counter would only be set if instances were used for vocabulary construction.
-            # It is possible to use only directly load the saved vocabulary for which we do not have
-            # the counter to print above statistics.
-            if not ignore_error:
-                raise ConfigurationError("Counter must be retained for printing vocabulary statistics.")
+            # _retained_counter would be set only if instances were used for vocabulary construction.
+            logger.info("Vocabulary statistics cannot be printed since " \
+                        "dataset instances were not used for its construction.")

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -214,7 +214,7 @@ class Vocabulary(Registrable):
         self._index_to_token = _IndexToTokenDefaultDict(self._non_padded_namespaces,
                                                         self._padding_token,
                                                         self._oov_token)
-        self._retained_counter = None
+        self._retained_counter: Optional[Dict[str, Dict[str, int]]] = None
         # Made an empty vocabulary, now extend it.
         self._extend(counter,
                      min_count,

--- a/allennlp/tests/commands/dry_run_test.py
+++ b/allennlp/tests/commands/dry_run_test.py
@@ -1,9 +1,11 @@
 # pylint: disable=invalid-name,no-self-use
+import argparse
 import os
 
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.commands.dry_run import dry_run_from_params
+from allennlp.commands.dry_run import DryRun, dry_run_from_args, dry_run_from_params
+from allennlp.data import Vocabulary
 
 class TestDryRun(AllenNlpTestCase):
     def setUp(self):
@@ -36,20 +38,114 @@ class TestDryRun(AllenNlpTestCase):
         })
 
     def test_dry_run_doesnt_overwrite_vocab(self):
-        vocab_path = self.TEST_DIR / 'pre-defined-vocab'
-        os.mkdir(vocab_path)
-        # Put something in the vocab directory
-        with open(vocab_path / "test.txt", "a+") as open_file:
-            open_file.write("test")
+        pass
 
-        self.params['vocabulary'] = {}
-        self.params['vocabulary']['directory_path'] = vocab_path
+    def test_dry_run_without_vocabulary_key(self):
+        dry_run_from_params(self.params, self.TEST_DIR)
+
+    def test_dry_run_makes_vocab(self):
+        vocab_path = self.TEST_DIR / 'vocabulary'
 
         dry_run_from_params(self.params, self.TEST_DIR)
 
-        # Shouldn't have been overwritten.
-        predefined_vocab_files = os.listdir(vocab_path)
-        assert set(predefined_vocab_files) == {'test.txt'}
-        # But we should have written the created vocab to serialisation_dir/vocab:
-        new_vocab_files = os.listdir(self.TEST_DIR / 'vocabulary')
-        assert set(new_vocab_files) == {'tokens.txt', 'non_padded_namespaces.txt', 'labels.txt'}
+        vocab_files = os.listdir(vocab_path)
+        assert set(vocab_files) == {'labels.txt', 'non_padded_namespaces.txt', 'tokens.txt'}
+
+        with open(vocab_path / 'tokens.txt') as f:
+            tokens = [line.strip() for line in f]
+
+        tokens.sort()
+        assert tokens == ['.', '@@UNKNOWN@@', 'animals', 'are', 'birds', 'cats', 'dogs', 'snakes']
+
+        with open(vocab_path / 'labels.txt') as f:
+            labels = [line.strip() for line in f]
+
+        labels.sort()
+        assert labels == ['N', 'V']
+
+    def test_dry_run_with_extension(self):
+        existing_serialization_dir = self.TEST_DIR / 'existing'
+        extended_serialization_dir = self.TEST_DIR / 'extended'
+        existing_vocab_path = existing_serialization_dir / 'vocabulary'
+        extended_vocab_path = extended_serialization_dir / 'vocabulary'
+
+        vocab = Vocabulary()
+        vocab.add_token_to_namespace('some_weird_token_1', namespace='tokens')
+        vocab.add_token_to_namespace('some_weird_token_2', namespace='tokens')
+        os.makedirs(existing_serialization_dir, exist_ok=True)
+        vocab.save_to_files(existing_vocab_path)
+
+        self.params['vocabulary'] = {}
+        self.params['vocabulary']['directory_path'] = existing_vocab_path
+        self.params['vocabulary']['extend'] = True
+        self.params['vocabulary']['min_count'] = {"tokens" : 3}
+        dry_run_from_params(self.params, extended_serialization_dir)
+
+        vocab_files = os.listdir(extended_vocab_path)
+        assert set(vocab_files) == {'labels.txt', 'non_padded_namespaces.txt', 'tokens.txt'}
+
+        with open(extended_vocab_path / 'tokens.txt') as f:
+            tokens = [line.strip() for line in f]
+
+        assert tokens[0] == '@@UNKNOWN@@'
+        assert tokens[1] == 'some_weird_token_1'
+        assert tokens[2] == 'some_weird_token_2'
+
+        tokens.sort()
+        assert tokens == ['.', '@@UNKNOWN@@', 'animals', 'are',
+                          'some_weird_token_1', 'some_weird_token_2']
+
+        with open(extended_vocab_path / 'labels.txt') as f:
+            labels = [line.strip() for line in f]
+
+        labels.sort()
+        assert labels == ['N', 'V']
+
+    def test_dry_run_without_extension(self):
+        existing_serialization_dir = self.TEST_DIR / 'existing'
+        extended_serialization_dir = self.TEST_DIR / 'extended'
+        existing_vocab_path = existing_serialization_dir / 'vocabulary'
+        extended_vocab_path = extended_serialization_dir / 'vocabulary'
+
+        vocab = Vocabulary()
+        # if extend is False, its users responsibility to make sure that dataset instances
+        # will be indexible by provided vocabulary. At least @@UNKNOWN@@ should be present in
+        # namespace for which there could be OOV entries seen in dataset during indexing.
+        # For `tokens` ns, new words will be seen but `tokens` has @@UNKNOWN@@ token.
+        # but for 'labels' ns, there is no @@UNKNOWN@@ so required to add 'N', 'V' upfront.
+        vocab.add_token_to_namespace('some_weird_token_1', namespace='tokens')
+        vocab.add_token_to_namespace('some_weird_token_2', namespace='tokens')
+        vocab.add_token_to_namespace('N', namespace='labels')
+        vocab.add_token_to_namespace('V', namespace='labels')
+        os.makedirs(existing_serialization_dir, exist_ok=True)
+        vocab.save_to_files(existing_vocab_path)
+
+        self.params['vocabulary'] = {}
+        self.params['vocabulary']['directory_path'] = existing_vocab_path
+        self.params['vocabulary']['extend'] = False
+        dry_run_from_params(self.params, extended_serialization_dir)
+
+        with open(extended_vocab_path / 'tokens.txt') as f:
+            tokens = [line.strip() for line in f]
+
+        assert tokens[0] == '@@UNKNOWN@@'
+        assert tokens[1] == 'some_weird_token_1'
+        assert tokens[2] == 'some_weird_token_2'
+        assert len(tokens) == 3
+
+    def test_make_vocab_args(self):
+        parser = argparse.ArgumentParser(description="Testing")
+        subparsers = parser.add_subparsers(title='Commands', metavar='')
+        DryRun().add_subparser('dry-run', subparsers)
+        for serialization_arg in ["-s", "--serialization-dir"]:
+            raw_args = ["dry-run", "path/to/params", serialization_arg, "serialization_dir"]
+            args = parser.parse_args(raw_args)
+            assert args.func == dry_run_from_args
+            assert args.param_path == "path/to/params"
+            assert args.serialization_dir == "serialization_dir"
+
+    def test_dataset_statistics_printing(self):
+        pass
+
+    def test_vocabulary_statistics_printing(self):
+        pass

--- a/allennlp/tests/commands/dry_run_test.py
+++ b/allennlp/tests/commands/dry_run_test.py
@@ -153,9 +153,3 @@ class TestDryRun(AllenNlpTestCase):
             assert args.func == dry_run_from_args
             assert args.param_path == "path/to/params"
             assert args.serialization_dir == "serialization_dir"
-
-    def test_dataset_statistics_printing(self):
-        pass
-
-    def test_vocabulary_statistics_printing(self):
-        pass

--- a/allennlp/tests/commands/dry_run_test.py
+++ b/allennlp/tests/commands/dry_run_test.py
@@ -2,10 +2,13 @@
 import argparse
 import os
 
+import pytest
+
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.commands.dry_run import DryRun, dry_run_from_args, dry_run_from_params
 from allennlp.data import Vocabulary
+from allennlp.common.checks import ConfigurationError
 
 class TestDryRun(AllenNlpTestCase):
     def setUp(self):
@@ -38,7 +41,15 @@ class TestDryRun(AllenNlpTestCase):
         })
 
     def test_dry_run_doesnt_overwrite_vocab(self):
-        pass
+        vocab_path = self.TEST_DIR / 'vocabulary'
+        os.mkdir(vocab_path)
+        # Put something in the vocab directory
+        with open(vocab_path / "test.txt", "a+") as open_file:
+            open_file.write("test")
+        # It should raise error if vocab dir is non-empty
+        with pytest.raises(ConfigurationError):
+            dry_run_from_params(self.params, self.TEST_DIR)
+
 
     def test_dry_run_without_vocabulary_key(self):
         dry_run_from_params(self.params, self.TEST_DIR)

--- a/allennlp/tests/commands/dry_run_test.py
+++ b/allennlp/tests/commands/dry_run_test.py
@@ -50,7 +50,6 @@ class TestDryRun(AllenNlpTestCase):
         with pytest.raises(ConfigurationError):
             dry_run_from_params(self.params, self.TEST_DIR)
 
-
     def test_dry_run_without_vocabulary_key(self):
         dry_run_from_params(self.params, self.TEST_DIR)
 

--- a/allennlp/tests/commands/make_vocab_test.py
+++ b/allennlp/tests/commands/make_vocab_test.py
@@ -1,9 +1,10 @@
 # pylint: disable=invalid-name,no-self-use
+import argparse
 import os
 
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.commands.make_vocab import make_vocab_from_params
+from allennlp.commands.make_vocab import MakeVocab, make_vocab_from_args, make_vocab_from_params
 from allennlp.data import Vocabulary
 
 class TestMakeVocab(AllenNlpTestCase):
@@ -141,3 +142,14 @@ class TestMakeVocab(AllenNlpTestCase):
         assert tokens[1] == 'some_weird_token_1'
         assert tokens[2] == 'some_weird_token_2'
         assert len(tokens) == 3
+
+    def test_make_vocab_args(self):
+        parser = argparse.ArgumentParser(description="Testing")
+        subparsers = parser.add_subparsers(title='Commands', metavar='')
+        MakeVocab().add_subparser('make-vocab', subparsers)
+        for serialization_arg in ["-s", "--serialization-dir"]:
+            raw_args = ["make-vocab", "path/to/params", serialization_arg, "serialization_dir"]
+            args = parser.parse_args(raw_args)
+            assert args.func == make_vocab_from_args
+            assert args.param_path == "path/to/params"
+            assert args.serialization_dir == "serialization_dir"

--- a/allennlp/tests/commands/make_vocab_test.py
+++ b/allennlp/tests/commands/make_vocab_test.py
@@ -1,12 +1,10 @@
 # pylint: disable=invalid-name,no-self-use
 import os
 
-import pytest
-
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.commands.make_vocab import make_vocab_from_params
+from allennlp.data import Vocabulary
 
 class TestMakeVocab(AllenNlpTestCase):
     def setUp(self):
@@ -38,17 +36,14 @@ class TestMakeVocab(AllenNlpTestCase):
                 }
         })
 
-    def test_make_vocab_fails_without_vocabulary_key(self):
-        with pytest.raises(ConfigurationError):
-            make_vocab_from_params(self.params)
+    def test_make_vocab_succeeds_without_vocabulary_key(self):
+        vocab_path = self.TEST_DIR / 'vocabulary'
+        make_vocab_from_params(self.params, vocab_path)
 
     def test_make_vocab_makes_vocab(self):
         vocab_path = self.TEST_DIR / 'vocabulary'
 
-        self.params['vocabulary'] = {}
-        self.params['vocabulary']['directory_path'] = vocab_path
-
-        make_vocab_from_params(self.params)
+        make_vocab_from_params(self.params, vocab_path)
 
         vocab_files = os.listdir(vocab_path)
         assert set(vocab_files) == {'labels.txt', 'non_padded_namespaces.txt', 'tokens.txt'}
@@ -69,10 +64,9 @@ class TestMakeVocab(AllenNlpTestCase):
         vocab_path = self.TEST_DIR / 'vocabulary'
 
         self.params['vocabulary'] = {}
-        self.params['vocabulary']['directory_path'] = vocab_path
         self.params['vocabulary']['min_count'] = {"tokens" : 3}
 
-        make_vocab_from_params(self.params)
+        make_vocab_from_params(self.params, vocab_path)
 
         vocab_files = os.listdir(vocab_path)
         assert set(vocab_files) == {'labels.txt', 'non_padded_namespaces.txt', 'tokens.txt'}
@@ -84,6 +78,42 @@ class TestMakeVocab(AllenNlpTestCase):
         assert tokens == ['.', '@@UNKNOWN@@', 'animals', 'are']
 
         with open(vocab_path / 'labels.txt') as f:
+            labels = [line.strip() for line in f]
+
+        labels.sort()
+        assert labels == ['N', 'V']
+
+    def test_make_vocab_with_extension(self):
+        existing_vocab_path = self.TEST_DIR / 'vocabulary_existing'
+        extended_vocab_path = self.TEST_DIR / 'vocabulary_extended'
+
+        vocab = Vocabulary()
+        vocab.add_token_to_namespace('some_weird_token_1', namespace='tokens')
+        vocab.add_token_to_namespace('some_weird_token_2', namespace='tokens')
+        os.makedirs(existing_vocab_path, exist_ok=True)
+        vocab.save_to_files(existing_vocab_path)
+
+        self.params['vocabulary'] = {}
+        self.params['vocabulary']['directory_path'] = existing_vocab_path
+        self.params['vocabulary']['extend'] = True
+        self.params['vocabulary']['min_count'] = {"tokens" : 3}
+        make_vocab_from_params(self.params, extended_vocab_path)
+
+        vocab_files = os.listdir(extended_vocab_path)
+        assert set(vocab_files) == {'labels.txt', 'non_padded_namespaces.txt', 'tokens.txt'}
+
+        with open(extended_vocab_path / 'tokens.txt') as f:
+            tokens = [line.strip() for line in f]
+
+        assert tokens[0] == '@@UNKNOWN@@'
+        assert tokens[1] == 'some_weird_token_1'
+        assert tokens[2] == 'some_weird_token_2'
+
+        tokens.sort()
+        assert tokens == ['.', '@@UNKNOWN@@', 'animals', 'are',
+                          'some_weird_token_1', 'some_weird_token_2']
+
+        with open(extended_vocab_path / 'labels.txt') as f:
             labels = [line.strip() for line in f]
 
         labels.sort()

--- a/allennlp/tests/commands/make_vocab_test.py
+++ b/allennlp/tests/commands/make_vocab_test.py
@@ -118,3 +118,26 @@ class TestMakeVocab(AllenNlpTestCase):
 
         labels.sort()
         assert labels == ['N', 'V']
+
+    def test_make_vocab_without_extension(self):
+        existing_vocab_path = self.TEST_DIR / 'vocabulary_existing'
+        extended_vocab_path = self.TEST_DIR / 'vocabulary_extended'
+
+        vocab = Vocabulary()
+        vocab.add_token_to_namespace('some_weird_token_1', namespace='tokens')
+        vocab.add_token_to_namespace('some_weird_token_2', namespace='tokens')
+        os.makedirs(existing_vocab_path, exist_ok=True)
+        vocab.save_to_files(existing_vocab_path)
+
+        self.params['vocabulary'] = {}
+        self.params['vocabulary']['directory_path'] = existing_vocab_path
+        self.params['vocabulary']['extend'] = False
+        make_vocab_from_params(self.params, extended_vocab_path)
+
+        with open(extended_vocab_path / 'tokens.txt') as f:
+            tokens = [line.strip() for line in f]
+
+        assert tokens[0] == '@@UNKNOWN@@'
+        assert tokens[1] == 'some_weird_token_1'
+        assert tokens[2] == 'some_weird_token_2'
+        assert len(tokens) == 3


### PR DESCRIPTION
Usage of `vocab_params` ("vocabulary" key in config.json) in `make-vocab` command is not in sync with usage of `vocab_params` in other commands. IMO, behaviour of `vocab_params` should be similar in both.

In `train` command, `"vocabulary": "directory_path"` is the input for vocabulary construction. If `"extend"=true` is given, then vocabulary would be loaded from "directory_path" and dataset-read-instances will be used to extend it with. Otherwise, vocabulary is loaded from "directory_path" and is used as it is. 

```
# vocab_params
"vocabulary": {
    "directory_path": "vocabulary_dir_path"
    "extend": true # false
}
```
In both cases, the output vocabulary is dumped in `serialization_dir/vocabulary`.

However, in `make-vocab`, `"vocabulary": "directory_path"` is taken as the **output path**, where vocabulary will be dumped instead of input path. This is not consistent with other usage and makes it somewhat confusing. More importantly, because of this, `extend` key is **ignored** and **prevents** to use of `make-vocab` for **vocab extension**.

This PR changes input-output for `make-vocab` command. Input is through params of "vocabulary" key just like `train` and dumps is in `serialization_dir/vocabulary`. Hence `vocab_params` behaves in `make-vocab` exactly as `train` and vocab-extention happens implicitly if `extend` is passed as true. It also works if vocab_params are absent. But now, one does need to pass serialization_dir just like `train` for output.

I had to change some tests because of this change.