### PR TITLE
Add IOB1 support to SpanBasedF1Metric

### DIFF
--- a/allennlp/data/dataset_readers/dataset_utils/span_utils.py
+++ b/allennlp/data/dataset_readers/dataset_utils/span_utils.py
@@ -159,7 +159,7 @@ def iob1_tags_to_spans(tag_sequence: List[str],
         Note that the label `does not` contain any BIO tag prefixes.
     """
     classes_to_ignore = classes_to_ignore or []
-    spans = set()
+    spans: Set[Tuple[str, Tuple[int, int]]] = set()
     span_start = 0
     span_end = 0
     active_conll_tag = None

--- a/allennlp/data/dataset_readers/dataset_utils/span_utils.py
+++ b/allennlp/data/dataset_readers/dataset_utils/span_utils.py
@@ -165,15 +165,15 @@ def iob1_tags_to_spans(tag_sequence: List[str],
     active_conll_tag = None
     for index, string_tag in enumerate(tag_sequence):
         prev_string_tag = tag_sequence[index-1] if index - 1 > -1 else None
-        prev_bio_tag = prev_string_tag[0]
-        prev_conll_tag = prev_string_tag[2:]
+        prev_bio_tag = prev_string_tag[0] if prev_string_tag is not None else None
+        prev_conll_tag = prev_string_tag[2:] if prev_string_tag is not None else None
 
         curr_bio_tag = string_tag[0]
         curr_conll_tag = string_tag[2:]
 
         if curr_bio_tag not in ["B", "I", "O"]:
             raise InvalidTagSequence(tag_sequence)
-        if curr_bio_tag == "O" or conll_tag in classes_to_ignore:
+        if curr_bio_tag == "O" or curr_conll_tag in classes_to_ignore:
             # The span has ended.
             if active_conll_tag is not None:
                 spans.add((active_conll_tag, (span_start, span_end)))
@@ -187,11 +187,11 @@ def iob1_tags_to_spans(tag_sequence: List[str],
             # and active tag to new span.
             if active_conll_tag is not None:
                 spans.add((active_conll_tag, (span_start, span_end)))
-            active_conll_tag = conll_tag
+            active_conll_tag = curr_conll_tag
             span_start = index
             span_end = index
         else:
-            # bio_tag == "I" and conll_tag == active_conll_tag
+            # bio_tag == "I" and curr_conll_tag == active_conll_tag
             # We're continuing a span.
             span_end += 1
     # Last token might have been a part of a valid span.

--- a/allennlp/data/dataset_readers/dataset_utils/span_utils.py
+++ b/allennlp/data/dataset_readers/dataset_utils/span_utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Set, Tuple, TypeVar
+from typing import Callable, List, Optional, Set, Tuple, TypeVar
 
 from allennlp.data.dataset_readers.dataset_utils.ontonotes import TypedStringSpan
 from allennlp.data.tokenizers.token import Token
@@ -198,7 +198,10 @@ def iob1_tags_to_spans(tag_sequence: List[str],
     return list(spans)
 
 
-def _iob1_start_of_chunk(prev_bio_tag, prev_conll_tag, curr_bio_tag, curr_conll_tag):
+def _iob1_start_of_chunk(prev_bio_tag: Optional[str],
+                         prev_conll_tag: Optional[str],
+                         curr_bio_tag: str,
+                         curr_conll_tag: str) -> bool:
     if curr_bio_tag == 'B':
         return True
     if curr_bio_tag == "I" and prev_bio_tag == "O":

--- a/allennlp/data/dataset_readers/dataset_utils/span_utils.py
+++ b/allennlp/data/dataset_readers/dataset_utils/span_utils.py
@@ -163,11 +163,9 @@ def iob1_tags_to_spans(tag_sequence: List[str],
     span_start = 0
     span_end = 0
     active_conll_tag = None
+    prev_bio_tag = None
+    prev_conll_tag = None
     for index, string_tag in enumerate(tag_sequence):
-        prev_string_tag = tag_sequence[index-1] if index - 1 > -1 else None
-        prev_bio_tag = prev_string_tag[0] if prev_string_tag is not None else None
-        prev_conll_tag = prev_string_tag[2:] if prev_string_tag is not None else None
-
         curr_bio_tag = string_tag[0]
         curr_conll_tag = string_tag[2:]
 
@@ -178,9 +176,6 @@ def iob1_tags_to_spans(tag_sequence: List[str],
             if active_conll_tag is not None:
                 spans.add((active_conll_tag, (span_start, span_end)))
             active_conll_tag = None
-            # We don't care about tags we are
-            # told to ignore, so we do nothing.
-            continue
         elif _iob1_start_of_chunk(prev_bio_tag, prev_conll_tag,
                                   curr_bio_tag, curr_conll_tag):
             # We are entering a new span; reset indices
@@ -194,6 +189,9 @@ def iob1_tags_to_spans(tag_sequence: List[str],
             # bio_tag == "I" and curr_conll_tag == active_conll_tag
             # We're continuing a span.
             span_end += 1
+
+        prev_bio_tag = string_tag[0]
+        prev_conll_tag = string_tag[2:]
     # Last token might have been a part of a valid span.
     if active_conll_tag is not None:
         spans.add((active_conll_tag, (span_start, span_end)))

--- a/allennlp/tests/data/dataset_readers/dataset_utils/span_utils_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_utils/span_utils_test.py
@@ -47,34 +47,34 @@ class SpanUtilsTest(AllenNlpTestCase):
 
     def test_iob1_tags_to_spans_extracts_correct_spans_without_labels(self):
         tag_sequence = ["I", "B", "I", "O", "B", "I", "B", "B"]
-        spans = span_utils.bio_tags_to_spans(tag_sequence)
+        spans = span_utils.iob1_tags_to_spans(tag_sequence)
         assert set(spans) == {("", (0, 0)), ("", (1, 2)), ("", (4, 5)), ("", (6, 6)), ("", (7, 7))}
 
         # Check that it raises when we use U- tags for single tokens.
         tag_sequence = ["O", "B", "I", "O", "B", "I", "U", "U"]
         with self.assertRaises(span_utils.InvalidTagSequence):
-            spans = span_utils.bio_tags_to_spans(tag_sequence)
+            spans = span_utils.iob1_tags_to_spans(tag_sequence)
 
         # Check that invalid IOB1 sequences are also handled as spans.
         tag_sequence = ["O", "B", "I", "O", "I", "B", "I", "B", "I", "I"]
-        spans = span_utils.bio_tags_to_spans(tag_sequence)
+        spans = span_utils.iob1_tags_to_spans(tag_sequence)
         assert set(spans) == {('', (1, 2)), ('', (4, 4)), ('', (5, 6)), ('', (7, 9))}
 
     def test_iob1_tags_to_spans_extracts_correct_spans(self):
         tag_sequence = ["I-ARG2", "B-ARG1", "I-ARG1", "O", "B-ARG2", "I-ARG2", "B-ARG1", "B-ARG2"]
-        spans = span_utils.bio_tags_to_spans(tag_sequence)
+        spans = span_utils.iob1_tags_to_spans(tag_sequence)
         assert set(spans) == {("ARG2", (0, 0)), ("ARG1", (1, 2)), ("ARG2", (4, 5)),
                               ("ARG1", (6, 6)), ("ARG2", (7, 7))}
 
         # Check that it raises when we use U- tags for single tokens.
         tag_sequence = ["O", "B-ARG1", "I-ARG1", "O", "B-ARG2", "I-ARG2", "U-ARG1", "U-ARG2"]
         with self.assertRaises(span_utils.InvalidTagSequence):
-            spans = span_utils.bio_tags_to_spans(tag_sequence)
+            spans = span_utils.iob1_tags_to_spans(tag_sequence)
 
         # Check that invalid IOB1 sequences are also handled as spans.
         tag_sequence = ["O", "B-ARG1", "I-ARG1", "O", "I-ARG1", "B-ARG2",
                         "I-ARG2", "B-ARG1", "I-ARG2", "I-ARG2"]
-        spans = span_utils.bio_tags_to_spans(tag_sequence)
+        spans = span_utils.iob1_tags_to_spans(tag_sequence)
         assert set(spans) == {("ARG1", (1, 2)), ("ARG1", (4, 4)), ("ARG2", (5, 6)),
                               ("ARG1", (7, 7)), ("ARG2", (8, 9))}
 

--- a/allennlp/tests/data/dataset_readers/dataset_utils/span_utils_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_utils/span_utils_test.py
@@ -45,6 +45,39 @@ class SpanUtilsTest(AllenNlpTestCase):
         spans = span_utils.bio_tags_to_spans(tag_sequence, ["ARG1", "V"])
         assert set(spans) == {("ARG2", (6, 7)), ("ARG2", (9, 9))}
 
+    def test_iob1_tags_to_spans_extracts_correct_spans_without_labels(self):
+        tag_sequence = ["I", "B", "I", "O", "B", "I", "B", "B"]
+        spans = span_utils.bio_tags_to_spans(tag_sequence)
+        assert set(spans) == {("", (0, 0)), ("", (1, 2)), ("", (4, 5)), ("", (6, 6)), ("", (7, 7))}
+
+        # Check that it raises when we use U- tags for single tokens.
+        tag_sequence = ["O", "B", "I", "O", "B", "I", "U", "U"]
+        with self.assertRaises(span_utils.InvalidTagSequence):
+            spans = span_utils.bio_tags_to_spans(tag_sequence)
+
+        # Check that invalid IOB1 sequences are also handled as spans.
+        tag_sequence = ["O", "B", "I", "O", "I", "B", "I", "B", "I", "I"]
+        spans = span_utils.bio_tags_to_spans(tag_sequence)
+        assert set(spans) == {('', (1, 2)), ('', (4, 4)), ('', (5, 6)), ('', (7, 9))}
+
+    def test_iob1_tags_to_spans_extracts_correct_spans(self):
+        tag_sequence = ["I-ARG2", "B-ARG1", "I-ARG1", "O", "B-ARG2", "I-ARG2", "B-ARG1", "B-ARG2"]
+        spans = span_utils.bio_tags_to_spans(tag_sequence)
+        assert set(spans) == {("ARG2", (0, 0)), ("ARG1", (1, 2)), ("ARG2", (4, 5)),
+                              ("ARG1", (6, 6)), ("ARG2", (7, 7))}
+
+        # Check that it raises when we use U- tags for single tokens.
+        tag_sequence = ["O", "B-ARG1", "I-ARG1", "O", "B-ARG2", "I-ARG2", "U-ARG1", "U-ARG2"]
+        with self.assertRaises(span_utils.InvalidTagSequence):
+            spans = span_utils.bio_tags_to_spans(tag_sequence)
+
+        # Check that invalid IOB1 sequences are also handled as spans.
+        tag_sequence = ["O", "B-ARG1", "I-ARG1", "O", "I-ARG1", "B-ARG2",
+                        "I-ARG2", "B-ARG1", "I-ARG2", "I-ARG2"]
+        spans = span_utils.bio_tags_to_spans(tag_sequence)
+        assert set(spans) == {("ARG1", (1, 2)), ("ARG1", (4, 4)), ("ARG2", (5, 6)),
+                              ("ARG1", (7, 7)), ("ARG2", (8, 9))}
+
     def test_enumerate_spans_enumerates_all_spans(self):
         tokenizer = SpacyWordSplitter(pos_tags=True)
         sentence = tokenizer.split_words("This is a sentence.")

--- a/allennlp/training/metrics/span_based_f1_measure.py
+++ b/allennlp/training/metrics/span_based_f1_measure.py
@@ -10,6 +10,7 @@ from allennlp.training.metrics.metric import Metric
 from allennlp.data.dataset_readers.dataset_utils.span_utils import (
         bio_tags_to_spans,
         bioul_tags_to_spans,
+        iob1_tags_to_spans,
         TypedStringSpan
 )
 
@@ -57,9 +58,9 @@ class SpanBasedF1Measure(Metric):
             spans in a BIO tagging scheme which are typically not included.
         label_encoding : ``str``, optional (default = "BIO")
             The encoding used to specify label span endpoints in the sequence.
-            Valid options are "BIO" or "BIOUL".
+            Valid options are "BIO", "IOB1", or BIOUL".
         """
-        if label_encoding not in ["BIO", "BIOUL"]:
+        if label_encoding not in ["BIO", "IOB1", "BIOUL"]:
             raise ConfigurationError("Unknown label encoding - expected 'BIO' or 'BIOUL'.")
 
         self._label_encoding = label_encoding
@@ -136,6 +137,9 @@ class SpanBasedF1Measure(Metric):
             if self._label_encoding == "BIO":
                 predicted_spans = bio_tags_to_spans(predicted_string_labels, self._ignore_classes)
                 gold_spans = bio_tags_to_spans(gold_string_labels, self._ignore_classes)
+            elif self._label_encoding == "IOB1":
+                predicted_spans = iob1_tags_to_spans(predicted_string_labels, self._ignore_classes)
+                gold_spans = iob1_tags_to_spans(gold_string_labels, self._ignore_classes)
             elif self._label_encoding == "BIOUL":
                 predicted_spans = bioul_tags_to_spans(predicted_string_labels, self._ignore_classes)
                 gold_spans = bioul_tags_to_spans(gold_string_labels, self._ignore_classes)


### PR DESCRIPTION
This PR adds IOB1 support to the SpanBasedF1Metric. This was a bit tricky to write, so I'll add some details about my thought process below (might help in review).

So we've got 3 tags (B, I, O), meaning that there are 3^2 = 9 possible transitions between tags. We also have to take into account whether the current conll tag differs from the previous conll tag, bringing up the total to 9 * 2 = 18.

Here are the expected outcomes for each of the cases:

<img width="333" alt="screen shot 2018-07-16 at 1 40 27 pm" src="https://user-images.githubusercontent.com/7272031/42742422-d547960e-88fd-11e8-81d3-fca6e146e7db.png">

Here's where I believe they're each accounted for in the code (based on which branch they fall into of the main if-elif-else)

<img width="311" alt="screen shot 2018-07-16 at 1 46 18 pm" src="https://user-images.githubusercontent.com/7272031/42742525-9cd41472-88fe-11e8-9194-d5efec7f6799.png">

In particular, the else could also be written as `bio_tag == "I" and conll_tag == active_conll_tag`, and nothing would change (any and all combinations would still fall into one of these 3 categories).
