### PR TITLE
Add Covariance and PearsonCorrelation metrics

### DIFF
--- a/allennlp/tests/training/metrics/covariance_test.py
+++ b/allennlp/tests/training/metrics/covariance_test.py
@@ -27,6 +27,12 @@ class CovarianceTest(AllenNlpTestCase):
             covariance(timestep_predictions, timestep_labels)
             assert_allclose(expected_covariance, covariance.get_metric(), rtol=1e-5)
 
+        # Test reset
+        covariance.reset()
+        covariance(torch.FloatTensor(predictions), torch.FloatTensor(labels))
+        assert_allclose(np.cov(predictions.reshape(-1), labels.reshape(-1))[0, 1],
+                        covariance.get_metric(), rtol=1e-5)
+
     def test_covariance_masked_computation(self):
         covariance = Covariance()
         batch_size = 100
@@ -48,3 +54,9 @@ class CovarianceTest(AllenNlpTestCase):
                                          fweights=mask[:stride * (i + 1), :].reshape(-1))[0, 1]
             covariance(timestep_predictions, timestep_labels, timestep_mask)
             assert_allclose(expected_covariance, covariance.get_metric(), rtol=1e-5)
+
+        # Test reset
+        covariance.reset()
+        covariance(torch.FloatTensor(predictions), torch.FloatTensor(labels), torch.FloatTensor(mask))
+        assert_allclose(np.cov(predictions.reshape(-1), labels.reshape(-1), fweights=mask.reshape(-1))[0, 1],
+                        covariance.get_metric(), rtol=1e-5)

--- a/allennlp/tests/training/metrics/covariance_test.py
+++ b/allennlp/tests/training/metrics/covariance_test.py
@@ -1,0 +1,53 @@
+# pylint: disable=no-self-use,invalid-name,protected-access
+import torch
+import numpy as np
+from numpy.testing import assert_allclose
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.training.metrics import Covariance
+
+
+class CovarianceTest(AllenNlpTestCase):
+    def test_covariance_unmasked_computation(self):
+        covariance = Covariance()
+        batch_size = 100
+        num_labels = 10
+        predictions = np.random.randn(batch_size, num_labels).astype("float32")
+        labels = 0.5 * predictions + np.random.randn(batch_size, num_labels).astype("float32")
+
+        stride = 10
+
+        for i in range(batch_size // stride):
+            timestep_predictions = predictions[stride * i:stride * (i+1), :]
+            timestep_labels = labels[stride * i:stride * (i+1), :]
+            # Flatten the predictions and labels thus far, so numpy treats them as
+            # independent observations.
+            expected_covariance = np.cov(predictions[:stride * (i + 1), :].reshape(-1),
+                                         labels[:stride * (i + 1), :].reshape(-1))[0, 1]
+            covariance(torch.FloatTensor(timestep_predictions),
+                       torch.FloatTensor(timestep_labels))
+            assert_allclose(expected_covariance, covariance.get_metric(), rtol=1e-5)
+
+    def test_covariance_masked_computation(self):
+        covariance = Covariance()
+        batch_size = 100
+        num_labels = 10
+        predictions = np.random.randn(batch_size, num_labels).astype("float32")
+        labels = 0.5 * predictions + np.random.randn(batch_size, num_labels).astype("float32")
+        # Random binary mask
+        mask = np.random.randint(0, 2, size=(batch_size, num_labels)).astype("float32")
+        stride = 10
+
+        for i in range(batch_size // stride):
+            timestep_predictions = predictions[stride * i:stride * (i+1), :]
+            timestep_labels = labels[stride * i:stride * (i+1), :]
+            timestep_mask = mask[stride * i:stride * (i+1), :]
+            # Flatten the predictions, labels, and mask thus far, so numpy treats them as
+            # independent observations.
+            expected_covariance = np.cov(predictions[:stride * (i + 1), :].reshape(-1),
+                                         labels[:stride * (i + 1), :].reshape(-1),
+                                         fweights=mask[:stride * (i + 1), :].reshape(-1))[0, 1]
+            covariance(torch.FloatTensor(timestep_predictions),
+                       torch.FloatTensor(timestep_labels),
+                       torch.FloatTensor(timestep_mask))
+            assert_allclose(expected_covariance, covariance.get_metric(), rtol=1e-5)

--- a/allennlp/tests/training/metrics/covariance_test.py
+++ b/allennlp/tests/training/metrics/covariance_test.py
@@ -18,14 +18,13 @@ class CovarianceTest(AllenNlpTestCase):
         stride = 10
 
         for i in range(batch_size // stride):
-            timestep_predictions = predictions[stride * i:stride * (i+1), :]
-            timestep_labels = labels[stride * i:stride * (i+1), :]
+            timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
+            timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
             # Flatten the predictions and labels thus far, so numpy treats them as
             # independent observations.
             expected_covariance = np.cov(predictions[:stride * (i + 1), :].reshape(-1),
                                          labels[:stride * (i + 1), :].reshape(-1))[0, 1]
-            covariance(torch.FloatTensor(timestep_predictions),
-                       torch.FloatTensor(timestep_labels))
+            covariance(timestep_predictions, timestep_labels)
             assert_allclose(expected_covariance, covariance.get_metric(), rtol=1e-5)
 
     def test_covariance_masked_computation(self):
@@ -39,15 +38,13 @@ class CovarianceTest(AllenNlpTestCase):
         stride = 10
 
         for i in range(batch_size // stride):
-            timestep_predictions = predictions[stride * i:stride * (i+1), :]
-            timestep_labels = labels[stride * i:stride * (i+1), :]
-            timestep_mask = mask[stride * i:stride * (i+1), :]
+            timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
+            timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
+            timestep_mask = torch.FloatTensor(mask[stride * i:stride * (i+1), :])
             # Flatten the predictions, labels, and mask thus far, so numpy treats them as
             # independent observations.
             expected_covariance = np.cov(predictions[:stride * (i + 1), :].reshape(-1),
                                          labels[:stride * (i + 1), :].reshape(-1),
                                          fweights=mask[:stride * (i + 1), :].reshape(-1))[0, 1]
-            covariance(torch.FloatTensor(timestep_predictions),
-                       torch.FloatTensor(timestep_labels),
-                       torch.FloatTensor(timestep_mask))
+            covariance(timestep_predictions, timestep_labels, timestep_mask)
             assert_allclose(expected_covariance, covariance.get_metric(), rtol=1e-5)

--- a/allennlp/tests/training/metrics/pearson_correlation_test.py
+++ b/allennlp/tests/training/metrics/pearson_correlation_test.py
@@ -51,3 +51,10 @@ class PearsonCorrelationTest(AllenNlpTestCase):
                                                                                covariance_matrices[1, 1])
             pearson_correlation(timestep_predictions, timestep_labels, timestep_mask)
             assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
+        # Test reset
+        pearson_correlation.reset()
+        pearson_correlation(torch.FloatTensor(predictions), torch.FloatTensor(labels), torch.FloatTensor(mask))
+        covariance_matrices = np.cov(predictions.reshape(-1), labels.reshape(-1), fweights=mask.reshape(-1))
+        expected_pearson_correlation = covariance_matrices[0, 1] / np.sqrt(covariance_matrices[0, 0] *
+                                                                           covariance_matrices[1, 1])
+        assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)

--- a/allennlp/tests/training/metrics/pearson_correlation_test.py
+++ b/allennlp/tests/training/metrics/pearson_correlation_test.py
@@ -24,6 +24,11 @@ class PearsonCorrelationTest(AllenNlpTestCase):
                                                        labels[:stride * (i + 1), :].reshape(-1))[0, 1]
             pearson_correlation(timestep_predictions, timestep_labels)
             assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
+        # Test reset
+        pearson_correlation.reset()
+        pearson_correlation(torch.FloatTensor(predictions), torch.FloatTensor(labels))
+        assert_allclose(np.corrcoef(predictions.reshape(-1), labels.reshape(-1))[0, 1],
+                        pearson_correlation.get_metric(), rtol=1e-5)
 
     def test_pearson_correlation_masked_computation(self):
         pearson_correlation = PearsonCorrelation()

--- a/allennlp/tests/training/metrics/pearson_correlation_test.py
+++ b/allennlp/tests/training/metrics/pearson_correlation_test.py
@@ -1,0 +1,48 @@
+# pylint: disable=no-self-use,invalid-name,protected-access
+import torch
+import numpy as np
+from numpy.testing import assert_allclose
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.training.metrics import PearsonCorrelation
+
+
+class PearsonCorrelationTest(AllenNlpTestCase):
+    def test_pearson_correlation_unmasked_computation(self):
+        pearson_correlation = PearsonCorrelation()
+        batch_size = 100
+        num_labels = 10
+        predictions = np.random.randn(batch_size, num_labels).astype("float32")
+        labels = 0.5 * predictions + np.random.randn(batch_size, num_labels).astype("float32")
+
+        stride = 10
+
+        for i in range(batch_size // stride):
+            timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
+            timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
+            expected_pearson_correlation = np.corrcoef(predictions[:stride * (i + 1), :].reshape(-1),
+                                                       labels[:stride * (i + 1), :].reshape(-1))[0, 1]
+            pearson_correlation(timestep_predictions, timestep_labels)
+            assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
+
+    def test_pearson_correlation_masked_computation(self):
+        pearson_correlation = PearsonCorrelation()
+        batch_size = 100
+        num_labels = 10
+        predictions = np.random.randn(batch_size, num_labels).astype("float32")
+        labels = 0.5 * predictions + np.random.randn(batch_size, num_labels).astype("float32")
+        # Random binary mask
+        mask = np.random.randint(0, 2, size=(batch_size, num_labels)).astype("float32")
+        stride = 10
+
+        for i in range(batch_size // stride):
+            timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
+            timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
+            timestep_mask = torch.FloatTensor(mask[stride * i:stride * (i+1), :])
+            covariance_matrices = np.cov(predictions[:stride * (i + 1), :].reshape(-1),
+                                         labels[:stride * (i + 1), :].reshape(-1),
+                                         fweights=mask[:stride * (i + 1), :].reshape(-1))
+            expected_pearson_correlation = covariance_matrices[0, 1] / np.sqrt(covariance_matrices[0, 0] *
+                                                                               covariance_matrices[1, 1])
+            pearson_correlation(timestep_predictions, timestep_labels, timestep_mask)
+            assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)

--- a/allennlp/training/metrics/__init__.py
+++ b/allennlp/training/metrics/__init__.py
@@ -15,6 +15,7 @@ from allennlp.training.metrics.evalb_bracketing_scorer import EvalbBracketingSco
 from allennlp.training.metrics.f1_measure import F1Measure
 from allennlp.training.metrics.mean_absolute_error import MeanAbsoluteError
 from allennlp.training.metrics.mention_recall import MentionRecall
+from allennlp.training.metrics.pearson_correlation import PearsonCorrelation
 from allennlp.training.metrics.span_based_f1_measure import SpanBasedF1Measure
 from allennlp.training.metrics.squad_em_and_f1 import SquadEmAndF1
 from allennlp.training.metrics.wikitables_accuracy import WikiTablesAccuracy

--- a/allennlp/training/metrics/__init__.py
+++ b/allennlp/training/metrics/__init__.py
@@ -9,6 +9,7 @@ from allennlp.training.metrics.average import Average
 from allennlp.training.metrics.boolean_accuracy import BooleanAccuracy
 from allennlp.training.metrics.categorical_accuracy import CategoricalAccuracy
 from allennlp.training.metrics.conll_coref_scores import ConllCorefScores
+from allennlp.training.metrics.covariance import Covariance
 from allennlp.training.metrics.entropy import Entropy
 from allennlp.training.metrics.evalb_bracketing_scorer import EvalbBracketingScorer, DEFAULT_EVALB_DIR
 from allennlp.training.metrics.f1_measure import F1Measure

--- a/allennlp/training/metrics/covariance.py
+++ b/allennlp/training/metrics/covariance.py
@@ -10,6 +10,20 @@ from allennlp.training.metrics.metric import Metric
 class Covariance(Metric):
     """
     This ``Metric`` calculates the unbiased sample covariance between two tensors.
+    Each element in the two tensors is assumed to be a different observation of the
+    variable (i.e., the input tensors are implicitly flattened into vectors and the
+    covariance is calculated between the vectors).
+
+    This implementation is mostly modeled after the streaming_covariance function in Tensorflow.
+    See https://github.com/tensorflow/tensorflow/blob/v1.10.1/tensorflow/contrib/metrics/python/ops/metric_ops.py#L3127-L3264 .
+
+    The following is copied from the Tensorflow documentation:
+
+    The algorithm used for this online computation is described in
+    https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online .
+    Specifically, the formula used to combine two sample comoments is
+    `C_AB = C_A + C_B + (E[x_A] - E[x_B]) * (E[y_A] - E[y_B]) * n_A * n_B / n_AB`
+    The comoment for a single batch of data is simply `sum((x - E[x]) * (y - E[y]))`, optionally masked.
     """
     def __init__(self) -> None:
         self._total_prediction_mean = 0.0

--- a/allennlp/training/metrics/covariance.py
+++ b/allennlp/training/metrics/covariance.py
@@ -14,8 +14,8 @@ class Covariance(Metric):
     variable (i.e., the input tensors are implicitly flattened into vectors and the
     covariance is calculated between the vectors).
 
-    This implementation is mostly modeled after the streaming_covariance function in Tensorflow.
-    See https://github.com/tensorflow/tensorflow/blob/v1.10.1/tensorflow/contrib/metrics/python/ops/metric_ops.py#L3127-L3264 .
+    This implementation is mostly modeled after the streaming_covariance function in Tensorflow. See:
+    https://github.com/tensorflow/tensorflow/blob/v1.10.1/tensorflow/contrib/metrics/python/ops/metric_ops.py#L3127
 
     The following is copied from the Tensorflow documentation:
 

--- a/allennlp/training/metrics/covariance.py
+++ b/allennlp/training/metrics/covariance.py
@@ -55,7 +55,8 @@ class Covariance(Metric):
         updated_count = self._total_count + num_batch_items
 
         batch_mean_prediction = torch.sum(predictions) / num_batch_items
-        delta_mean_prediction = ((batch_mean_prediction - self._total_prediction_mean) * num_batch_items) / updated_count
+        delta_mean_prediction = ((batch_mean_prediction - self._total_prediction_mean) *
+                                 num_batch_items) / updated_count
         previous_total_prediction_mean = self._total_prediction_mean
         self._total_prediction_mean += delta_mean_prediction.item()
 
@@ -70,9 +71,9 @@ class Covariance(Metric):
         else:
             batch_comoment = torch.sum(batch_coresiduals)
         delta_comoment = (
-            batch_comoment + (previous_total_prediction_mean - batch_mean_prediction) *
-            (previous_total_label_mean - batch_mean_label) *
-            (previous_count * num_batch_items / updated_count))
+                batch_comoment + (previous_total_prediction_mean - batch_mean_prediction) *
+                (previous_total_label_mean - batch_mean_label) *
+                (previous_count * num_batch_items / updated_count))
         self._total_comoment += delta_comoment.item()
         self._total_count = updated_count
 

--- a/allennlp/training/metrics/covariance.py
+++ b/allennlp/training/metrics/covariance.py
@@ -80,7 +80,7 @@ class Covariance(Metric):
         """
         Returns
         -------
-        The accumulated mean absolute error.
+        The accumulated covariance.
         """
         covariance = self._total_comoment / (self._total_count - 1)
         if reset:

--- a/allennlp/training/metrics/covariance.py
+++ b/allennlp/training/metrics/covariance.py
@@ -28,7 +28,7 @@ class Covariance(Metric):
     def __init__(self) -> None:
         self._total_prediction_mean = 0.0
         self._total_label_mean = 0.0
-        self._total_comoment = 0.0
+        self._total_co_moment = 0.0
         self._total_count = 0.0
 
     def __call__(self,
@@ -81,14 +81,14 @@ class Covariance(Metric):
 
         batch_coresiduals = (predictions - batch_mean_prediction) * (gold_labels - batch_mean_label)
         if mask is not None:
-            batch_comoment = torch.sum(batch_coresiduals * mask)
+            batch_co_moment = torch.sum(batch_coresiduals * mask)
         else:
-            batch_comoment = torch.sum(batch_coresiduals)
-        delta_comoment = (
-                batch_comoment + (previous_total_prediction_mean - batch_mean_prediction) *
+            batch_co_moment = torch.sum(batch_coresiduals)
+        delta_co_moment = (
+                batch_co_moment + (previous_total_prediction_mean - batch_mean_prediction) *
                 (previous_total_label_mean - batch_mean_label) *
                 (previous_count * num_batch_items / updated_count))
-        self._total_comoment += delta_comoment.item()
+        self._total_co_moment += delta_co_moment.item()
         self._total_count = updated_count
 
     def get_metric(self, reset: bool = False):
@@ -97,7 +97,7 @@ class Covariance(Metric):
         -------
         The accumulated covariance.
         """
-        covariance = self._total_comoment / (self._total_count - 1)
+        covariance = self._total_co_moment / (self._total_count - 1)
         if reset:
             self.reset()
         return covariance
@@ -106,5 +106,5 @@ class Covariance(Metric):
     def reset(self):
         self._total_prediction_mean = 0.0
         self._total_label_mean = 0.0
-        self._total_comoment = 0.0
+        self._total_co_moment = 0.0
         self._total_count = 0.0

--- a/allennlp/training/metrics/covariance.py
+++ b/allennlp/training/metrics/covariance.py
@@ -1,0 +1,95 @@
+from typing import Optional
+
+from overrides import overrides
+import torch
+
+from allennlp.training.metrics.metric import Metric
+
+
+@Metric.register("covariance")
+class Covariance(Metric):
+    """
+    This ``Metric`` calculates the unbiased sample covariance between two tensors.
+    """
+    def __init__(self) -> None:
+        self._total_prediction_mean = 0.0
+        self._total_label_mean = 0.0
+        self._total_comoment = 0.0
+        self._total_count = 0.0
+
+    def __call__(self,
+                 predictions: torch.Tensor,
+                 gold_labels: torch.Tensor,
+                 mask: Optional[torch.Tensor] = None):
+        """
+        Parameters
+        ----------
+        predictions : ``torch.Tensor``, required.
+            A tensor of predictions of shape (batch_size, ...).
+        gold_labels : ``torch.Tensor``, required.
+            A tensor of the same shape as ``predictions``.
+        mask: ``torch.Tensor``, optional (default = None).
+            A tensor of the same shape as ``predictions``.
+        """
+        predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)
+        # Flatten predictions, gold_labels, and mask. We calculate the covariance between
+        # the vectors, since each element in the predictions and gold_labels tensor is assumed
+        # to be a separate observation.
+        predictions = predictions.view(-1)
+        gold_labels = gold_labels.view(-1)
+
+        if mask is not None:
+            mask = mask.view(-1)
+            predictions *= mask
+            gold_labels *= mask
+            num_batch_items = torch.sum(mask).item()
+        else:
+            num_batch_items = gold_labels.numel()
+
+        # Note that self._total_count must be a float or int at all times
+        # If it is a 1-dimension Tensor, the previous count will equal the updated_count.
+        # The sampe applies for previous_total_prediction_mean and
+        # previous_total_label_mean below -- we handle this in the code by
+        # calling .item() judiciously.
+        previous_count = self._total_count
+        updated_count = self._total_count + num_batch_items
+
+        batch_mean_prediction = torch.sum(predictions) / num_batch_items
+        delta_mean_prediction = ((batch_mean_prediction - self._total_prediction_mean) * num_batch_items) / updated_count
+        previous_total_prediction_mean = self._total_prediction_mean
+        self._total_prediction_mean += delta_mean_prediction.item()
+
+        batch_mean_label = torch.sum(gold_labels) / num_batch_items
+        delta_mean_label = ((batch_mean_label - self._total_label_mean) * num_batch_items) / updated_count
+        previous_total_label_mean = self._total_label_mean
+        self._total_label_mean += delta_mean_label.item()
+
+        batch_coresiduals = (predictions - batch_mean_prediction) * (gold_labels - batch_mean_label)
+        if mask is not None:
+            batch_comoment = torch.sum(batch_coresiduals * mask)
+        else:
+            batch_comoment = torch.sum(batch_coresiduals)
+        delta_comoment = (
+            batch_comoment + (previous_total_prediction_mean - batch_mean_prediction) *
+            (previous_total_label_mean - batch_mean_label) *
+            (previous_count * num_batch_items / updated_count))
+        self._total_comoment += delta_comoment.item()
+        self._total_count = updated_count
+
+    def get_metric(self, reset: bool = False):
+        """
+        Returns
+        -------
+        The accumulated mean absolute error.
+        """
+        covariance = self._total_comoment / (self._total_count - 1)
+        if reset:
+            self.reset()
+        return covariance
+
+    @overrides
+    def reset(self):
+        self._total_prediction_mean = 0.0
+        self._total_label_mean = 0.0
+        self._total_comoment = 0.0
+        self._total_count = 0.0

--- a/allennlp/training/metrics/pearson_correlation.py
+++ b/allennlp/training/metrics/pearson_correlation.py
@@ -17,8 +17,8 @@ class PearsonCorrelation(Metric):
     implicitly flattened into vectors and the correlation is calculated
     between the vectors).
 
-    This implementation is mostly modeled after the streaming_pearson_correlation function in Tensorflow.
-    See https://github.com/tensorflow/tensorflow/blob/v1.10.1/tensorflow/contrib/metrics/python/ops/metric_ops.py#L3267-L3351
+    This implementation is mostly modeled after the streaming_pearson_correlation function in Tensorflow. See
+    https://github.com/tensorflow/tensorflow/blob/v1.10.1/tensorflow/contrib/metrics/python/ops/metric_ops.py#L3267
 
     This metric delegates to the Covariance metric the tracking of three [co]variances:
 

--- a/allennlp/training/metrics/pearson_correlation.py
+++ b/allennlp/training/metrics/pearson_correlation.py
@@ -1,0 +1,59 @@
+from typing import Optional
+import math
+
+from overrides import overrides
+import torch
+
+from allennlp.training.metrics.covariance import Covariance
+from allennlp.training.metrics.metric import Metric
+
+
+@Metric.register("pearson_correlation")
+class PearsonCorrelation(Metric):
+    """
+    This ``Metric`` calculates the sample Pearson correlation coefficient (r)
+    between two tensors.
+    """
+    def __init__(self) -> None:
+        self._predictions_labels_covariance = Covariance()
+        self._predictions_variance = Covariance()
+        self._labels_variance = Covariance()
+
+    def __call__(self,
+                 predictions: torch.Tensor,
+                 gold_labels: torch.Tensor,
+                 mask: Optional[torch.Tensor] = None):
+        """
+        Parameters
+        ----------
+        predictions : ``torch.Tensor``, required.
+            A tensor of predictions of shape (batch_size, ...).
+        gold_labels : ``torch.Tensor``, required.
+            A tensor of the same shape as ``predictions``.
+        mask: ``torch.Tensor``, optional (default = None).
+            A tensor of the same shape as ``predictions``.
+        """
+        predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)
+        self._predictions_labels_covariance(predictions, gold_labels, mask)
+        self._predictions_variance(predictions, predictions, mask)
+        self._labels_variance(gold_labels, gold_labels, mask)
+
+    def get_metric(self, reset: bool = False):
+        """
+        Returns
+        -------
+        The accumulated sample Pearson correlation.
+        """
+        covariance = self._predictions_labels_covariance.get_metric(reset=reset)
+        predictions_variance = self._predictions_variance.get_metric(reset=reset)
+        labels_variance = self._labels_variance.get_metric(reset=reset)
+        if reset:
+            self.reset()
+        pearson_r = covariance / (math.sqrt(predictions_variance) * math.sqrt(labels_variance))
+        return pearson_r
+
+    @overrides
+    def reset(self):
+        self._predictions_labels_covariance.reset()
+        self._predictions_variance.reset()
+        self._labels_variance.reset()

--- a/allennlp/training/metrics/pearson_correlation.py
+++ b/allennlp/training/metrics/pearson_correlation.py
@@ -12,7 +12,23 @@ from allennlp.training.metrics.metric import Metric
 class PearsonCorrelation(Metric):
     """
     This ``Metric`` calculates the sample Pearson correlation coefficient (r)
-    between two tensors.
+    between two tensors. Each element in the two tensors is assumed to be
+    a different observation of the variable (i.e., the input tensors are
+    implicitly flattened into vectors and the correlation is calculated
+    between the vectors).
+
+    This implementation is mostly modeled after the streaming_pearson_correlation function in Tensorflow.
+    See https://github.com/tensorflow/tensorflow/blob/v1.10.1/tensorflow/contrib/metrics/python/ops/metric_ops.py#L3267-L3351
+
+    This metric delegates to the Covariance metric the tracking of three [co]variances:
+
+    - ``covariance(predictions, labels)``, i.e. covariance
+    - ``covariance(predictions, predictions)``, i.e. variance of ``predictions``
+    - ``covariance(labels, labels)``, i.e. variance of ``labels``
+
+    If we have these values, the sample Pearson correlation coefficient is simply:
+
+    r = covariance * (sqrt(predictions_variance) * sqrt(labels_variance))
     """
     def __init__(self) -> None:
         self._predictions_labels_covariance = Covariance()

--- a/doc/api/allennlp.training.metrics.rst
+++ b/doc/api/allennlp.training.metrics.rst
@@ -17,6 +17,7 @@ allennlp.training.metrics
 * :ref:`F1Measure<f1-measure>`
 * :ref:`MeanAbsoluteError<mean-absolute-error>`
 * :ref:`MentionRecall<mention-recall>`
+* :ref:`PearsonCorrelation<pearson-correlation>`
 * :ref:`SpanBasedF1Measure<span-based-f1-measure>`
 * :ref:`SquadEmAndF1<squad-em-and-f1>`
 * :ref:`WikiTablesAccuracy<wikitables-accuracy>`
@@ -85,6 +86,12 @@ allennlp.training.metrics
 
 .. _mention-recall:
 .. automodule:: allennlp.training.metrics.mention_recall
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _pearson-correlation:
+.. automodule:: allennlp.training.metrics.pearson_correlation
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/api/allennlp.training.metrics.rst
+++ b/doc/api/allennlp.training.metrics.rst
@@ -11,6 +11,7 @@ allennlp.training.metrics
 * :ref:`BooleanAccuracy<boolean-accuracy>`
 * :ref:`CategoricalAccuracy<categorical-accuracy>`
 * :ref:`ConllCorefScores<conll-coref-scores>`
+* :ref:`Covariance<covariance>`
 * :ref:`Entropy<entropy>`
 * :ref:`EvalbBracketingScorer<evalb>`
 * :ref:`F1Measure<f1-measure>`
@@ -48,6 +49,12 @@ allennlp.training.metrics
 
 .. _conll-coref-scores:
 .. automodule:: allennlp.training.metrics.conll_coref_scores
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _covariance:
+.. automodule:: allennlp.training.metrics.covariance
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
This PR implements an online algorithm for calculating Covariance and the sample Pearson correlation coefficient.

This was actually nontrivial, I mostly referenced the tensorflow [streaming_covariance metric](https://github.com/tensorflow/tensorflow/blob/4dcfddc5d12018a5a0fdca652b9221ed95e9eb23/tensorflow/contrib/metrics/python/ops/metric_ops.py#L3127-L3264) in implementing this. Their implementation is a vectorized version of the weighted algorithm [on this wikipedia page](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online)

The tests simply ensure that the streaming Covariance and PearsonCorrelation match up with what numpy would calculate, which I believe is a reasonable correctness check.