### PR TITLE
use managers for queues

### DIFF
--- a/allennlp/data/iterators/multiprocess_iterator.py
+++ b/allennlp/data/iterators/multiprocess_iterator.py
@@ -1,7 +1,7 @@
 from typing import Iterable, Iterator, List, Optional
 import logging
 
-from torch.multiprocessing import Process, Queue, get_logger
+from torch.multiprocessing import Manager, Process, Queue, get_logger
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.data.instance import Instance
@@ -107,8 +107,9 @@ class MultiprocessIterator(DataIterator):
         if num_epochs is None:
             raise ConfigurationError("Multiprocess Iterator must be run for a fixed number of epochs")
 
-        output_queue = Queue(self.output_queue_size)
-        input_queue = Queue(self.output_queue_size * self.batch_size)
+        manager = Manager()
+        output_queue = manager.Queue(self.output_queue_size)
+        input_queue = manager.Queue(self.output_queue_size * self.batch_size)
 
         # Start process that populates the queue.
         self.queuer = Process(target=_queuer, args=(instances, input_queue, self.num_workers, num_epochs))


### PR DESCRIPTION
this was a real nightmare to debug, but it seems like it fixes the problem. (as best as I can tell it was some kind of race condition with queues getting deleted before they were done being used. the `Manager` seems to avoid that.)

verified by building the Dockerfile.pip image and running the relevant tests inside it