### PR TITLE
Add average parameter to sequence cross entropy

### DIFF
--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -598,15 +598,17 @@ def sequence_cross_entropy_with_logits(logits: torch.FloatTensor,
     negative_log_likelihood = negative_log_likelihood_flat.view(*targets.size())
     # shape : (batch, sequence_length)
     negative_log_likelihood = negative_log_likelihood * weights.float()
-    # shape : (batch_size,)
-    per_batch_loss = negative_log_likelihood.sum(1) / (weights.sum(1).float() + 1e-13)
 
     if average == "batch":
+        # shape : (batch_size,)
+        per_batch_loss = negative_log_likelihood.sum(1) / (weights.sum(1).float() + 1e-13)
         num_non_empty_sequences = ((weights.sum(1) > 0).float().sum() + 1e-13)
         return per_batch_loss.sum() / num_non_empty_sequences
     elif average == "token":
         return negative_log_likelihood.sum() / (weights.sum().float() + 1e-13)
     else:
+        # shape : (batch_size,)
+        per_batch_loss = negative_log_likelihood.sum(1) / (weights.sum(1).float() + 1e-13)
         return per_batch_loss
 
 

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -511,7 +511,8 @@ def weighted_sum(matrix: torch.Tensor, attention: torch.Tensor) -> torch.Tensor:
 def sequence_cross_entropy_with_logits(logits: torch.FloatTensor,
                                        targets: torch.LongTensor,
                                        weights: torch.FloatTensor,
-                                       batch_average: bool = True,
+                                       batch_average: bool = None,
+                                       average: str = "batch",
                                        label_smoothing: float = None) -> torch.FloatTensor:
     """
     Computes the cross entropy loss of a sequence, weighted with respect to
@@ -533,6 +534,16 @@ def sequence_cross_entropy_with_logits(logits: torch.FloatTensor,
     batch_average : bool, optional, (default = True).
         A bool indicating whether the loss should be averaged across the batch,
         or returned as a vector of losses per batch element.
+
+        .. deprecated:: 0.6.2
+           ``batch_average`` was deprecated and replaced with
+           the more general ``average`` in version 0.6.2. It will be removed
+           in version 0.8.
+
+    average: str, optional (default = "batch")
+        If "batch", average the loss across the batches. If "token", averaged
+        the loss across each item in the input. If ``None``, return a vector
+        of losses per batch element.
     label_smoothing : ``float``, optional (default = None)
         Whether or not to apply label smoothing to the cross-entropy loss.
         For example, with a label smoothing value of 0.2, a 4 class classifcation
@@ -542,10 +553,26 @@ def sequence_cross_entropy_with_logits(logits: torch.FloatTensor,
     Returns
     -------
     A torch.FloatTensor representing the cross entropy loss.
-    If ``batch_average == True``, the returned loss is a scalar.
-    If ``batch_average == False``, the returned loss is a vector of shape (batch_size,).
+    If ``average=="batch"`` or ``average=="token"``, the returned loss is a scalar.
+    If ``average is None``, the returned loss is a vector of shape (batch_size,).
 
     """
+    if batch_average is not None:
+        # Maintain old behavior
+        if batch_average:
+            warnings.warn("batch_average=True was deprecated and replaced "
+                          "with average='batch' in version 0.6.2. It will be "
+                          "removed in version 0.8.", DeprecationWarning)
+            average = "batch"
+        else:
+            warnings.warn("batch_average=False was deprecated and replaced "
+                          "with average=None in version 0.6.2. It will be "
+                          "removed in version 0.8.", DeprecationWarning)
+            average = None
+    if average not in {None, "token", "batch"}:
+        raise ValueError("Got averaage f{average}, expected one of "
+                         "None, 'token', or 'batch'")
+
     # shape : (batch * sequence_length, num_classes)
     logits_flat = logits.view(-1, logits.size(-1))
     # shape : (batch * sequence_length, num_classes)
@@ -574,10 +601,13 @@ def sequence_cross_entropy_with_logits(logits: torch.FloatTensor,
     # shape : (batch_size,)
     per_batch_loss = negative_log_likelihood.sum(1) / (weights.sum(1).float() + 1e-13)
 
-    if batch_average:
+    if average == "batch":
         num_non_empty_sequences = ((weights.sum(1) > 0).float().sum() + 1e-13)
         return per_batch_loss.sum() / num_non_empty_sequences
-    return per_batch_loss
+    elif average == "token":
+        return negative_log_likelihood.sum() / (weights.sum().float() + 1e-13)
+    else:
+        return per_batch_loss
 
 
 def replace_masked_values(tensor: torch.Tensor, mask: torch.Tensor, replace_with: float) -> torch.Tensor:


### PR DESCRIPTION
- Deprecates the `batch_average` param and replaces it with the much more flexible `average` param.
- token-level averaging of losses. This is useful for language modeling / when you have a sequence of independent and unrelated decisions.