### PR TITLE
use empty list for no package not empty string

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -274,7 +274,7 @@ def import_submodules(package_name: str) -> None:
 
     # Import at top level
     module = importlib.import_module(package_name)
-    path = getattr(module, '__path__', '')
+    path = getattr(module, '__path__', [])
 
     # walk_packages only finds immediate children, so need to recurse.
     for _, name, _ in pkgutil.walk_packages(path):


### PR DESCRIPTION
fixes #1597 

(the root cause is that prior to 3.7, pkgutil.walk_packages let you get away with passing in an empty string as the path as a no-op, starting in 3.7 this throws an error, so I changed it to an empty list)