### PR TITLE
multiprocess dataset reader

### DIFF
--- a/allennlp/data/dataset_readers/__init__.py
+++ b/allennlp/data/dataset_readers/__init__.py
@@ -15,6 +15,7 @@ from allennlp.data.dataset_readers.ontonotes_ner import OntonotesNamedEntityReco
 from allennlp.data.dataset_readers.coreference_resolution import ConllCorefReader, WinobiasReader
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.dataset_readers.language_modeling import LanguageModelingReader
+from allennlp.data.dataset_readers.multiprocess_dataset_reader import MultiprocessDatasetReader
 from allennlp.data.dataset_readers.nlvr import NlvrDatasetReader
 from allennlp.data.dataset_readers.penn_tree_bank import PennTreeBankConstituencySpanDatasetReader
 from allennlp.data.dataset_readers.reading_comprehension import SquadReader, TriviaQaReader, QuACReader

--- a/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
+++ b/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
@@ -1,0 +1,123 @@
+from typing import List, Iterable
+import glob
+import logging
+import queue
+import random
+
+from torch.multiprocessing import Process, Queue
+
+from allennlp.data.dataset_readers.dataset_reader import DatasetReader
+from allennlp.data.instance import Instance
+
+logger = logging.getLogger(__file__)  # pylint: disable=invalid-name
+
+
+def _worker(reader: DatasetReader,
+            input_queue: Queue,
+            output_queue: Queue) -> None:
+    """
+    A worker that pulls filenames off the input queue, uses the dataset reader
+    to read them, and places the generated instances on the output queue.
+    When there are no filenames left on the input queue, it puts ``None``
+    on the output queue and doesn't do anything else.
+    """
+    # Keep going as long as there are things on the queue
+    while True:
+        try:
+            # All of the possible files are put on the queue before
+            # any workers are even started, so if the queue is empty
+            # it really means there's no more work to do. Which means
+            # that ``get_nowait`` and breaking out of the loop are correct.
+            file_path = input_queue.get_nowait()
+        except queue.Empty:
+            break
+
+        for instance in reader.read(file_path):
+            output_queue.put(instance)
+
+    # Put None on the queue to signify that we've finished
+    output_queue.put(None)
+
+
+@DatasetReader.register('multiprocess')
+class MultiprocessDatasetReader(DatasetReader):
+    """
+    Wraps another dataset reader and uses it to read from multiple input files
+    using multiple processes. Note that in this case the ``file_path`` passed to ``read()``
+    should be a glob, and that the dataset reader will return instances from all files
+    matching the glob.
+
+    Parameters
+    ----------
+    base_reader : ``DatasetReader``
+        Each process will use this dataset reader to read zero or more files.
+    num_workers : ``int``
+        How many data-reading processes to run simultaneously.
+    epochs_per_read : ``int``, (optional, default=1)
+        Normally a call to ``DatasetReader.read()`` returns a single epoch worth of instances,
+        and your ``DataIterator`` handles iteration over multiple epochs. However, in the
+        multiple-process case, it's possible that you'd want finished workers to continue on to the
+        next epoch even while others are still finishing the previous epoch. Passing in a value
+        larger than 1 allows that to happen.
+    lazy : ``bool``, (optional, default=True)
+        Most of our dataset readers are eager by default; however, if you're using this one
+        it's probably because you have a lot of data (and in particular don't want to load it
+        all into memory), so laziness is the default.
+    """
+    def __init__(self,
+                 base_reader: DatasetReader,
+                 num_workers: int,
+                 epochs_per_read: int = 1,
+                 lazy: bool = True) -> None:
+        super().__init__(lazy=lazy)
+
+        self.reader = base_reader
+        self.num_workers = num_workers
+        self.epochs_per_read = epochs_per_read
+
+    def text_to_instance(self, *args, **kwargs) -> Instance:
+        """
+        Just delegate to the base reader text_to_instance.
+        """
+        # pylint: disable=arguments-differ
+        return self.reader.text_to_instance(*args, **kwargs)
+
+    def _read(self, file_path: str) -> Iterable[Instance]:
+        shards = glob.glob(file_path)
+        num_shards = len(shards)
+
+        # If we want multiple epochs per read, put shards in the queue multiple times.
+        input_queue = Queue(num_shards * self.epochs_per_read + self.num_workers)
+        for _ in range(self.epochs_per_read):
+            random.shuffle(shards)
+            for shard in shards:
+                input_queue.put(shard)
+
+        # TODO(joelgrus): where does this number come from?
+        output_queue = Queue(1000)
+
+        processes: List[Process] = []
+        num_finished = 0
+
+        for worker_id in range(self.num_workers):
+            process = Process(target=_worker,
+                              args=(self.reader, input_queue, output_queue))
+            logger.info(f"starting worker {worker_id}")
+            process.start()
+            processes.append(process)
+
+        # Keep going as long as not all the workers have finished.
+        while num_finished < self.num_workers:
+            item = output_queue.get()
+            if item is None:
+                # None means a worker has finished, so increment the finished count.
+                num_finished += 1
+                logger.info(f"{num_finished}/{self.num_workers} finished")
+            else:
+                # Otherwise it's an ``Instance``, so yield it up.
+                yield item
+
+        # Once we know all the workers are done, join all the processes.
+        logger.info("done reading, joining processes")
+        for process in processes:
+            process.join()

--- a/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
+++ b/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
@@ -121,3 +121,4 @@ class MultiprocessDatasetReader(DatasetReader):
         logger.info("done reading, joining processes")
         for process in processes:
             process.join()
+        processes.clear()

--- a/allennlp/data/iterators/__init__.py
+++ b/allennlp/data/iterators/__init__.py
@@ -7,3 +7,4 @@ from allennlp.data.iterators.data_iterator import DataIterator
 from allennlp.data.iterators.basic_iterator import BasicIterator
 from allennlp.data.iterators.bucket_iterator import BucketIterator
 from allennlp.data.iterators.epoch_tracking_bucket_iterator import EpochTrackingBucketIterator
+from allennlp.data.iterators.multiprocess_iterator import MultiprocessIterator

--- a/allennlp/data/iterators/multiprocess_iterator.py
+++ b/allennlp/data/iterators/multiprocess_iterator.py
@@ -1,0 +1,134 @@
+from typing import Iterable, Iterator, List, Optional
+import logging
+
+from torch.multiprocessing import Process, Queue
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.common.util import lazy_groups_of
+from allennlp.data.instance import Instance
+from allennlp.data.iterators.data_iterator import DataIterator, TensorDict
+from allennlp.data.dataset import Batch
+from allennlp.data.vocabulary import Vocabulary
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+def _create_tensor_dicts(input_queue: Queue,
+                         output_queue: Queue,
+                         max_instances_in_memory: int,
+                         batch_size: int,
+                         cuda_device: int,
+                         vocab: Vocabulary) -> None:
+    """
+    Pulls at most ``max_instances_in_memory`` from the input_queue,
+    groups them into batches of size ``batch_size``, converts them
+    to ``TensorDict`` s, and puts them on the ``output_queue``.
+    """
+    instances: List[Instance] = []
+
+    def make_batches() -> None:
+        for batch_instances in lazy_groups_of(iter(instances), batch_size):
+            batch = Batch(batch_instances)
+
+            if vocab is not None:
+                batch.index_instances(vocab)
+
+            padding_lengths = batch.get_padding_lengths()
+            tensor_dict = batch.as_tensor_dict(padding_lengths,
+                                               cuda_device=cuda_device)
+
+            output_queue.put(tensor_dict)
+        instances.clear()
+
+    while True:
+        instance = input_queue.get()
+        if instance is None:
+            # no more instances, create one last batch, and stick None there.
+            if instances:
+                make_batches()
+            output_queue.put(None)
+            break
+        else:
+            instances.append(instance)
+            if len(instances) >= max_instances_in_memory:
+                make_batches()
+
+def _queuer(instances: Iterable[Instance],
+            input_queue: Queue,
+            num_workers: int,
+            num_epochs: Optional[int]) -> None:
+    """
+    Reads Instances from the iterable and puts them in the input_queue.
+    """
+    epoch = 0
+
+    while num_epochs is None or epoch < num_epochs:
+        epoch += 1
+        for instance in instances:
+            input_queue.put(instance)
+
+    # now put a None for each worker
+    for _ in range(num_workers):
+        input_queue.put(None)
+
+@DataIterator.register("multiprocess")
+class MultiprocessIterator(DataIterator):
+    def __init__(self,
+                 num_workers: int = 1,
+                 max_instances_in_memory: int = 1000,
+                 batch_size: int = 32) -> None:
+        super().__init__()
+        self.num_workers = num_workers
+        self.batch_size = batch_size
+        self.max_instances_in_memory = max_instances_in_memory
+        self.vocab: Vocabulary = None
+
+        self.processes: List[Process] = []
+        self.queuer: Optional[Process] = None
+
+    def _create_batches(self, instances: Iterable[Instance], shuffle: bool) -> Iterable[Batch]:
+        raise RuntimeError("MultiprocessIterator doesn't use create_batches")
+
+    def __call__(self,
+                 instances: Iterable[Instance],
+                 num_epochs: int = None,
+                 shuffle: bool = True,
+                 cuda_device: int = -1) -> Iterator[TensorDict]:
+
+        # If you run it forever, the multiprocesses won't shut down correctly.
+        # TODO(joelgrus) find a solution for this
+        if num_epochs is None:
+            raise ConfigurationError("Multiprocess Iterator must be run for a fixed number of epochs")
+
+        # TODO(joelgrus) are these the right sizes?
+        input_queue = Queue(1000)
+        output_queue = Queue(1000)
+
+        # Start the tensor-dict workers.
+        for _ in range(self.num_workers):
+            args = (input_queue, output_queue,
+                    self.max_instances_in_memory, self.batch_size, cuda_device, self.vocab)
+
+            process = Process(target=_create_tensor_dicts, args=args)
+            process.start()
+            self.processes.append(process)
+
+        # Start the queue-populating worker.
+        self.queuer = Process(target=_queuer, args=(instances, input_queue, self.num_workers, num_epochs))
+        self.queuer.start()
+
+        num_finished = 0
+        while num_finished < self.num_workers:
+            item = output_queue.get()
+            if item is None:
+                # finished
+                num_finished += 1
+                print(num_finished, self.num_workers)
+            else:
+                yield item
+
+        self.queuer.join()
+        self.queuer = None
+
+        for process in self.processes:
+            process.join()
+        self.processes.clear()

--- a/allennlp/tests/data/dataset_readers/multiprocess_dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/multiprocess_dataset_reader_test.py
@@ -1,0 +1,95 @@
+# pylint: disable=no-self-use,invalid-name
+from typing import Tuple
+from collections import Counter
+
+from allennlp.data.dataset_readers import MultiprocessDatasetReader, SequenceTaggingDatasetReader
+from allennlp.data.instance import Instance
+from allennlp.data.iterators import BasicIterator
+from allennlp.data.vocabulary import Vocabulary
+from allennlp.common.testing import AllenNlpTestCase
+
+def fingerprint(instance: Instance) -> Tuple[str, ...]:
+    """
+    Get a hashable representation of a sequence tagging instance
+    that can be put in a Counter.
+    """
+    text_tuple = tuple(t.text for t in instance.fields["tokens"].tokens)  # type: ignore
+    labels_tuple = tuple(instance.fields["tags"].labels)                  # type: ignore
+    return text_tuple + labels_tuple
+
+
+class TestMultiprocessDatasetReader(AllenNlpTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        # use SequenceTaggingDatasetReader as the base reader
+        self.base_reader = SequenceTaggingDatasetReader(lazy=True)
+        base_file_path = AllenNlpTestCase.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'
+
+
+        # Make 100 copies of the data
+        raw_data = open(base_file_path).read()
+        for i in range(100):
+            file_path = self.TEST_DIR / f'sequence_tagging_{i}.tsv'
+            with open(file_path, 'w') as f:
+                f.write(raw_data)
+
+        self.glob = str(self.TEST_DIR / 'sequence_tagging_*.tsv')
+
+        # For some of the tests we need a vocab, we'll just use the base_reader for that.
+        self.vocab = Vocabulary.from_instances(self.base_reader.read(str(base_file_path)))
+
+    def test_multiprocess_read(self):
+        reader = MultiprocessDatasetReader(base_reader=self.base_reader, num_workers=4)
+
+        all_instances = []
+
+        for instance in reader.read(self.glob):
+            all_instances.append(instance)
+
+        # 100 files * 4 sentences / file
+        assert len(all_instances) == 100 * 4
+
+        counts = Counter(fingerprint(instance) for instance in all_instances)
+
+        # should have the exact same data 100 times
+        assert len(counts) == 4
+        assert counts[("cats", "are", "animals", ".", "N", "V", "N", "N")] == 100
+        assert counts[("dogs", "are", "animals", ".", "N", "V", "N", "N")] == 100
+        assert counts[("snakes", "are", "animals", ".", "N", "V", "N", "N")] == 100
+        assert counts[("birds", "are", "animals", ".", "N", "V", "N", "N")] == 100
+
+    def test_multiple_epochs(self):
+        reader = MultiprocessDatasetReader(base_reader=self.base_reader,
+                                           num_workers=2,
+                                           epochs_per_read=3)
+
+        all_instances = []
+
+        for instance in reader.read(self.glob):
+            all_instances.append(instance)
+
+        # 100 files * 4 sentences per file * 3 epochs
+        assert len(all_instances) == 100 * 4 * 3
+
+        counts = Counter(fingerprint(instance) for instance in all_instances)
+
+        # should have the exact same data 100 * 3 times
+        assert len(counts) == 4
+        assert counts[("cats", "are", "animals", ".", "N", "V", "N", "N")] == 300
+        assert counts[("dogs", "are", "animals", ".", "N", "V", "N", "N")] == 300
+        assert counts[("snakes", "are", "animals", ".", "N", "V", "N", "N")] == 300
+        assert counts[("birds", "are", "animals", ".", "N", "V", "N", "N")] == 300
+
+    def test_with_iterator(self):
+        reader = MultiprocessDatasetReader(base_reader=self.base_reader, num_workers=2)
+        instances = reader.read(self.glob)
+
+        iterator = BasicIterator(batch_size=32)
+        iterator.index_with(self.vocab)
+
+        batches = [batch for batch in iterator(instances, num_epochs=1)]
+
+        # 400 instances / batch_size 32 = 12 full batches + 1 batch of 16
+        sizes = sorted([len(batch['tags']) for batch in batches])
+        assert sizes == [16] + 12 * [32]

--- a/allennlp/tests/data/iterators/multiprocess_iterator_test.py
+++ b/allennlp/tests/data/iterators/multiprocess_iterator_test.py
@@ -1,0 +1,15 @@
+# pylint: disable=no-self-use,invalid-name
+from allennlp.data.iterators import MultiprocessIterator
+from allennlp.tests.data.iterators.basic_iterator_test import IteratorTest
+
+class TestMultiprocessIterator(IteratorTest):
+    def test_yield_one_epoch_iterates_over_the_data_once(self):
+        for test_instances in (self.instances, self.lazy_instances):
+            iterator = MultiprocessIterator(num_workers=4, batch_size=2)
+            batches = list(iterator(test_instances, num_epochs=1))
+            # We just want to get the single-token array for the text field in the instance.
+            instances = [tuple(instance.detach().cpu().numpy())
+                         for batch in batches
+                         for instance in batch['text']["tokens"]]
+            assert len(instances) == 5
+            self.assert_instances_are_correct(instances)

--- a/allennlp/tests/data/iterators/multiprocess_iterator_test.py
+++ b/allennlp/tests/data/iterators/multiprocess_iterator_test.py
@@ -39,7 +39,7 @@ class TestMultiprocessIterator(IteratorTest):
         iterator = MultiprocessIterator(num_workers=2, batch_size=32)
         iterator.index_with(vocab)
 
-        instances = [instance for instance in reader.read(glob)]
+        instances = reader.read(glob)
 
         tensor_dicts = iterator(instances, num_epochs=1)
         sizes = [len(tensor_dict['tags']) for tensor_dict in tensor_dicts]

--- a/allennlp/tests/data/iterators/multiprocess_iterator_test.py
+++ b/allennlp/tests/data/iterators/multiprocess_iterator_test.py
@@ -1,6 +1,10 @@
 # pylint: disable=no-self-use,invalid-name
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.dataset_readers import SequenceTaggingDatasetReader, MultiprocessDatasetReader
 from allennlp.data.iterators import MultiprocessIterator
+from allennlp.data.vocabulary import Vocabulary
 from allennlp.tests.data.iterators.basic_iterator_test import IteratorTest
+
 
 class TestMultiprocessIterator(IteratorTest):
     def test_yield_one_epoch_iterates_over_the_data_once(self):
@@ -13,3 +17,30 @@ class TestMultiprocessIterator(IteratorTest):
                          for instance in batch['text']["tokens"]]
             assert len(instances) == 5
             self.assert_instances_are_correct(instances)
+
+    def test_multiprocess_reader_with_multiprocess_iterator(self):
+        # use SequenceTaggingDatasetReader as the base reader
+        base_reader = SequenceTaggingDatasetReader(lazy=True)
+        base_file_path = AllenNlpTestCase.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'
+
+        # Make 100 copies of the data
+        raw_data = open(base_file_path).read()
+        for i in range(100):
+            file_path = self.TEST_DIR / f'sequence_tagging_{i}.tsv'
+            with open(file_path, 'w') as f:
+                f.write(raw_data)
+
+        glob = str(self.TEST_DIR / 'sequence_tagging_*.tsv')
+
+        # For some of the tests we need a vocab, we'll just use the base_reader for that.
+        vocab = Vocabulary.from_instances(base_reader.read(str(base_file_path)))
+        reader = MultiprocessDatasetReader(base_reader=base_reader, num_workers=2)
+
+        iterator = MultiprocessIterator(num_workers=2, batch_size=32)
+        iterator.index_with(vocab)
+
+        instances = [instance for instance in reader.read(glob)]
+
+        tensor_dicts = iterator(instances, num_epochs=1)
+        sizes = [len(tensor_dict['tags']) for tensor_dict in tensor_dicts]
+        assert sum(sizes) == 400

--- a/doc/api/allennlp.data.dataset_readers.multiprocess_dataset_reader.rst
+++ b/doc/api/allennlp.data.dataset_readers.multiprocess_dataset_reader.rst
@@ -1,0 +1,7 @@
+allennlp.data.dataset_readers.multiprocess_dataset_reader
+===========================================================
+
+.. automodule:: allennlp.data.dataset_readers.multiprocess_dataset_reader
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/allennlp.data.dataset_readers.rst
+++ b/doc/api/allennlp.data.dataset_readers.rst
@@ -17,6 +17,7 @@ allennlp.data.dataset_readers
   allennlp.data.dataset_readers.ontonotes_ner
   allennlp.data.dataset_readers.coreference_resolution
   allennlp.data.dataset_readers.language_modeling
+  allennlp.data.dataset_readers.multiprocess_dataset_reader
   allennlp.data.dataset_readers.nlvr
   allennlp.data.dataset_readers.penn_tree_bank
   allennlp.data.dataset_readers.reading_comprehension


### PR DESCRIPTION
I think this is a pretty reasonable approach. At a high level, here's what happens:

* there's a new `MultiprocessDatasetReader` that wraps an existing DatasetReader and handles all the multiprocessing functionality
* in the calypso code there was not a clear division between the dataset reader and the iterator; in particular, it allowed you to multiprocess over multiple epochs, so I added an otherwise out-of-place `epochs_per_read` parameter to this dataset reader to allow the same functionality. 
* similarly, in the calypso code the multiprocessing stuff handled batching as well. here I left things separated, so the multiprocess reader uses multiple processes to generate instances, and batching is still done in a single process by the iterator
* it's possible then that *batching* is a major bottleneck, in which case we would need to figure out a way for the iterator to also use multiple processes, my sense is that parallelizing that would be quite a bit more complicated than this