### PR TITLE
Add --force option to find-lr command

### DIFF
--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -43,7 +43,7 @@ which to write the results.
                            additional packages to include
 """
 
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 import argparse
 import re
 import os
@@ -121,17 +121,20 @@ def find_learning_rate_from_args(args: argparse.Namespace) -> None:
     """
     params = Params.from_file(args.param_path, args.overrides)
     find_learning_rate_model(params, args.serialization_dir,
-                             args.start_lr, args.end_lr,
-                             args.num_batches, args.linear, args.stopping_factor, args.force)
+                             start_lr=args.start_lr,
+                             end_lr=args.end_lr,
+                             num_batches=args.num_batches,
+                             linear_steps=args.linear,
+                             stopping_factor=args.stopping_factor,
+                             force=args.force)
 
-def find_learning_rate_model(params: Params,
-                             serialization_dir: str,
-                             start_lr: float,
-                             end_lr: float,
-                             num_batches: int,
-                             linear_steps: bool,
-                             stopping_factor: Optional[float],
-                             force: bool) -> None:
+def find_learning_rate_model(params: Params, serialization_dir: str,
+                             start_lr: float = 1e-5,
+                             end_lr: float = 10,
+                             num_batches: int = 100,
+                             linear_steps: bool = False,
+                             stopping_factor: float = None,
+                             force: bool = False) -> None:
     """
     Runs learning rate search for given `num_batches` and saves the results in ``serialization_dir``
 
@@ -207,9 +210,12 @@ def find_learning_rate_model(params: Params,
                                   validation_iterator=None)
 
     logger.info(f'Starting learning rate search from {start_lr} to {end_lr} in {num_batches} iterations.')
-    learning_rates, losses = search_learning_rate(trainer, start_lr,
-                                                  end_lr, num_batches,
-                                                  linear_steps, stopping_factor)
+    learning_rates, losses = search_learning_rate(trainer,
+                                                  start_lr=start_lr,
+                                                  end_lr=end_lr,
+                                                  num_batches=num_batches,
+                                                  linear_steps=linear_steps,
+                                                  stopping_factor=stopping_factor)
     logger.info(f'Finished learning rate search.')
     losses = _smooth(losses, 0.98)
 
@@ -220,7 +226,7 @@ def search_learning_rate(trainer: Trainer,
                          end_lr: float = 10,
                          num_batches: int = 100,
                          linear_steps: bool = False,
-                         stopping_factor: Optional[float] = 4.0) -> Tuple[List[float], List[float]]:
+                         stopping_factor: float = None) -> Tuple[List[float], List[float]]:
     """
     Runs training loop on the model using :class:`~allennlp.training.trainer.Trainer`
     increasing learning rate from ``start_lr`` to ``end_lr`` recording the losses.

--- a/allennlp/tests/commands/find_learning_rate_test.py
+++ b/allennlp/tests/commands/find_learning_rate_test.py
@@ -44,25 +44,25 @@ class TestFindLearningRate(AllenNlpTestCase):
                     })
 
     def test_find_learning_rate(self):
-        find_learning_rate_model(self.params(),
-                                 serialization_dir=os.path.join(self.TEST_DIR, 'test_find_learning_rate'),
+        find_learning_rate_model(self.params(), os.path.join(self.TEST_DIR, 'test_find_learning_rate'),
                                  start_lr=1e-5,
                                  end_lr=1,
                                  num_batches=100,
                                  linear_steps=True,
-                                 stopping_factor=None)
+                                 stopping_factor=None,
+                                 force=False)
 
         # It's OK if serialization dir exists but is empty:
         serialization_dir2 = os.path.join(self.TEST_DIR, 'empty_directory')
         assert not os.path.exists(serialization_dir2)
         os.makedirs(serialization_dir2)
-        find_learning_rate_model(self.params(),
-                                 serialization_dir=serialization_dir2,
+        find_learning_rate_model(self.params(), serialization_dir2,
                                  start_lr=1e-5,
                                  end_lr=1,
                                  num_batches=100,
                                  linear_steps=True,
-                                 stopping_factor=None)
+                                 stopping_factor=None,
+                                 force=False)
 
         # It's not OK if serialization dir exists and has junk in it non-empty:
         serialization_dir3 = os.path.join(self.TEST_DIR, 'non_empty_directory')
@@ -72,13 +72,22 @@ class TestFindLearningRate(AllenNlpTestCase):
             f.write("TEST")
 
         with pytest.raises(ConfigurationError):
-            find_learning_rate_model(self.params(),
-                                     serialization_dir=serialization_dir3,
+            find_learning_rate_model(self.params(), serialization_dir3,
                                      start_lr=1e-5,
                                      end_lr=1,
                                      num_batches=100,
                                      linear_steps=True,
-                                     stopping_factor=None)
+                                     stopping_factor=None,
+                                     force=False)
+
+        # ... unless you use the --force flag.
+        find_learning_rate_model(self.params(), serialization_dir3,
+                                 start_lr=1e-5,
+                                 end_lr=1,
+                                 num_batches=100,
+                                 linear_steps=True,
+                                 stopping_factor=None,
+                                 force=True)
 
 
     def test_find_learning_rate_args(self):


### PR DESCRIPTION
It often takes a couple runs to get the right start and end learning rates and number of batches, so it's convenient when you can just overwrite the last serialization directory. This also just cleans up the docstrings a little for consistency.