### PR TITLE
Make LinearAttention and LinearMatrixAttention memory-efficient

### DIFF
--- a/allennlp/modules/attention/linear_attention.py
+++ b/allennlp/modules/attention/linear_attention.py
@@ -64,12 +64,7 @@ class LinearAttention(Attention):
 
     @overrides
     def _forward_internal(self, vector: torch.Tensor, matrix: torch.Tensor) -> torch.Tensor:
-        # TODO(mattg): Remove the need for this tiling.
-        # https://github.com/allenai/allennlp/pull/1235#issuecomment-391540133
-        tiled_vector = vector.unsqueeze(1).expand(vector.size()[0],
-                                                  matrix.size()[1],
-                                                  vector.size()[1])
-
-        combined_tensors = util.combine_tensors(self._combination, [tiled_vector, matrix])
-        dot_product = torch.matmul(combined_tensors, self._weight_vector)
-        return self._activation(dot_product + self._bias)
+        combined_tensors = util.weighted_tensor_combination(self._combination,
+                                                            [vector.unsqueeze(1), matrix],
+                                                            self._weight_vector)
+        return self._activation(combined_tensors.squeeze(1) + self._bias)

--- a/allennlp/modules/attention/linear_attention.py
+++ b/allennlp/modules/attention/linear_attention.py
@@ -64,7 +64,7 @@ class LinearAttention(Attention):
 
     @overrides
     def _forward_internal(self, vector: torch.Tensor, matrix: torch.Tensor) -> torch.Tensor:
-        combined_tensors = util.weighted_tensor_combination(self._combination,
-                                                            [vector.unsqueeze(1), matrix],
-                                                            self._weight_vector)
+        combined_tensors = util.combine_tensors_and_multiply(self._combination,
+                                                             [vector.unsqueeze(1), matrix],
+                                                             self._weight_vector)
         return self._activation(combined_tensors.squeeze(1) + self._bias)

--- a/allennlp/modules/matrix_attention/linear_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/linear_matrix_attention.py
@@ -67,7 +67,7 @@ class LinearMatrixAttention(MatrixAttention):
     def forward(self,  # pylint: disable=arguments-differ
                 matrix_1: torch.Tensor,
                 matrix_2: torch.Tensor) -> torch.Tensor:
-        combined_tensors = util.weighted_tensor_combination(self._combination,
-                                                            [matrix_1.unsqueeze(2), matrix_2.unsqueeze(1)],
-                                                            self._weight_vector)
+        combined_tensors = util.combine_tensors_and_multiply(self._combination,
+                                                             [matrix_1.unsqueeze(2), matrix_2.unsqueeze(1)],
+                                                             self._weight_vector)
         return self._activation(combined_tensors + self._bias)

--- a/allennlp/modules/matrix_attention/linear_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/linear_matrix_attention.py
@@ -67,17 +67,7 @@ class LinearMatrixAttention(MatrixAttention):
     def forward(self,  # pylint: disable=arguments-differ
                 matrix_1: torch.Tensor,
                 matrix_2: torch.Tensor) -> torch.Tensor:
-        # TODO(mattg): Remove the need for this tiling.
-        # https://github.com/allenai/allennlp/pull/1235#issuecomment-391540133
-        tiled_matrix_1 = matrix_1.unsqueeze(2).expand(matrix_1.size()[0],
-                                                      matrix_1.size()[1],
-                                                      matrix_2.size()[1],
-                                                      matrix_1.size()[2])
-        tiled_matrix_2 = matrix_2.unsqueeze(1).expand(matrix_2.size()[0],
-                                                      matrix_1.size()[1],
-                                                      matrix_2.size()[1],
-                                                      matrix_2.size()[2])
-
-        combined_tensors = util.combine_tensors(self._combination, [tiled_matrix_1, tiled_matrix_2])
-        dot_product = torch.matmul(combined_tensors, self._weight_vector)
-        return self._activation(dot_product + self._bias)
+        combined_tensors = util.weighted_tensor_combination(self._combination,
+                                                            [matrix_1.unsqueeze(2), matrix_2.unsqueeze(1)],
+                                                            self._weight_vector)
+        return self._activation(combined_tensors + self._bias)

--- a/allennlp/tests/modules/attention/linear_attention_test.py
+++ b/allennlp/tests/modules/attention/linear_attention_test.py
@@ -11,7 +11,7 @@ from allennlp.modules.attention import LinearAttention
 from allennlp.modules.attention.attention import Attention
 
 
-class LinearAttentionTests(AllenNlpTestCase):
+class LinearAttentionTest(AllenNlpTestCase):
 
     def test_can_init_linear(self):
         legacy_attention = Attention.from_params(Params({"type": "linear",
@@ -27,3 +27,17 @@ class LinearAttentionTests(AllenNlpTestCase):
                         Variable(torch.FloatTensor([[[1, 2, 3], [4, 5, 6]]])))
 
         assert_almost_equal(output.data.numpy(), numpy.array([[0.0474, 0.9526]]), decimal=2)
+
+    def test_bidaf_trilinear_similarity(self):
+        linear = LinearAttention(2, 2, combination='x,y,x*y', normalize=False)
+        linear._weight_vector = Parameter(torch.FloatTensor([-.3, .5, 2.0, -1.0, 1, 1]))
+        linear._bias = Parameter(torch.FloatTensor([.0]))
+        output = linear(torch.FloatTensor([[4, 5]]),
+                        torch.FloatTensor([[[1, 2], [4, 5], [7, 8], [10, 11]]]))
+
+        assert_almost_equal(output.data.numpy(),
+                            numpy.array([[-1.2 + 2.5 + 2 + -2 + 4 + 10,
+                                          -1.2 + 2.5 + 8 + -5 + 16 + 25,
+                                          -1.2 + 2.5 + 14 + -8 + 28 + 40,
+                                          -1.2 + 2.5 + 20 + -11 + 40 + 55]]),
+                            decimal=2)

--- a/allennlp/tests/modules/matrix_attention/linear_matrix_attention_test.py
+++ b/allennlp/tests/modules/matrix_attention/linear_matrix_attention_test.py
@@ -2,7 +2,6 @@
 import numpy
 from numpy.testing import assert_almost_equal
 import torch
-from torch.autograd import Variable
 from torch.nn import Parameter
 
 from allennlp.common import Params
@@ -23,9 +22,27 @@ class TestLinearMatrixAttention(AllenNlpTestCase):
         linear = LinearMatrixAttention(3, 3)
         linear._weight_vector = Parameter(torch.FloatTensor([-.3, .5, 2.0, -1.0, 1, 1]))
         linear._bias = Parameter(torch.FloatTensor([.1]))
-        output = linear(Variable(torch.FloatTensor([[[0, 0, 0], [4, 5, 6]], [[-7, -8, -9], [10, 11, 12]]])),
-                        Variable(torch.FloatTensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])))
+        output = linear(torch.FloatTensor([[[0, 0, 0], [4, 5, 6]], [[-7, -8, -9], [10, 11, 12]]]),
+                        torch.FloatTensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]))
 
         assert_almost_equal(output.data.numpy(), numpy.array([[[4.1000, 7.1000], [17.4000, 20.4000]],
                                                               [[-9.8000, -6.8000], [36.6000, 39.6000]]]),
+                            decimal=2)
+
+    def test_bidaf_trilinear_similarity(self):
+        linear = LinearMatrixAttention(2, 2, combination='x,y,x*y')
+        linear._weight_vector = Parameter(torch.FloatTensor([-.3, .5, 2.0, -1.0, 1, 1]))
+        linear._bias = Parameter(torch.FloatTensor([.0]))
+        output = linear(torch.FloatTensor([[[0, 0], [4, 5]], [[-7, -8], [10, 11]]]),
+                        torch.FloatTensor([[[1, 2], [4, 5]], [[7, 8], [10, 11]]]))
+
+        assert_almost_equal(output.data.numpy(),
+                            numpy.array([[[0 + 0 + 2 + -2 + 0 + 0,
+                                           0 + 0 + 8 + -5 + 0 + 0],
+                                          [-1.2 + 2.5 + 2 + -2 + 4 + 10,
+                                           -1.2 + 2.5 + 8 + -5 + 16 + 25]],
+                                         [[2.1 + -4 + 14 + -8 + -49 + -64,
+                                           2.1 + -4 + 20 + -11 + -70 + -88],
+                                          [-3 + 5.5 + 14 + -8 + 70 + 88,
+                                           -3 + 5.5 + 20 + -11 + 100 + 121]]]),
                             decimal=2)

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -779,3 +779,19 @@ class TestNnUtil(AllenNlpTestCase):
 
         with pytest.raises(ConfigurationError):
             util.weighted_tensor_combination("x%y", tensors, weight)
+
+    def test_weighted_tensor_combination_with_same_batch_size_and_embedding_dim(self):
+        tensors = [torch.Tensor([[[5, 5], [4, 4]], [[2, 3], [1, 1]]])]
+        weight = torch.Tensor([4, 5])
+
+        combination = "x"
+        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+                            [[20 + 25, 16 + 20], [8 + 15, 4 + 5]])
+
+        tensors = [torch.Tensor([[[5, 5], [2, 2]], [[4, 4], [3, 3]]]),
+                   torch.Tensor([[[2, 3]], [[1, 1]]])]
+        weight = torch.Tensor([4, 5])
+        combination = "x*y"
+        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+                            [[5 * 2 * 4 + 5 * 3 * 5, 2 * 2 * 4 + 2 * 3 * 5],
+                             [4 * 1 * 4 + 4 * 1 * 5, 3 * 1 * 4 + 3 * 1 * 5]])

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -733,65 +733,68 @@ class TestNnUtil(AllenNlpTestCase):
         numpy.testing.assert_almost_equal(result[0].detach().cpu().numpy(), tensor2tensor_result)
         numpy.testing.assert_almost_equal(result[1].detach().cpu().numpy(), tensor2tensor_result)
 
-    def test_weighted_tensor_combination(self):
+    def test_combine_tensors_and_multiply(self):
         tensors = [torch.Tensor([[[2, 3]]]), torch.Tensor([[[5, 5]]])]
         weight = torch.Tensor([4, 5])
 
         combination = "x"
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight),
                             [[8 + 15]])
 
         combination = "y"
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight),
                             [[20 + 25]])
 
         combination = "x,y"
         weight2 = torch.Tensor([4, 5, 4, 5])
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight2),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight2),
                             [[8 + 20 + 15 + 25]])
 
         combination = "x-y"
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight),
                             [[-3 * 4 + -2 * 5]])
 
         combination = "y-x"
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight),
                             [[3 * 4 + 2 * 5]])
 
         combination = "y+x"
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight),
                             [[7 * 4 + 8 * 5]])
 
         combination = "y*x"
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight),
                             [[10 * 4 + 15 * 5]])
 
         combination = "y/x"
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight),
                             [[(5 / 2) * 4 + (5 / 3) * 5]], decimal=4)
 
         combination = "x/y"
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight),
                             [[(2 / 5) * 4 + (3 / 5) * 5]], decimal=4)
 
         with pytest.raises(ConfigurationError):
-            util.weighted_tensor_combination("x+y+y", tensors, weight)
+            util.combine_tensors_and_multiply("x+y+y", tensors, weight)
 
         with pytest.raises(ConfigurationError):
-            util.weighted_tensor_combination("x%y", tensors, weight)
+            util.combine_tensors_and_multiply("x%y", tensors, weight)
 
-    def test_weighted_tensor_combination_with_same_batch_size_and_embedding_dim(self):
-        tensors = [torch.Tensor([[[5, 5], [4, 4]], [[2, 3], [1, 1]]])]
-        weight = torch.Tensor([4, 5])
+    def test_combine_tensors_and_multiply_with_same_batch_size_and_embedding_dim(self):
+        # This test just makes sure we handle some potential edge cases where the lengths of all
+        # dimensions are the same, making sure that the multiplication with the weight vector
+        # happens along the right dimension (it should be the last one).
+        tensors = [torch.Tensor([[[5, 5], [4, 4]], [[2, 3], [1, 1]]])]  # (2, 2, 2)
+        weight = torch.Tensor([4, 5])  # (2,)
 
         combination = "x"
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight),
                             [[20 + 25, 16 + 20], [8 + 15, 4 + 5]])
 
         tensors = [torch.Tensor([[[5, 5], [2, 2]], [[4, 4], [3, 3]]]),
                    torch.Tensor([[[2, 3]], [[1, 1]]])]
         weight = torch.Tensor([4, 5])
         combination = "x*y"
-        assert_almost_equal(util.weighted_tensor_combination(combination, tensors, weight),
+        assert_almost_equal(util.combine_tensors_and_multiply(combination, tensors, weight),
                             [[5 * 2 * 4 + 5 * 3 * 5, 2 * 2 * 4 + 2 * 3 * 5],
                              [4 * 1 * 4 + 4 * 1 * 5, 3 * 1 * 4 + 3 * 1 * 5]])


### PR DESCRIPTION
This removes the need for the `TriLinearAttention` that Chris implemented for #804, as our `LinearMatrixAttention` now uses memory-efficient operations.

cc @eunsol