### PR TITLE
filter out numpy 'size changed' warnings

### DIFF
--- a/allennlp/__init__.py
+++ b/allennlp/__init__.py
@@ -5,6 +5,12 @@ import sys
 if sys.version_info < (3, 6):
     raise RuntimeError("AllenNLP requires Python 3.6 or later")
 
+# We get a lot of these spurious warnings,
+# see https://github.com/ContinuumIO/anaconda-issues/issues/6678
+import warnings
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+
 try:
     # On some systems this prevents the dreaded
     # ImportError: dlopen: cannot load any more object with static TLS


### PR DESCRIPTION
@schmmd suggested pinning to an early numpy version, but I'd rather not cause problems with people who might need the later version for some reason.