### PR TITLE
Add a dimension check to DialogQA, fix example configuration

### DIFF
--- a/allennlp/models/reading_comprehension/dialog_qa.py
+++ b/allennlp/models/reading_comprehension/dialog_qa.py
@@ -6,13 +6,14 @@ import torch
 import torch.nn.functional as F
 from torch.nn.functional import nll_loss
 
-from allennlp.tools import squad_eval
+from allennlp.common.checks import check_dimensions_match
 from allennlp.data import Vocabulary
 from allennlp.models.model import Model
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder
-from allennlp.modules.matrix_attention.linear_matrix_attention import LinearMatrixAttention
 from allennlp.modules.input_variational_dropout import InputVariationalDropout
+from allennlp.modules.matrix_attention.linear_matrix_attention import LinearMatrixAttention
 from allennlp.nn import InitializerApplicator, util
+from allennlp.tools import squad_eval
 from allennlp.training.metrics import Average, BooleanAccuracy, CategoricalAccuracy
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -92,6 +93,12 @@ class DialogQA(Model):
         self._span_end_predictor = TimeDistributed(torch.nn.Linear(self._encoding_dim, 1))
         self._span_yesno_predictor = TimeDistributed(torch.nn.Linear(self._encoding_dim, 3))
         self._span_followup_predictor = TimeDistributed(self._followup_lin)
+
+        check_dimensions_match(phrase_layer.get_input_dim(),
+                               text_field_embedder.get_output_dim() +
+                               marker_embedding_dim * num_context_answers,
+                               "phrase layer input dim",
+                               "embedding dim + marker dim * num context answers")
 
         initializer(self)
 

--- a/training_config/dialog_qa.jsonnet
+++ b/training_config/dialog_qa.jsonnet
@@ -46,7 +46,7 @@
             "type": "gru",
             "bidirectional": true,
             "hidden_size": 100,
-            "input_size": 1124,
+            "input_size": 1144,
             "num_layers": 1
         },
         "residual_encoder": {


### PR DESCRIPTION
Fixes #1931.

#1875 was incorrect; this fixes it, restoring the original training configuration, and adds the correct dimension check to the model.