### PR TITLE
Output details when running check-links.

### DIFF
--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -16,11 +16,15 @@ class MatchTuple(NamedTuple):
 
 def url_ok(match_tuple: MatchTuple) -> Tuple[MatchTuple, bool]:
     try:
-        return (match_tuple, requests.get(match_tuple.link).ok)
+        result = requests.get(match_tuple.link)
+        print(f"  {result.status_code}: {match_tuple.source}")
+        return (match_tuple, result.ok)
     except requests.ConnectionError:
         return (match_tuple, False)
 
 if __name__ == "__main__":
+
+    print("Finding all markdown files in the current directory...")
 
     project_root = (pathlib.Path(__file__).parent / "..").resolve() # pylint: disable=no-member
     markdown_files = project_root.glob('**/*.md')
@@ -34,17 +38,20 @@ if __name__ == "__main__":
                 for name, link in matches:
                     if 'localhost' not in link:
                         all_matches.add(MatchTuple(source=str(markdown_file), name=name, link=link))
+    print(f"  {len(all_matches)} markdown files found")
+
+    print("Checking to make sure we can retrieve each web URL...")
 
     with Pool(processes=10) as pool:
         results = pool.map(url_ok, [match for match in list(all_matches)])
     unreachable_results = [result for result in results if not result[1]]
 
     if unreachable_results:
-        print("UnReachable Links:")
+        print(f"Unreachable Links ({len(unreachable_results)}):")
         for index, result in enumerate(unreachable_results):
-            print("\n{}.".format(index))
-            print("Source: " + result[0].source)
-            print("Name: " + result[0].name)
-            print("Link: " + result[0].link)
+            print("  " + str(index))
+            print("  Source: " + result[0].source)
+            print("  Name: " + result[0].name)
+            print("  Link: " + result[0].link)
         sys.exit(1)
     print("No Unreachable link found.")


### PR DESCRIPTION
I added this detail because the script appeared to be hanging.  The real issue was that `npm install` adds a ton of markdown files.  This is less likely going forward because the demo is no longer contained in this repository.

```
Finding all markdown files in the current directory...
  16618 markdown files found
Checking to make sure we can retrieve each web URL...
  404: /Users/michaels/hack/allenai/allennlp/demo/node_modules/resolve-dir/README.md
  200: /Users/michaels/hack/allenai/allennlp/demo/node_modules/json3/README.md
  200: /Users/michaels/hack/allenai/allennlp/demo/node_modules/parse-glob/README.md
  200: /Users/michaels/hack/allenai/allennlp/demo/node_modules/babel-register/node_modules/core-js/CHANGELOG.md
  200: /Users/michaels/hack/allenai/allennlp/demo/node_modules/babel-runtime/node_modules/core-js/CHANGELOG.md
  200: /Users/michaels/hack/allenai/allennlp/demo/node_modules/webpack/node_modules/yargs-parser/CHANGELOG.md
  200: /Users/michaels/hack/allenai/allennlp/demo/node_modules/webpack/node_modules/yargs/CHANGELOG.md
...
```