### PR TITLE
Fix for import_submodules

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -293,7 +293,7 @@ def import_submodules(package_name: str) -> None:
     for module_finder, name, _ in pkgutil.walk_packages(path):
         # Sometimes when you import third-party libraries that are on your path,
         # `pkgutil.walk_packages` returns those too, so we need to skip them.
-        if path_string and module_finder.path not in path_string:
+        if path_string and module_finder.path != path_string:
             continue
         subpackage = f"{package_name}.{name}"
         import_submodules(subpackage)

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -287,7 +287,7 @@ def import_submodules(package_name: str) -> None:
     # Import at top level
     module = importlib.import_module(package_name)
     path = getattr(module, '__path__', [])
-    path_string = '' if len(path) == 0 else path[0]
+    path_string = '' if not path else path[0]
 
     # walk_packages only finds immediate children, so need to recurse.
     for module_finder, name, _ in pkgutil.walk_packages(path):

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -287,9 +287,14 @@ def import_submodules(package_name: str) -> None:
     # Import at top level
     module = importlib.import_module(package_name)
     path = getattr(module, '__path__', [])
+    path_string = '' if len(path) == 0 else path[0]
 
     # walk_packages only finds immediate children, so need to recurse.
-    for _, name, _ in pkgutil.walk_packages(path):
+    for module_finder, name, _ in pkgutil.walk_packages(path):
+        # Sometimes when you import third-party libraries that are on your path,
+        # `pkgutil.walk_packages` returns those too, so we need to skip them.
+        if path_string and module_finder.path not in path_string:
+            continue
         subpackage = f"{package_name}.{name}"
         import_submodules(subpackage)
 


### PR DESCRIPTION
I'm really not sure what circumstance led me to run into this, but this change fixed the problem.  I don't understand why others haven't run into this issue; maybe it's because I was using `allennlp` just in my `PYTHONPATH`, instead of installing it through pip?

The exact command I was running was:

```bash
PYTHONPATH=~/clone/allennlp:. python ~/clone/allennlp/allennlp/run.py train training_config/latent_alignment.json -s /tmp/align -f --include-package weak_supervision
```