### PR TITLE
Add command to generate / manage sub-experiments from root experiment config.

### DIFF
--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -10,6 +10,7 @@ from allennlp.commands.fine_tune import FineTune
 from allennlp.commands.make_vocab import MakeVocab
 from allennlp.commands.predict import Predict
 from allennlp.commands.dry_run import DryRun
+from allennlp.commands.generate_subexperiments import GenerateSubexperiments
 from allennlp.commands.subcommand import Subcommand
 from allennlp.commands.test_install import TestInstall
 from allennlp.commands.train import Train
@@ -42,7 +43,7 @@ def main(prog: str = None,
             "fine-tune": FineTune(),
             "dry-run": DryRun(),
             "test-install": TestInstall(),
-
+            "generate-subexperiments": GenerateSubexperiments(),
             # Superseded by overrides
             **subcommand_overrides
     }
@@ -51,7 +52,7 @@ def main(prog: str = None,
         subparser = subcommand.add_subparser(name, subparsers)
         # configure doesn't need include-package because it imports
         # whatever classes it needs.
-        if name != "configure":
+        if name not in ["configure", "generate-subexperiments"]:
             subparser.add_argument('--include-package',
                                    type=str,
                                    action='append',

--- a/allennlp/commands/generate_subexperiments.py
+++ b/allennlp/commands/generate_subexperiments.py
@@ -197,10 +197,9 @@ class SequenceOfChanges:
     def __str__(self) -> str:
         return ','.join([str(change) for change in self.changes])
 
-    # TODO: should I make execute inplace operation?
     def execute(self, source_config: Params) -> Params:
         """
-            Applies each change in this SequenceOfChanges sequentially.
+        Applies each change in this SequenceOfChanges sequentially.
         """
         updated_config = deepcopy(source_config)
         for change in self.changes:

--- a/allennlp/commands/generate_subexperiments.py
+++ b/allennlp/commands/generate_subexperiments.py
@@ -6,7 +6,7 @@ to store the generated subexperiment configs.
 
 .. code-block:: bash
 
-    $ allennlp generate_subexperiments --help
+    $ allennlp generate-subexperiments --help
     usage: allennlp generate-subexperiments [-h]
                                             root_experiment_file generator_file
                                             subexperiments_dir

--- a/allennlp/commands/generate_subexperiments.py
+++ b/allennlp/commands/generate_subexperiments.py
@@ -1,0 +1,339 @@
+"""
+The ``generate_subexperiments`` subcommand can be used to generate
+configs of subexperiments from a base/root experiment. It requires a
+root config file, sub experiment generator config file and directory
+to store the generated subexperiment configs.
+
+.. code-block:: bash
+
+    $ allennlp generate_subexperiments --help
+    usage: allennlp generate-subexperiments [-h]
+                                            root_experiment_file generator_file
+                                            subexperiments_dir
+
+    Generate subexperiment configs form root experiment config.
+
+    positional arguments:
+      root_experiment_file  path to root experiment config file
+      generator_file        path to sub-experiment generator config file
+      subexperiments_dir    output directory to store generated config files
+
+    optional arguments:
+      -h, --help            show this help message and exit
+"""
+import itertools
+from copy import deepcopy
+import shutil
+from typing import Union, Sequence, Iterable
+from collections import OrderedDict
+import argparse
+import os
+import json
+import ast
+import logging
+
+import _jsonnet
+
+from allennlp.commands.subcommand import Subcommand
+from allennlp.common.params import Params, parse_overrides, with_fallback
+from allennlp.common.checks import ConfigurationError
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class Change:
+    """
+    Encodes a single change from source config to updated config which doesn't need to be
+    internally combined. Eg. change num_dim of embeddings to 300, which requires 'model.
+    text_field_embedder.tokens.pretrained_file' set to '/pretrained_files/glove.6B.300d.
+    txt.gz' and 'model.text_field_embedder.embedding_dim' set to 300. Change has tuple of
+    keys and tuple of values of same size. Corresponding key will be set to corresponding
+    value when this Change is executed. Key is string with dot (.) to represent nesting
+    (as in jsonnet). Value are any valid jsonnet expression strings with access to extra
+    variable ``current``, which refers to state of source config before change execution.
+
+    Parameters
+    ----------
+    key_tuple : ``Sequence[str]``,
+        tuple of jsonnet field references expressed in strings.
+        eg ("trainer.num_epochs", "trainer.batch_size").
+    value_tuple : ``Sequence[str]``,
+        tuple of jsonnet expressions of expressed in strings of same size as `key_tuple`.
+        Corresponding key will be set to corresponding value when this Change is executed.
+        Value must be valid jsonnet expression with access to ``current`` variable refer
+        ing to state of source config before change execution.
+        Eg 1. `key_tuple`: ("50", "64") for `key_tuple`: ("trainer.num_epochs", "trainer.batch_size").
+        Eg 2. `key_tuple`: ("model.tuple_feedforward.hidden_dims") and value tuple:
+        ("[200 for _ in std.range(1, current.model.tuple_feedforward.num_layers)]")
+    key_name : ``str``, optional (joined ``key_tuple``s with '-')
+        This name will be used to refer to key in experiment id which has this change exectued.
+        key can often be very large, key_name provides good short name that is easy to parse for
+        humans. Eg. You can keep 'bidrectional' if you set 'model.seq2vec_encoder.bidirectional
+        in this change.
+    value_name : ``str``, optional (joined ``value_tuple``s with '-')
+        This name will be used to refer to value in experiment id which has this change exectued.
+        Eg. You can keep 'true' if you set 'model.seq2vec_encoder.bidirectional" to True in this
+        change. This key,value change will be referred as ``key_name``=`value_name` in the
+        experiment id.
+    """
+    def __init__(self,
+                 key_tuple: Sequence[str],
+                 value_tuple: Sequence[str],
+                 key_name: Union[str, int, bool] = None,
+                 value_name: Union[str, int, bool] = None) -> None:
+        if not isinstance(key_tuple, (list, tuple)):
+            raise ConfigurationError("key_tuple: '{}' must be tuple / list".format(key_tuple))
+        if not isinstance(value_tuple, (list, tuple)):
+            raise ConfigurationError("value_tuple: '{}' must be tuple / list".format(value_tuple))
+        if len(key_tuple) != len(value_tuple):
+            raise ConfigurationError("key_tuple: '{}' and value_tuple: '{}' "
+                                     "both must be tuples of same size.".format(key_tuple, value_tuple))
+        self.key_tuple = key_tuple
+        self.value_tuple = value_tuple
+        self.key_name = key_name or "_".join(key_tuple)
+        self.value_name = value_name or "_".join(value_tuple)
+        valid_key_name = any(isinstance(self.key_name, _type) for _type in [str, int, bool])
+        valid_value_name = any(isinstance(self.value_name, _type) for _type in [str, int, bool])
+        if not valid_key_name or not valid_value_name:
+            raise ConfigurationError("Value name and Key name must be string / int / bool")
+
+    def __str__(self) -> str:
+        return "{}={}".format(self.key_name, self.value_name)
+
+    def execute(self, source_config: Params) -> Params:
+        """
+        Takes in source_config and executes the change that this instance encodes.
+        """
+        define_current_var = 'local current = {} ;'.format(json.dumps(source_config.as_dict()))
+        overrides_dict = {}
+        for key, value in zip(self.key_tuple, self.value_tuple):
+            try:
+                value_evaluated = _jsonnet.evaluate_snippet("", define_current_var+value).strip()
+            except:
+                raise ConfigurationError("Following is not valid jsonnet expression:\n"
+                                         "{}".format(define_current_var+value))
+            # value_evaluated can be int / string / dict / bool. But it will be represented
+            # in terms of json objects. Eg. if value_evaluated is True, it will be 'true'.
+            # Since it may not be dict, json.loads does following is required.
+            for json_str, py_str in [('null', 'None'), ('true', 'True'), ('false', 'False')]:
+                value_evaluated = value_evaluated.replace(json_str, py_str)
+            try:
+                value_evaluated = ast.literal_eval(value_evaluated)
+            except:
+                raise ConfigurationError("{} could not be parsed as python expression.".format(value_evaluated))
+            overrides_dict[key] = value_evaluated
+        overrides_dict = parse_overrides(json.dumps(overrides_dict))
+        changed_config = with_fallback(preferred=overrides_dict,
+                                       fallback=source_config.as_dict())
+        return Params(changed_config)
+
+    @classmethod
+    def from_params(cls, change_params: Params) -> 'Change':
+        key_tuple = change_params.pop("key_tuple")
+        value_tuple = change_params.pop("value_tuple")
+        default_key_name = "_".join(key_tuple)
+        default_value_name = "_".join(value_tuple)
+        key_name = change_params.pop("key_name", default_key_name)
+        value_name = change_params.pop("value_name", default_value_name)
+        return cls(key_tuple=key_tuple, value_tuple=value_tuple,
+                   key_name=key_name, value_name=value_name)
+
+
+class GroupOfChanges:
+    """
+    Encodes group of similar Changes to be used one at a time.
+    Eg. group for trying embedding sizes from 100, 200 and 300.
+
+    Parameters
+    ----------
+    changes : ``Sequence[Change]``,
+        List/Tuple of changes with same ``key_tuple``
+    """
+    def __init__(self, changes: Sequence[Change] = ()) -> None:
+        if len({tuple(change.key_tuple) for change in changes}) > 1:
+            raise ConfigurationError("A GroupOfChanges must have single key_tuple.")
+        self.changes = changes
+
+    def __str__(self) -> str:
+        return ','.join([str(change) for change in self.changes])
+
+    @classmethod
+    def from_params(cls, change_params: Params) -> 'GroupOfChanges':
+        key_tuple = change_params.pop("key_tuple")
+        value_tuples = change_params.pop("value_tuples")
+        default_key_name = "_".join([str(key) for key in key_tuple])
+        default_value_names = ["_".join([str(value) for value in value_tuple])
+                               for value_tuple in value_tuples]
+        key_name = change_params.pop("key_name", default_key_name)
+        value_names = change_params.pop("value_names", default_value_names)
+
+        if len(value_tuples) != len(value_names):
+            raise ConfigurationError("Number of value tuples '{}' and corresponding "
+                                     "value names '{}' must be same.".format(value_tuples, value_names))
+        changes = [Change(key_tuple=key_tuple, value_tuple=value_tuple,
+                          key_name=key_name, value_name=value_name)
+                   for value_tuple, value_name in zip(value_tuples, value_names)]
+        return cls(changes)
+
+
+class SequenceOfChanges:
+    """
+    Encodes sequence of Changes to be executed in that order.
+    Eg. Set model.seq2vec_encoder.bidirectional set to True, Set embedding dim to 300
+    and Use glove embeddings of 300D.
+
+    Parameters
+    ----------
+    changes : ``Sequence[Change]``,
+        List/Tuple of changes
+    """
+
+    def __init__(self, changes: Sequence[Change] = ()) -> None:
+        if len({tuple(change.key_tuple) for change in changes}) < len(changes):
+            logger.info("Some changes have same 'key_tuple'. On executing "
+                        "this sequence, only later change will retain.")
+        self.changes = changes
+
+    def __str__(self) -> str:
+        return ','.join([str(change) for change in self.changes])
+
+    # TODO: should I make execute inplace operation?
+    def execute(self, source_config: Params) -> Params:
+        """
+            Applies each change in this SequenceOfChanges sequentially.
+        """
+        updated_config = deepcopy(source_config)
+        for change in self.changes:
+            updated_config = change.execute(updated_config)
+        return updated_config
+
+    @classmethod
+    def from_params_list(cls, changes_params: Sequence[Params] = ()) -> 'SequenceOfChanges':
+        return cls([Change.from_params(change_params) for change_params in changes_params])
+
+
+class SubExperimentsGenerator:
+    """
+    Takes root experiment config, sequence of pre-combine changes, sequence of
+    post-combine changes, and a list of groups of changes to be made combinations from.
+    Combinations are generated from list of groups taking one from each group at a
+    time. For each resultant combination (sequence of changes), changes are executed
+    in following order: pre-combine changes, combination sequence, post-combine changes.
+    Resulting generated experiment configs can be stored in directory by calling save.
+
+    Parameters
+    ----------
+    root_config : ``Params``
+        root/base experiment config to generate sub-experiments from.
+    pre_combine_changes : ``SequenceOfChanges``
+        Sequence of changes to be applied before combination.
+    to_be_combined_changes : ``Sequence[GroupOfChanges]``
+        List/Tuple of groups of changes to be combined across. One change will be
+        taken from each group for one experiment.
+    post_combine_changes : ``SequenceOfChanges``
+        Sequence of changes to be applied after applying a combination of change.
+    """
+    def __init__(self,
+                 root_config: Params,
+                 pre_combine_changes: SequenceOfChanges = SequenceOfChanges(()),
+                 to_be_combined_changes: Sequence[GroupOfChanges] = (),
+                 post_combine_changes: SequenceOfChanges = SequenceOfChanges(())) -> None:
+        self._root_config = root_config
+        self._pre_combine_changes = pre_combine_changes
+        self._to_be_combined_changes = to_be_combined_changes
+        self._post_combine_changes = post_combine_changes
+        self._subexperiments = self._generate()
+
+    @classmethod
+    def from_params(cls,
+                    root_config: Params,
+                    generator_config: Params) -> 'SubExperimentsGenerator':
+
+        pre_combine_configs = generator_config.pop("pre_combine_changes", ())
+        if not isinstance(pre_combine_configs, (list, tuple)):
+            raise ConfigurationError("key 'pre_combine_changes' must be a list/tuple")
+        pre_combine_changes = SequenceOfChanges.from_params_list(pre_combine_configs)
+
+        post_combine_configs = generator_config.pop("post_combine_changes", ())
+        if not isinstance(post_combine_configs, (list, tuple)):
+            raise ConfigurationError("key 'post_combine_changes' must be a list/tuple")
+        post_combine_changes = SequenceOfChanges.from_params_list(post_combine_configs)
+
+        group_change_configs = generator_config.pop("combine_changes")
+        to_be_combined_changes = [GroupOfChanges.from_params(group_change_config)
+                                  for group_change_config in group_change_configs]
+
+        return cls(root_config=root_config,
+                   pre_combine_changes=pre_combine_changes,
+                   to_be_combined_changes=to_be_combined_changes,
+                   post_combine_changes=post_combine_changes)
+
+    def _generate_combinations_of_changes(self) -> Iterable[SequenceOfChanges]:
+        """
+        Makes combinations from groups of changes,by taking one change from each group
+        for each combination. Encodes each combinations as SequenceOfChanges.
+        """
+        list_of_group_of_changes = [group_of_changes.changes
+                                    for group_of_changes in self._to_be_combined_changes]
+        for combination_changes in itertools.product(*list_of_group_of_changes):
+            yield SequenceOfChanges(combination_changes)
+
+    def _generate(self) -> OrderedDict:
+        """
+        Generates sub-experiments and returns ordered dict keyed by experiment name
+        and valued by final experiment config params.
+        """
+        subexperiments: OrderedDict = OrderedDict({})
+        combinations_of_changes = self._generate_combinations_of_changes()
+        for combination in combinations_of_changes:
+            experiment_config = self._pre_combine_changes.execute(self._root_config)
+            experiment_config = combination.execute(experiment_config)
+            experiment_config = self._post_combine_changes.execute(experiment_config)
+            experiment_name = str(combination)
+            subexperiments[experiment_name] = experiment_config
+            logger.info("Generated: %s", experiment_name)
+        logger.info("%s subexperiments generated", len(subexperiments)) # temporary
+        return subexperiments
+
+    def save(self,
+             subexperiments_dir: str,
+             root_name: str = "",
+             order: bool = True) -> None:
+        """ Stores the generated experiment configs in ``subexperiments_dir``."""
+        if os.path.isdir(subexperiments_dir):
+            force = input("The subexperiments_dir: '{}' exists. Delete? Y/N".format(subexperiments_dir))
+            if 'n' in force.lower():
+                exit("Terminated by user.")
+            shutil.rmtree(subexperiments_dir)
+        os.makedirs(subexperiments_dir)
+        for index, subexperiment in enumerate(self._subexperiments.items()):
+            subexperiment_name, subexperiment_config = subexperiment
+            order_name = str(index+1) if order else ""
+            file_name = ".".join([order_name, root_name, subexperiment_name, "json"])
+            file_path = os.path.join(subexperiments_dir, file_name)
+            subexperiment_config.to_file(file_path)
+
+
+class GenerateSubexperiments(Subcommand):
+    def add_subparser(self, name: str, parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
+        # pylint: disable=protected-access
+        description = '''Generate subexperiment configs form root experiment config.'''
+        subparser = parser.add_parser(name, description=description, help='Train a model')
+        subparser.add_argument('root_experiment_file', type=str,
+                               help='path to root experiment config file')
+        subparser.add_argument('generator_file', type=str,
+                               help='path to sub-experiment generator config file')
+        subparser.add_argument('subexperiments_dir', type=str,
+                               help='output directory to store generated config files')
+        subparser.set_defaults(func=generate_subexperiments_from_args)
+        return subparser
+
+
+def generate_subexperiments_from_args(args: argparse.Namespace):
+
+    root_config = Params.from_file(args.root_experiment_file)
+    generator_config = Params.from_file(args.generator_file)
+    root_experiment_name = os.path.splitext(args.root_experiment_file)[0]
+
+    generator = SubExperimentsGenerator.from_params(root_config, generator_config)
+    generator.save(args.subexperiments_dir, root_name=root_experiment_name)

--- a/allennlp/tests/commands/generate_subexperiments_test.py
+++ b/allennlp/tests/commands/generate_subexperiments_test.py
@@ -1,0 +1,442 @@
+# pylint: disable=no-self-use,protected-access
+import os
+from copy import deepcopy
+import argparse
+
+import pytest
+
+from allennlp.common.params import Params
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.common.checks import ConfigurationError
+from allennlp.commands.generate_subexperiments import generate_subexperiments_from_args, \
+    Change, GroupOfChanges, SequenceOfChanges, SubExperimentsGenerator, GenerateSubexperiments
+
+class TestGenerateSubexperiments(AllenNlpTestCase):
+
+    def setUp(self):
+        super(TestGenerateSubexperiments, self).setUp()
+        # not a valid experiment config. used it to for brevity of tests.
+        self.root_config = Params({
+                "model": {
+                        "pretrained_file": "glove.6B.100d.txt.gz",
+                        "embedding_dim": 100,
+                        "seq2vec_encoder": {
+                                "bidirectional": False,
+                                "input_size": 100,
+                                "hidden_size": 100
+                        },
+                        "classifier": {
+                                "input_dim": 100, # 100 is incorrect input_dim
+                                "num_layers": 2,
+                                "hidden_dims": [200, 3]
+                        }
+                }})
+
+        self.change_config_1 = Params({"key_tuple": ["model.pretrained_file", "model.embedding_dim"],
+                                       "value_tuple": ["'glove.6B.200d.txt.gz'", "200"],
+                                       "key_name": "glove_embedding_dim",
+                                       "value_name": "200"})
+
+        self.change_config_2 = Params({"key_tuple": ["model.seq2vec_encoder.bidirectional"],
+                                       "value_tuple": ["!current.model.seq2vec_encoder.bidirectional"],
+                                       "key_name": "bidirectional",
+                                       "value_name": "toggle"})
+
+        self.change_config_3 = Params({"key_tuple": ["model.classifier_feedforward.input_dim"],
+                                       "value_tuple": [
+                                               """if current.model.seq2vec_encoder.bidirectional
+                                               then current.model.seq2vec_encoder.hidden_size * 2
+                                               else current.model.seq2vec_encoder.hidden_size
+                                               """],
+                                       "key_name": "adjust",
+                                       "value_name": "ff_input_dim"})
+
+        self.group_of_changes_config_1 = Params({"key_tuple": ["model.pretrained_file", "model.embedding_dim"],
+                                                 "value_tuples": [
+                                                         ["'glove.6B.100d.txt.gz'", "100"],
+                                                         ["'glove.6B.200d.txt.gz'", "200"],
+                                                         ["'glove.6B.300d.txt.gz'", "300"]
+                                                 ],
+                                                 "value_names": ["100d", "200d", "300d"],
+                                                 "key_name": "glove_dim"})
+
+        self.group_of_changes_config_2 = Params({"key_tuple": ["model.seq2vec_encoder.bidirectional"],
+                                                 "value_tuples": [
+                                                         ["true"],
+                                                         ["false"]
+                                                 ], # value_names can be inferred implicitly
+                                                 "key_name": "bidirectional"})
+
+    def test_change(self):
+        # test simple change (no current referecing required)
+        # 1. Use 200d glove instead of 100d:
+        key_tuple = ("model.pretrained_file", "model.embedding_dim")
+        value_tuple = ("'glove.6B.200d.txt.gz'", "200")
+        key_name = "glove_embedding_dim"
+        value_name = "200"
+        change1 = Change(key_tuple=key_tuple, value_tuple=value_tuple,
+                         key_name=key_name, value_name=value_name)
+        assert str(change1) == "glove_embedding_dim=200"
+        updated_config = change1.execute(self.root_config)
+        updated_config_dict = updated_config.as_dict()
+        expected_updated_config_dict = deepcopy(self.root_config)
+        expected_updated_config_dict["model"]["pretrained_file"] = "glove.6B.200d.txt.gz"
+        expected_updated_config_dict["model"]["embedding_dim"] = 200
+        assert updated_config_dict == expected_updated_config_dict
+
+        # test complex change with jsonnet expression ('current' referece required)
+        # 2. Toggle bidirectional seq2vec encoder:
+        key_tuple = ("model.seq2vec_encoder.bidirectional",)
+        value_tuple = ("!current.model.seq2vec_encoder.bidirectional",)
+        key_name = "bidirectional"
+        value_name = "toggle"
+        change2 = Change(key_tuple=key_tuple, value_tuple=value_tuple,
+                         key_name=key_name, value_name=value_name)
+        assert str(change2) == "bidirectional=toggle"
+        updated_config = change2.execute(updated_config)
+        updated_config_dict = updated_config.as_dict()
+        assert updated_config_dict["model"]["seq2vec_encoder"]["bidirectional"]
+
+        # test complex change with jsonnet expression ('current' referece required)
+        # 3. Reset input_dim of classifier  based on bidirectional setting
+        key_tuple = ("model.classifier_feedforward.input_dim",)
+        value_tuple = ("if current.model.seq2vec_encoder.bidirectional "
+                       "then current.model.seq2vec_encoder.hidden_size * 2 "
+                       "else current.model.seq2vec_encoder.hidden_size",)
+        key_name = "adjust"
+        value_name = "ff_input_dim"
+        change3 = Change(key_tuple=key_tuple, value_tuple=value_tuple,
+                         key_name=key_name, value_name=value_name)
+        assert str(change3) == "adjust=ff_input_dim"
+        updated_config = change3.execute(updated_config)
+        updated_config_dict = updated_config.as_dict()
+        assert updated_config_dict["model"]["classifier_feedforward"]["input_dim"] == 200
+
+        # test default / inferred change names
+        key_tuple = ("model.pretrained_file", "model.embedding_dim")
+        value_tuple = ("'glove.6B.200d.txt.gz'", "200")
+        change = Change(key_tuple=key_tuple, value_tuple=value_tuple)
+        assert str(change) == "model.pretrained_file_model.embedding_dim='glove.6B.200d.txt.gz'_200"
+
+
+    def test_change_from_params(self):
+        # test simple change (no current referecing required)
+        # 1. Use 200d glove instead of 100d:
+        change_params = Params({"key_tuple": ["model.pretrained_file", "model.embedding_dim"],
+                                "value_tuple": ["'glove.6B.200d.txt.gz'", "200"],
+                                "value_name": "glove_embedding_dim",
+                                "key_name": "200"})
+        change1 = Change.from_params(change_params)
+        updated_config = change1.execute(self.root_config)
+        updated_config_dict = updated_config.as_dict()
+        expected_updated_config_dict = deepcopy(self.root_config)
+        expected_updated_config_dict["model"]["pretrained_file"] = "glove.6B.200d.txt.gz"
+        expected_updated_config_dict["model"]["embedding_dim"] = 200
+        assert updated_config_dict == expected_updated_config_dict
+
+        # test complicated change (current object referecing required)
+        # 2. Toggle bidirectional seq2vec encoder:
+        change_params = Params({"key_tuple": ["model.seq2vec_encoder.bidirectional"],
+                                "value_tuple": ["!current.model.seq2vec_encoder.bidirectional"]})
+        change2 = Change.from_params(change_params)
+        updated_config = change2.execute(updated_config)
+        updated_config_dict = updated_config.as_dict()
+        assert updated_config_dict["model"]["seq2vec_encoder"]["bidirectional"]
+
+        # test complicated change (current object referecing required)
+        # 3. Reset input_dim of classifier  based on bidirectional setting
+        change_params = Params({"key_tuple": ["model.classifier_feedforward.input_dim"],
+                                "value_tuple": [
+                                        """if current.model.seq2vec_encoder.bidirectional
+                                        then current.model.seq2vec_encoder.hidden_size * 2
+                                        else current.model.seq2vec_encoder.hidden_size
+                                    """],
+                                "value_name": "adjust",
+                                "key_name": "ff_input_dim"})
+        change = Change.from_params(change_params)
+        updated_config = change.execute(updated_config)
+        updated_config_dict = updated_config.as_dict()
+        assert updated_config_dict["model"]["classifier_feedforward"]["input_dim"] == 200
+
+    def test_invalid_change(self):
+        # 1. Err if key_tuple is not tuple:
+        with pytest.raises(ConfigurationError):
+            Change(key_tuple="model.pretrained_file",
+                   value_tuple=("'glove.6B.200d.txt.gz'", "200"))
+        # 2. Err if value_tuple is not tuple:
+        with pytest.raises(ConfigurationError):
+            Change(key_tuple=("model.pretrained_file", "model.embedding_dim"),
+                   value_tuple="'glove.6B.200d.txt.gz'")
+        # 3. Err if key_tuple and value_tuple and not of same size.
+        with pytest.raises(ConfigurationError):
+            Change(key_tuple=("model.pretrained_file", "model.embedding_dim"),
+                   value_tuple=("'glove.6B.200d.txt.gz'", "200", "something"))
+
+    def test_invalid_change_from_params(self):
+        # 1. Err if key_tuple is not tuple:
+        with pytest.raises(ConfigurationError):
+            Change.from_params(Params({"key_tuple": "model.pretrained_file",
+                                       "value_tuple": ["'glove.6B.200d.txt.gz'", "200"]}))
+        # 2. Err if value_tuple is not tuple:
+        with pytest.raises(ConfigurationError):
+            Change.from_params(Params({"key_tuple": ["model.pretrained_file", "model.embedding_dim"],
+                                       "value_tuple": "'glove.6B.200d.txt.gz'"}))
+        # 3. Err if key_tuple and value_tuple and not of same size.
+        with pytest.raises(ConfigurationError):
+            Change.from_params(Params({"key_tuple": ["model.pretrained_file", "model.embedding_dim"],
+                                       "value_tuple": ["'glove.6B.200d.txt.gz'", "200", "something"]}))
+
+    def test_sequence_of_changes(self):
+        # 1. Test a Sequence of Changes (from constructor)
+        change_1 = Change.from_params(self.change_config_1)
+        change_2 = Change.from_params(self.change_config_2)
+        change_3 = Change.from_params(self.change_config_3)
+        changes = SequenceOfChanges([change_1, change_2, change_3])
+        assert str(changes) == "glove_embedding_dim=200,bidirectional=toggle,adjust=ff_input_dim"
+        updated_config = changes.execute(self.root_config)
+        updated_config_dict = updated_config.as_dict()
+        assert updated_config_dict["model"]["pretrained_file"] == "glove.6B.200d.txt.gz"
+        assert updated_config_dict["model"]["embedding_dim"] == 200
+        assert updated_config_dict["model"]["seq2vec_encoder"]["bidirectional"]
+        assert updated_config_dict["model"]["classifier_feedforward"]["input_dim"] == 200
+
+        # 2. Test a Sequence of Changes (from constructor)
+        # test same set of changes in different order: bidirectional toggle before last
+        # ensure 'current' variable reference works appropriately
+        changes = SequenceOfChanges([change_1, change_3, change_2])
+        assert str(changes) == "glove_embedding_dim=200,adjust=ff_input_dim,bidirectional=toggle"
+        updated_config = changes.execute(self.root_config)
+        updated_config_dict = updated_config.as_dict()
+        assert updated_config_dict["model"]["pretrained_file"] == "glove.6B.200d.txt.gz"
+        assert updated_config_dict["model"]["embedding_dim"] == 200
+        assert updated_config_dict["model"]["seq2vec_encoder"]["bidirectional"]
+        assert updated_config_dict["model"]["classifier_feedforward"]["input_dim"] == 100 # Diff than 200 above
+
+    def test_sequence_of_changes_from_params(self):
+        params_list = [Params({"key_tuple": ["model.pretrained_file", "model.embedding_dim"],
+                               "value_tuple": ["'glove.6B.200d.txt.gz'", "200"]}),
+                       Params({"key_tuple": ["model.seq2vec_encoder.bidirectional"],
+                               "value_tuple": ["!current.model.seq2vec_encoder.bidirectional"]})]
+        changes = SequenceOfChanges.from_params_list(params_list)
+        updated_config = changes.execute(self.root_config)
+        updated_config_dict = updated_config.as_dict()
+        assert updated_config_dict["model"]["pretrained_file"] == "glove.6B.200d.txt.gz"
+        assert updated_config_dict["model"]["embedding_dim"] == 200
+        assert updated_config_dict["model"]["seq2vec_encoder"]["bidirectional"]
+
+    def test_group_of_changes(self):
+        # test valid group_of_changes
+        change1 = Change(key_tuple=("model.pretrained_file", "model.embedding_dim"),
+                         value_tuple=("'glove.6B.100d.txt.gz'", "100"))
+        change2 = Change(key_tuple=("model.pretrained_file", "model.embedding_dim"),
+                         value_tuple=("'glove.6B.200d.txt.gz'", "200"))
+        change3 = Change(key_tuple=("model.pretrained_file", "model.embedding_dim"),
+                         value_tuple=("'glove.6B.300d.txt.gz'", "300"))
+        changes = GroupOfChanges([change1, change2, change3])
+
+        assert len(changes.changes) == 3
+        # test invalid group_of_changes
+        change_different_key = Change(key_tuple=("model.seq2vec_encoder.bidirectional",),
+                                      value_tuple=("true",))
+        with pytest.raises(ConfigurationError):
+            GroupOfChanges([change1, change2, change_different_key])
+
+    def test_group_of_changes_from_params(self):
+        group_of_changes_1 = GroupOfChanges.from_params(Params({
+                "key_tuple": ["model.pretrained_file", "model.embedding_dim"],
+                "value_tuples": [
+                        ["'glove.6B.100d.txt.gz'", "100"],
+                        ["'glove.6B.200d.txt.gz'", "200"],
+                        ["'glove.6B.300d.txt.gz'", "300"]
+                ],
+                "value_names": ["100d", "200d", "300d"],
+                "key_name": "glove_dim"
+                }))
+        group_of_changes_1 = GroupOfChanges.from_params(self.group_of_changes_config_1) # remove above?
+
+        group_of_changes_2 = GroupOfChanges.from_params(Params({
+                "key_tuple": ["model.seq2vec_encoder.bidirectional"],
+                "value_tuples": [
+                        ["true"],
+                        ["false"]
+                ], # value_names can be inferred implicitly
+                "key_name": "bidirectional"
+                }))
+        group_of_changes_2 = GroupOfChanges.from_params(self.group_of_changes_config_2) # remove above?
+
+        assert len(group_of_changes_1.changes) == 3
+        assert len(group_of_changes_2.changes) == 2
+
+
+    def test_combination_of_groups_of_changes(self):
+        group_of_changes_1 = GroupOfChanges.from_params(self.group_of_changes_config_1)
+        group_of_changes_2 = GroupOfChanges.from_params(self.group_of_changes_config_2)
+
+        to_be_combined_changes = [group_of_changes_1, group_of_changes_2]
+        generator = SubExperimentsGenerator(root_config=self.root_config,
+                                            to_be_combined_changes=to_be_combined_changes)
+
+        subexperiments = generator._subexperiments
+        subexperiment_configs = subexperiments.values()
+        assert len(subexperiments) == 6
+        # generator._subexperiments is already set, calling .save will suffice.
+        # Following is only to test methods separately.
+
+        combinations = generator._generate_combinations_of_changes()
+        assert len(list(combinations)) == 6
+
+        # Test there are 6 unique combinations
+        unique_result_dicts = []
+        for subexperiment_config in subexperiment_configs:
+            result_dict = subexperiment_config.as_dict()
+            if result_dict not in unique_result_dicts:
+                unique_result_dicts.append(result_dict)
+        assert len(unique_result_dicts) == 6
+
+        # verify there are 3 and 2 values for change 1 and chage 2 respectively
+        pretrained_files = {result_dict["model"]["pretrained_file"]
+                            for result_dict in unique_result_dicts}
+        expected_pretrained_files = {"glove.6B.100d.txt.gz",
+                                     "glove.6B.200d.txt.gz",
+                                     "glove.6B.300d.txt.gz"}
+        assert pretrained_files == expected_pretrained_files # change 1
+
+        embedding_dims = {result_dict["model"]["embedding_dim"]
+                          for result_dict in unique_result_dicts}
+        expected_embedding_dims = {100, 200, 300}
+        assert embedding_dims == expected_embedding_dims # change 1
+
+        bidirectionals = {result_dict["model"]["seq2vec_encoder"]["bidirectional"]
+                          for result_dict in unique_result_dicts}
+        expected_bidirectionals = {True, False}
+        assert bidirectionals == expected_bidirectionals # change 2
+
+        # Make sure these 6 combinations are different in only 2 change fields that we asked for
+        unique_result_dicts = []
+        for subexperiment_config in subexperiment_configs:
+            result_dict = subexperiment_config.as_dict()
+            result_dict["model"].pop("pretrained_file") # change1
+            result_dict["model"].pop("embedding_dim")   # change1
+            result_dict["model"]["seq2vec_encoder"].pop("bidirectional")   # change2
+            if result_dict not in unique_result_dicts:
+                unique_result_dicts.append(result_dict)
+        assert len(unique_result_dicts) == 1
+
+    def test_subexperiment_generator(self):
+        generator_config = Params({
+                # Make combinations of 3 different embeddings sizes and bidirectional On/Off
+                "combine_changes":[
+                        {
+                                "key_tuple": ["model.pretrained_file", "model.embedding_dim"],
+                                "value_tuples": [
+                                        ["'glove.6B.100d.txt.gz'", "100"],
+                                        ["'glove.6B.200d.txt.gz'", "200"],
+                                        ["'glove.6B.300d.txt.gz'", "300"]
+                                ],
+                                "value_names": ["100d", "200d", "300d"],
+                                "key_name": "glove_dim"
+                        },
+                        {
+                                "key_tuple": ["model.seq2vec_encoder.bidirectional"],
+                                "value_tuples": [
+                                        ["true"],
+                                        ["false"]
+                                ],
+                                "key_name": "bidirectional"
+                        }
+                ],
+                # Adjust classifier input after generating each combination.
+                "post_combine_changes": [
+                        {
+                                "key_tuple": ["model.classifier_feedforward.input_dim"],
+                                "value_tuple": [
+                                        """if current.model.seq2vec_encoder.bidirectional
+                                        then current.model.seq2vec_encoder.hidden_size * 2
+                                        else current.model.seq2vec_encoder.hidden_size
+                                        """],
+                                # following names won't be added in experiment id. No identifier
+                                # needed because it's a change that all combinations will have.
+                                "value_name": "adjust",
+                                "key_name": "ff_input_dim"
+                        }
+                ]
+        })
+
+        # 1. Test SubExperimentGenerator.from_params
+        generator = SubExperimentsGenerator.from_params(self.root_config, generator_config)
+        assert len(generator._subexperiments) == 6
+
+        expected_sub_experiment_names = {'glove_dim=100d,bidirectional=true',
+                                         'glove_dim=100d,bidirectional=false',
+                                         'glove_dim=200d,bidirectional=true',
+                                         'glove_dim=200d,bidirectional=false',
+                                         'glove_dim=300d,bidirectional=true',
+                                         'glove_dim=300d,bidirectional=false'}
+        assert set(generator._subexperiments.keys()) == expected_sub_experiment_names
+
+        # test few of the generated configs:
+        # a.
+        subexperiment_config = generator._subexperiments['glove_dim=100d,bidirectional=true']
+        assert subexperiment_config.get("model").get("pretrained_file") == "glove.6B.100d.txt.gz"
+        assert subexperiment_config.get("model").get("embedding_dim") == 100
+        assert subexperiment_config.get("model").get("seq2vec_encoder").get("bidirectional")
+
+        # b.
+        subexperiment_config = generator._subexperiments['glove_dim=200d,bidirectional=false']
+        assert subexperiment_config.get("model").get("pretrained_file") == "glove.6B.200d.txt.gz"
+        assert subexperiment_config.get("model").get("embedding_dim") == 200
+        assert not subexperiment_config.get("model").get("seq2vec_encoder").get("bidirectional")
+
+        # c.
+        subexperiment_config = generator._subexperiments['glove_dim=300d,bidirectional=true']
+        assert subexperiment_config.get("model").get("pretrained_file") == "glove.6B.300d.txt.gz"
+        assert subexperiment_config.get("model").get("embedding_dim") == 300
+        assert subexperiment_config.get("model").get("seq2vec_encoder").get("bidirectional")
+
+        # make sure post combine adjustment changes have been applied in each.
+        for _, subexperiment_config in generator._subexperiments.items():
+            classifier_input = subexperiment_config.get("model").get("classifier_feedforward").get("input_dim")
+            seq2vec_hidden = subexperiment_config.get("model").get("seq2vec_encoder").get("hidden_size")
+            seq2vec_bidirectional = subexperiment_config.get("model").get("seq2vec_encoder").get("bidirectional")
+            assert classifier_input == 2 * seq2vec_hidden if seq2vec_bidirectional else seq2vec_hidden
+
+        # 2. Test SubExperimentGenerator.save
+        subexperiments_dir = self.TEST_DIR / 'subexperiments_save'
+        generator.save(subexperiments_dir, "root_exp_name")
+        file_names = set(os.listdir(subexperiments_dir))
+
+        expected_file_names = {'1.root_exp_name.glove_dim=100d,bidirectional=true.json',
+                               '2.root_exp_name.glove_dim=100d,bidirectional=false.json',
+                               '3.root_exp_name.glove_dim=200d,bidirectional=true.json',
+                               '4.root_exp_name.glove_dim=200d,bidirectional=false.json',
+                               '5.root_exp_name.glove_dim=300d,bidirectional=true.json',
+                               '6.root_exp_name.glove_dim=300d,bidirectional=false.json'}
+        assert expected_file_names == file_names
+
+    def test_generate_subexperiments_args(self):
+        parser = argparse.ArgumentParser(description="Testing")
+        subparsers = parser.add_subparsers(title='Commands', metavar='')
+        GenerateSubexperiments().add_subparser('generate-subexperiments', subparsers)
+
+        raw_args = ["generate-subexperiments", "path/to/root_config",
+                    "path/to/subexperiment_config", "path/to/output_dir"]
+        args = parser.parse_args(raw_args)
+
+        assert args.func == generate_subexperiments_from_args
+        assert args.root_experiment_file == "path/to/root_config"
+        assert args.generator_file == "path/to/subexperiment_config"
+        assert args.subexperiments_dir == "path/to/output_dir"
+
+        # all three arguments are required and no more permitted
+        with self.assertRaises(SystemExit) as cm: # pylint: disable=invalid-name
+            args = parser.parse_args(["generate-subexperiments", "path_arg1"])
+            assert cm.exception.code == 2  # argparse code for incorrect usage
+
+        with self.assertRaises(SystemExit) as cm: # pylint: disable=invalid-name
+            args = parser.parse_args(["generate-subexperiments", "path_arg1", "path_arg2"])
+            assert cm.exception.code == 2  # argparse code for incorrect usage
+
+        with self.assertRaises(SystemExit) as cm: # pylint: disable=invalid-name
+            args = parser.parse_args(["generate-subexperiments", "path_arg1", "path_arg2",
+                                      "path_arg3", "path_arg4"])
+            assert cm.exception.code == 2  # argparse code for incorrect usage

--- a/doc/api/allennlp.commands.generate_subexperiments.rst
+++ b/doc/api/allennlp.commands.generate_subexperiments.rst
@@ -1,0 +1,4 @@
+allennlp.commands.generate_subexperiments
+==========================================
+
+.. automodule:: allennlp.commands.generate_subexperiments

--- a/doc/api/allennlp.commands.rst
+++ b/doc/api/allennlp.commands.rst
@@ -28,6 +28,8 @@ The included module ``allennlp.run`` is such a script:
                     training utilities.
         test-install
                     Run the unit tests.
+        generate-subexperiments
+                    Generate subexperiment configs form root experiment config.
 
 However, it only knows about the models and classes that are
 included with AllenNLP. Once you start creating custom models,
@@ -45,6 +47,7 @@ calls ``main()``.
     allennlp.commands.elmo
     allennlp.commands.dry_run
     allennlp.commands.test_install
+    allennlp.commands.generate_subexperiments
 
 .. automodule:: allennlp.commands
    :members:


### PR DESCRIPTION


This PR adds a command to generate and easily manage sub-experiments config files from a root experiment config file.

A typical scenarios that (I guess) everyone faces is: I have my experiment model up and running. Nice! But there are lots of things that can be yet configured. I have setting K1 that can take V1a, V1b and V1c values and setting K2 that can take V2a, V2b values and I want to try the combinations of these changes and analyse the results.

One can potentially use `--override` and write a script to try and report these things, but its quite an additional overhead to what this command provides. `--override` is in fact handy for quick checks but not really good when one has to manage bunch of experiment changes and analyse their combinations.

For such scenario one (at least I) typically wants way to:

1. **Part A** Easily generate valid experiment configurations for all 3X2=6 possibilities and organize them in easily identifiable config files.
2. **Part B** Train models using these generated experiment config files.
3. **Part C** And evaluate the trained models on set of test datas and give a analysable/searchable report (preferrably nice html tables).

I have been using Part A, B, C in my work but for now only part A (`generate-subexperiments` command) is PR ready.

To use `generate-subexperiments` command, one needs to pass:

```
1. root_experiment_config   config on which all changed defined in generator_config will be exectued.
2. generator_config         config defining how to generate subexperiments from root experiment.
3. output_directory         where generated config files will be stored.
```

The changes and combinations can be quite complicated at times, but using directly what jsonnet provides makes configuring generator pretty flexible. Let's say my model is `venue-classifier` from [allennlp-as-library](https://github.com/allenai/allennlp-as-a-library-example/blob/master/experiments/venue_classifier.json)  and I want to try out following things:

1. Group 1 (different sized glove embeddings) : 100d, 200d and 300d
2. Group 2 (lstm): bidirectional, unidirectional

So I want to generate 3 X 2 = 6 experiment config files and have them easily organized. There are some caveats here: if lstm `bidirectional` is ON, I would need to double the `input_dim` of `classifier_feedforward`. So in each of these 6 experiment congis, I need to make some post combination corrections. Assume projection is ON and so I don't need to adjust `input_dim` of lstm based on used `embedding_dim`.

The following generator config file would do the required:
```python
{
"combine_changes":[
        { # Group 1 of changes  (3 changes)
                "key_tuple": ["model.pretrained_file", "model.embedding_dim"],
                "value_tuples": [
                        ["'files/glove.6B.100d.txt.gz'", "100"],
                        ["'files/glove.6B.200d.txt.gz'", "200"],
                        ["'files/glove.6B.300d.txt.gz'", "300"]
                ],
                "value_names": ["100d", "200d", "300d"],
                "key_name": "glove_dim"
        },
        { # Group 2 of changes (2 changes)
                "key_tuple": ["model.title_encoder.bidirectional", "model.abstract_encoder.bidirectional"],
                "value_tuples": [
                        ["true", "true"],
                        ["false", "false"]
                ], # value_names can be inferred as well.
                "key_name": "bidirectional"
        }
],
# Sequence of changes for post combination corrections
"post_combine_changes": [
        { # Adjust classifier input after generating each combination.
                "key_tuple": ["model.classifier_feedforward.input_dim"],
                "value_tuple": [
                        """if current.model.title_encoder.bidirectional
                        then current.model.title_encoder.hidden_size * 4
                        else current.model.title_encoder.hidden_size * 2
                        """],
                # following names won't be added in experiment id. No identifier
                # needed because it's a change that all combinations will have.
                "value_name": "adjust",
                "key_name": "ff_input_dim"
        }
]
}
```

This will generate 6 valid experiment configs from root (`venue_classifier.json`) and will identify them with following names:

```
1. -> glove_dim=100d,bidirectional=true
2. -> glove_dim=100d,bidirectional=false
3. -> glove_dim=200d,bidirectional=true
4. -> glove_dim=200d,bidirectional=false
5. -> glove_dim=300d,bidirectional=true
6. -> glove_dim=300d,bidirectional=false
```

There are three parts of a generator config: `"pre_combine_changes"`, `"combine_changes"` and `"post_combine_changes"`. Combinations of groups of changes in `combine_changes` will be used to identify sub experiments. For each of these combinations following changes will be applied in order: sequence of `pre_combine_changes`, combination sequence for current experiment and sequence of `post_combine_changes`.

Because of what jsonnet allows one to do, generation config is very flexible. Each value in a `value_tuple` is a string of valid jsonnet expression. A jsonnet expression need not result in json, but can be string/int/bool etc as well. This makes configuring changes easy. `current` is a special jsonnet variable availble to refer to current state of config just before executing that specific change. Key names and value names make the final generated file names easy for human parsing and managing.

I guess the above example should be self-explanatory. Please check tests for more examples, if not.

