### PR TITLE
typing is part of standard library from python3.6 (gives errors on python3.7)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,6 @@ torch>=0.4.0,<0.5.0
 # Parameter parsing (but not on Windows).
 jsonnet==0.10.0 ; sys.platform != 'win32'
 
-# Type checking for python
-typing; python_version < '3.5'
-
 # Adds an @overrides decorator for better documentation and error checking when using subclasses.
 overrides
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ torch>=0.4.0,<0.5.0
 jsonnet==0.10.0 ; sys.platform != 'win32'
 
 # Type checking for python
-typing
+typing; python_version < '3.5'
 
 # Adds an @overrides decorator for better documentation and error checking when using subclasses.
 overrides

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(name='allennlp',
       install_requires=[
           'torch>=0.4.0,<0.5.0',
           "jsonnet==0.10.0 ; sys.platform != 'win32'",
-          'typing',
+          'typing;python_version<"3.5"',
           'overrides',
           'nltk',
           'spacy>=2.0,<2.1',

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,6 @@ setup(name='allennlp',
       install_requires=[
           'torch>=0.4.0,<0.5.0',
           "jsonnet==0.10.0 ; sys.platform != 'win32'",
-          'typing;python_version<"3.5"',
           'overrides',
           'nltk',
           'spacy>=2.0,<2.1',


### PR DESCRIPTION
installing it on python3.7 causes AttributeError: type object 'Callable' has no attribute '_abc_registry'
refers #1457 and python/typing/issues/573.

To reproduce the issue simply install allennlp in a new environment with python3.7 and then run the command `allennlp predict https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2018.05.25.tar.gz srl-examples.jsonl` given on the demo site https://allennlp.org/models.
It will produce the following error:
```text
Traceback (most recent call last):
  File "/usr/lib64/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/martino/kmi/allennlp_playground/venv/lib/python3.7/site-packages/allennlp/run.py", line 15, in <module>
    from allennlp.commands import main  # pylint: disable=wrong-import-position
  File "/home/martino/kmi/allennlp_playground/venv/lib/python3.7/site-packages/allennlp/commands/__init__.py", line 1, in <module>
    from typing import Dict
  File "/home/martino/kmi/allennlp_playground/venv/lib/python3.7/site-packages/typing.py", line 1347, in <module>
    class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
  File "/home/martino/kmi/allennlp_playground/venv/lib/python3.7/site-packages/typing.py", line 1003, in __new__
    self._abc_registry = extra._abc_registry
AttributeError: type object 'Callable' has no attribute '_abc_registry'
```

The solution is not to install the backport package `typing` on the latest python versions.