### PR TITLE
Add file friendly logging for elmo.

### DIFF
--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -69,7 +69,7 @@ import numpy
 import torch
 
 from allennlp.common.tqdm import Tqdm
-from allennlp.common.util import lazy_groups_of
+from allennlp.common.util import lazy_groups_of, prepare_global_logging
 from allennlp.common.checks import ConfigurationError
 from allennlp.data.token_indexers.elmo_indexer import ELMoTokenCharactersIndexer
 from allennlp.nn.util import remove_sentence_boundaries

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -57,6 +57,7 @@ https://arxiv.org/abs/1802.05365
 import argparse
 import json
 import logging
+import os
 from typing import IO, List, Iterable, Tuple
 import warnings
 
@@ -116,6 +117,8 @@ class Elmo(Subcommand):
                 default=DEFAULT_WEIGHT_FILE,
                 help='The path to the ELMo weight file.')
         subparser.add_argument('--batch-size', type=int, default=DEFAULT_BATCH_SIZE, help='The batch size to use.')
+        subparser.add_argument('--file-friendly-logging', default=False, action='store_true',
+                help='outputs tqdm status on separate lines and slows tqdm refresh rate.')
         subparser.add_argument('--cuda-device', type=int, default=-1, help='The cuda_device to run on.')
         subparser.add_argument(
                 '--forget-sentences',
@@ -369,6 +372,8 @@ def elmo_command(args):
         output_format = "top"
     elif args.average:
         output_format = "average"
+
+    prepare_global_logging(os.path.realpath(os.path.dirname(args.output_file)), args.file_friendly_logging)
 
     with torch.no_grad():
         elmo_embedder.embed_file(

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -118,7 +118,7 @@ class Elmo(Subcommand):
                 help='The path to the ELMo weight file.')
         subparser.add_argument('--batch-size', type=int, default=DEFAULT_BATCH_SIZE, help='The batch size to use.')
         subparser.add_argument('--file-friendly-logging', default=False, action='store_true',
-                help='outputs tqdm status on separate lines and slows tqdm refresh rate.')
+                               help='outputs tqdm status on separate lines and slows tqdm refresh rate.')
         subparser.add_argument('--cuda-device', type=int, default=-1, help='The cuda_device to run on.')
         subparser.add_argument(
                 '--forget-sentences',


### PR DESCRIPTION
Presently if you run a Beaker job with the `elmo` command, you don't get any progress.

This change somewhat unnecessarily outputs `stdout.txt` and `stderr.txt`--but this allowed maximal re-use of code and doesn't hurt.