### PR TITLE
add min_padding_length to TokenCharactersIndexer (#1954)

### DIFF
--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -18,9 +18,6 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
 
     Parameters
     ----------
-    min_padding_length: ``int``, optional (default=``0``)
-        We use this value as the minimum length of padding. Usually used with :class:``CnnEncoder``, its
-        value should be set to the maximum value of ``ngram_filter_sizes`` correspondingly.
     namespace : ``str``, optional (default=``token_characters``)
         We will use this namespace in the :class:`Vocabulary` to map the characters in each token
         to indices.
@@ -33,20 +30,24 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
         These are prepended to the tokens provided to ``tokens_to_indices``.
     end_tokens : ``List[str]``, optional (default=``None``)
         These are appended to the tokens provided to ``tokens_to_indices``.
+    min_padding_length: ``int``, optional (default=``0``)
+        We use this value as the minimum length of padding. Usually used with :class:``CnnEncoder``, its
+        value should be set to the maximum value of ``ngram_filter_sizes`` correspondingly.
     """
     # pylint: disable=no-self-use
     def __init__(self,
-                 min_padding_length: int = 0,
                  namespace: str = 'token_characters',
                  character_tokenizer: CharacterTokenizer = CharacterTokenizer(),
                  start_tokens: List[str] = None,
-                 end_tokens: List[str] = None) -> None:
-        self._min_padding_length = min_padding_length
+                 end_tokens: List[str] = None,
+                 min_padding_length: int = 0) -> None:
         self._namespace = namespace
         self._character_tokenizer = character_tokenizer
 
         self._start_tokens = [Token(st) for st in (start_tokens or [])]
         self._end_tokens = [Token(et) for et in (end_tokens or [])]
+
+        self._min_padding_length = min_padding_length
 
     @overrides
     def count_vocab_items(self, token: Token, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -18,6 +18,9 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
 
     Parameters
     ----------
+    min_padding_length: ``int``, optional (default=``0``)
+        We use this value as the minimum length of padding. Usually used with :class:``CnnEncoder``, its
+        value should be set to the maximum value of ``ngram_filter_sizes`` correspondingly.
     namespace : ``str``, optional (default=``token_characters``)
         We will use this namespace in the :class:`Vocabulary` to map the characters in each token
         to indices.
@@ -33,10 +36,12 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
     """
     # pylint: disable=no-self-use
     def __init__(self,
+                 min_padding_length: int = 0,
                  namespace: str = 'token_characters',
                  character_tokenizer: CharacterTokenizer = CharacterTokenizer(),
                  start_tokens: List[str] = None,
                  end_tokens: List[str] = None) -> None:
+        self._min_padding_length = min_padding_length
         self._namespace = namespace
         self._character_tokenizer = character_tokenizer
 
@@ -76,7 +81,7 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
 
     @overrides
     def get_padding_lengths(self, token: List[int]) -> Dict[str, int]:
-        return {'num_token_characters': len(token)}
+        return {'num_token_characters': max(len(token), self._min_padding_length)}
 
     @overrides
     def get_padding_token(self) -> List[int]:

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -41,13 +41,12 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
                  start_tokens: List[str] = None,
                  end_tokens: List[str] = None,
                  min_padding_length: int = 0) -> None:
+        self._min_padding_length = min_padding_length
         self._namespace = namespace
         self._character_tokenizer = character_tokenizer
 
         self._start_tokens = [Token(st) for st in (start_tokens or [])]
         self._end_tokens = [Token(et) for et in (end_tokens or [])]
-
-        self._min_padding_length = min_padding_length
 
     @overrides
     def count_vocab_items(self, token: Token, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/modules/token_embedders/elmo_token_embedder.py
+++ b/allennlp/modules/token_embedders/elmo_token_embedder.py
@@ -114,6 +114,7 @@ class ElmoTokenEmbedder(TokenEmbedder):
         else:
             vocab_to_cache = None
         projection_dim = params.pop_int("projection_dim", None)
+        scalar_mix_parameters = params.pop('scalar_mix_parameters', None)
         params.assert_empty(cls.__name__)
         return cls(options_file=options_file,
                    weight_file=weight_file,
@@ -121,4 +122,5 @@ class ElmoTokenEmbedder(TokenEmbedder):
                    dropout=dropout,
                    requires_grad=requires_grad,
                    projection_dim=projection_dim,
-                   vocab_to_cache=vocab_to_cache)
+                   vocab_to_cache=vocab_to_cache,
+                   scalar_mix_parameters=scalar_mix_parameters)

--- a/allennlp/tests/data/token_indexers/character_token_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/character_token_indexer_test.py
@@ -87,7 +87,7 @@ class CharacterTokenIndexerTest(AllenNlpTestCase):
         value_padding_lengths = 0
         for token in indices["char"]:
             item = indexer.get_padding_lengths(token)
-            key, value = item.keys(), item.values()
+            value = item.values()
             value_padding_lengths = max(value_padding_lengths, max(value))
         padded = indexer.pad_token_sequence(indices,
                                             {"char": len(indices["char"])},

--- a/allennlp/tests/data/token_indexers/character_token_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/character_token_indexer_test.py
@@ -61,3 +61,33 @@ class CharacterTokenIndexerTest(AllenNlpTestCase):
         assert indices == {"char": [[8, 3, 9],
                                     [3, 4, 5, 6, 4, 5, 6, 1, 1, 1],
                                     [8, 10, 3, 9]]}
+
+    def test_min_padding_length(self):
+        sentence = "AllenNLP is awesome ."
+        tokens = [Token(token) for token in sentence.split(" ")]
+        vocab = Vocabulary()
+        vocab.add_token_to_namespace("A", namespace="characters")  # 2
+        vocab.add_token_to_namespace("l", namespace="characters")  # 3
+        vocab.add_token_to_namespace("e", namespace="characters")  # 4
+        vocab.add_token_to_namespace("n", namespace="characters")  # 5
+        vocab.add_token_to_namespace("N", namespace="characters")  # 6
+        vocab.add_token_to_namespace("L", namespace="characters")  # 7
+        vocab.add_token_to_namespace("P", namespace="characters")  # 8
+        vocab.add_token_to_namespace("i", namespace="characters")  # 9
+        vocab.add_token_to_namespace("s", namespace="characters")  # 10
+        vocab.add_token_to_namespace("a", namespace="characters")  # 11
+        vocab.add_token_to_namespace("w", namespace="characters")  # 12
+        vocab.add_token_to_namespace("o", namespace="characters")  # 13
+        vocab.add_token_to_namespace("m", namespace="characters")  # 14
+        vocab.add_token_to_namespace(".", namespace="characters")  # 15
+
+        indexer = TokenCharactersIndexer("characters", min_padding_length=10)
+        indices = indexer.tokens_to_indices(tokens, vocab, "char")
+        padded = indexer.pad_token_sequence(indices,
+                                            {"char": len(indices["char"])},
+                                            {key_padding_lengths: value_padding_lengths})
+        assert padded == {"char": [[2, 3, 3, 4, 5, 6, 7, 8, 0, 0],
+                                   [9, 10, 0, 0, 0, 0, 0, 0, 0, 0],
+                                   [11, 12, 4, 10, 13, 14, 4, 0, 0, 0],
+                                   [15, 0, 0, 0, 0, 0, 0, 0, 0, 0]]}
+

--- a/allennlp/tests/data/token_indexers/character_token_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/character_token_indexer_test.py
@@ -96,4 +96,3 @@ class CharacterTokenIndexerTest(AllenNlpTestCase):
                                    [9, 10, 0, 0, 0, 0, 0, 0, 0, 0],
                                    [11, 12, 4, 10, 13, 14, 4, 0, 0, 0],
                                    [15, 0, 0, 0, 0, 0, 0, 0, 0, 0]]}
-


### PR DESCRIPTION
patch to #1954 

Although the parameter `min_padding_length` is provided a default value (`0`), I think it may be a better idea with no default value.