### PR TITLE
Make num_start_types optional in transition functions

### DIFF
--- a/allennlp/state_machines/transition_functions/coverage_transition_function.py
+++ b/allennlp/state_machines/transition_functions/coverage_transition_function.py
@@ -29,13 +29,16 @@ class CoverageTransitionFunction(BasicTransitionFunction):
     encoder_output_dim : ``int``
     action_embedding_dim : ``int``
     input_attention : ``Attention``
-    num_start_types : ``int``
     activation : ``Activation``, optional (default=relu)
         The activation that gets applied to the decoder LSTM input and to the action query.
     predict_start_type_separately : ``bool``, optional (default=True)
         If ``True``, we will predict the initial action (which is typically the base type of the
         logical form) using a different mechanism than our typical action decoder.  We basically
         just do a projection of the hidden state, and don't update the decoder RNN.
+    num_start_types : ``int``, optional (default=None)
+        If ``predict_start_type_separately`` is ``True``, this is the number of start types that
+        are in the grammar.  We need this so we can construct parameters with the right shape.
+        This is unused if ``predict_start_type_separately`` is ``False``.
     add_action_bias : ``bool``, optional (default=True)
         If ``True``, there has been a bias dimension added to the embedding of each action, which
         gets used when predicting the next action.  We add a dimension of ones to our predicted
@@ -46,9 +49,9 @@ class CoverageTransitionFunction(BasicTransitionFunction):
                  encoder_output_dim: int,
                  action_embedding_dim: int,
                  input_attention: Attention,
-                 num_start_types: int,
                  activation: Activation = Activation.by_name('relu')(),
                  predict_start_type_separately: bool = True,
+                 num_start_types: int = None,
                  add_action_bias: bool = True,
                  dropout: float = 0.0) -> None:
         super().__init__(encoder_output_dim=encoder_output_dim,

--- a/allennlp/state_machines/transition_functions/linking_coverage_transition_function.py
+++ b/allennlp/state_machines/transition_functions/linking_coverage_transition_function.py
@@ -30,13 +30,16 @@ class LinkingCoverageTransitionFunction(CoverageTransitionFunction):
     encoder_output_dim : ``int``
     action_embedding_dim : ``int``
     input_attention : ``Attention``
-    num_start_types : ``int``
     activation : ``Activation``, optional (default=relu)
         The activation that gets applied to the decoder LSTM input and to the action query.
     predict_start_type_separately : ``bool``, optional (default=True)
         If ``True``, we will predict the initial action (which is typically the base type of the
         logical form) using a different mechanism than our typical action decoder.  We basically
         just do a projection of the hidden state, and don't update the decoder RNN.
+    num_start_types : ``int``, optional (default=None)
+        If ``predict_start_type_separately`` is ``True``, this is the number of start types that
+        are in the grammar.  We need this so we can construct parameters with the right shape.
+        This is unused if ``predict_start_type_separately`` is ``False``.
     add_action_bias : ``bool``, optional (default=True)
         If ``True``, there has been a bias dimension added to the embedding of each action, which
         gets used when predicting the next action.  We add a dimension of ones to our predicted
@@ -47,9 +50,9 @@ class LinkingCoverageTransitionFunction(CoverageTransitionFunction):
                  encoder_output_dim: int,
                  action_embedding_dim: int,
                  input_attention: Attention,
-                 num_start_types: int,
                  activation: Activation = Activation.by_name('relu')(),
                  predict_start_type_separately: bool = True,
+                 num_start_types: int = None,
                  add_action_bias: bool = True,
                  mixture_feedforward: FeedForward = None,
                  dropout: float = 0.0) -> None:

--- a/allennlp/state_machines/transition_functions/linking_transition_function.py
+++ b/allennlp/state_machines/transition_functions/linking_transition_function.py
@@ -32,13 +32,16 @@ class LinkingTransitionFunction(BasicTransitionFunction):
     encoder_output_dim : ``int``
     action_embedding_dim : ``int``
     input_attention : ``Attention``
-    num_start_types : ``int``
     activation : ``Activation``, optional (default=relu)
         The activation that gets applied to the decoder LSTM input and to the action query.
     predict_start_type_separately : ``bool``, optional (default=True)
         If ``True``, we will predict the initial action (which is typically the base type of the
         logical form) using a different mechanism than our typical action decoder.  We basically
         just do a projection of the hidden state, and don't update the decoder RNN.
+    num_start_types : ``int``, optional (default=None)
+        If ``predict_start_type_separately`` is ``True``, this is the number of start types that
+        are in the grammar.  We need this so we can construct parameters with the right shape.
+        This is unused if ``predict_start_type_separately`` is ``False``.
     add_action_bias : ``bool``, optional (default=True)
         If ``True``, there has been a bias dimension added to the embedding of each action, which
         gets used when predicting the next action.  We add a dimension of ones to our predicted
@@ -53,9 +56,9 @@ class LinkingTransitionFunction(BasicTransitionFunction):
                  encoder_output_dim: int,
                  action_embedding_dim: int,
                  input_attention: Attention,
-                 num_start_types: int,
                  activation: Activation = Activation.by_name('relu')(),
                  predict_start_type_separately: bool = True,
+                 num_start_types: int = None,
                  add_action_bias: bool = True,
                  mixture_feedforward: FeedForward = None,
                  dropout: float = 0.0) -> None:


### PR DESCRIPTION
The `num_start_types` parameter is only required in certain circumstances, but it was not an optional parameter, which made for some unnecessary code in some models.  This PR fixes that.