### PR TITLE
Add learning rate to logs

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -747,11 +747,11 @@ class Trainer:
             self._save_checkpoint(epoch, validation_metric_per_epoch, is_best=is_best_so_far)
             self._metrics_to_tensorboard(epoch, train_metrics, val_metrics=val_metrics)
             self._metrics_to_console(train_metrics, val_metrics)
-            for ind, param_group in enumerate(self._optimizer.param_groups):
+            for index, param_group in enumerate(self._optimizer.param_groups):
                 learning_rate = param_group.get("lr")
                 if learning_rate is not None:
                     self._tensorboard.add_train_scalar(
-                            f"learning_rate/param_group{ind:d}", learning_rate, epoch)
+                            f"learning_rate/param_group{index:d}", learning_rate, epoch)
 
             if self._learning_rate_scheduler:
                 # The LRScheduler API is agnostic to whether your schedule requires a validation metric -


### PR DESCRIPTION
This adds the learning rate for all parameter groups to the logs for each epoch. This is especially helpful when trying to fine-tune the learning rate.

![learning_rate_logging1](https://user-images.githubusercontent.com/8812459/44429400-34660980-a54c-11e8-9c2a-83f83a3313ae.png)

![learning_rate_loggin2](https://user-images.githubusercontent.com/8812459/44429413-392abd80-a54c-11e8-9ba7-8d108273b100.png)
