### PR TITLE
be friendlier to windows users

### DIFF
--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -81,7 +81,7 @@ def cached_path(url_or_filename: Union[str, Path], cache_dir: str = None) -> str
     if parsed.scheme in ('http', 'https'):
         # URL, so get it from the cache (downloading if necessary)
         return get_from_cache(url_or_filename, cache_dir)
-    elif parsed.scheme == '' and os.path.exists(url_or_filename):
+    elif os.path.exists(url_or_filename):
         # File, and it exists.
         return url_or_filename
     elif parsed.scheme == '':

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -12,26 +12,25 @@ import logging
 import os
 
 from overrides import overrides
+
 # _jsonnet doesn't work on Windows, so we have to use fakes.
 try:
     from _jsonnet import evaluate_file, evaluate_snippet
 except ImportError:
-    evaluate_file = _fake_evaluate_file
-    evaluate_snippet = _fake_evaluate_snippet
+    def evaluate_file(filename: str, **_kwargs) -> str:
+        logger.warning(f"_jsonnet not loaded, treating {filename} as json")
+        with open(filename, 'r') as evaluation_file:
+            return evaluation_file.read()
+
+    def evaluate_snippet(_filename: str, expr: str, **_kwargs) -> str:
+        logger.warning(f"_jsonnet not loaded, treating snippet as json")
+        return expr
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
-def _fake_evaluate_file(filename: str, **_kwargs) -> str:
-    logger.warning(f"_jsonnet not loaded, treating {filename} as json")
-    with open(filename, 'r') as evaluation_file:
-        return evaluation_file.read()
-
-def _fake_evaluate_snippet(_filename: str, expr: str, **_kwargs) -> str:
-    logger.warning(f"_jsonnet not loaded, treating snippet as json")
-    return expr
 
 def unflatten(flat_dict: Dict[str, Any]) -> Dict[str, Any]:
     """

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -8,10 +8,15 @@ import importlib
 import logging
 import pkgutil
 import random
-import resource
 import subprocess
 import sys
 import os
+
+try:
+    import resource
+except ImportError:
+    # resource doesn't exist on Windows systems
+    resource = None
 
 import torch
 import numpy
@@ -283,7 +288,7 @@ def peak_memory_mb() -> float:
 
     Only works on OSX and Linux, returns 0.0 otherwise.
     """
-    if sys.platform not in ('linux', 'darwin'):
+    if resource is None or sys.platform not in ('linux', 'darwin'):
         return 0.0
 
     # TODO(joelgrus): For whatever, our pinned version 0.521 of mypy does not like

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@
 # please visit http://pytorch.org/ and install the relevant version.
 torch>=0.4.0,<0.5.0
 
-# Parameter parsing.
-jsonnet==0.10.0
+# Parameter parsing (but not on Windows).
+jsonnet==0.10.0 ; sys.platform != 'win32'
 
 # Type checking for python
 typing

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(name='allennlp',
                                       "tests.*", "tests"]),
       install_requires=[
           'torch>=0.4.0,<0.5.0',
-          'jsonnet==0.10.0',
+          "jsonnet==0.10.0 ; sys.platform != 'win32'",
           'typing',
           'overrides',
           'nltk',


### PR DESCRIPTION
these are small things that prevent allennlp from running on windows, this isn't all the way to getting it to work, but it's a step in that direction:

(1) jsonnet won't pip install on windows right now, so I disabled it in `requirements.txt` if the platform is windows
(2) accordingly, in `params.py` we wrap the `import _jsonnet` in a try-catch block, and if it can't be imported we stub in alternative functions that log a warning and assume the configuration is pure JSON
(3) the `resource` module doesn't exist on Windows, so in `util.py` we import it conditionally, and then we check that it's there before we use it
(4) on unix, urlparse.scheme is an empty string for a file, but on windows it isn't, so I just removed that check in `cached_path`, it should be fine to just check if the file exists whatever the scheme is