### PR TITLE
Add a scirpt to report broken links in all markdowns.

### DIFF
--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -1,0 +1,48 @@
+#! /usr/bin/env python
+"""
+Goes through all the inline-links in markdown files and reports the breakages.
+"""
+import re
+import sys
+import pathlib
+from multiprocessing.dummy import Pool
+from collections import namedtuple
+from typing import Tuple
+import requests
+
+MatchTuple = namedtuple('MatchTuple', 'source name link')
+
+def url_ok(match_tuple: MatchTuple) -> Tuple[MatchTuple, bool]:
+    try:
+        return (match_tuple, requests.get(match_tuple.link).ok)
+    except requests.ConnectionError:
+        return (match_tuple, False)
+
+if __name__ == "__main__":
+
+    project_root = (pathlib.Path(__file__).parent / "..").resolve() # pylint: disable=no-member
+    markdown_files = project_root.glob('**/*.md')
+
+    all_matches = set()
+    url_regex = re.compile(r'\[([^!][^\]]+)\]\((http[s]?[^)(]+)\)')
+    for markdown_file in markdown_files:
+        with open(markdown_file) as handle:
+            for line in handle.readlines():
+                matches = url_regex.findall(line)
+                for match in matches:
+                    if 'localhost' not in match[1]:
+                        all_matches.add(MatchTuple(source=markdown_file, name=match[0], link=match[1]))
+
+    with Pool(processes=10) as pool:
+        RESULTS = pool.map(url_ok, [match for match in list(all_matches)])
+    unreachable_results = [result for result in RESULTS if not result[1]]
+
+    if unreachable_results:
+        print("UnReachable Links:")
+        for index, result in enumerate(unreachable_results):
+            print("\n{}.".format(index))
+            print("Source: " + str(result[0].source))
+            print("Name: " + result[0].name)
+            print("Link: " + result[0].link)
+        sys.exit(1)
+    print("No Unreachable link found.")

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
                         all_matches.add(MatchTuple(source=str(markdown_file), name=name, link=link))
 
     with Pool(processes=10) as pool:
-        results = map(url_ok, [match for match in list(all_matches)])
+        results = pool.map(url_ok, [match for match in list(all_matches)])
     unreachable_results = [result for result in results if not result[1]]
 
     if unreachable_results:

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -6,11 +6,13 @@ import re
 import sys
 import pathlib
 from multiprocessing.dummy import Pool
-from collections import namedtuple
-from typing import Tuple
+from typing import Tuple, NamedTuple
 import requests
 
-MatchTuple = namedtuple('MatchTuple', 'source name link')
+class MatchTuple(NamedTuple):
+    source: str
+    name: str
+    link: str
 
 def url_ok(match_tuple: MatchTuple) -> Tuple[MatchTuple, bool]:
     try:
@@ -31,7 +33,7 @@ if __name__ == "__main__":
                 matches = url_regex.findall(line)
                 for name, link in matches:
                     if 'localhost' not in link:
-                        all_matches.add(MatchTuple(source=markdown_file, name=name, link=link))
+                        all_matches.add(MatchTuple(source=str(markdown_file), name=name, link=link))
 
     with Pool(processes=10) as pool:
         results = map(url_ok, [match for match in list(all_matches)])
@@ -41,7 +43,7 @@ if __name__ == "__main__":
         print("UnReachable Links:")
         for index, result in enumerate(unreachable_results):
             print("\n{}.".format(index))
-            print("Source: " + str(result[0].source))
+            print("Source: " + result[0].source)
             print("Name: " + result[0].name)
             print("Link: " + result[0].link)
         sys.exit(1)

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -29,13 +29,13 @@ if __name__ == "__main__":
         with open(markdown_file) as handle:
             for line in handle.readlines():
                 matches = url_regex.findall(line)
-                for match in matches:
-                    if 'localhost' not in match[1]:
-                        all_matches.add(MatchTuple(source=markdown_file, name=match[0], link=match[1]))
+                for name, link in matches:
+                    if 'localhost' not in link:
+                        all_matches.add(MatchTuple(source=markdown_file, name=name, link=link))
 
     with Pool(processes=10) as pool:
-        RESULTS = pool.map(url_ok, [match for match in list(all_matches)])
-    unreachable_results = [result for result in RESULTS if not result[1]]
+        results = map(url_ok, [match for match in list(all_matches)])
+    unreachable_results = [result for result in results if not result[1]]
 
     if unreachable_results:
         print("UnReachable Links:")

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -37,12 +37,17 @@ def main(checks):
             run("./scripts/check_docs.py", shell=True, check=True)
             print("check docs passed")
 
+        if "check-links" in checks:
+            print("LinksValidity (check):", flush=True)
+            run("./scripts/check_links.py", shell=True, check=True)
+            print("check links passed")
+
     except CalledProcessError:
         # squelch the exception stacktrace
         sys.exit(1)
 
 if __name__ == "__main__":
-    checks = ['pytest', 'pylint', 'mypy', 'build-docs', 'check-docs']
+    checks = ['pytest', 'pylint', 'mypy', 'build-docs', 'check-docs', 'check-links']
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--checks', type=str, required=False, nargs='+', choices=checks)

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -38,7 +38,7 @@ def main(checks):
             print("check docs passed")
 
         if "check-links" in checks:
-            print("LinksValidity (check):", flush=True)
+            print("Checking links in Markdown files:", flush=True)
             run("./scripts/check_links.py", shell=True, check=True)
             print("check links passed")
 


### PR DESCRIPTION
This PR adds a script to report broken links in all markdowns in the project.

```
time python scripts/verify.py --checks check-links
UnReachable Links:
Verifying with ['check-links']
LinksValidity (check):

UnReachable Links:

0.
Source: /Users/harshtrivedi/allennlp/tutorials/getting_started/using_as_a_library_pt2.md
Name: on GitHub
Link: https://github.com/allenai/allennlp-as-a-library-example/tree/0.5.1

1.
Source: /Users/harshtrivedi/allennlp/tutorials/getting_started/using_as_a_library_pt2.md
Name: `static_html`
Link: https://github.com/allenai/allennlp-as-a-library-example/tree/0.5.1/static_html

2.
Source: /Users/harshtrivedi/allennlp/tutorials/getting_started/using_as_a_library_pt2.md
Name: its own file
Link: https://github.com/allenai/allennlp-as-a-library-example/blob/0.5.1/static_html/demo.css

3.
Source: /Users/harshtrivedi/allennlp/tutorials/getting_started/using_as_a_library_pt2.md
Name: add a `script` tag to load chart.js
Link: https://github.com/allenai/allennlp-as-a-library-example/blob/0.5.1/static_html/index.html#L47

4.
Source: /Users/harshtrivedi/allennlp/tutorials/getting_started/using_as_a_library_pt2.md
Name: `my_library/__init__.py`
Link: https://github.com/allenai/allennlp-as-a-library-example/blob/0.5.1/my_library/__init__.py

5.
Source: /Users/harshtrivedi/allennlp/tutorials/getting_started/using_as_a_library_pt2.md
Name: can be very simple
Link: https://github.com/allenai/allennlp-as-a-library-example/blob/0.5.1/my_library/predictors/paper_classifier_predictor.py

6.
Source: /Users/harshtrivedi/allennlp/tutorials/getting_started/using_as_a_library_pt2.md
Name: placing that inside our `output` div
Link: https://github.com/allenai/allennlp-as-a-library-example/blob/0.5.1/static_html/index.html#L61

7.
Source: /Users/harshtrivedi/allennlp/tutorials/getting_started/using_pretrained_models.md
Name: Named Entity Recognition model
Link: http://allennlp.org/models/#named-entity-recognition

8.
Source: /Users/harshtrivedi/allennlp/tutorials/getting_started/using_as_a_library_pt2.md
Name: as a test fixture
Link: https://github.com/allenai/allennlp-as-a-library-example/tree/0.5.1/tests/fixtures

9.
Source: /Users/harshtrivedi/allennlp/tutorials/getting_started/using_as_a_library_pt2.md
Name: `text_to_instance`
Link: https://github.com/allenai/allennlp-as-a-library-example/blob/0.5.1/my_library/dataset_readers/semantic_scholar_papers.py#L68

python scripts/verify.py --checks check-links  2.97s user 0.70s system 34% cpu 10.761 total
```

Takes about 10 seconds.