### PR TITLE
Prevent inspect_cache from swallowing exception.

### DIFF
--- a/scripts/inspect_cache.py
+++ b/scripts/inspect_cache.py
@@ -18,8 +18,9 @@ if not cached_files:
     print('No cached datasets found.')
 
 for filename in cached_files:
-    url, etag = filename_to_url(filename)
-    print('Filename: %s' % filename)
-    print('Url: %s' % url)
-    print('ETag: %s' % etag)
-    print()
+    if not filename.endswith("json"):
+        url, etag = filename_to_url(filename)
+        print('Filename: %s' % filename)
+        print('Url: %s' % url)
+        print('ETag: %s' % etag)
+        print()

--- a/scripts/inspect_cache.py
+++ b/scripts/inspect_cache.py
@@ -6,16 +6,20 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(__file__, os.par
 from allennlp.common.file_utils import filename_to_url
 from allennlp.common.file_utils import DATASET_CACHE
 
-try:
-    cached_files = os.listdir(DATASET_CACHE)
-    if not cached_files:
-        print('No cached datasets found.')
+print(f"Looking for datasets in {DATASET_CACHE}...")
+if not os.path.exists(DATASET_CACHE):
+    print('Directory does not exist.')
+    print('No cached datasets found.')
 
-    for filename in cached_files:
-        url, etag = filename_to_url(filename)
-        print('Filename: %s' % filename)
-        print('Url: %s' % url)
-        print('ETag: %s' % etag)
-        print()
-except FileNotFoundError:
-    print('No cached datasets found.')    
+cached_files = os.listdir(DATASET_CACHE)
+
+if not cached_files:
+    print('Directory is empty.')
+    print('No cached datasets found.')
+
+for filename in cached_files:
+    url, etag = filename_to_url(filename)
+    print('Filename: %s' % filename)
+    print('Url: %s' % url)
+    print('ETag: %s' % etag)
+    print()


### PR DESCRIPTION
I was confused because the previous implementation was telling me:

```
No cached datasets found.
```

Instead of giving me a more accurate exception:

```
FileNotFoundError: file /Users/michael/.allennlp/datasets/dd04ba717be48bea13525e4293a243477876cdb0f0166abb8b09b5ed2e17cb3e.d68991c3e6de7fbcb5cf3e605d0e298f12cb857ca9d70aa8683abc886aa49edd.json.json not found
```

This change prevents such exceptions from being swallowed.