### PR TITLE
WIP: save learning rate scheduler to training state

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -838,6 +838,9 @@ class Trainer:
                               'val_metric_per_epoch': val_metric_per_epoch,
                               'optimizer': self._optimizer.state_dict(),
                               'batch_num_total': self._batch_num_total}
+            if self._learning_rate_scheduler is not None:
+                training_state["learning_rate_scheduler"] = \
+                    self._learning_rate_scheduler.scheduler.state_dict()
             training_path = os.path.join(self._serialization_dir,
                                          "training_state_epoch_{}.th".format(epoch))
             torch.save(training_state, training_path)
@@ -942,6 +945,9 @@ class Trainer:
         training_state = torch.load(training_state_path, map_location=util.device_mapping(-1))
         self._model.load_state_dict(model_state)
         self._optimizer.load_state_dict(training_state["optimizer"])
+        if self._learning_rate_scheduler is not None and "learning_rate_scheduler" in training_state:
+            self._learning_rate_scheduler.scheduler.load_state_dict(
+                    training_state["learning_rate_scheduler"])
         move_optimizer_to_cuda(self._optimizer)
 
         # We didn't used to save `validation_metric_per_epoch`, so we can't assume


### PR DESCRIPTION
When using a learning rate scheduler, I think user probably expects the scheduler to pick up where it left off when restoring a trainer from a checkpoint. This makes sure that the scheduler state is stored with each checkpoint when a scheduler is used. Let me know if you have any comments!

**TODO:**
- [x] modify `Trainer._restore_checkpoint`
- [x] modify `Trainer._save_checkpoint`
- [ ] add unit tests for `Trainer`
- [ ] add unit tests for `CosineWithRestarts` scheduler to make sure state is correctly restored