### PR TITLE
minor memory improvements in _joint_likelihood() of ConditionalRandomField with advanced indexing

### DIFF
--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -255,26 +255,13 @@ class ConditionalRandomField(torch.nn.Module):
         else:
             score = 0.0
 
-        # Broadcast the transition scores to one per batch element
-        broadcast_transitions = self.transitions.view(1, num_tags, num_tags).expand(batch_size, num_tags, num_tags)
-
         # Add up the scores for the observed transitions and all the inputs but the last
         for i in range(sequence_length - 1):
             # Each is shape (batch_size,)
             current_tag, next_tag = tags[i], tags[i+1]
 
             # The scores for transitioning from current_tag to next_tag
-            transition_score = (
-                    broadcast_transitions
-                    # Choose the current_tag-th row for each input
-                    .gather(1, current_tag.view(batch_size, 1, 1).expand(batch_size, 1, num_tags))
-                    # Squeeze down to (batch_size, num_tags)
-                    .squeeze(1)
-                    # Then choose the next_tag-th column for each of those
-                    .gather(1, next_tag.view(batch_size, 1))
-                    # And squeeze down to (batch_size,)
-                    .squeeze(1)
-            )
+            transition_score = self.transitions[current_tag.view(-1), next_tag.view(-1)]
 
             # The score for using current_tag
             emit_score = logits[i].gather(1, current_tag.view(batch_size, 1)).squeeze(1)
@@ -286,10 +273,7 @@ class ConditionalRandomField(torch.nn.Module):
         # Transition from last state to "stop" state. To start with, we need to find the last tag
         # for each instance.
         last_tag_index = mask.sum(0).long() - 1
-        last_tags = tags.gather(0, last_tag_index.view(1, batch_size).expand(sequence_length, batch_size))
-
-        # Is (sequence_length, batch_size), but all the columns are the same, so take the first.
-        last_tags = last_tags[0]
+        last_tags = torch.gather(tags, 0, last_tag_index.view(1, batch_size)).view(-1)
 
         # Compute score of transitioning to `stop_tag` from each "last tag".
         if self.include_start_end_transitions:

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -242,7 +242,7 @@ class ConditionalRandomField(torch.nn.Module):
         """
         Computes the numerator term for the log-likelihood, which is just score(inputs, tags)
         """
-        batch_size, sequence_length, num_tags = logits.data.shape
+        batch_size, sequence_length, _ = logits.data.shape
 
         # Transpose batch size and sequence dimensions:
         logits = logits.transpose(0, 1).contiguous()
@@ -273,7 +273,7 @@ class ConditionalRandomField(torch.nn.Module):
         # Transition from last state to "stop" state. To start with, we need to find the last tag
         # for each instance.
         last_tag_index = mask.sum(0).long() - 1
-        last_tags = torch.gather(tags, 0, last_tag_index.view(1, batch_size)).view(-1)
+        last_tags = torch.gather(tags, 0, last_tag_index.view(1, batch_size)).squeeze(0)
 
         # Compute score of transitioning to `stop_tag` from each "last tag".
         if self.include_start_end_transitions:

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -273,7 +273,7 @@ class ConditionalRandomField(torch.nn.Module):
         # Transition from last state to "stop" state. To start with, we need to find the last tag
         # for each instance.
         last_tag_index = mask.sum(0).long() - 1
-        last_tags = torch.gather(tags, 0, last_tag_index.view(1, batch_size)).squeeze(0)
+        last_tags = tags.gather(0, last_tag_index.view(1, batch_size)).squeeze(0)
 
         # Compute score of transitioning to `stop_tag` from each "last tag".
         if self.include_start_end_transitions:


### PR DESCRIPTION
Minor memory improvements possible in the _joint_likelihood() function of the ConditionalRandomField class by utilizing the advanced indexing feature of PyTorch (https://github.com/pytorch/pytorch/releases/tag/v0.2.0). 

Elliminates the need to expand transitions matrix by batch size (line 258 - 260) and to expand the tensor containing indices to the last tags by batch size (line 289).