### PR TITLE
Don't error if fine-tune serialization dir already exists

### DIFF
--- a/allennlp/commands/fine_tune.py
+++ b/allennlp/commands/fine_tune.py
@@ -141,7 +141,7 @@ def fine_tune_model(model: Model,
         down tqdm's output to only once every 10 seconds.
     """
     prepare_environment(params)
-    os.makedirs(serialization_dir)
+    os.makedirs(serialization_dir, exist_ok=True)
     prepare_global_logging(serialization_dir, file_friendly_logging)
 
     serialization_params = deepcopy(params).as_dict(quiet=True)

--- a/allennlp/commands/fine_tune.py
+++ b/allennlp/commands/fine_tune.py
@@ -141,6 +141,10 @@ def fine_tune_model(model: Model,
         down tqdm's output to only once every 10 seconds.
     """
     prepare_environment(params)
+    if os.path.exists(serialization_dir) and os.listdir(serialization_dir):
+        raise ConfigurationError(f"Serialization directory ({serialization_dir}) "
+                                 f"already exists and is not empty.")
+
     os.makedirs(serialization_dir, exist_ok=True)
     prepare_global_logging(serialization_dir, file_friendly_logging)
 


### PR DESCRIPTION
Changing this to match the behavior of other commands, like [`train`](https://github.com/allenai/allennlp/blob/82686c10bdca062a7e41825000c39372de354479/allennlp/commands/train.py#L222) and [`make-vocab`](https://github.com/allenai/allennlp/blob/1402b7c02aede1a8f832f64cdfb2e9ef1157faca/allennlp/commands/make_vocab.py#L83). 

This causes `fine-tune` to fail with beaker at the moment.