### PR TITLE
predicting_paper_venues_pt1.md to reflect the updated test code

### DIFF
--- a/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt1.md
+++ b/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt1.md
@@ -78,12 +78,14 @@ The basic API of the `DatasetReader` is just that we need to instantiate the obj
 
 ```python
 from allennlp.common.testing import AllenNlpTestCase
+from allennlp.common.util import ensure_list
+
 from my_library.dataset_readers import SemanticScholarDatasetReader
 
 class TestSemanticScholarDatasetReader(AllenNlpTestCase):
     def test_read_from_file(self):
         reader = SemanticScholarDatasetReader()
-        dataset = reader.read('tests/fixtures/s2_papers.jsonl')
+        instances = ensure_list(reader.read('tests/fixtures/s2_papers.jsonl'))
 ```
 
 Then we just want to make sure that the resulting dataset looks like we expect.  We'll refer you to
@@ -112,16 +114,16 @@ are given as `Lists` here, but other than that, this just mimics the relevant fi
 blobs in the data file.  We'll have our test make sure that what we read matches this:
 
 ```python
-        assert len(dataset.instances) == 10
-        fields = dataset.instances[0].fields
+        assert len(instances) == 10
+        fields = instances[0].fields
         assert [t.text for t in fields["title"].tokens] == instance1["title"]
         assert [t.text for t in fields["abstract"].tokens[:5]] == instance1["abstract"]
         assert fields["label"].label == instance1["venue"]
-        fields = dataset.instances[1].fields
+        fields = instances[1].fields
         assert [t.text for t in fields["title"].tokens] == instance2["title"]
         assert [t.text for t in fields["abstract"].tokens[:5]] == instance2["abstract"]
         assert fields["label"].label == instance2["venue"]
-        fields = dataset.instances[2].fields
+        fields = instances[2].fields
         assert [t.text for t in fields["title"].tokens] == instance3["title"]
         assert [t.text for t in fields["abstract"].tokens[:5]] == instance3["abstract"]
         assert fields["label"].label == instance3["venue"]


### PR DESCRIPTION
This fixes #1872 

I have updated the 2nd and 4th code snippets within predicting_paper_venues_pt1.md to reflect the test code that it references which is the [semantic scholar dataset reader test](https://github.com/allenai/allennlp-as-a-library-example/blob/master/tests/dataset_readers/semantic_scholar_dataset_reader_test.py) within the [allennlp as a library example repository](https://github.com/allenai/allennlp-as-a-library-example).