### PR TITLE
Move vocabulary save to after model setup

### DIFF
--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -273,9 +273,11 @@ def train_model(params: Params,
              if key in datasets_for_vocab_creation)
     )
 
+    model = Model.from_params(vocab=vocab, params=params.pop('model'))
+
+    # Initializing the model can have side effect of expanding the vocabulary
     vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
 
-    model = Model.from_params(vocab=vocab, params=params.pop('model'))
     iterator = DataIterator.from_params(params.pop("iterator"))
     iterator.index_with(vocab)
     validation_iterator_params = params.pop("validation_iterator", None)


### PR DESCRIPTION
@DeNeutoy I forgot to include this in https://github.com/allenai/allennlp/pull/1817. This is a bit ugly as it's during the model initialization that the vocabulary pulls in the extra embeddings. Maybe there's a better way to do this, it might mess up other places as well. FYI @matt-gardner 