### PR TITLE
Added default predictor for bimpm model

### DIFF
--- a/allennlp/predictors/predictor.py
+++ b/allennlp/predictors/predictor.py
@@ -14,6 +14,7 @@ DEFAULT_PREDICTORS = {
         'biaffine_parser': 'biaffine-dependency-parser',
         'bidaf': 'machine-comprehension',
         'bidaf-ensemble': 'machine-comprehension',
+        'bimpm': 'textual-entailment',
         'constituency_parser': 'constituency-parser',
         'coref': 'coreference-resolution',
         'crf_tagger': 'sentence-tagger',


### PR DESCRIPTION
Since `bimpm` uses fields similar to `DecomposableAttention` model,  `textual-entailment` predictor is made as the default for `bimpm`.