### PR TITLE
Fix module docstring for training.learning_rate_schedulers

### DIFF
--- a/allennlp/training/learning_rate_schedulers.py
+++ b/allennlp/training/learning_rate_schedulers.py
@@ -10,8 +10,8 @@ The available learning rate schedulers from PyTorch are
 * `"exponential" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.ExponentialLR>`_
 * `"reduce_on_plateau" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.ReduceLROnPlateau>`_
 
-In addition, AllenNLP also provides a Noam schedule and `cosine with restarts <https://arxiv.org/abs/1608.03983>`_, which are
-registered as "noam" and "cosine", respectively.
+In addition, AllenNLP also provides a Noam schedule and `cosine with restarts
+<https://arxiv.org/abs/1608.03983>`_, which are registered as "noam" and "cosine", respectively.
 """
 
 import logging

--- a/allennlp/training/learning_rate_schedulers.py
+++ b/allennlp/training/learning_rate_schedulers.py
@@ -1,15 +1,17 @@
 """
-AllenNLP just uses
+AllenNLP uses most
 `PyTorch learning rate schedulers <http://pytorch.org/docs/master/optim.html#how-to-adjust-learning-rate>`_,
 with a thin wrapper to allow registering them and instantiating them ``from_params``.
 
-The available learning rate schedulers are
+The available learning rate schedulers from PyTorch are
 
 * `"step" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.StepLR>`_
 * `"multi_step" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.MultiStepLR>`_
 * `"exponential" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.ExponentialLR>`_
 * `"reduce_on_plateau" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.ReduceLROnPlateau>`_
-* `"cosine" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.CosineAnnealingLR>`_
+
+In addition, AllenNLP also provides a Noam schedule and `cosine with restarts <https://arxiv.org/abs/1608.03983>`_, which are
+registered as "noam" and "cosine", respectively.
 """
 
 import logging


### PR DESCRIPTION
This is needed due to my last PR: https://github.com/allenai/allennlp/pull/1647, but I forgot to update this. Apologies.