### PR TITLE
Make _ElmoBiLM._token_embedder.requires_grad False when vocab_to_cache is provided

### DIFF
--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -496,13 +496,18 @@ class _ElmoBiLm(torch.nn.Module):
                  vocab_to_cache: List[str] = None) -> None:
         super(_ElmoBiLm, self).__init__()
 
-        self._token_embedder = _ElmoCharacterEncoder(options_file, weight_file, requires_grad=False if vocab_to_cache is not None else requires_grad)
+        self._token_embedder = _ElmoCharacterEncoder(options_file,
+                                                     weight_file,
+                                                     requires_grad=False
+                                                     if vocab_to_cache is not None else requires_grad)
 
         self._requires_grad = requires_grad
         if requires_grad and vocab_to_cache:
             logging.warning("You are fine tuning ELMo and caching char CNN word vectors. "
                             "This behaviour is not guaranteed to be well defined, particularly. "
-                            "if not all of your inputs will occur in the vocabulary cache.")
+                            "if not all of your inputs will occur in the vocabulary cache. "
+                            "_ElmoCharacterEncoder will be frozen because "
+                            "it is not used after word embedding caching.")
         # This is an embedding, used to look up cached
         # word vectors built from character level cnn embeddings.
         self._word_embedding = None

--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -60,7 +60,7 @@ class Elmo(torch.nn.Module):
         Should we apply layer normalization (passed to ``ScalarMix``)?
     dropout : ``float``, optional, (default = 0.5).
         The dropout to be applied to the ELMo representations.
-    vocab_to_cache : ``List[str]``, optional, (default = 0.5).
+    vocab_to_cache : ``List[str]``, optional, (default = None).
         A list of words to pre-compute and cache character convolutions
         for. If you use this option, Elmo expects that you pass word
         indices of shape (batch_size, timesteps) to forward, instead
@@ -482,7 +482,7 @@ class _ElmoBiLm(torch.nn.Module):
         ELMo hdf5 weight file
     requires_grad: ``bool``, optional
         If True, compute gradient of ELMo parameters for fine tuning.
-    vocab_to_cache : ``List[str]``, optional, (default = 0.5).
+    vocab_to_cache : ``List[str]``, optional, (default = None).
         A list of words to pre-compute and cache character convolutions
         for. If you use this option, _ElmoBiLm expects that you pass word
         indices of shape (batch_size, timesteps) to forward, instead
@@ -496,7 +496,7 @@ class _ElmoBiLm(torch.nn.Module):
                  vocab_to_cache: List[str] = None) -> None:
         super(_ElmoBiLm, self).__init__()
 
-        self._token_embedder = _ElmoCharacterEncoder(options_file, weight_file, requires_grad=requires_grad)
+        self._token_embedder = _ElmoCharacterEncoder(options_file, weight_file, requires_grad=False if vocab_to_cache is not None else requires_grad)
 
         self._requires_grad = requires_grad
         if requires_grad and vocab_to_cache:

--- a/allennlp/tests/modules/elmo_test.py
+++ b/allennlp/tests/modules/elmo_test.py
@@ -273,17 +273,37 @@ class TestElmoRequiresGrad(ElmoTestCase):
         batch_size = 3
         seq_len = 4
         char_ids = torch.from_numpy(numpy.random.randint(0, 262, (batch_size, seq_len, 50)))
-        embeddings = embedder(char_ids)
-        loss = embeddings.sum()
-        loss.backward()
+        for _ in range(2):
+            embeddings = embedder(char_ids)
+            loss = embeddings.sum()
+            loss.backward()
 
-        elmo_grads = [param.grad for name, param in embedder.named_parameters() if '_elmo_lstm' in name]
-        if requires_grad:
-            # None of the elmo grads should be None.
-            assert all([grad is not None for grad in elmo_grads])
-        else:
-            # All of the elmo grads should be None.
-            assert all([grad is None for grad in elmo_grads])
+            elmo_grads = [param.grad for name, param in embedder.named_parameters() if '_elmo_lstm' in name]
+            if requires_grad:
+                # None of the elmo grads should be None.
+                assert all([grad is not None for grad in elmo_grads])
+            else:
+                # All of the elmo grads should be None.
+                assert all([grad is None for grad in elmo_grads])
+
+    def _run_test_with_vocab_to_cache(self, requires_grad):
+        vocab_to_cache = [ '<pad>', 'hello', 'world' ]
+        embedder = ElmoTokenEmbedder(self.options_file, self.weight_file, requires_grad=requires_grad, vocab_to_cache=vocab_to_cache)
+        word_tensor = torch.tensor([[[1, 2]]])
+        for _ in range(2):
+            embeddings = embedder(word_tensor)
+            loss = embeddings.sum()
+            loss.backward()
+
+            elmo_grads = [param.grad for name, param in embedder.named_parameters() if '_elmo_lstm' in name and '_token_embedder' not in name]
+            if requires_grad:
+                # None of the elmo grads should be None.
+                assert all([grad is not None for grad in elmo_grads])
+            else:
+                # All of the elmo grads should be None.
+                assert all([grad is None for grad in elmo_grads])
+
+            assert all([param.grad is None for name, param in embedder.named_parameters() if '_token_embedder' in name])
 
     def test_elmo_requires_grad(self):
         self._run_test(True)


### PR DESCRIPTION
This PR is to address https://github.com/allenai/allennlp/issues/1644. When `vocab_to_cache` is provided, `_ElmoBiLM._token_embedder.requires_grad` should be `False` regardless if the `requires_grad` paramemter because 

1. It can cause `RuntimeError` (as per https://github.com/allenai/allennlp/issues/1644)
2. ` _ElmoBiLM._word_embedding` is already created and cached when `vocab_to_cache` is provided, and therefore `_ElmoBiLM._token_embedder` will not be used later anyways.