### PR TITLE
Add config for non-elmo constituency parser, rename existing parser config

### DIFF
--- a/training_config/constituency_parser_elmo.jsonnet
+++ b/training_config/constituency_parser_elmo.jsonnet
@@ -1,9 +1,14 @@
-// Configuration for a constituency parser based on:
+// Configuration for an Elmo-augmented constituency parser based on:
 //   Stern, Mitchell et al. “A Minimal Span-Based Neural Constituency Parser.” ACL (2017).
 {
     "dataset_reader":{
         "type":"ptb_trees",
-        "use_pos_tags": true
+        "use_pos_tags": true,
+        "token_indexers": {
+          "elmo": {
+            "type": "elmo_characters"
+          }
+        }
     },
     "train_data_path": std.extVar('PTB_TRAIN_PATH'),
     "validation_data_path": std.extVar('PTB_DEV_PATH'),
@@ -12,11 +17,13 @@
       "type": "constituency_parser",
       "text_field_embedder": {
         "token_embedders": {
-          "tokens": {
-            "type": "embedding",
-            "embedding_dim": 100,
-            "trainable": true
-          }
+            "elmo": {
+                "type": "elmo_token_embedder",
+                "dropout": 0.2,
+                "options_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/2x4096_512_2048cnn_2xhighway/elmo_2x4096_512_2048cnn_2xhighway_options.json",
+                "weight_file": "https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/2x4096_512_2048cnn_2xhighway/elmo_2x4096_512_2048cnn_2xhighway_weights.hdf5",
+                "do_layer_norm": false
+            }
         }
       },
       "pos_tag_embedding":{
@@ -31,7 +38,7 @@
       ],
       "encoder": {
         "type": "lstm",
-        "input_size": 150,
+        "input_size": 1074,
         "hidden_size": 250,
         "num_layers": 2,
         "bidirectional": true,
@@ -72,4 +79,3 @@
       }
     }
   }
-


### PR DESCRIPTION
- renames existing `constituency_parser.jsonnet` (which has elmo) to `constituency_parser_elmo.jsonnet` to match the other configs
- adds new `constituency_parser.jsonnet` that follows the same embedding strategy as the original paper (https://arxiv.org/abs/1705.03919), 100d randomly initialized and updated word vectors.