### PR TITLE
Fix start of tqdm logging in training.

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -455,8 +455,6 @@ class Trainer:
                                          num_epochs=1,
                                          cuda_device=self._iterator_device)
         num_training_batches = self._iterator.get_num_batches(self._train_data)
-        train_generator_tqdm = Tqdm.tqdm(train_generator,
-                                         total=num_training_batches)
         self._last_log = time.time()
         last_save_time = time.time()
 
@@ -468,6 +466,8 @@ class Trainer:
             histogram_parameters = set(self._model.get_parameters_for_histogram_tensorboard_logging())
 
         logger.info("Training")
+        train_generator_tqdm = Tqdm.tqdm(train_generator,
+                                         total=num_training_batches)
         for batch in train_generator_tqdm:
             batches_this_epoch += 1
             self._batch_num_total += 1


### PR DESCRIPTION
Before:
```
2018-07-15 11:08:52,306 - Peak CPU memory usage MB: 839.0656
  0%|          | 0/369 [00:00<?, ?it/s]2018-07-15 11:08:52,321 - Training
accuracy: 0.6882, prec: 0.6277, rec: 0.3557, f1: 0.4541, loss: 0.5876 ||: 100%|##########| 369/369 [00:37<00:00,  9.75it/s]
2018-07-15 11:09:30,161 - Validating
accuracy: 0.6933, prec: 0.7124, rec: 0.6560, f1: 0.6830, loss: 0.5581 ||: 100%|##########| 21/21 [00:00<00:00, 24.23it/s]
```

After:
```
2018-07-15 11:10:27,697 - Peak CPU memory usage MB: 839.528448
2018-07-15 11:10:27,707 - Training
accuracy: 0.6882, prec: 0.6277, rec: 0.3557, f1: 0.4541, loss: 0.5876 ||: 100%|##########| 369/369 [00:37<00:00,  9.91it/s]
2018-07-15 11:11:04,929 - Validating
accuracy: 0.6933, prec: 0.7124, rec: 0.6560, f1: 0.6830, loss: 0.5581 ||: 100%|##########| 21/21 [00:00<00:00, 23.49it/s]
```

On a related note, if descriptions are too long (leads to new line), the tqdm updates doesn't print nice. This is perhaps because tqdm doesn't support multiline bars and am not sure if anything can be done about it! Eg: 

<img width="1258" alt="screen shot 2018-07-15 at 11 18 41 am" src="https://user-images.githubusercontent.com/3285313/42735395-fbfcee9e-8820-11e8-9606-5406e8162fd1.png">

This isn't as such important .. but still if someone has a idea to fix this, let me know.