### PR TITLE
copy bin/ into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ COPY requirements.txt .
 COPY scripts/install_requirements.sh scripts/install_requirements.sh
 RUN ./scripts/install_requirements.sh
 
+COPY bin/ bin/
 COPY scripts/ scripts/
 COPY allennlp/ allennlp/
 COPY pytest.ini pytest.ini


### PR DESCRIPTION
Our instructions for command line usage didn't work in a docker image because we didn't copy `bin/` into the image.
Fixes #1582