### PR TITLE
[for discussion] change token_to_indices -> tokens_to_indices (in preparation for byte pair encoding)

### DIFF
--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -53,8 +53,7 @@ class TextField(SequenceField[Dict[str, torch.Tensor]]):
     def index(self, vocab: Vocabulary):
         token_arrays = {}
         for indexer_name, indexer in self._token_indexers.items():
-            arrays = [indexer.token_to_indices(token, vocab) for token in self.tokens]
-            token_arrays[indexer_name] = arrays
+            token_arrays.update(indexer.tokens_to_indices(self.tokens, vocab, indexer_name))
         self._indexed_tokens = token_arrays
 
     @overrides

--- a/allennlp/data/token_indexers/dep_label_indexer.py
+++ b/allennlp/data/token_indexers/dep_label_indexer.py
@@ -38,9 +38,13 @@ class DepLabelIndexer(TokenIndexer[int]):
         counter[self.namespace][dep_label] += 1
 
     @overrides
-    def token_to_indices(self, token: Token, vocabulary: Vocabulary) -> int:
-        dep_label = token.dep_ or 'NONE'
-        return vocabulary.get_token_index(dep_label, self.namespace)
+    def tokens_to_indices(self,
+                          tokens: List[Token],
+                          vocabulary: Vocabulary,
+                          index_name: str) -> Dict[str, List[int]]:
+        dep_labels = [token.dep_ or 'NONE' for token in tokens]
+
+        return {index_name: [vocabulary.get_token_index(dep_label, self.namespace) for dep_label in dep_labels]}
 
     @overrides
     def get_padding_token(self) -> int:

--- a/allennlp/data/token_indexers/elmo_indexer.py
+++ b/allennlp/data/token_indexers/elmo_indexer.py
@@ -93,12 +93,14 @@ class ELMoTokenCharactersIndexer(TokenIndexer[List[int]]):
         pass
 
     @overrides
-    def token_to_indices(self, token: Token, vocabulary: Vocabulary) -> List[int]:
+    def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary, index_name: str) -> Dict[str, List[List[int]]]:
         # pylint: disable=unused-argument
-        if token.text is None:
+        texts = [token.text for token in tokens]
+
+        if any(text is None for text in texts):
             raise ConfigurationError('ELMoTokenCharactersIndexer needs a tokenizer '
                                      'that retains text')
-        return ELMoCharacterMapper.convert_word_to_char_ids(token.text)
+        return {index_name: [ELMoCharacterMapper.convert_word_to_char_ids(text) for text in texts]}
 
     @overrides
     def get_padding_lengths(self, token: List[int]) -> Dict[str, int]:

--- a/allennlp/data/token_indexers/elmo_indexer.py
+++ b/allennlp/data/token_indexers/elmo_indexer.py
@@ -93,7 +93,10 @@ class ELMoTokenCharactersIndexer(TokenIndexer[List[int]]):
         pass
 
     @overrides
-    def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary, index_name: str) -> Dict[str, List[List[int]]]:
+    def tokens_to_indices(self,
+                          tokens: List[Token],
+                          vocabulary: Vocabulary,
+                          index_name: str) -> Dict[str, List[List[int]]]:
         # pylint: disable=unused-argument
         texts = [token.text for token in tokens]
 

--- a/allennlp/data/token_indexers/ner_tag_indexer.py
+++ b/allennlp/data/token_indexers/ner_tag_indexer.py
@@ -34,7 +34,10 @@ class NerTagIndexer(TokenIndexer[int]):
         counter[self._namespace][tag] += 1
 
     @overrides
-    def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary, index_name: str) -> Dict[str, List[int]]:
+    def tokens_to_indices(self,
+                          tokens: List[Token],
+                          vocabulary: Vocabulary,
+                          index_name: str) -> Dict[str, List[int]]:
         tags = ['NONE' if token.ent_type_ is None else token.ent_type_ for token in tokens]
 
         return {index_name: [vocabulary.get_token_index(tag, self._namespace) for tag in tags]}

--- a/allennlp/data/token_indexers/ner_tag_indexer.py
+++ b/allennlp/data/token_indexers/ner_tag_indexer.py
@@ -34,11 +34,10 @@ class NerTagIndexer(TokenIndexer[int]):
         counter[self._namespace][tag] += 1
 
     @overrides
-    def token_to_indices(self, token: Token, vocabulary: Vocabulary) -> int:
-        tag = token.ent_type_
-        if tag is None:
-            tag = 'NONE'
-        return vocabulary.get_token_index(tag, self._namespace)
+    def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary, index_name: str) -> Dict[str, List[int]]:
+        tags = ['NONE' if token.ent_type_ is None else token.ent_type_ for token in tokens]
+
+        return {index_name: [vocabulary.get_token_index(tag, self._namespace) for tag in tags]}
 
     @overrides
     def get_padding_token(self) -> int:

--- a/allennlp/data/token_indexers/pos_tag_indexer.py
+++ b/allennlp/data/token_indexers/pos_tag_indexer.py
@@ -45,7 +45,10 @@ class PosTagIndexer(TokenIndexer[int]):
         counter[self._namespace][tag] += 1
 
     @overrides
-    def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary, index_name: str) -> Dict[str, List[int]]:
+    def tokens_to_indices(self,
+                          tokens: List[Token],
+                          vocabulary: Vocabulary,
+                          index_name: str) -> Dict[str, List[int]]:
         tags: List[str] = []
 
         for token in tokens:

--- a/allennlp/data/token_indexers/pos_tag_indexer.py
+++ b/allennlp/data/token_indexers/pos_tag_indexer.py
@@ -45,14 +45,20 @@ class PosTagIndexer(TokenIndexer[int]):
         counter[self._namespace][tag] += 1
 
     @overrides
-    def token_to_indices(self, token: Token, vocabulary: Vocabulary) -> int:
-        if self._coarse_tags:
-            tag = token.pos_
-        else:
-            tag = token.tag_
-        if tag is None:
-            tag = 'NONE'
-        return vocabulary.get_token_index(tag, self._namespace)
+    def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary, index_name: str) -> Dict[str, List[int]]:
+        tags: List[str] = []
+
+        for token in tokens:
+            if self._coarse_tags:
+                tag = token.pos_
+            else:
+                tag = token.tag_
+            if tag is None:
+                tag = 'NONE'
+
+            tags.append(tag)
+
+        return {index_name: [vocabulary.get_token_index(tag, self._namespace) for tag in tags]}
 
     @overrides
     def get_padding_token(self) -> int:

--- a/allennlp/data/token_indexers/single_id_token_indexer.py
+++ b/allennlp/data/token_indexers/single_id_token_indexer.py
@@ -37,17 +37,21 @@ class SingleIdTokenIndexer(TokenIndexer[int]):
             counter[self.namespace][text] += 1
 
     @overrides
-    def token_to_indices(self, token: Token, vocabulary: Vocabulary) -> int:
-        if getattr(token, 'text_id', None) is not None:
-            # `text_id` being set on the token means that we aren't using the vocab, we just use
-            # this id instead.
-            index = token.text_id
-        else:
-            text = token.text
-            if self.lowercase_tokens:
-                text = text.lower()
-            index = vocabulary.get_token_index(text, self.namespace)
-        return index
+    def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary, index_name: str) -> Dict[str, List[int]]:
+        indices: List[int] = []
+
+        for token in tokens:
+            if getattr(token, 'text_id', None) is not None:
+                # `text_id` being set on the token means that we aren't using the vocab, we just use
+                # this id instead.
+                indices.append(token.text_id)
+            else:
+                text = token.text
+                if self.lowercase_tokens:
+                    text = text.lower()
+                indices.append(vocabulary.get_token_index(text, self.namespace))
+
+        return {index_name: indices}
 
     @overrides
     def get_padding_token(self) -> int:

--- a/allennlp/data/token_indexers/single_id_token_indexer.py
+++ b/allennlp/data/token_indexers/single_id_token_indexer.py
@@ -37,7 +37,10 @@ class SingleIdTokenIndexer(TokenIndexer[int]):
             counter[self.namespace][text] += 1
 
     @overrides
-    def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary, index_name: str) -> Dict[str, List[int]]:
+    def tokens_to_indices(self,
+                          tokens: List[Token],
+                          vocabulary: Vocabulary,
+                          index_name: str) -> Dict[str, List[int]]:
         indices: List[int] = []
 
         for token in tokens:

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -45,19 +45,25 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
                 counter[self._namespace][character.text] += 1
 
     @overrides
-    def token_to_indices(self, token: Token, vocabulary: Vocabulary) -> List[int]:
-        indices = []
-        if token.text is None:
-            raise ConfigurationError('TokenCharactersIndexer needs a tokenizer that retains text')
-        for character in self._character_tokenizer.tokenize(token.text):
-            if getattr(character, 'text_id', None) is not None:
-                # `text_id` being set on the token means that we aren't using the vocab, we just
-                # use this id instead.
-                index = character.text_id
-            else:
-                index = vocabulary.get_token_index(character.text, self._namespace)
-            indices.append(index)
-        return indices
+    def tokens_to_indices(self,
+                          tokens: List[Token],
+                          vocabulary: Vocabulary,
+                          index_name: str) -> Dict[str, List[List[int]]]:
+        indices: List[List[int]] = []
+        for token in tokens:
+            token_indices: List[int] = []
+            if token.text is None:
+                raise ConfigurationError('TokenCharactersIndexer needs a tokenizer that retains text')
+            for character in self._character_tokenizer.tokenize(token.text):
+                if getattr(character, 'text_id', None) is not None:
+                    # `text_id` being set on the token means that we aren't using the vocab, we just
+                    # use this id instead.
+                    index = character.text_id
+                else:
+                    index = vocabulary.get_token_index(character.text, self._namespace)
+                token_indices.append(index)
+            indices.append(token_indices)
+        return {index_name: indices}
 
     @overrides
     def get_padding_lengths(self, token: List[int]) -> Dict[str, int]:

--- a/allennlp/data/token_indexers/token_indexer.py
+++ b/allennlp/data/token_indexers/token_indexer.py
@@ -1,5 +1,4 @@
 from typing import Dict, List, TypeVar, Generic
-from collections import defaultdict
 
 from allennlp.common import Registrable
 from allennlp.data.tokenizers.token import Token

--- a/allennlp/data/token_indexers/token_indexer.py
+++ b/allennlp/data/token_indexers/token_indexer.py
@@ -31,19 +31,6 @@ class TokenIndexer(Generic[TokenType], Registrable):
         """
         raise NotImplementedError
 
-    @staticmethod
-    def _merge(dicts: List[Dict[str, TokenType]]) -> Dict[str, List[TokenType]]:
-        """
-        Merge a list of dicts into a dict of lists.
-        """
-        indices_dicts: Dict[str, List] = defaultdict(list)
-
-        for indices_dict in dicts:
-            for index_name, indices in indices_dict.items():
-                indices_dicts[index_name].append(indices)
-
-        return indices_dicts
-
     def tokens_to_indices(self,
                           tokens: List[Token],
                           vocabulary: Vocabulary,

--- a/allennlp/tests/data/token_indexers/character_token_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/character_token_indexer_test.py
@@ -31,7 +31,7 @@ class CharacterTokenIndexerTest(AllenNlpTestCase):
                                  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
 
-    def test_token_to_indices_produces_correct_characters(self):
+    def test_tokens_to_indices_produces_correct_characters(self):
         vocab = Vocabulary()
         vocab.add_token_to_namespace("A", namespace='characters')
         vocab.add_token_to_namespace("s", namespace='characters')
@@ -41,5 +41,5 @@ class CharacterTokenIndexerTest(AllenNlpTestCase):
         vocab.add_token_to_namespace("c", namespace='characters')
 
         indexer = TokenCharactersIndexer("characters")
-        indices = indexer.token_to_indices(Token("sentential"), vocab)
-        assert indices == [3, 4, 5, 6, 4, 5, 6, 1, 1, 1]
+        indices = indexer.tokens_to_indices([Token("sentential")], vocab, "char")
+        assert indices == {"char": [[3, 4, 5, 6, 4, 5, 6, 1, 1, 1]]}

--- a/allennlp/tests/data/token_indexers/dep_label_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/dep_label_indexer_test.py
@@ -23,15 +23,15 @@ class TestDepLabelIndexer(AllenNlpTestCase):
         assert counter["dep_labels"] == {"ROOT": 1, "nsubj": 1,
                                          "det": 1, "NONE": 2, "attr": 1, "punct": 1}
 
-    def test_token_to_indices_uses_pos_tags(self):
+    def test_tokens_to_indices_uses_pos_tags(self):
         tokens = self.tokenizer.split_words("This is a sentence.")
         tokens = [t for t in tokens] + [Token("</S>")]
         vocab = Vocabulary()
         root_index = vocab.add_token_to_namespace('ROOT', namespace='dep_labels')
         none_index = vocab.add_token_to_namespace('NONE', namespace='dep_labels')
         indexer = DepLabelIndexer()
-        assert indexer.token_to_indices(tokens[1], vocab) == root_index
-        assert indexer.token_to_indices(tokens[-1], vocab) == none_index
+        assert indexer.tokens_to_indices([tokens[1]], vocab, "tokens1") == {"tokens1": [root_index]}
+        assert indexer.tokens_to_indices([tokens[-1]], vocab, "tokens-1") == {"tokens-1": [none_index]}
 
     def test_padding_functions(self):
         indexer = DepLabelIndexer()

--- a/allennlp/tests/data/token_indexers/elmo_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/elmo_indexer_test.py
@@ -7,43 +7,41 @@ from allennlp.data.token_indexers import ELMoTokenCharactersIndexer
 class TestELMoTokenCharactersIndexer(AllenNlpTestCase):
     def test_bos_to_char_ids(self):
         indexer = ELMoTokenCharactersIndexer()
-        indices = indexer.token_to_indices(Token('<S>'), Vocabulary())
+        indices = indexer.tokens_to_indices([Token('<S>')], Vocabulary(), "test-elmo")
         expected_indices = [259, 257, 260, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261]
-        assert indices == expected_indices
+        assert indices == {"test-elmo": [expected_indices]}
 
     def test_eos_to_char_ids(self):
         indexer = ELMoTokenCharactersIndexer()
-        indices = indexer.token_to_indices(Token('</S>'), Vocabulary())
+        indices = indexer.tokens_to_indices([Token('</S>')], Vocabulary(), "test-eos")
         expected_indices = [259, 258, 260, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261]
-        assert indices == expected_indices
+        assert indices == {"test-eos": [expected_indices]}
 
     def test_unicode_to_char_ids(self):
         indexer = ELMoTokenCharactersIndexer()
-        indices = indexer.token_to_indices(Token(chr(256) + 't'), Vocabulary())
+        indices = indexer.tokens_to_indices([Token(chr(256) + 't')], Vocabulary(), "test-unicode")
         expected_indices = [259, 197, 129, 117, 260, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261, 261, 261, 261, 261,
                             261, 261, 261, 261, 261]
-        assert indices == expected_indices
+        assert indices == {"test-unicode": [expected_indices]}
 
     def test_elmo_as_array_produces_token_sequence(self): # pylint: disable=invalid-name
         indexer = ELMoTokenCharactersIndexer()
-        indices = [
-                indexer.token_to_indices(Token(token), Vocabulary())
-                for token in ['Second', '.']
-        ]
+        tokens = [Token('Second'), Token('.')]
+        indices = indexer.tokens_to_indices(tokens, Vocabulary(), "test-elmo")["test-elmo"]
         padded_tokens = indexer.pad_token_sequence(indices,
                                                    desired_num_tokens=3,
                                                    padding_lengths={})

--- a/allennlp/tests/data/token_indexers/ner_tag_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/ner_tag_indexer_test.py
@@ -21,7 +21,7 @@ class TestNerTagIndexer(AllenNlpTestCase):
             indexer.count_vocab_items(token, counter)
         assert counter["ner_tags"] == {'PERSON': 2, 'ORG': 1, 'NONE': 6}
 
-    def test_token_to_indices_uses_ner_tags(self):
+    def test_tokens_to_indices_uses_ner_tags(self):
         tokens = self.tokenizer.split_words("Larry Page is CEO of Google.")
         tokens = [t for t in tokens] + [Token("</S>")]
         vocab = Vocabulary()
@@ -29,8 +29,8 @@ class TestNerTagIndexer(AllenNlpTestCase):
         none_index = vocab.add_token_to_namespace('NONE', namespace='ner_tags')
         vocab.add_token_to_namespace('ORG', namespace='ner_tags')
         indexer = NerTagIndexer()
-        assert indexer.token_to_indices(tokens[1], vocab) == person_index
-        assert indexer.token_to_indices(tokens[-1], vocab) == none_index
+        assert indexer.tokens_to_indices([tokens[1]], vocab, "tokens1") == {"tokens1": [person_index]}
+        assert indexer.tokens_to_indices([tokens[-1]], vocab, "tokens-1") == {"tokens-1": [none_index]}
 
     def test_padding_functions(self):
         indexer = NerTagIndexer()

--- a/allennlp/tests/data/token_indexers/pos_tag_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pos_tag_indexer_test.py
@@ -27,7 +27,7 @@ class TestPosTagIndexer(AllenNlpTestCase):
             indexer.count_vocab_items(token, counter)
         assert counter["pos_tags"] == {'VERB': 1, 'PUNCT': 1, 'DET': 2, 'NOUN': 1, 'NONE': 2}
 
-    def test_token_to_indices_uses_pos_tags(self):
+    def test_tokens_to_indices_uses_pos_tags(self):
         tokens = self.tokenizer.split_words("This is a sentence.")
         tokens = [t for t in tokens] + [Token("</S>")]
         vocab = Vocabulary()
@@ -35,10 +35,15 @@ class TestPosTagIndexer(AllenNlpTestCase):
         cop_index = vocab.add_token_to_namespace('VBZ', namespace='pos_tags')
         none_index = vocab.add_token_to_namespace('NONE', namespace='pos_tags')
         indexer = PosTagIndexer(coarse_tags=True)
-        assert indexer.token_to_indices(tokens[1], vocab) == verb_index
-        assert indexer.token_to_indices(tokens[-1], vocab) == none_index
+
+        indices = indexer.tokens_to_indices(tokens, vocab, "tokens")
+        assert len(indices) == 1
+        assert "tokens" in len(indices)
+        assert indices["tokens"][1] == verb_index
+        assert indices["tokens"][-1] == none_index
+
         indexer._coarse_tags = False  # pylint: disable=protected-access
-        assert indexer.token_to_indices(tokens[1], vocab) == cop_index
+        assert indexer.tokens_to_indices([tokens[1]], vocab, "coarse") == {"coarse": [cop_index]}
 
     def test_padding_functions(self):
         indexer = PosTagIndexer()

--- a/allennlp/tests/data/token_indexers/pos_tag_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pos_tag_indexer_test.py
@@ -34,11 +34,16 @@ class TestPosTagIndexer(AllenNlpTestCase):
         verb_index = vocab.add_token_to_namespace('VERB', namespace='pos_tags')
         cop_index = vocab.add_token_to_namespace('VBZ', namespace='pos_tags')
         none_index = vocab.add_token_to_namespace('NONE', namespace='pos_tags')
+        # Have to add other tokens too, since we're calling `tokens_to_indices` on all of them
+        vocab.add_token_to_namespace('DET', namespace='pos_tags')
+        vocab.add_token_to_namespace('NOUN', namespace='pos_tags')
+        vocab.add_token_to_namespace('PUNCT', namespace='pos_tags')
+
         indexer = PosTagIndexer(coarse_tags=True)
 
         indices = indexer.tokens_to_indices(tokens, vocab, "tokens")
         assert len(indices) == 1
-        assert "tokens" in len(indices)
+        assert "tokens" in indices
         assert indices["tokens"][1] == verb_index
         assert indices["tokens"][-1] == none_index
 

--- a/allennlp/tests/modules/elmo_test.py
+++ b/allennlp/tests/modules/elmo_test.py
@@ -296,16 +296,19 @@ class TestElmoTokenRepresentation(ElmoTestCase):
     def test_elmo_token_representation(self):
         # Load the test words and convert to char ids
         with open(os.path.join(self.elmo_fixtures_path, 'vocab_test.txt'), 'r') as fin:
-            tokens = fin.read().strip().split('\n')
+            words = fin.read().strip().split('\n')
 
+        vocab = Vocabulary()
         indexer = ELMoTokenCharactersIndexer()
-        indices = [indexer.token_to_indices(Token(token), Vocabulary()) for token in tokens]
+        tokens = [Token(word) for word in words]
+
+        indices = indexer.tokens_to_indices(tokens, vocab, "elmo")
         # There are 457 tokens. Reshape into 10 batches of 50 tokens.
         sentences = []
         for k in range(10):
             sentences.append(
                     indexer.pad_token_sequence(
-                            indices[(k * 50):((k + 1) * 50)], desired_num_tokens=50, padding_lengths={}
+                            indices["elmo"][(k * 50):((k + 1) * 50)], desired_num_tokens=50, padding_lengths={}
                     )
             )
         batch = torch.from_numpy(numpy.array(sentences))
@@ -334,7 +337,7 @@ class TestElmoTokenRepresentation(ElmoTestCase):
         elmo_token_embedder = _ElmoCharacterEncoder(self.options_file, self.weight_file)
 
         for correct_index, token in [[0, '<S>'], [2, '</S>']]:
-            indices = indexer.token_to_indices(Token(token), Vocabulary())
-            indices = torch.from_numpy(numpy.array(indices)).view(1, 1, -1)
+            indices = indexer.token_to_indices([Token(token)], Vocabulary(), "correct")
+            indices = torch.from_numpy(numpy.array(indices["correct"])).view(1, 1, -1)
             embeddings = elmo_token_embedder(indices)['token_embedding']
             assert numpy.allclose(embeddings[0, correct_index, :].data.numpy(), embeddings[0, 1, :].data.numpy())

--- a/allennlp/tests/modules/elmo_test.py
+++ b/allennlp/tests/modules/elmo_test.py
@@ -337,7 +337,7 @@ class TestElmoTokenRepresentation(ElmoTestCase):
         elmo_token_embedder = _ElmoCharacterEncoder(self.options_file, self.weight_file)
 
         for correct_index, token in [[0, '<S>'], [2, '</S>']]:
-            indices = indexer.token_to_indices([Token(token)], Vocabulary(), "correct")
+            indices = indexer.tokens_to_indices([Token(token)], Vocabulary(), "correct")
             indices = torch.from_numpy(numpy.array(indices["correct"])).view(1, 1, -1)
             embeddings = elmo_token_embedder(indices)['token_embedding']
             assert numpy.allclose(embeddings[0, correct_index, :].data.numpy(), embeddings[0, 1, :].data.numpy())

--- a/scripts/create_elmo_embeddings_from_vocab.py
+++ b/scripts/create_elmo_embeddings_from_vocab.py
@@ -48,7 +48,7 @@ def main(vocab_path: str,
     tokens = [tokens[0]] + ["<S>", "</S>"] + tokens[1:]
 
     indexer = ELMoTokenCharactersIndexer()
-    indices = [indexer.token_to_indices(Token(token), Vocabulary()) for token in tokens]
+    indices = indexer.tokens_to_indices([Token(token) for token in tokens], Vocabulary(), "indices")["indices"]
     sentences = []
     for k in range((len(indices) // 50) + 1):
         sentences.append(indexer.pad_token_sequence(indices[(k * 50):((k + 1) * 50)],


### PR DESCRIPTION
I replaced

```
TokenIndexer.token_to_indices(self, token: Token, vocabulary: Vocabulary) -> TokenType:
```

with

```
TokenIndexer.tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary, index_name: str) -> Dict[str, List[TokenType]]:
```

this addresses two things:

(1) the indices are no longer determined on a per-token basis; instead they can be determined by multiple tokens
(2) a single token indexer can now return multiple sets of indices

initially I was trying to leave things backward compatible, but eventually I decided this would be cleaner. this is a breaking change, but only for people who are writing their own token indexers or fields, which is probably not too many people?

