### PR TITLE
make tables nice in validation summary

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -624,23 +624,28 @@ class Trainer:
         Logs all of the train metrics (and validation metrics, if provided) to the console.
         """
         val_metrics = val_metrics or {}
-        dual_message_template = "Training %s : %3f    Validation %s : %3f "
-        message_template = "%s %s : %3f "
+        dual_message_template = "%s |  %8.3f  |  %8.3f"
+        no_val_message_template = "%s |  %8.3f  |  %8s"
+        no_train_message_template = "%s |  %8s  |  %8.3f"
+        header_template = "%s |  %-10s"
 
         metric_names = set(train_metrics.keys())
         if val_metrics:
             metric_names.update(val_metrics.keys())
 
+        name_length = max([len(x) for x in metric_names])
+
+        logger.info(header_template, "Training".rjust(name_length + 13), "Validation")
         for name in metric_names:
             train_metric = train_metrics.get(name)
             val_metric = val_metrics.get(name)
 
             if val_metric is not None and train_metric is not None:
-                logger.info(dual_message_template, name, train_metric, name, val_metric)
+                logger.info(dual_message_template, name.ljust(name_length), train_metric, val_metric)
             elif val_metric is not None:
-                logger.info(message_template, "Validation", name, val_metric)
+                logger.info(no_train_message_template, name.ljust(name_length), "N/A", val_metric)
             elif train_metric is not None:
-                logger.info(message_template, "Training", name, train_metric)
+                logger.info(no_val_message_template, name.ljust(name_length), train_metric, "N/A")
 
     def _validation_loss(self) -> Tuple[float, int]:
         """


### PR DESCRIPTION
Looking at logs to get results in beaker is so annoying, so this makes it a bit nicer by aligning stuff.

Before:
```
2018-07-13 15:53:07,899 - INFO - allennlp.training.trainer - Training f1-measure-overall : 0.000000    Validation f1-measure-overall : 0.000000
2018-07-13 15:53:07,900 - INFO - allennlp.training.trainer - Training precision-overall : 0.000000    Validation precision-overall : 0.000000
2018-07-13 15:53:07,900 - INFO - allennlp.training.trainer - Training recall-overall : 0.000000    Validation recall-overall : 0.000000
```

After:
```
2018-07-13 15:50:03,244 - INFO - allennlp.training.trainer -                        Training |  Validation
2018-07-13 15:50:03,245 - INFO - allennlp.training.trainer - f1-measure-overall |     0.000  |     0.000
2018-07-13 15:50:03,245 - INFO - allennlp.training.trainer - loss               |    19.060  |    17.070
2018-07-13 15:50:03,245 - INFO - allennlp.training.trainer - recall-overall     |     0.000  |     0.000
2018-07-13 15:50:03,246 - INFO - allennlp.training.trainer - precision-overall  |     0.000  |     0.000
```