### PR TITLE
Bug fix binary expression in updates to grammar

### DIFF
--- a/allennlp/semparse/worlds/atis_world.py
+++ b/allennlp/semparse/worlds/atis_world.py
@@ -155,7 +155,7 @@ class AtisWorld():
                 new_binary_expressions.extend([month_binary_expression,
                                                day_binary_expression])
 
-                new_binary_expressions = tuple(new_binary_expressions) + new_grammar['biexpr'].members
+                new_binary_expressions = new_binary_expressions + list(new_grammar['biexpr'].members)
                 new_grammar['biexpr'] = OneOf(*new_binary_expressions, name='biexpr')
                 self._update_expression_reference(new_grammar, 'condition', 'biexpr')
         return new_grammar

--- a/allennlp/semparse/worlds/atis_world.py
+++ b/allennlp/semparse/worlds/atis_world.py
@@ -90,7 +90,7 @@ class AtisWorld():
         # This will give us a shallow copy. We have to be careful here because the ``Grammar`` object
         # contains ``Expression`` objects that have tuples containing the members of that expression.
         # We have to create new sub-expression objects so that original grammar is not mutated.
-        new_grammar = AtisWorld.sql_table_context.grammar._copy()
+        new_grammar = copy(AtisWorld.sql_table_context.grammar)
 
         numbers = self._get_numeric_database_values('number')
         number_literals = [Literal(number) for number in numbers]

--- a/allennlp/semparse/worlds/atis_world.py
+++ b/allennlp/semparse/worlds/atis_world.py
@@ -87,8 +87,8 @@ class AtisWorld():
         ternary expression will refer to the start and end times.
         """
 
-        # This will give us a shallow copy, but that's OK because everything
-        # inside is immutable so we get a new copy of it.
+        # This will give us a shallow copy. Some of the compound expressions such as
+        # ``OneOf`` contain lists of their members, so we have to be careful to update them.
         new_grammar = copy(AtisWorld.sql_table_context.grammar)
 
         numbers = self._get_numeric_database_values('number')
@@ -154,7 +154,9 @@ class AtisWorld():
                 new_binary_expressions.extend([month_binary_expression,
                                                day_binary_expression])
 
-            new_grammar['biexpr'].members = new_grammar['biexpr'].members + tuple(new_binary_expressions)
+                new_binary_expressions = tuple(new_binary_expressions) + new_grammar['biexpr'].members
+                new_grammar['biexpr'] = OneOf(*new_binary_expressions, name='biexpr')
+                self._update_expression_reference(new_grammar, 'condition', 'biexpr')
         return new_grammar
 
     def _get_numeric_database_values(self,

--- a/allennlp/semparse/worlds/atis_world.py
+++ b/allennlp/semparse/worlds/atis_world.py
@@ -87,9 +87,10 @@ class AtisWorld():
         ternary expression will refer to the start and end times.
         """
 
-        # This will give us a shallow copy. Some of the compound expressions such as
-        # ``OneOf`` contain lists of their members, so we have to be careful to update them.
-        new_grammar = copy(AtisWorld.sql_table_context.grammar)
+        # This will give us a shallow copy. We have to be careful here because the ``Grammar`` object
+        # contains ``Expression`` objects that have tuples containing the members of that expression.
+        # We have to create new sub-expression objects so that original grammar is not mutated.
+        new_grammar = AtisWorld.sql_table_context.grammar._copy()
 
         numbers = self._get_numeric_database_values('number')
         number_literals = [Literal(number) for number in numbers]


### PR DESCRIPTION
Fixes a bug where the base grammar binary expressions get mutated due to shallow copy. ``Grammar`` objects contain expressions i.e. ``OneOf`` that have tuples of the members that we want to modify. Just modifying the members will mutate the old copy.

https://github.com/erikrose/parsimonious/blob/master/parsimonious/grammar.py#L82 The docs in ``parsimonious`` states that all expressions are created from scratch but shallow copy doesn't actually clone child objects. Below is a simple example of the issue:

```
>>> from parsimonious import Grammar
>>> my_grammar = Grammar(r"""
...     styled_text = bold_text / italic_text
...     bold_text   = "((" text "))"
...     italic_text = "''" text "''"
...     text        = ~"[A-Z 0-9]*"i
...     """)
>>> new_grammar = my_grammar._copy()
>>> new_grammar['styled_text'].members
(<Sequence bold_text = "((" text "))">, <Sequence italic_text = "''" text "''">)
>>> new_grammar['styled_text'].members = new_grammar['styled_text'].members + (new_grammar['italic_text'],)
>>> new_grammar['styled_text'].members
(<Sequence bold_text = "((" text "))">, <Sequence italic_text = "''" text "''">, <Sequence italic_text = "''" text "''">)
>>> my_grammar['styled_text'].members
(<Sequence bold_text = "((" text "))">, <Sequence italic_text = "''" text "''">, <Sequence italic_text = "''" text "''">)
```