### PR TITLE
DenseSparseAdam + CRF Feedforward layer

### DIFF
--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -6,7 +6,7 @@ from torch.nn.modules.linear import Linear
 
 from allennlp.common.checks import check_dimensions_match
 from allennlp.data import Vocabulary
-from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder, ConditionalRandomField
+from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder, ConditionalRandomField, FeedForward
 from allennlp.modules.conditional_random_field import allowed_transitions
 from allennlp.models.model import Model
 from allennlp.nn import InitializerApplicator, RegularizerApplicator
@@ -31,6 +31,8 @@ class CrfTagger(Model):
     label_namespace : ``str``, optional (default=``labels``)
         This is needed to compute the SpanBasedF1Measure metric.
         Unless you did something unusual, the default value should be what you want.
+    feedforward : ``FeedForward``, optional, (default = None).
+        An optional feedforward layer to apply after the encoder.
     dropout:  ``float``, optional (detault=``None``)
     verbose_metrics : ``bool``, optional (default = False)
         If true, metrics will be returned per label class in addition
@@ -51,6 +53,7 @@ class CrfTagger(Model):
                  encoder: Seq2SeqEncoder,
                  label_namespace: str = "labels",
                  constraint_type: str = None,
+                 feedforward: FeedForward = None,
                  include_start_end_transitions: bool = True,
                  dropout: float = None,
                  verbose_metrics: bool = False,
@@ -67,7 +70,13 @@ class CrfTagger(Model):
             self.dropout = torch.nn.Dropout(dropout)
         else:
             self.dropout = None
-        self.tag_projection_layer = TimeDistributed(Linear(self.encoder.get_output_dim(),
+        self._feedforward = feedforward
+
+        if feedforward is not None:
+            output_dim = feedforward.get_output_dim()
+        else:
+            output_dim = self.encoder.get_output_dim()
+        self.tag_projection_layer = TimeDistributed(Linear(output_dim,
                                                            self.num_tags))
 
         if constraint_type is not None:
@@ -85,8 +94,12 @@ class CrfTagger(Model):
                                               tag_namespace=label_namespace,
                                               label_encoding=constraint_type or "BIO")
 
+
         check_dimensions_match(text_field_embedder.get_output_dim(), encoder.get_input_dim(),
                                "text field embedding dim", "encoder input dim")
+        if feedforward is not None:
+            check_dimensions_match(encoder.get_output_dim(), feedforward.get_input_dim(),
+                                   "encoder output dim", "feedforward input dim")
         initializer(self)
 
     @overrides
@@ -136,6 +149,9 @@ class CrfTagger(Model):
 
         if self.dropout:
             encoded_text = self.dropout(encoded_text)
+
+        if self._feedforward is not None:
+            encoded_text = self._feedforward(encoded_text)
 
         logits = self.tag_projection_layer(encoded_text)
         best_paths = self.crf.viterbi_tags(logits, mask)

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -6,7 +6,8 @@ from torch.nn.modules.linear import Linear
 
 from allennlp.common.checks import check_dimensions_match
 from allennlp.data import Vocabulary
-from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder, ConditionalRandomField, FeedForward
+from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder
+from allennlp.modules import ConditionalRandomField, FeedForward
 from allennlp.modules.conditional_random_field import allowed_transitions
 from allennlp.models.model import Model
 from allennlp.nn import InitializerApplicator, RegularizerApplicator

--- a/allennlp/tests/training/optimizer_test.py
+++ b/allennlp/tests/training/optimizer_test.py
@@ -105,4 +105,3 @@ class TestDenseSparseAdam(AllenNlpTestCase):
         iterator = BasicIterator(2)
         iterator.index_with(self.vocab)
         Trainer(self.model, optimizer, iterator, self.instances).train()
-                

--- a/allennlp/tests/training/optimizer_test.py
+++ b/allennlp/tests/training/optimizer_test.py
@@ -5,6 +5,8 @@ from allennlp.common.params import Params
 from allennlp.models.simple_tagger import SimpleTagger
 from allennlp.data.dataset_readers import SequenceTaggingDatasetReader
 from allennlp.training.optimizers import Optimizer
+from allennlp.training.trainer import Trainer
+from allennlp.data.iterators import BasicIterator
 
 
 class TestOptimizer(AllenNlpTestCase):
@@ -69,3 +71,38 @@ class TestOptimizer(AllenNlpTestCase):
         assert len(param_groups[1]['params']) == 2
         # the embedding + recurrent connections left in the default group
         assert len(param_groups[2]['params']) == 3
+
+
+class TestDenseSparseAdam(AllenNlpTestCase):
+
+    def setUp(self):
+        super(TestDenseSparseAdam, self).setUp()
+        self.instances = SequenceTaggingDatasetReader().read(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv')
+        self.vocab = Vocabulary.from_instances(self.instances)
+        self.model_params = Params({
+                "text_field_embedder": {
+                        "tokens": {
+                                "type": "embedding",
+                                "embedding_dim": 5,
+                                "sparse": True
+                                }
+                        },
+                "encoder": {
+                        "type": "lstm",
+                        "input_size": 5,
+                        "hidden_size": 7,
+                        "num_layers": 2
+                        }
+                })
+        self.model = SimpleTagger.from_params(vocab=self.vocab, params=self.model_params)
+
+    def test_can_optimise_model_with_dense_and_sparse_params(self):
+        optimizer_params = Params({
+                "type": "dense_sparse_adam"
+        })
+        parameters = [[n, p] for n, p in self.model.named_parameters() if p.requires_grad]
+        optimizer = Optimizer.from_params(parameters, optimizer_params)
+        iterator = BasicIterator(2)
+        iterator.index_with(self.vocab)
+        Trainer(self.model, optimizer, iterator, self.instances).train()
+                

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -131,7 +131,14 @@ Registrable._registry[Optimizer] = {   # pylint: disable=protected-access
 
 @Optimizer.register('dense_sparse_adam')
 class DenseSparseAdam(torch.optim.Optimizer):
-    """Implements Adam algorithm with dense & sparse gradients.
+    # pylint: disable=protected-access,cell-var-from-loop
+    # pylint: disable=unneeded-not,misplaced-comparison-constant
+    # pylint: disable=len-as-condition,invalid-name,anomalous-backslash-in-string
+    """
+    NOTE: This class has been copied verbatim from the separate Dense and
+    Sparse versions of Adam in Pytorch.
+
+    Implements Adam algorithm with dense & sparse gradients.
     It has been proposed in `Adam: A Method for Stochastic Optimization`_.
     Arguments:
         params (iterable): iterable of parameters to optimize or dicts defining

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -141,15 +141,13 @@ class DenseSparseAdam(torch.optim.Optimizer):
     Implements Adam algorithm with dense & sparse gradients.
     It has been proposed in Adam: A Method for Stochastic Optimization.
     Arguments:
-    params (iterable): iterable of parameters to optimize or dicts defining
-        parameter groups
+    params (iterable): iterable of parameters to optimize or dicts defining parameter groups
     lr (float, optional): learning rate (default: 1e-3)
     betas (Tuple[float, float], optional): coefficients used for computing
-        running averages of gradient and its square (default: (0.9, 0.999))
+    running averages of gradient and its square (default: (0.9, 0.999))
     eps (float, optional): term added to the denominator to improve
-        numerical stability (default: 1e-8)
+    numerical stability (default: 1e-8)
     """
-
     def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8):
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -168,6 +168,7 @@ class DenseSparseAdam(torch.optim.Optimizer):
     def step(self, closure=None):
         """
         Performs a single optimization step.
+
         Parameters
         ----------
         closure : ``callable``, optional.

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -140,6 +140,7 @@ class DenseSparseAdam(torch.optim.Optimizer):
 
     Implements Adam algorithm with dense & sparse gradients.
     It has been proposed in Adam: A Method for Stochastic Optimization.
+
     Parameters
     ----------
     params : ``iterable``

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -139,17 +139,15 @@ class DenseSparseAdam(torch.optim.Optimizer):
     Sparse versions of Adam in Pytorch.
 
     Implements Adam algorithm with dense & sparse gradients.
-    It has been proposed in `Adam: A Method for Stochastic Optimization`_.
+    It has been proposed in Adam: A Method for Stochastic Optimization.
     Arguments:
-        params (iterable): iterable of parameters to optimize or dicts defining
-            parameter groups
-        lr (float, optional): learning rate (default: 1e-3)
-        betas (Tuple[float, float], optional): coefficients used for computing
-            running averages of gradient and its square (default: (0.9, 0.999))
-        eps (float, optional): term added to the denominator to improve
-            numerical stability (default: 1e-8)
-    .. _Adam\: A Method for Stochastic Optimization:
-        https://arxiv.org/abs/1412.6980
+    params (iterable): iterable of parameters to optimize or dicts defining
+        parameter groups
+    lr (float, optional): learning rate (default: 1e-3)
+    betas (Tuple[float, float], optional): coefficients used for computing
+        running averages of gradient and its square (default: (0.9, 0.999))
+    eps (float, optional): term added to the denominator to improve
+        numerical stability (default: 1e-8)
     """
 
     def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8):

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -140,13 +140,17 @@ class DenseSparseAdam(torch.optim.Optimizer):
 
     Implements Adam algorithm with dense & sparse gradients.
     It has been proposed in Adam: A Method for Stochastic Optimization.
-    Arguments:
-    params (iterable): iterable of parameters to optimize or dicts defining parameter groups
-    lr (float, optional): learning rate (default: 1e-3)
-    betas (Tuple[float, float], optional): coefficients used for computing
-    running averages of gradient and its square (default: (0.9, 0.999))
-    eps (float, optional): term added to the denominator to improve
-    numerical stability (default: 1e-8)
+    Parameters
+    ----------
+    params : ``iterable``
+        iterable of parameters to optimize or dicts defining parameter groups
+    lr : ``float``, optional (default: 1e-3)
+        The learning rate.
+    betas : ``Tuple[float, float]``, optional (default: (0.9, 0.999))
+        coefficients used for computing running averages of gradient
+        and its square.
+    eps : ``float``, optional, (default: 1e-8)
+        A term added to the denominator to improve numerical stability.
     """
     def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8):
         if not 0.0 <= lr:
@@ -161,10 +165,12 @@ class DenseSparseAdam(torch.optim.Optimizer):
         super(DenseSparseAdam, self).__init__(params, defaults)
 
     def step(self, closure=None):
-        """Performs a single optimization step.
-        Arguments:
-            closure (callable, optional): A closure that reevaluates the model
-                and returns the loss.
+        """
+        Performs a single optimization step.
+        Parameters
+        ----------
+        closure : ``callable``, optional.
+            A closure that reevaluates the model and returns the loss.
         """
         loss = None
         if closure is not None:

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -17,6 +17,7 @@ The available optimizers are
 
 import logging
 import re
+import math
 from typing import List, Any, Dict
 
 import torch
@@ -125,3 +126,112 @@ Registrable._registry[Optimizer] = {   # pylint: disable=protected-access
         "adamax": torch.optim.Adamax,
         "averaged_sgd": torch.optim.ASGD,
 }
+
+
+
+@Optimizer.register('dense_sparse_adam')
+class DenseSparseAdam(torch.optim.Optimizer):
+    """Implements Adam algorithm with dense & sparse gradients.
+    It has been proposed in `Adam: A Method for Stochastic Optimization`_.
+    Arguments:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups
+        lr (float, optional): learning rate (default: 1e-3)
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its square (default: (0.9, 0.999))
+        eps (float, optional): term added to the denominator to improve
+            numerical stability (default: 1e-8)
+    .. _Adam\: A Method for Stochastic Optimization:
+        https://arxiv.org/abs/1412.6980
+    """
+
+    def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8):
+        if not 0.0 <= lr:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if not 0.0 <= eps:
+            raise ValueError("Invalid epsilon value: {}".format(eps))
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
+        defaults = dict(lr=lr, betas=betas, eps=eps)
+        super(DenseSparseAdam, self).__init__(params, defaults)
+
+    def step(self, closure=None):
+        """Performs a single optimization step.
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+                grad = p.grad.data
+
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state['step'] = 0
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = torch.zeros_like(p.data)
+                    # Exponential moving average of squared gradient values
+                    state['exp_avg_sq'] = torch.zeros_like(p.data)
+
+                state['step'] += 1
+
+                exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']
+                beta1, beta2 = group['betas']
+
+                if grad.is_sparse:
+                    grad = grad.coalesce()  # the update is non-linear so indices must be unique
+                    grad_indices = grad._indices()
+                    grad_values = grad._values()
+                    size = grad.size()
+
+                    def make_sparse(values):
+                        constructor = grad.new
+                        if grad_indices.dim() == 0 or values.dim() == 0:
+                            return constructor().resize_as_(grad)
+                        return constructor(grad_indices, values, size)
+
+                    # Decay the first and second moment running average coefficient
+                    #      old <- b * old + (1 - b) * new
+                    # <==> old += (1 - b) * (new - old)
+                    old_exp_avg_values = exp_avg._sparse_mask(grad)._values()
+                    exp_avg_update_values = grad_values.sub(old_exp_avg_values).mul_(1 - beta1)
+                    exp_avg.add_(make_sparse(exp_avg_update_values))
+                    old_exp_avg_sq_values = exp_avg_sq._sparse_mask(grad)._values()
+                    exp_avg_sq_update_values = grad_values.pow(2).sub_(old_exp_avg_sq_values).mul_(1 - beta2)
+                    exp_avg_sq.add_(make_sparse(exp_avg_sq_update_values))
+
+                    # Dense addition again is intended, avoiding another _sparse_mask
+                    numer = exp_avg_update_values.add_(old_exp_avg_values)
+                    exp_avg_sq_update_values.add_(old_exp_avg_sq_values)
+                    denom = exp_avg_sq_update_values.sqrt_().add_(group['eps'])
+                    del exp_avg_update_values, exp_avg_sq_update_values
+
+                    bias_correction1 = 1 - beta1 ** state['step']
+                    bias_correction2 = 1 - beta2 ** state['step']
+                    step_size = group['lr'] * math.sqrt(bias_correction2) / bias_correction1
+
+                    p.data.add_(make_sparse(-step_size * numer.div_(denom)))
+
+                else:
+                    # Decay the first and second moment running average coefficient
+                    exp_avg.mul_(beta1).add_(1 - beta1, grad)
+                    exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
+                    denom = exp_avg_sq.sqrt().add_(group['eps'])
+
+                    bias_correction1 = 1 - beta1 ** state['step']
+                    bias_correction2 = 1 - beta2 ** state['step']
+                    step_size = group['lr'] * math.sqrt(bias_correction2) / bias_correction1
+
+                    p.data.addcdiv_(-step_size, exp_avg, denom)
+
+        return loss

--- a/tutorials/getting_started/using_as_a_library_pt1.md
+++ b/tutorials/getting_started/using_as_a_library_pt1.md
@@ -575,5 +575,5 @@ allennlp train \
 When we do this, we get to around 80% validation accuracy after a few epochs of training.
 
 To see how to make predictions and build a demo for our new model, see the
-[Making Predictions and Creating a Demo](making_predictions_and_creating_a_demo.md) tutorial, which continues
+[Making Predictions and Creating a Demo](using_as_a_library_pt2.md) tutorial, which continues
 where this tutorial leaves off.


### PR DESCRIPTION

Adds:
- DenseSparseAdam - this is just the dense and sparse versions of adam in pytorch combined, which makes it a lot less annoying to handle. I'll probably submit a PR to Pytorch with this at somepoint. I didn't modify the source at all apart from docstrings, so it needed a lot of `pylint: ignore`s.

- Ability to add a `Feedforward` layer after the encoder part in the CRF model (I needed this to reproduce some fine-grained NER results).