### PR TITLE
Link tutorial site from tutorials/README.md.

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,6 +1,8 @@
 # Tutorials
 
-These tutorials relate to the version of AllenNLP at the git commit SHA you are currently looking at (likely the HEAD commit of the master branch).  If you want to see the tutorials that relate to the latest pip release, please see https://github.com/allenai/allennlp/tree/v0.7.1/tutorials.
+### If you're just starting, please check out [the tutorial on our website](https://allennlp.org/tutorials). We've designed it to be the simplest and quickest way to get your toes wet with AllenNLP.
+
+The tutorials available here on the repo relate to the version of AllenNLP at the git commit SHA you are currently looking at (likely the HEAD commit of the master branch).  If you want to see the tutorials that relate to the latest pip release, please see https://github.com/allenai/allennlp/tree/v0.7.1/tutorials.
 
 ## Getting Started
 


### PR DESCRIPTION
Previously ctrl-f on https://github.com/allenai/allennlp for "tutorial" would send you first to `tutorials/README.md` which had no mention of Joel and Aaron's fancy new tutorial.

Should now be impossible to miss.