### PR TITLE
Fix use of scalar tensors in ConllCorefScores

### DIFF
--- a/allennlp/tests/training/metrics/conll_coref_scores_test.py
+++ b/allennlp/tests/training/metrics/conll_coref_scores_test.py
@@ -1,7 +1,5 @@
 # pylint: disable=no-self-use,invalid-name,protected-access
 import torch
-import pytest
-import numpy
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.training.metrics import ConllCorefScores

--- a/allennlp/tests/training/metrics/conll_coref_scores_test.py
+++ b/allennlp/tests/training/metrics/conll_coref_scores_test.py
@@ -1,0 +1,21 @@
+# pylint: disable=no-self-use,invalid-name,protected-access
+import torch
+import pytest
+import numpy
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.training.metrics import ConllCorefScores
+
+class ConllCorefScoresTest(AllenNlpTestCase):
+    def test_get_predicted_clusters(self):
+        top_spans = torch.Tensor([[0, 1], [4, 6], [8, 9]]).long()
+        antecedent_indices = torch.Tensor([[-1, -1, -1],
+                                           [0, -1, -1],
+                                           [0, 1, -1]]).long()
+        predicted_antecedents = torch.Tensor([-1, -1, 1]).long()
+        clusters, mention_to_cluster = ConllCorefScores.get_predicted_clusters(top_spans,
+                                                                               antecedent_indices,
+                                                                               predicted_antecedents)
+        assert len(clusters) == 1
+        assert set(clusters[0]) == {(4, 6), (8, 9)}
+        assert mention_to_cluster == {(4, 6): clusters[0], (8, 9): clusters[0]}


### PR DESCRIPTION
Fixes #1545.

@nelson-liu, can you run a quick check on this branch, to make sure this actually gives similar scores to pre-pytorch-0.4 in the first epoch of training?  From my test, I'm reasonably sure that this fixes the issue, but I don't have this model already set up to train, so I haven't checked that.