### PR TITLE
Match vocab generation in currently online Event2Mind model.

### DIFF
--- a/allennlp/data/dataset_readers/event2mind.py
+++ b/allennlp/data/dataset_readers/event2mind.py
@@ -104,14 +104,15 @@ class Event2MindDatasetReader(DatasetReader):
                                 )
                 # Generate instances where each token of input appears once.
                 else:
-                    # To the extent that sources are duplicated in the dataset
-                    # (which appears common), we will duplicate them here.
-                    yield self.text_to_instance(source_sequence, "none", "none", "none")
                     for xintent in xintents:
+                        # NOTE: source_sequence should really be broken out and deduplicated. We're
+                        # adding it here to ensure we generate the same vocabulary as the model at
+                        # https://s3-us-west-2.amazonaws.com/allennlp/models/event2mind-2018.10.05.tar.gz
+                        # was trained against.
+                        yield self.text_to_instance(source_sequence, xintent, "none", "none")
+                    for xreact in xreacts:
                         # Since "none" is a special token we don't mind it
                         # appearing a disproportionate number of times.
-                        yield self.text_to_instance("none", xintent, "none", "none")
-                    for xreact in xreacts:
                         yield self.text_to_instance("none", "none", xreact, "none")
                     for oreact in oreacts:
                         yield self.text_to_instance("none", "none", "none", oreact)

--- a/allennlp/tests/data/dataset_readers/event2mind_test.py
+++ b/allennlp/tests/data/dataset_readers/event2mind_test.py
@@ -74,7 +74,7 @@ class TestEvent2MindDatasetReader:
         )
         instances = ensure_list(instances)
 
-        assert len(instances) == 21
+        assert len(instances) == 17
         instance = instances[0]
         assert get_text("source", instance) == ["@start@", "it", "is", "personx", "'s",
                                                 "favorite", "animal", "@end@"]
@@ -82,34 +82,28 @@ class TestEvent2MindDatasetReader:
         assert get_text("xreact", instance) == ["@start@", "none", "@end@"]
         assert get_text("oreact", instance) == ["@start@", "none", "@end@"]
 
-        instance = instances[6]
+        instance = instances[5]
         assert get_text("source", instance) == ["@start@", "personx", "drives",
                                                 "persony", "'s", "truck", "@end@"]
-        assert get_text("xintent", instance) == ["@start@", "none", "@end@"]
+        assert get_text("xintent", instance) == ["@start@", "move", "@end@"]
         assert get_text("xreact", instance) == ["@start@", "none", "@end@"]
         assert get_text("oreact", instance) == ["@start@", "none", "@end@"]
 
         instance = instances[7]
         assert get_text("source", instance) == ["@start@", "none", "@end@"]
-        assert get_text("xintent", instance) == ["@start@", "move", "@end@"]
-        assert get_text("xreact", instance) == ["@start@", "none", "@end@"]
+        assert get_text("xintent", instance) == ["@start@", "none", "@end@"]
+        assert get_text("xreact", instance) == ["@start@", "grateful", "@end@"]
         assert get_text("oreact", instance) == ["@start@", "none", "@end@"]
 
         instance = instances[9]
         assert get_text("source", instance) == ["@start@", "none", "@end@"]
         assert get_text("xintent", instance) == ["@start@", "none", "@end@"]
-        assert get_text("xreact", instance) == ["@start@", "grateful", "@end@"]
-        assert get_text("oreact", instance) == ["@start@", "none", "@end@"]
-
-        instance = instances[11]
-        assert get_text("source", instance) == ["@start@", "none", "@end@"]
-        assert get_text("xintent", instance) == ["@start@", "none", "@end@"]
         assert get_text("xreact", instance) == ["@start@", "none", "@end@"]
         assert get_text("oreact", instance) == ["@start@", "charitable", "@end@"]
 
-        instance = instances[13]
-        assert get_text("source", instance) == ["@start@", "personx", "gets", "persony",
-                                                "'s", "mother", "@end@"]
-        assert get_text("xintent", instance) == ["@start@", "none", "@end@"]
+        instance = instances[14]
+        assert get_text("source", instance) == ["@start@", "personx", "drives",
+                                                "persony", "'s", "truck", "@end@"]
+        assert get_text("xintent", instance) == ["@start@", "for", "fun", "@end@"]
         assert get_text("xreact", instance) == ["@start@", "none", "@end@"]
         assert get_text("oreact", instance) == ["@start@", "none", "@end@"]


### PR DESCRIPTION
- I noticed this difference while retraining the model to account for https://github.com/allenai/allennlp/pull/1944.
- With this change we generate the exact same vocab as was used for the 10/5 model and now the new 10/26 model.
- In the long run we'll want to be more principled with our vocab. In the short term I'm more concerned with ensuring that we can retrain consistently.