### PR TITLE
Don't use a hard-coded temp directory.

### DIFF
--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -3,10 +3,12 @@ import logging
 import os
 import pathlib
 import shutil
+import tempfile
 from unittest import TestCase
 
 from allennlp.common.checks import log_pytorch_version_info
 
+TEST_DIR = tempfile.mkdtemp(prefix="allennlp_tests")
 
 class AllenNlpTestCase(TestCase):  # pylint: disable=too-many-public-methods
     """
@@ -31,7 +33,7 @@ class AllenNlpTestCase(TestCase):  # pylint: disable=too-many-public-methods
         logging.getLogger('urllib3.connectionpool').disabled = True
         log_pytorch_version_info()
 
-        self.TEST_DIR = pathlib.Path("/tmp/allennlp_tests/")
+        self.TEST_DIR = pathlib.Path(TEST_DIR)
 
         os.makedirs(self.TEST_DIR, exist_ok=True)
 


### PR DESCRIPTION
Fixes https://github.com/allenai/allennlp/issues/1539 and makes AllenNLP less system-dependent.