### PR TITLE
input_size of phrase_layer: 1144 -> 1124

### DIFF
--- a/training_config/dialog_qa.jsonnet
+++ b/training_config/dialog_qa.jsonnet
@@ -46,7 +46,7 @@
             "type": "gru",
             "bidirectional": true,
             "hidden_size": 100,
-            "input_size": 1144,
+            "input_size": 1124,
             "num_layers": 1
         },
         "residual_encoder": {


### PR DESCRIPTION
fix wrong config of `input_size` of `phrase_layer`.
This is the bug-fix to [\[Bug\] Wrong `input_size` of `phrase_layer` in `allennlp/training_config/dialog_qa.json`.](https://github.com/allenai/allennlp/issues/1874)

The better way to make config valid is to provide some `check_dimensions_match`s as in `bidaf.py`.