### PR TITLE
Fix calculation of estimated time remaining

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -760,7 +760,7 @@ class Trainer:
                 training_elapsed_time = time.time() - training_start_time
                 estimated_time_remaining = training_elapsed_time * \
                     ((self._num_epochs - epoch_counter) / float(epoch - epoch_counter + 1) - 1)
-                formatted_time = time.strftime("%H:%M:%S", time.gmtime(estimated_time_remaining))
+                formatted_time = str(datetime.timedelta(seconds=int(estimated_time_remaining)))
                 logger.info("Estimated training time remaining: %s", formatted_time)
 
             epochs_trained += 1


### PR DESCRIPTION
This line: https://github.com/allenai/allennlp/blob/6b37dd2be54c0ac178feee2d4428ac9f07d4c5a6/allennlp/training/trainer.py#L763
calculates (or incorrectly formats) the wrong estimated time remaining when [`estimated_time_remaining`](https://github.com/allenai/allennlp/blob/6b37dd2be54c0ac178feee2d4428ac9f07d4c5a6/allennlp/training/trainer.py#L761-L762) is greater than 1 day, since [`time.gmtime`](https://docs.python.org/3/library/time.html#time.gmtime) interprets the number of seconds as time since the epoch, not a time duration.