### PR TITLE
Move cache breaking command to the end.

### DIFF
--- a/Dockerfile.pip
+++ b/Dockerfile.pip
@@ -21,8 +21,6 @@ WORKDIR /stage/allennlp
 
 ARG VERSION
 ARG SOURCE_COMMIT
-ENV VERSION=$VERSION
-ENV SOURCE_COMMIT=$SOURCE_COMMIT
 
 # Install the specified version of AllenNLP.
 RUN if [ ! -z "$VERSION" ]; \
@@ -33,5 +31,8 @@ RUN if [ ! -z "$VERSION" ]; \
     fi
 
 LABEL maintainer="allennlp-contact@allenai.org"
+
+ENV VERSION=$VERSION
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
 
 ENTRYPOINT ["allennlp"]


### PR DESCRIPTION
I noticed that some of our master builds were slow.  Investigating the Docker build it looked like the cache was breaking when the commit SHA was specified--which makes sense as it changes for each commit.  This moves these potentially cache-breaking commands to the end so we can re-use more of our images.