### PR TITLE
Remove a step from verify.

### DIFF
--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -42,18 +42,12 @@ def main(checks):
             run("./scripts/check_links.py", shell=True, check=True)
             print("check links passed")
 
-        if "check-requirements" in checks:
-            print("Checking requirements.txt vs setup.py:", flush=True)
-            run("./scripts/check_requirements.py", shell=True, check=True)
-            print("check requirements passed")
-
     except CalledProcessError:
         # squelch the exception stacktrace
         sys.exit(1)
 
 if __name__ == "__main__":
-    checks = ['pytest', 'pylint', 'mypy', 'build-docs', 'check-docs', 'check-links',
-              'check-requirements']
+    checks = ['pytest', 'pylint', 'mypy', 'build-docs', 'check-docs', 'check-links']
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--checks', type=str, required=False, nargs='+', choices=checks)


### PR DESCRIPTION
Checking to make sure `requirements.txt` and `setup.py` are the same no longer makes sense because we've merged `requirements.txt` and `requirements_test.txt`.  We may want to add this check back if we modified it to make sure that `requirements.txt` is a superset of `setup.py`.