### PR TITLE
make max_vocab_size default to None for a given namespace in Vocabulary._extend

### DIFF
--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -490,7 +490,7 @@ class Vocabulary(Registrable):
                 pretrained_list = None
             token_counts = list(counter[namespace].items())
             token_counts.sort(key=lambda x: x[1], reverse=True)
-            max_vocab = max_vocab_size[namespace]
+            max_vocab = max_vocab_size.get(namespace)
             if max_vocab:
                 token_counts = token_counts[:max_vocab]
             for token, count in token_counts:

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -490,7 +490,10 @@ class Vocabulary(Registrable):
                 pretrained_list = None
             token_counts = list(counter[namespace].items())
             token_counts.sort(key=lambda x: x[1], reverse=True)
-            max_vocab = max_vocab_size.get(namespace)
+            try:
+                max_vocab = max_vocab_size[namespace]
+            except KeyError:
+                max_vocab = None
             if max_vocab:
                 token_counts = token_counts[:max_vocab]
             for token, count in token_counts:

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -671,3 +671,17 @@ class TestVocabulary(AllenNlpTestCase):
         words = vocab.get_index_to_token_vocabulary().values()
         # Additional 2 tokens are '@@PADDING@@' and '@@UNKNOWN@@' by default
         assert len(words) == 3
+
+    def test_max_vocab_size_partial_dict(self):
+        indexers = {"tokens": SingleIdTokenIndexer(), "token_characters": TokenCharactersIndexer()}
+        instance = Instance({
+            'text': TextField([Token(w) for w in 'The quick brown fox lay down for a rest'.split(' ')], indexers)
+        })
+        dataset = Batch([instance])
+        params = Params({
+                "max_vocab_size": {
+                        "tokens": 1
+                }
+        })
+
+        vocab = Vocabulary.from_params(params=params, instances=dataset)

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -675,7 +675,7 @@ class TestVocabulary(AllenNlpTestCase):
     def test_max_vocab_size_partial_dict(self):
         indexers = {"tokens": SingleIdTokenIndexer(), "token_characters": TokenCharactersIndexer()}
         instance = Instance({
-            'text': TextField([Token(w) for w in 'The quick brown fox lay down for a rest'.split(' ')], indexers)
+            'text': TextField([Token(w) for w in 'Abc def ghi jkl mno pqr stu vwx yz'.split(' ')], indexers)
         })
         dataset = Batch([instance])
         params = Params({
@@ -685,3 +685,5 @@ class TestVocabulary(AllenNlpTestCase):
         })
 
         vocab = Vocabulary.from_params(params=params, instances=dataset)
+        assert len(vocab.get_index_to_token_vocabulary("tokens").values()) == 3 # 1 + 2
+        assert len(vocab.get_index_to_token_vocabulary("token_characters").values()) == 28 # 26 + 2

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -675,7 +675,7 @@ class TestVocabulary(AllenNlpTestCase):
     def test_max_vocab_size_partial_dict(self):
         indexers = {"tokens": SingleIdTokenIndexer(), "token_characters": TokenCharactersIndexer()}
         instance = Instance({
-            'text': TextField([Token(w) for w in 'Abc def ghi jkl mno pqr stu vwx yz'.split(' ')], indexers)
+                'text': TextField([Token(w) for w in 'Abc def ghi jkl mno pqr stu vwx yz'.split(' ')], indexers)
         })
         dataset = Batch([instance])
         params = Params({


### PR DESCRIPTION
This change allows users to specify max_vocab_size per-namespace in an experiment config without having to provide a max_vocab_size for every namespace.