### PR TITLE
Enable setting scalar mix parameters for ScalarMix and Elmo

### DIFF
--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -69,6 +69,10 @@ class Elmo(torch.nn.Module):
     keep_sentence_boundaries : ``bool``, optional, (default=False)
         If True, the representation of the sentence boundary tokens are
         not removed.
+    scalar_mix_parameters : ``List[int]``, optional, (default=None)
+        If not ``None``, use these scalar mix parameters to weight the representations
+        produced by different layers. These mixing weights are not updated during
+        training.
     module : ``torch.nn.Module``, optional, (default = None).
         If provided, then use this module instead of the pre-trained ELMo biLM.
         If using this option, then pass ``None`` for both ``options_file``
@@ -87,6 +91,7 @@ class Elmo(torch.nn.Module):
                  dropout: float = 0.5,
                  vocab_to_cache: List[str] = None,
                  keep_sentence_boundaries: bool = False,
+                 scalar_mix_parameters: List[float] = None,
                  module: torch.nn.Module = None) -> None:
         super(Elmo, self).__init__()
 
@@ -106,7 +111,11 @@ class Elmo(torch.nn.Module):
         self._dropout = Dropout(p=dropout)
         self._scalar_mixes: Any = []
         for k in range(num_output_representations):
-            scalar_mix = ScalarMix(self._elmo_lstm.num_layers, do_layer_norm=do_layer_norm)
+            scalar_mix = ScalarMix(
+                    self._elmo_lstm.num_layers,
+                    do_layer_norm=do_layer_norm,
+                    initial_scalar_parameters=scalar_mix_parameters,
+                    trainable=scalar_mix_parameters is None)
             self.add_module('scalar_mix_{}'.format(k), scalar_mix)
             self._scalar_mixes.append(scalar_mix)
 

--- a/allennlp/tests/modules/scalar_mix_test.py
+++ b/allennlp/tests/modules/scalar_mix_test.py
@@ -30,6 +30,18 @@ class TestScalarMix(AllenNlpTestCase):
         with pytest.raises(ConfigurationError):
             _ = mixture(tensors)
 
+    def test_scalar_mix_throws_error_on_incorrect_initial_scalar_parameters_length(self):
+        with pytest.raises(ConfigurationError):
+            ScalarMix(3, initial_scalar_parameters=[0.0, 0.0])
+
+    def test_scalar_mix_trainable_with_initial_scalar_parameters(self):
+        initial_scalar_parameters = [1.0, 2.0, 3.0]
+        mixture = ScalarMix(3, initial_scalar_parameters=initial_scalar_parameters,
+                            trainable=False)
+        for i, scalar_mix_parameter in enumerate(mixture.scalar_parameters):
+            assert scalar_mix_parameter.requires_grad is False
+            assert scalar_mix_parameter.item() == initial_scalar_parameters[i]
+
     def test_scalar_mix_layer_norm(self):
         mixture = ScalarMix(3, do_layer_norm='scalar_norm_reg')
 


### PR DESCRIPTION
This PR enables a user to specify a (frozen) scalar mix to use with ELMo