### PR TITLE
Add IOB1 as allowed CRF constraint

### DIFF
--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -88,29 +88,16 @@ def is_transition_allowed(constraint_type: str,
     ``bool``
         Whether the transition is allowed under the given ``constraint_type``.
     """
+    # pylint: disable=too-many-return-statements
     if to_tag == "START" or from_tag == "END":
         # Cannot transition into START or from END
         return False
-    if from_tag == "START":
-        if constraint_type == "BIOUL":
-            return to_tag in ('O', 'B', 'U')
-        elif constraint_type == "BIO":
-            return to_tag in ('O', 'B')
-        elif constraint_type == "IOB1":
-            return to_tag in ('O', 'I')
-        else:
-            raise ConfigurationError(f"Unknown constraint type: {constraint_type}")
-    if to_tag == "END":
-        if constraint_type == "BIOUL":
-            return from_tag in ('O', 'L', 'U')
-        elif constraint_type == "BIO":
-            return from_tag in ('O', 'B', 'I')
-        elif constraint_type == "IOB1":
-            return from_tag in ('O', 'B', 'I')
-        else:
-            raise ConfigurationError(f"Unknown constraint type: {constraint_type}")
 
     if constraint_type == "BIOUL":
+        if from_tag == "START":
+            return to_tag in ('O', 'B', 'U')
+        if to_tag == "END":
+            return from_tag in ('O', 'L', 'U')
         return any([
                 # O can transition to O, B-* or U-*
                 # L-x can transition to O, B-*, or U-*
@@ -121,6 +108,10 @@ def is_transition_allowed(constraint_type: str,
                 from_tag in ('B', 'I') and to_tag in ('I', 'L') and from_entity == to_entity
         ])
     elif constraint_type == "BIO":
+        if from_tag == "START":
+            return to_tag in ('O', 'B')
+        if to_tag == "END":
+            return from_tag in ('O', 'B', 'I')
         return any([
                 # Can always transition to O or B-x
                 to_tag in ('O', 'B'),
@@ -128,6 +119,10 @@ def is_transition_allowed(constraint_type: str,
                 to_tag == 'I' and from_tag in ('B', 'I') and from_entity == to_entity
         ])
     elif constraint_type == "IOB1":
+        if from_tag == "START":
+            return to_tag in ('O', 'I')
+        if to_tag == "END":
+            return from_tag in ('O', 'B', 'I')
         return any([
                 # Can always transition to O or I-x
                 to_tag in ('O', 'I'),

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -9,9 +9,9 @@ from allennlp.common.checks import ConfigurationError
 import allennlp.nn.util as util
 
 
-def allowed_transitions(constraint_type: str, tokens: Dict[int, str]) -> List[Tuple[int, int]]:
+def allowed_transitions(constraint_type: str, labels: Dict[int, str]) -> List[Tuple[int, int]]:
     """
-    Given tokens and a constraint type, returns the allowed transitions. It will
+    Given labels and a constraint type, returns the allowed transitions. It will
     additionally include transitions for the start and end states, which are used
     by the conditional random field.
 
@@ -20,68 +20,68 @@ def allowed_transitions(constraint_type: str, tokens: Dict[int, str]) -> List[Tu
     constraint_type : ``str``, required
         Indicates which constraint to apply. Current choices are
         "BIO", "IOB1", and BIOUL".
-    tokens : ``Dict[int, str]``, required
-        A mapping {token_id -> token}. Most commonly this would be the value from
+    labels : ``Dict[int, str]``, required
+        A mapping {label_id -> label}. Most commonly this would be the value from
         Vocabulary.get_index_to_token_vocabulary()
 
     Returns
     -------
     ``List[Tuple[int, int]]``
-        The allowed transitions (from_token_id, to_token_id).
+        The allowed transitions (from_label_id, to_label_id).
     """
-    n_tags = len(tokens)
+    n_tags = len(labels)
     start_tag = n_tags
     end_tag = n_tags + 1
 
     allowed = []
     if constraint_type == "BIOUL":
-        for i, (from_tag, *from_entity) in tokens.items():
-            for j, (to_tag, *to_entity) in tokens.items():
+        for i, (from_tag, *from_entity) in labels.items():
+            for j, (to_tag, *to_entity) in labels.items():
                 if is_transition_allowed(constraint_type, from_tag, from_entity,
                                          to_tag, to_entity):
                     allowed.append((i, j))
 
         # start transitions
-        for i, (to_bioul, *to_entity) in tokens.items():
+        for i, (to_bioul, *to_entity) in labels.items():
             if to_bioul in ('O', 'B', 'U'):
                 allowed.append((start_tag, i))
 
         # end transitions
-        for i, (from_bioul, *from_entity) in tokens.items():
+        for i, (from_bioul, *from_entity) in labels.items():
             if from_bioul in ('O', 'L', 'U'):
                 allowed.append((i, end_tag))
 
     elif constraint_type == "BIO":
-        for i, (from_tag, *from_entity) in tokens.items():
-            for j, (to_tag, *to_entity) in tokens.items():
+        for i, (from_tag, *from_entity) in labels.items():
+            for j, (to_tag, *to_entity) in labels.items():
                 if is_transition_allowed(constraint_type, from_tag, from_entity,
                                          to_tag, to_entity):
                     allowed.append((i, j))
 
         # start transitions
-        for i, (to_bio, *to_entity) in tokens.items():
+        for i, (to_bio, *to_entity) in labels.items():
             if to_bio in ('O', 'B'):
                 allowed.append((start_tag, i))
 
         # end transitions
-        for i, (from_bio, *from_entity) in tokens.items():
+        for i, (from_bio, *from_entity) in labels.items():
             if from_bio in ('O', 'B', 'I'):
                 allowed.append((i, end_tag))
 
     elif constraint_type == "IOB1":
-        for i, (from_tag, *from_entity) in tokens.items():
-            for j, (to_tag, *to_entity) in tokens.items():
+        for i, (from_tag, *from_entity) in labels.items():
+            for j, (to_tag, *to_entity) in labels.items():
                 if is_transition_allowed(constraint_type, from_tag, from_entity,
                                          to_tag, to_entity):
                     allowed.append((i, j))
 
         # start transitions
-        for i, (to_bio, *to_entity) in tokens.items():
+        for i, (to_bio, *to_entity) in labels.items():
             if to_bio in ('O', 'I'):
                 allowed.append((start_tag, i))
 
         # end transitions
-        for i, (from_bio, *from_entity) in tokens.items():
+        for i, (from_bio, *from_entity) in labels.items():
             if from_bio in ('O', 'B', 'I'):
                 allowed.append((i, end_tag))
 

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -29,9 +29,9 @@ def allowed_transitions(constraint_type: str, labels: Dict[int, str]) -> List[Tu
     ``List[Tuple[int, int]]``
         The allowed transitions (from_label_id, to_label_id).
     """
-    n_tags = len(labels)
-    start_tag = n_tags
-    end_tag = n_tags + 1
+    num_tags = len(labels)
+    start_tag = num_tags
+    end_tag = num_tags + 1
 
     allowed = []
     if constraint_type == "BIOUL":

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -35,20 +35,10 @@ def allowed_transitions(constraint_type: str, tokens: Dict[int, str]) -> List[Tu
 
     allowed = []
     if constraint_type == "BIOUL":
-        for i, (from_bioul, *from_entity) in tokens.items():
-            for j, (to_bioul, *to_entity) in tokens.items():
-
-                is_allowed = any([
-                        # O can transition to O, B-* or U-*
-                        # L-x can transition to O, B-*, or U-*
-                        # U-x can transition to O, B-*, or U-*
-                        from_bioul in ('O', 'L', 'U') and to_bioul in ('O', 'B', 'U'),
-                        # B-x can only transition to I-x or L-x
-                        # I-x can only transition to I-x or L-x
-                        from_bioul in ('B', 'I') and to_bioul in ('I', 'L') and from_entity == to_entity
-                ])
-
-                if is_allowed:
+        for i, (from_tag, *from_entity) in tokens.items():
+            for j, (to_tag, *to_entity) in tokens.items():
+                if is_transition_allowed(constraint_type, from_tag, from_entity,
+                                         to_tag, to_entity):
                     allowed.append((i, j))
 
         # start transitions
@@ -62,17 +52,10 @@ def allowed_transitions(constraint_type: str, tokens: Dict[int, str]) -> List[Tu
                 allowed.append((i, end_tag))
 
     elif constraint_type == "BIO":
-        for i, (from_bio, *from_entity) in tokens.items():
-            for j, (to_bio, *to_entity) in tokens.items():
-
-                is_allowed = any([
-                        # Can always transition to O or B-x
-                        to_bio in ('O', 'B'),
-                        # Can only transition to I-x from B-x or I-x
-                        to_bio == 'I' and from_bio in ('B', 'I') and from_entity == to_entity
-                ])
-
-                if is_allowed:
+        for i, (from_tag, *from_entity) in tokens.items():
+            for j, (to_tag, *to_entity) in tokens.items():
+                if is_transition_allowed(constraint_type, from_tag, from_entity,
+                                         to_tag, to_entity):
                     allowed.append((i, j))
 
         # start transitions
@@ -86,18 +69,10 @@ def allowed_transitions(constraint_type: str, tokens: Dict[int, str]) -> List[Tu
                 allowed.append((i, end_tag))
 
     elif constraint_type == "IOB1":
-        for i, (from_bio, *from_entity) in tokens.items():
-            for j, (to_bio, *to_entity) in tokens.items():
-
-                is_allowed = any([
-                        # Can always transition to O or I-x
-                        to_bio in ('O', 'I'),
-                        # Can only transition to B-x from B-x or I-x, where
-                        # x is the same tag.
-                        to_bio == 'B' and from_bio in ('B', 'I') and from_entity == to_entity
-                ])
-
-                if is_allowed:
+        for i, (from_tag, *from_entity) in tokens.items():
+            for j, (to_tag, *to_entity) in tokens.items():
+                if is_transition_allowed(constraint_type, from_tag, from_entity,
+                                         to_tag, to_entity):
                     allowed.append((i, j))
 
         # start transitions
@@ -114,6 +89,68 @@ def allowed_transitions(constraint_type: str, tokens: Dict[int, str]) -> List[Tu
         raise ConfigurationError(f"Unknown constraint type: {constraint_type}")
 
     return allowed
+
+
+def is_transition_allowed(constraint_type: str,
+                          from_tag: str,
+                          from_entity: str,
+                          to_tag: str,
+                          to_entity: str):
+    """
+    Given a constraint type and strings ``from_tag`` and ``to_tag`` that
+    represent the origin and destination of the transition, return whether
+    the transition is allowed under the given constraint type.
+
+    Parameters
+    ----------
+    constraint_type : ``str``, required
+        Indicates which constraint to apply. Current choices are
+        "BIO", "IOB1", and BIOUL".
+    from_tag : ``str``, required
+        The tag that the transition originates from. For example, if the
+        label is ``I-PER``, the ``from_tag`` is ``I``.
+    from_entity: ``str``, required
+        The entity corresponding to the ``from_tag``. For example, if the
+        label is ``I-PER``, the ``from_entity`` is ``PER``.
+    to_tag : ``str``, required
+        The tag that the transition leads to. For example, if the
+        label is ``I-PER``, the ``to_tag`` is ``I``.
+    to_entity: ``str``, required
+        The entity corresponding to the ``to_tag``. For example, if the
+        label is ``I-PER``, the ``to_entity`` is ``PER``.
+
+    Returns
+    -------
+    ``bool``
+        Whether the transition is allowed under the given ``constraint_type``.
+    """
+    if constraint_type == "BIOUL":
+        return any([
+            # O can transition to O, B-* or U-*
+            # L-x can transition to O, B-*, or U-*
+            # U-x can transition to O, B-*, or U-*
+            from_tag in ('O', 'L', 'U') and to_tag in ('O', 'B', 'U'),
+            # B-x can only transition to I-x or L-x
+            # I-x can only transition to I-x or L-x
+            from_tag in ('B', 'I') and to_tag in ('I', 'L') and from_entity == to_entity
+        ])
+    elif constraint_type == "BIO":
+        return any([
+            # Can always transition to O or B-x
+            to_tag in ('O', 'B'),
+            # Can only transition to I-x from B-x or I-x
+            to_tag == 'I' and from_tag in ('B', 'I') and from_entity == to_entity
+        ])
+    elif constraint_type == "IOB1":
+        return any([
+            # Can always transition to O or I-x
+            to_tag in ('O', 'I'),
+            # Can only transition to B-x from B-x or I-x, where
+            # x is the same tag.
+            to_tag == 'B' and from_tag in ('B', 'I') and from_entity == to_entity
+        ])
+    else:
+        raise ConfigurationError(f"Unknown constraint type: {constraint_type}")
 
 
 class ConditionalRandomField(torch.nn.Module):

--- a/allennlp/tests/modules/conditional_random_field_test.py
+++ b/allennlp/tests/modules/conditional_random_field_test.py
@@ -217,5 +217,18 @@ class TestConditionalRandomField(AllenNlpTestCase):
             (9, 0), (9, 1),                 (9, 4), (9, 5),                 (9, 8)
         }
 
+        iob1_labels = ['O', 'B-X', 'I-X', 'B-Y', 'I-Y'] # start tag, end tag
+        #              0     1      2      3      4         5          6
+        allowed = allowed_transitions("IOB1", dict(enumerate(iob1_labels)))
+
+        # The empty spaces in this matrix indicate disallowed transitions.
+        assert set(allowed) == {                         # Extra column for end tag.
+            (0, 0),         (0, 2),         (0, 4),         (0, 6),
+            (1, 0), (1, 1), (1, 2),         (1, 4),         (1, 6),
+            (2, 0), (2, 1), (2, 2),         (2, 4),         (2, 6),
+            (3, 0),         (3, 2), (3, 3), (3, 4),         (3, 6),
+            (4, 0),         (4, 2), (4, 3), (4, 4),         (4, 6),
+            (5, 0),         (5, 2),         (5, 4),                # Extra row for start tag
+        }
         with raises(ConfigurationError):
             allowed_transitions("allennlp", {})

--- a/allennlp/tests/modules/conditional_random_field_test.py
+++ b/allennlp/tests/modules/conditional_random_field_test.py
@@ -222,7 +222,7 @@ class TestConditionalRandomField(AllenNlpTestCase):
         allowed = allowed_transitions("IOB1", dict(enumerate(iob1_labels)))
 
         # The empty spaces in this matrix indicate disallowed transitions.
-        assert set(allowed) == {                         # Extra column for end tag.
+        assert set(allowed) == {                            # Extra column for end tag.
             (0, 0),         (0, 2),         (0, 4),         (0, 6),
             (1, 0), (1, 1), (1, 2),         (1, 4),         (1, 6),
             (2, 0), (2, 1), (2, 2),         (2, 4),         (2, 6),


### PR DESCRIPTION
This adds IOB1 coding as an allowed constraint for the CRF tagger.

Here's a table of allowed transitions for reference:

![](https://user-images.githubusercontent.com/7272031/42742422-d547960e-88fd-11e8-81d3-fca6e146e7db.png)
