### PR TITLE
fixing a bug in trainer for histograms

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -500,7 +500,7 @@ class Trainer:
                 for name, param in self._model.named_parameters():
                     param_updates[name].sub_(param.detach().cpu())
                     update_norm = torch.norm(param_updates[name].view(-1, ))
-                    param_norm = torch.norm(param.view(-1, ))
+                    param_norm = torch.norm(param.view(-1, )).cpu()
                     self._tensorboard.add_train_scalar("gradient_update/" + name,
                                                        update_norm / (param_norm + 1e-7),
                                                        batch_num_total)


### PR DESCRIPTION
otherwise it would raise an error in line 505 (expected object of type torch.FloatTensor but found type torch.cuda.FloatTensor for argument #2 'other')