### PR TITLE
Change log level to clean up allennlp command.

### DIFF
--- a/allennlp/common/registrable.py
+++ b/allennlp/common/registrable.py
@@ -53,7 +53,7 @@ class Registrable(FromParams):
 
     @classmethod
     def by_name(cls: Type[T], name: str) -> Type[T]:
-        logger.info(f"instantiating registered subclass {name} of {cls}")
+        logger.debug(f"instantiating registered subclass {name} of {cls}")
         if name not in Registrable._registry[cls]:
             raise ConfigurationError("%s is not a registered name for %s" % (name, cls.__name__))
         return Registrable._registry[cls].get(name)


### PR DESCRIPTION
This removes much of the noise from the `allennlp` command.

```
2018-11-01 15:48:30,734 - INFO - allennlp.common.registrable - instantiating registered subclass relu of <class 'allennlp.nn.activations.Activation'>
2018-11-01 15:48:30,735 - INFO - allennlp.common.registrable - instantiating registered subclass relu of <class 'allennlp.nn.activations.Activation'>
2018-11-01 15:48:30,736 - INFO - allennlp.common.registrable - instantiating registered subclass relu of <class 'allennlp.nn.activations.Activation'>
2018-11-01 15:48:30,736 - INFO - allennlp.common.registrable - instantiating registered subclass relu of <class 'allennlp.nn.activations.Activation'>
usage: allennlp

Run AllenNLP

optional arguments:
  -h, --help    show this help message and exit
  --version     show program's version number and exit

Commands:
  
    configure   Generate configuration stubs.
    train       Train a model
    evaluate    Evaluate the specified model + dataset
    predict     Use a trained model to make predictions.
    make-vocab  Create a vocabulary
    elmo        Use a trained model to make predictions.
    fine-tune   Continue training a model on a new dataset
    dry-run     Create a vocabulary, compute dataset statistics and other
                training utilities.
    test-install
                Run the unit tests.
    find-lr     Train a model
[INFO/MainProcess] process shutting down
```