### PR TITLE
Implement cosine with restarts

### DIFF
--- a/allennlp/tests/training/learning_rate_schedulers_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers_test.py
@@ -55,7 +55,7 @@ class CosineWithRestartsTest(AllenNlpTestCase):
 
     def test_from_params(self):
         optim = self._get_optimizer()
-        sched = LearningRateScheduler.from_params(optim, Params({"type": "cosine", "T_max": 5})).lr_scheduler
+        sched = LearningRateScheduler.from_params(optim, Params({"type": "cosine", "t_max": 5})).lr_scheduler
 
         assert sched.t_max == 5
         assert sched._initialized is True
@@ -64,7 +64,7 @@ class CosineWithRestartsTest(AllenNlpTestCase):
         assert optim.param_groups[0]["lr"] == 1.0
 
         with self.assertRaises(TypeError):
-            # T_max is required.
+            # t_max is required.
             LearningRateScheduler.from_params(optim, Params({"type": "cosine"}))
 
     def test_schedules(self):
@@ -104,9 +104,9 @@ class CosineWithRestartsTest(AllenNlpTestCase):
                               (90, 1.0)]),
         ]
 
-        for epochs, T_max, factor, lr_checks in cosine_schedule_cases:
+        for epochs, t_max, factor, lr_checks in cosine_schedule_cases:
             optimizer = self._get_optimizer()
-            scheduler = CosineWithRestarts(optimizer, T_max, factor=factor)
+            scheduler = CosineWithRestarts(optimizer, t_max, factor=factor)
             lrs = [optimizer.param_groups[0]["lr"]]
             for epoch in range(epochs):
                 scheduler.step(epoch)

--- a/allennlp/tests/training/learning_rate_schedulers_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers_test.py
@@ -1,10 +1,11 @@
 # pylint: disable=no-self-use,invalid-name,protected-access
 
 import torch
+
 from allennlp.common.checks import ConfigurationError
 from allennlp.training.optimizers import Optimizer
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.training.learning_rate_schedulers import LearningRateScheduler
+from allennlp.training.learning_rate_schedulers import LearningRateScheduler, CosineWithRestarts
 from allennlp.common.params import Params
 
 
@@ -41,3 +42,75 @@ class LearningRateSchedulersTest(AllenNlpTestCase):
                                                 Params({"type": "noam", "model_size": 10, "warmup_steps": 2000}))
         lrs.step(None)
         lrs.step_batch(None)
+
+
+class CosineWithRestartsTest(AllenNlpTestCase):
+
+    def setUp(self):
+        super(CosineWithRestartsTest, self).setUp()
+        self.model = torch.nn.Sequential(torch.nn.Linear(10, 10))
+
+    def _get_optimizer(self, lr: float = 1.0):
+        return Optimizer.from_params(self.model.named_parameters(), Params({"type": "sgd", "lr": lr}))
+
+    def test_from_params(self):
+        optim = self._get_optimizer()
+        sched = LearningRateScheduler.from_params(optim, Params({"type": "cosine", "T_max": 5})).lr_scheduler
+
+        assert sched.t_max == 5
+        assert sched._initialized is True
+
+        # Learning should be unchanged after initializing scheduler.
+        assert optim.param_groups[0]["lr"] == 1.0
+
+        with self.assertRaises(TypeError):
+            # T_max is required.
+            LearningRateScheduler.from_params(optim, Params({"type": "cosine"}))
+
+    def test_schedules(self):
+        cosine_schedule_cases = [
+                (30, 30, 1.0, [(0, 1.0),
+                               (15, 0.5000000000000001),
+                               (29, 0.0027390523158632996)]),
+                (10, 1, 2.0, [(0, 1.0),
+                              (1, 1.0),
+                              (2, 0.5),
+                              (3, 1.0)]),
+                (30, 1, 1.0, [(0, 1.0),
+                              (15, 1.0),
+                              (29, 1.0)]),
+                (60, 30, 1.0, [(0, 1.0),
+                               (15, 0.5000000000000001),
+                               (29, 0.0027390523158632996),
+                               (30, 1.0),
+                               (45, 0.5000000000000001),
+                               (59, 0.0027390523158632996)]),
+                (100, 30, 1.5, [(0, 1.0),
+                                (29, 0.0027390523158632996),
+                                (30, 1.0),
+                                (74, 0.0012179748700879012)]),
+                (210, 30, 2, [(0, 1.0),
+                              (29, 0.0027390523158632996),
+                              (30, 1.0),
+                              (89, 0.0006852326227130834),
+                              (90, 1.0),
+                              (209, 0.00017133751222137006)]),
+                (150, 30, 1, [(0, 1.0),
+                              (29, 0.0027390523158632996),
+                              (30, 1.0),
+                              (59, 0.0027390523158632996),
+                              (60, 1.0),
+                              (89, 0.0027390523158632996),
+                              (90, 1.0)]),
+        ]
+
+        for epochs, T_max, factor, lr_checks in cosine_schedule_cases:
+            optimizer = self._get_optimizer()
+            scheduler = CosineWithRestarts(optimizer, T_max, factor=factor)
+            lrs = [optimizer.param_groups[0]["lr"]]
+            for epoch in range(epochs):
+                scheduler.step(epoch)
+                lrs.append(optimizer.param_groups[0]["lr"])
+
+            for it, lr in lr_checks:
+                assert lrs[it] == lr

--- a/allennlp/training/learning_rate_schedulers.py
+++ b/allennlp/training/learning_rate_schedulers.py
@@ -12,13 +12,19 @@ The available learning rate schedulers are
 * `"cosine" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.CosineAnnealingLR>`_
 """
 
+import logging
 from typing import Optional
 
+import numpy as np
 import torch.optim.lr_scheduler
 from overrides import overrides
+
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.params import Params
 from allennlp.common.registrable import Registrable
+
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class LearningRateScheduler(Registrable):
@@ -126,6 +132,87 @@ class NoamLR(torch.optim.lr_scheduler._LRScheduler): # pylint: disable=protected
 
         return [scale for _ in range(len(self.base_lrs))]
 
+
+class CosineWithRestarts(torch.optim.lr_scheduler._LRScheduler):  # pylint: disable=protected-access
+    """
+    Cosine annealing with restarts.
+
+    This is decribed in the paper https://arxiv.org/abs/1608.03983.
+
+    Parameters
+    ----------
+    optimizer : torch.optim.Optimizer
+
+    T_max : int
+        The maximum number of iterations within the first cycle.
+
+    eta_min : float, optional (default: 0)
+        The minimum learning rate.
+
+    last_epoch : int, optional (default: -1)
+        The index of the last epoch.
+
+    factor : float, optional (default: 1)
+        The factor by which the cycle length (``T_max``) increasing after each
+        restart.
+
+    """
+
+    def __init__(self,
+                 optimizer: torch.optim.Optimizer,
+                 T_max: int,
+                 eta_min: float = 0.,
+                 last_epoch: int = -1,
+                 factor: float = 1.) -> None:
+        assert T_max > 0
+        assert eta_min >= 0
+        if T_max == 1 and factor == 1:
+            logger.warning("Cosine annealing scheduler will have no effect on the learning "
+                           "rate since T_max = 1 and factor = 1.")
+        self.t_max = T_max
+        self.eta_min = eta_min
+        self.factor = factor
+        self._last_restart: int = 0
+        self._cycle_counter: int = 0
+        self._cycle_factor: float = 1.
+        self._updated_cycle_len: int = T_max
+        self._initialized: bool = False
+        super(CosineWithRestarts, self).__init__(optimizer, last_epoch)
+
+    def get_lr(self):
+        """Get updated learning rate."""
+        # HACK: We need to check if this is the first time ``self.get_lr()`` was called,
+        # since ``torch.optim.lr_scheduler._LRScheduler`` will call ``self.get_lr()``
+        # when first initialized, but the learning rate should remain unchanged
+        # for the first epoch.
+        if not self._initialized:
+            self._initialized = True
+            return self.base_lrs
+
+        step = self.last_epoch + 1
+        self._cycle_counter = step - self._last_restart
+
+        lrs = [
+                self.eta_min + ((lr - self.eta_min) / 2) * (
+                        np.cos(
+                                np.pi *
+                                (self._cycle_counter % self._updated_cycle_len) /
+                                self._updated_cycle_len
+                        ) + 1
+                )
+                for lr in self.base_lrs
+        ]
+
+        if self._cycle_counter % self._updated_cycle_len == 0:
+            # Adjust the cycle length.
+            self._cycle_factor *= self.factor
+            self._cycle_counter = 0
+            self._updated_cycle_len = int(self._cycle_factor * self.t_max)
+            self._last_restart = step
+
+        return lrs
+
+
 # We just use the Pytorch LRSchedulers, so here we force them into
 # Registry._registry so we can build them from params.
 Registrable._registry[LearningRateScheduler] = {   # pylint: disable=protected-access
@@ -133,6 +220,6 @@ Registrable._registry[LearningRateScheduler] = {   # pylint: disable=protected-a
         "multi_step": torch.optim.lr_scheduler.MultiStepLR,
         "exponential": torch.optim.lr_scheduler.ExponentialLR,
         "reduce_on_plateau": torch.optim.lr_scheduler.ReduceLROnPlateau,
-        "cosine": torch.optim.lr_scheduler.CosineAnnealingLR,
+        "cosine": CosineWithRestarts,
         "noam": NoamLR,
 }

--- a/allennlp/training/learning_rate_schedulers.py
+++ b/allennlp/training/learning_rate_schedulers.py
@@ -124,7 +124,6 @@ class NoamLR(torch.optim.lr_scheduler._LRScheduler): # pylint: disable=protected
         for param_group, learning_rate in zip(self.optimizer.param_groups, self.get_lr()):
             param_group['lr'] = learning_rate
 
-
     def get_lr(self):
         step = max(self.last_epoch, 1)
         scale = self.factor *  (self.model_size ** (-0.5) *

--- a/allennlp/training/learning_rate_schedulers.py
+++ b/allennlp/training/learning_rate_schedulers.py
@@ -140,41 +140,40 @@ class CosineWithRestarts(torch.optim.lr_scheduler._LRScheduler):  # pylint: disa
 
     Parameters
     ----------
-    optimizer : torch.optim.Optimizer
+    optimizer : ``torch.optim.Optimizer``
 
-    T_max : int
+    t_max : ``int``
         The maximum number of iterations within the first cycle.
 
-    eta_min : float, optional (default: 0)
+    eta_min : ``float``, optional (default=0)
         The minimum learning rate.
 
-    last_epoch : int, optional (default: -1)
-        The index of the last epoch.
+    last_epoch : ``int``, optional (default=-1)
+        The index of the last epoch. This is used when restarting.
 
-    factor : float, optional (default: 1)
-        The factor by which the cycle length (``T_max``) increasing after each
-        restart.
+    factor : ``float``, optional (default=1)
+        The factor by which the cycle length (``T_max``) increases after each restart.
 
     """
 
     def __init__(self,
                  optimizer: torch.optim.Optimizer,
-                 T_max: int,
+                 t_max: int,
                  eta_min: float = 0.,
                  last_epoch: int = -1,
                  factor: float = 1.) -> None:
-        assert T_max > 0
+        assert t_max > 0
         assert eta_min >= 0
-        if T_max == 1 and factor == 1:
+        if t_max == 1 and factor == 1:
             logger.warning("Cosine annealing scheduler will have no effect on the learning "
                            "rate since T_max = 1 and factor = 1.")
-        self.t_max = T_max
+        self.t_max = t_max
         self.eta_min = eta_min
         self.factor = factor
         self._last_restart: int = 0
         self._cycle_counter: int = 0
         self._cycle_factor: float = 1.
-        self._updated_cycle_len: int = T_max
+        self._updated_cycle_len: int = t_max
         self._initialized: bool = False
         super(CosineWithRestarts, self).__init__(optimizer, last_epoch)
 

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -23,7 +23,6 @@ from torch.nn.parallel import replicate, parallel_apply
 from torch.nn.parallel.scatter_gather import scatter_kwargs, gather
 from tensorboardX import SummaryWriter
 
-
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.util import peak_memory_mb, gpu_memory_mb
@@ -34,6 +33,7 @@ from allennlp.models.model import Model
 from allennlp.nn import util
 from allennlp.training.learning_rate_schedulers import LearningRateScheduler
 from allennlp.training.optimizers import Optimizer
+
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
@@ -298,8 +298,8 @@ class Trainer:
             raise ConfigurationError("Expected an int or list for cuda_device, got {}".format(cuda_device))
 
         if isinstance(cuda_device, list):
-            logger.info(f"WARNING: Multiple GPU support is experimental not recommended for use. "
-                        "In some cases it may lead to incorrect results or undefined behavior.")
+            logger.warning(f"Multiple GPU support is experimental not recommended for use. "
+                           "In some cases it may lead to incorrect results or undefined behavior.")
             self._multiple_gpu = True
             self._cuda_devices = cuda_device
             # data_parallel will take care of transfering to cuda devices,


### PR DESCRIPTION
fixes #1642 

@matt-gardner I took a closer look at the discussion in [here](https://github.com/pytorch/pytorch/pull/6130), and I'm pretty sure this addresses all of those concerns. I think there's still room to add more features to this to match all of the options that tensor flow supports: https://github.com/tensorflow/tensorflow/blob/25c197e02393bd44f50079945409009dd4d434f8/tensorflow/python/training/learning_rate_decay.py#L608.

I choose to replace the registered `cosine` schedule from PyTorch with this one because the default expected behavior is the same. The behavior will differ of course if other options are supplied to the new scheduler, or if the total number of epochs is greater than `T_max`. However, in this scenario the behavior of PyTorch's cosine scheduler is actually undefined according to the paper referenced, and is therefore probably unexpected to the user. That is why I think this scheduler should replace the default pytorch one.

The other thing that may need to addressed is saving the state of schedulers here:

https://github.com/allenai/allennlp/blob/bca6c2a17741468b0d202c7a986ed1e407f507d2/allennlp/training/trainer.py#L814-L817

I think that would make resuming training more predictable, as the learning rate scheduler would start where it left off.