### PR TITLE
Add to_file method in Params and default preference ordering.

### DIFF
--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -36,7 +36,6 @@ import argparse
 import json
 import logging
 import os
-from copy import deepcopy
 import re
 
 import torch

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -257,9 +257,7 @@ def train_model(params: Params,
 
     check_for_gpu(params.get('trainer').get('cuda_device', -1))
 
-    serialization_params = deepcopy(params).as_dict(quiet=True)
-    with open(os.path.join(serialization_dir, CONFIG_NAME), "w") as param_file:
-        json.dump(serialization_params, param_file, indent=4)
+    params.to_file(os.path.join(serialization_dir, CONFIG_NAME))
 
     all_datasets = datasets_from_params(params)
     datasets_for_vocab_creation = set(params.pop("datasets_for_vocab_creation", all_datasets))

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -369,14 +369,14 @@ class Params(MutableMapping):
             "A" > "B" > "C". For multiple preference_orders first will be considered first.
             Keys not found, will have last but alphabetical preference. Default Preferences:
             ``[["dataset_reader", "iterator", "model", "train_data_path", "validation_data_path",
-                "test_data_path", "trainer", "vocabulary", "seeds"], ["type"]]``
+            "test_data_path", "trainer", "vocabulary"], ["type"]]``
         """
         params_dict = self.as_dict(quiet=True)
         if not preference_orders:
             preference_orders = []
             preference_orders.append(["dataset_reader", "iterator", "model",
                                       "train_data_path", "validation_data_path", "test_data_path",
-                                      "trainer", "vocabulary", "seeds"])
+                                      "trainer", "vocabulary"])
             preference_orders.append(["type"])
 
         def preference_ranks(key):

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -395,6 +395,7 @@ class Params(MutableMapping):
 
         return order_dict(params_dict, order_func)
 
+
 def pop_choice(params: Dict[str, Any],
                key: str,
                choices: List[Any],

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -354,9 +354,9 @@ class Params(MutableMapping):
 
         return Params(param_dict)
 
-    def to_file(self, params_file: str):
-        with open(params_file) as file:
-            json.dump(file, self.as_ordered_dict(), indent=4)
+    def to_file(self, params_file: str, preference_orders: List[List[str]] = None):
+        with open(params_file, "w") as handle:
+            json.dump(self.as_ordered_dict(preference_orders), handle, indent=4)
 
     def as_ordered_dict(self, preference_orders: List[List[str]] = None):
         """

--- a/allennlp/tests/common/params_test.py
+++ b/allennlp/tests/common/params_test.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import tempfile
+from collections import OrderedDict
 
 import pytest
 
@@ -284,22 +285,21 @@ class TestParams(AllenNlpTestCase):
         params = Params({"keyC": "valC", "keyB": "valB", "keyA": "valA", "keyE": "valE",
                          "keyD": {"keyDB": "valDB", "keyDA": "valDA"}})
         ordered_params_dict = params.as_ordered_dict(preference_orders)
-        ordered_params_dict_str = str(ordered_params_dict)
-        expected_dict_str = str(({'keyD': {'keyDA': 'valDA', 'keyDB': 'valDB'},
-                                  'keyC': 'valC', 'keyE': 'valE',
-                                  'keyA': 'valA', 'keyB': 'valB'}))
-        assert ordered_params_dict_str == expected_dict_str
+        expected_ordered_params_dict = OrderedDict({'keyD': {'keyDA': 'valDA', 'keyDB': 'valDB'},
+                                                    'keyC': 'valC', 'keyE': 'valE',
+                                                    'keyA': 'valA', 'keyB': 'valB'})
+        assert json.dumps(ordered_params_dict) == json.dumps(expected_ordered_params_dict)
 
     def test_to_file(self):
         # Test to_file works with or without preference orders
         params_dict = {"keyA": "valA", "keyB": "valB"}
-        ordered_params_dict = {"keyB": "valB", "keyA": "valA"}
+        expected_ordered_params_dict = OrderedDict({"keyB": "valB", "keyA": "valA"})
         params = Params(params_dict)
         file_path = self.TEST_DIR / 'config.jsonnet'
         # check with preference orders
         params.to_file(file_path, [["keyB", "keyA"]])
         with open(file_path, "r") as handle:
-            loaded_params_dict = json.load(handle)
-        assert str(ordered_params_dict) == str(loaded_params_dict)
+            ordered_params_dict = OrderedDict(json.load(handle))
+        assert json.dumps(expected_ordered_params_dict) == json.dumps(ordered_params_dict)
         # check without preference orders doesn't give error
         params.to_file(file_path)

--- a/allennlp/tests/common/params_test.py
+++ b/allennlp/tests/common/params_test.py
@@ -277,3 +277,19 @@ class TestParams(AllenNlpTestCase):
                 "a.b.filename": my_file,
                 "a.b.c.c_file": my_other_file
         }
+
+    def test_as_ordered_dict(self):
+        # keyD > keyC > keyE; keyDA > keyDB; Next all other keys alphabetically
+        preference_orders = [["keyD", "keyC", "keyE"], ["keyDA", "keyDB"]]
+        params = Params({"keyC": "valC", "keyB": "valB", "keyA": "valA", "keyE": "valE",
+                         "keyD": {"keyDB": "valDB", "keyDA": "valDA"}})
+        ordered_params_dict = params.as_ordered_dict(preference_orders)
+        ordered_params_dict_str = json.dumps(ordered_params_dict)
+        expected_dict_str = json.dumps(({'keyD': {'keyDA': 'valDA', 'keyDB': 'valDB'},
+                                         'keyC': 'valC', 'keyE': 'valE',
+                                         'keyA': 'valA', 'keyB': 'valB'}))
+        assert ordered_params_dict_str == expected_dict_str
+
+    def test_to_file(self):
+        # TODO(harsh) Add this test
+        pass

--- a/allennlp/tests/common/params_test.py
+++ b/allennlp/tests/common/params_test.py
@@ -284,12 +284,22 @@ class TestParams(AllenNlpTestCase):
         params = Params({"keyC": "valC", "keyB": "valB", "keyA": "valA", "keyE": "valE",
                          "keyD": {"keyDB": "valDB", "keyDA": "valDA"}})
         ordered_params_dict = params.as_ordered_dict(preference_orders)
-        ordered_params_dict_str = json.dumps(ordered_params_dict)
-        expected_dict_str = json.dumps(({'keyD': {'keyDA': 'valDA', 'keyDB': 'valDB'},
-                                         'keyC': 'valC', 'keyE': 'valE',
-                                         'keyA': 'valA', 'keyB': 'valB'}))
+        ordered_params_dict_str = str(ordered_params_dict)
+        expected_dict_str = str(({'keyD': {'keyDA': 'valDA', 'keyDB': 'valDB'},
+                                  'keyC': 'valC', 'keyE': 'valE',
+                                  'keyA': 'valA', 'keyB': 'valB'}))
         assert ordered_params_dict_str == expected_dict_str
 
     def test_to_file(self):
-        # TODO(harsh) Add this test
-        pass
+        # Test to_file works with or without preference orders
+        params_dict = {"keyA": "valA", "keyB": "valB"}
+        ordered_params_dict = {"keyB": "valB", "keyA": "valA"}
+        params = Params(params_dict)
+        file_path = self.TEST_DIR / 'config.jsonnet'
+        # check with preference orders
+        params.to_file(file_path, [["keyB", "keyA"]])
+        with open(file_path, "r") as handle:
+            loaded_params_dict = json.load(handle)
+        assert str(ordered_params_dict) == str(loaded_params_dict)
+        # check without preference orders doesn't give error
+        params.to_file(file_path)


### PR DESCRIPTION
This PR is in reference to (#1476). Besides that use case: I am generating bunch of experiment configs based on certain combinations of settings I want to explore. Having consistent ordering of keys generated across these output config files would be good for human parsing. Eg. Seeing `vocabulary` key to top, `train_data_path` at bottom and `validation_data_path` somewhere in middle seems quite off place . So this PR adds `to_file` counter part of `from_file` in Params, which saves the json in according to passed or default partial preference orderings. 

The default orderings are as: `dataset_reader > iterator > model > train_data_path > validation_data_path > test_data_path > trainer > vocabulary` and `type` key will always be on the top of its companions. This is the usual order in which we typically organize our experiment configs. Rest of the keys (any level) will be ordered later and alphabetically. 

Note that having order maintained from input config file isn't straightforward as discussed in (#1476) due to: (1) jsonnet changes the content before json sees it. (2) overriding dicts can any way make things ambiguous. 

This PR doesn't intent to maintain ordering of input file. But rather enforce a default partial ordering and resort to alphabetical order for remaining keys.