### PR TITLE
Fix Conll2003 reader docs to reflect true label namespace names

### DIFF
--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -63,8 +63,8 @@ class Conll2003DatasetReader(DatasetReader):
     feature_labels: ``Sequence[str]``, optional (default=``()``)
         These labels will be loaded as features into the corresponding instance fields:
         ``pos`` -> ``pos_tags``, ``chunk`` -> ``chunk_tags``, ``ner`` -> ``ner_tags``
-        Each will have its own namespace: ``pos_labels``, ``chunk_labels``, ``ner_labels``.
-        If you want to use one of the labels as a `feature` in your model, it should be
+        Each will have its own namespace: ``pos_tags``, ``chunk_tags``, ``ner_tags``.
+        If you want to use one of the tags as a `feature` in your model, it should be
         specified here.
     coding_scheme: ``str``, optional (default=``IOB1``)
         Specifies the coding scheme for ``ner_labels`` and ``chunk_labels``.

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -155,17 +155,17 @@ class Conll2003DatasetReader(DatasetReader):
             if pos_tags is None:
                 raise ConfigurationError("Dataset reader was specified to use pos_tags as "
                                          "features. Pass them to text_to_instance.")
-            instance_fields['pos_tags'] = SequenceLabelField(pos_tags, sequence, "pos_labels")
+            instance_fields['pos_tags'] = SequenceLabelField(pos_tags, sequence, "pos_tags")
         if 'chunk' in self.feature_labels:
             if coded_chunks is None:
                 raise ConfigurationError("Dataset reader was specified to use chunk tags as "
                                          "features. Pass them to text_to_instance.")
-            instance_fields['chunk_tags'] = SequenceLabelField(coded_chunks, sequence, "chunk_labels")
+            instance_fields['chunk_tags'] = SequenceLabelField(coded_chunks, sequence, "chunk_tags")
         if 'ner' in self.feature_labels:
             if coded_ner is None:
                 raise ConfigurationError("Dataset reader was specified to use NER tags as "
                                          " features. Pass them to text_to_instance.")
-            instance_fields['ner_tags'] = SequenceLabelField(coded_ner, sequence, "ner_labels")
+            instance_fields['ner_tags'] = SequenceLabelField(coded_ner, sequence, "ner_tags")
 
         # Add "tag label" to instance
         if self.tag_label == 'ner' and coded_ner is not None:

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -155,17 +155,17 @@ class Conll2003DatasetReader(DatasetReader):
             if pos_tags is None:
                 raise ConfigurationError("Dataset reader was specified to use pos_tags as "
                                          "features. Pass them to text_to_instance.")
-            instance_fields['pos_tags'] = SequenceLabelField(pos_tags, sequence, "pos_tags")
+            instance_fields['pos_tags'] = SequenceLabelField(pos_tags, sequence, "pos_labels")
         if 'chunk' in self.feature_labels:
             if coded_chunks is None:
                 raise ConfigurationError("Dataset reader was specified to use chunk tags as "
                                          "features. Pass them to text_to_instance.")
-            instance_fields['chunk_tags'] = SequenceLabelField(coded_chunks, sequence, "chunk_tags")
+            instance_fields['chunk_tags'] = SequenceLabelField(coded_chunks, sequence, "chunk_labels")
         if 'ner' in self.feature_labels:
             if coded_ner is None:
                 raise ConfigurationError("Dataset reader was specified to use NER tags as "
                                          " features. Pass them to text_to_instance.")
-            instance_fields['ner_tags'] = SequenceLabelField(coded_ner, sequence, "ner_tags")
+            instance_fields['ner_tags'] = SequenceLabelField(coded_ner, sequence, "ner_labels")
 
         # Add "tag label" to instance
         if self.tag_label == 'ner' and coded_ner is not None:


### PR DESCRIPTION
The docs for the conll2003 reader say:

```
    feature_labels: ``Sequence[str]``, optional (default=``()``)
        These labels will be loaded as features into the corresponding instance fields:
        ``pos`` -> ``pos_tags``, ``chunk`` -> ``chunk_tags``, ``ner`` -> ``ner_tags``
        Each will have its own namespace: ``pos_labels``, ``chunk_labels``, ``ner_labels``.
        If you want to use one of the labels as a `feature` in your model, it should be
        specified here.
```

however, the namespaces are improperly named `pos_tags`, `chunk_tags`, etc. This fixes them.

cc @matt-peters this might affect you?