### PR TITLE
WIP: Skip tests that require Java in test-install

### DIFF
--- a/allennlp/commands/test_install.py
+++ b/allennlp/commands/test_install.py
@@ -52,10 +52,10 @@ def _get_module_root():
 
 def _run_test(args: argparse.Namespace):
     initial_working_dir = os.getcwd()
-    module_root = _get_module_root()
-    logger.info("Changing directory to %s", module_root)
-    os.chdir(module_root)
-    test_dir = os.path.join(module_root, "tests")
+    module_parent = _get_module_root().parent
+    logger.info("Changing directory to %s", module_parent)
+    os.chdir(module_parent)
+    test_dir = os.path.join(module_parent, "allennlp")
     logger.info("Running tests at %s", test_dir)
     if args.run_all:
         # TODO(nfliu): remove this when notebooks have been rewritten as markdown.

--- a/allennlp/commands/test_install.py
+++ b/allennlp/commands/test_install.py
@@ -59,9 +59,10 @@ def _run_test(args: argparse.Namespace):
     logger.info("Running tests at %s", test_dir)
     if args.run_all:
         # TODO(nfliu): remove this when notebooks have been rewritten as markdown.
-        pytest.main([test_dir, '--color=no', '-k', 'not notebooks_test'])
+        ec = pytest.main([test_dir, '--color=no', '-k', 'not notebooks_test'])
     else:
-        pytest.main([test_dir, '--color=no', '-k', 'not sniff_test and not notebooks_test',
+        ec = pytest.main([test_dir, '--color=no', '-k', 'not sniff_test and not notebooks_test',
                      '-m', 'not java'])
     # Change back to original working directory after running tests
     os.chdir(initial_working_dir)
+    exit(ec)

--- a/allennlp/commands/test_install.py
+++ b/allennlp/commands/test_install.py
@@ -62,6 +62,6 @@ def _run_test(args: argparse.Namespace):
         pytest.main([test_dir, '--color=no', '-k', 'not notebooks_test'])
     else:
         pytest.main([test_dir, '--color=no', '-k', 'not sniff_test and not notebooks_test',
-                '-m', 'not java'])
+                     '-m', 'not java'])
     # Change back to original working directory after running tests
     os.chdir(initial_working_dir)

--- a/allennlp/commands/test_install.py
+++ b/allennlp/commands/test_install.py
@@ -59,8 +59,9 @@ def _run_test(args: argparse.Namespace):
     logger.info("Running tests at %s", test_dir)
     if args.run_all:
         # TODO(nfliu): remove this when notebooks have been rewritten as markdown.
-        pytest.main([test_dir, '-k', 'not notebooks_test'])
+        pytest.main([test_dir, '--color=no', '-k', 'not notebooks_test'])
     else:
-        pytest.main([test_dir, '-k', 'not sniff_test and not notebooks_test'])
+        pytest.main([test_dir, '--color=no', '-k', 'not sniff_test and not notebooks_test',
+                '-m', 'not java'])
     # Change back to original working directory after running tests
     os.chdir(initial_working_dir)

--- a/allennlp/commands/test_install.py
+++ b/allennlp/commands/test_install.py
@@ -59,10 +59,10 @@ def _run_test(args: argparse.Namespace):
     logger.info("Running tests at %s", test_dir)
     if args.run_all:
         # TODO(nfliu): remove this when notebooks have been rewritten as markdown.
-        ec = pytest.main([test_dir, '--color=no', '-k', 'not notebooks_test'])
+        exit_code = pytest.main([test_dir, '--color=no', '-k', 'not notebooks_test'])
     else:
-        ec = pytest.main([test_dir, '--color=no', '-k', 'not sniff_test and not notebooks_test',
-                     '-m', 'not java'])
+        exit_code = pytest.main([test_dir, '--color=no', '-k', 'not sniff_test and not notebooks_test',
+                                 '-m', 'not java'])
     # Change back to original working directory after running tests
     os.chdir(initial_working_dir)
-    exit(ec)
+    exit(exit_code)

--- a/allennlp/tests/models/semantic_parsing/wikitables/wikitables_erm_semantic_parser_test.py
+++ b/allennlp/tests/models/semantic_parsing/wikitables/wikitables_erm_semantic_parser_test.py
@@ -1,9 +1,11 @@
 # pylint: disable=no-self-use
 import os
+import pytest
 
 from allennlp.common.testing import ModelTestCase
 from allennlp.training.metrics.wikitables_accuracy import SEMPRE_ABBREVIATIONS_PATH, SEMPRE_GRAMMAR_PATH
 
+@pytest.mark.java
 class WikiTablesErmSemanticParserTest(ModelTestCase):
     def setUp(self):
         self.should_remove_sempre_abbreviations = not os.path.exists(SEMPRE_ABBREVIATIONS_PATH)

--- a/allennlp/tests/models/semantic_parsing/wikitables/wikitables_mml_semantic_parser_test.py
+++ b/allennlp/tests/models/semantic_parsing/wikitables/wikitables_mml_semantic_parser_test.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name,no-self-use,protected-access
 from collections import namedtuple
 import os
+import pytest
 
 from flaky import flaky
 from numpy.testing import assert_almost_equal
@@ -11,6 +12,7 @@ from allennlp.common.testing import ModelTestCase
 from allennlp.models import Model, WikiTablesMmlSemanticParser
 from allennlp.training.metrics.wikitables_accuracy import SEMPRE_ABBREVIATIONS_PATH, SEMPRE_GRAMMAR_PATH
 
+@pytest.mark.java
 class WikiTablesMmlSemanticParserTest(ModelTestCase):
     def setUp(self):
         self.should_remove_sempre_abbreviations = not os.path.exists(SEMPRE_ABBREVIATIONS_PATH)

--- a/allennlp/tests/predictors/wikitables_parser_test.py
+++ b/allennlp/tests/predictors/wikitables_parser_test.py
@@ -1,12 +1,13 @@
 # pylint: disable=no-self-use,invalid-name
 import os
+import pytest
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
 from allennlp.predictors.wikitables_parser import (SEMPRE_ABBREVIATIONS_PATH, SEMPRE_GRAMMAR_PATH)
 
-
+@pytest.mark.java
 class TestWikiTablesParserPredictor(AllenNlpTestCase):
     def setUp(self):
         super().setUp()

--- a/allennlp/tests/training/metrics/wikitables_accuracy_test.py
+++ b/allennlp/tests/training/metrics/wikitables_accuracy_test.py
@@ -1,11 +1,12 @@
 # pylint: disable=no-self-use,invalid-name,protected-access
 import os
+import pytest
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.training.metrics import WikiTablesAccuracy
 from allennlp.training.metrics.wikitables_accuracy import SEMPRE_ABBREVIATIONS_PATH, SEMPRE_GRAMMAR_PATH
 
-
+@pytest.mark.java
 class WikiTablesAccuracyTest(AllenNlpTestCase):
     def setUp(self):
         super().setUp()

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 testpaths = allennlp/tests/
 log_format = %(asctime)s - %(levelname)s - %(name)s - %(message)s
 log_level = DEBUG
+markers =
+    java


### PR DESCRIPTION
* Skip tests that require `java` when running `test-install` as we don't distribute Java via `pip`.
* Exit with the same exit code as `pytest` when running `test-install`.
* Run in the right directory so test fixtures are found.