### PR TITLE
Fixing the table format for the WikiTables executor

### DIFF
--- a/allennlp/data/dataset_readers/semantic_parsing/wikitables.py
+++ b/allennlp/data/dataset_readers/semantic_parsing/wikitables.py
@@ -267,7 +267,7 @@ class WikiTablesDatasetReader(DatasetReader):
         tokenized_question = tokenized_question or self._tokenizer.tokenize(question.lower())
         question_field = TextField(tokenized_question, self._question_token_indexers)
         metadata: Dict[str, Any] = {"question_tokens": [x.text for x in tokenized_question]}
-        metadata["original_table"] = "".join(table_lines)
+        metadata["original_table"] = "\n".join(table_lines)
         table_knowledge_graph = TableQuestionKnowledgeGraph.read_from_lines(table_lines, tokenized_question)
         table_metadata = MetadataField(table_lines)
         table_field = KnowledgeGraphField(table_knowledge_graph,

--- a/allennlp/predictors/wikitables_parser.py
+++ b/allennlp/predictors/wikitables_parser.py
@@ -69,7 +69,6 @@ class WikiTablesParserPredictor(Predictor):
                                                                 outputs['original_table'])
         return sanitize(outputs)
 
-
     def predict_batch_instance(self, instances: List[Instance]) -> List[JsonDict]:
         outputs = self._model.forward_on_instances(instances)
         for output in outputs:


### PR DESCRIPTION
This is the reason that the wikitables demo doesn't ever return an answer - the table wasn't formatted correctly.  @schmmd FYI.  After this is merged, updating the demo to point to this commit (or later) will fix the "answer" value in the wikitables demo.