### PR TITLE
Move ftfy to right section in requirements.txt, fix requirements check script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,9 @@ parsimonious==0.8.0
 # Used by semantic parsing code to format and postprocess SQL
 sqlparse==0.2.4
 
+# For text normalization
+ftfy
+
 #### ESSENTIAL LIBRARIES USED IN SCRIPTS ####
 # Used for downloading datasets over HTTP
 requests>=2.18
@@ -133,6 +136,3 @@ pypandoc
 
 # Pypi uploads
 twine==1.11.0
-
-# For text normalization
-ftfy

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -44,7 +44,7 @@ def main(checks):
 
         if "check-requirements" in checks:
             print("Checking requirements.txt against setup.py", flush=True)
-            run("./scripts/check_requirements_and_setup.py")
+            run("./scripts/check_requirements_and_setup.py", shell=True, check=True)
             print("check requirements passed")
 
     except CalledProcessError:


### PR DESCRIPTION
`./scripts/check_requirements_and_setup.py` was failing silently because `ftfy` was in the wrong section in `requirements.txt`. I fixed `./scripts/verify.py` so that errors found by the requirements-checking script will cause the CI pipeline to fail, and I also moved `ftfy` to the right section.