### PR TITLE
Enable multi-gpu training in find_learning_rate.py

### DIFF
--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -170,7 +170,12 @@ def find_learning_rate_model(params: Params, serialization_dir: str,
 
     prepare_environment(params)
 
-    check_for_gpu(params.get('trainer').get('cuda_device', -1))
+    cuda_device = params.params.get('trainer').get('cuda_device', -1)
+    if isinstance(cuda_device, list):
+        for device in cuda_device:
+             check_for_gpu(device)
+    else:
+        check_for_gpu(cuda_device)
 
     all_datasets = datasets_from_params(params)
     datasets_for_vocab_creation = set(params.pop("datasets_for_vocab_creation", all_datasets))

--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -173,7 +173,7 @@ def find_learning_rate_model(params: Params, serialization_dir: str,
     cuda_device = params.params.get('trainer').get('cuda_device', -1)
     if isinstance(cuda_device, list):
         for device in cuda_device:
-             check_for_gpu(device)
+            check_for_gpu(device)
     else:
         check_for_gpu(cuda_device)
 

--- a/allennlp/tests/commands/find_learning_rate_test.py
+++ b/allennlp/tests/commands/find_learning_rate_test.py
@@ -14,39 +14,41 @@ from allennlp.commands.train import datasets_from_params, Trainer
 from allennlp.commands.find_learning_rate import search_learning_rate, \
     find_learning_rate_from_args, find_learning_rate_model, FindLearningRate
 
+
 class TestFindLearningRate(AllenNlpTestCase):
 
     def setUp(self):
         super().setUp()
         self.params = lambda: Params({
-                        "model": {
-                            "type": "simple_tagger",
-                            "text_field_embedder": {
-                                "tokens": {
-                                    "type": "embedding",
-                                    "embedding_dim": 5
-                                }
-                            },
-                            "encoder": {
-                                "type": "lstm",
-                                "input_size": 5,
-                                "hidden_size": 7,
-                                "num_layers": 2
-                            }
-                        },
-                        "dataset_reader": {"type": "sequence_tagging"},
-                        "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
-                        "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
-                        "iterator": {"type": "basic", "batch_size": 2},
-                        "trainer": {
-                            "cuda_device": -1,
-                            "num_epochs": 2,
-                            "optimizer": "adam"
-                        }
-                    })
+            "model": {
+                "type": "simple_tagger",
+                "text_field_embedder": {
+                    "tokens": {
+                        "type": "embedding",
+                        "embedding_dim": 5
+                    }
+                },
+                "encoder": {
+                    "type": "lstm",
+                    "input_size": 5,
+                    "hidden_size": 7,
+                    "num_layers": 2
+                }
+            },
+            "dataset_reader": {"type": "sequence_tagging"},
+            "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+            "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+            "iterator": {"type": "basic", "batch_size": 2},
+            "trainer": {
+                "cuda_device": -1,
+                "num_epochs": 2,
+                "optimizer": "adam"
+            }
+        })
 
     def test_find_learning_rate(self):
-        find_learning_rate_model(self.params(), os.path.join(self.TEST_DIR, 'test_find_learning_rate'),
+        find_learning_rate_model(self.params(),
+                                 os.path.join(self.TEST_DIR, 'test_find_learning_rate'),
                                  start_lr=1e-5,
                                  end_lr=1,
                                  num_batches=100,
@@ -91,7 +93,6 @@ class TestFindLearningRate(AllenNlpTestCase):
                                  stopping_factor=None,
                                  force=True)
 
-
     def test_find_learning_rate_args(self):
         parser = argparse.ArgumentParser(description="Testing")
         subparsers = parser.add_subparsers(title='Commands', metavar='')
@@ -116,12 +117,37 @@ class TestFindLearningRate(AllenNlpTestCase):
             args = parser.parse_args(["find_lr", "path/to/params"])
             assert cm.exception.code == 2  # argparse code for incorrect usage
 
-            
+
     @pytest.mark.skipif(torch.cuda.device_count() < 2,
                         reason="Need multiple GPUs.")
     def test_find_learning_rate_multi_gpu(self):
-        self.params["trainer"]["cuda_device"] = [0, 1]
-        find_learning_rate_model(self.params(), 
+        multi_gpu_params = lambda: Params({
+            "model": {
+                "type": "simple_tagger",
+                "text_field_embedder": {
+                    "tokens": {
+                        "type": "embedding",
+                        "embedding_dim": 5
+                    }
+                },
+                "encoder": {
+                    "type": "lstm",
+                    "input_size": 5,
+                    "hidden_size": 7,
+                    "num_layers": 2
+                }
+            },
+            "dataset_reader": {"type": "sequence_tagging"},
+            "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+            "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+            "iterator": {"type": "basic", "batch_size": 2},
+            "trainer": {
+                "cuda_device": [0, 1],
+                "num_epochs": 2,
+                "optimizer": "adam"
+            }
+        })
+        find_learning_rate_model(multi_gpu_params(),
                                  os.path.join(self.TEST_DIR, 'test_find_learning_rate_multi_gpu'),
                                  start_lr=1e-5,
                                  end_lr=1,
@@ -130,35 +156,36 @@ class TestFindLearningRate(AllenNlpTestCase):
                                  stopping_factor=None,
                                  force=False)
 
+
 class TestSearchLearningRate(AllenNlpTestCase):
 
     def setUp(self):
         super().setUp()
         params = Params({
-                "model": {
-                    "type": "simple_tagger",
-                    "text_field_embedder": {
-                        "tokens": {
-                            "type": "embedding",
-                            "embedding_dim": 5
-                        }
-                    },
-                    "encoder": {
-                        "type": "lstm",
-                        "input_size": 5,
-                        "hidden_size": 7,
-                        "num_layers": 2
+            "model": {
+                "type": "simple_tagger",
+                "text_field_embedder": {
+                    "tokens": {
+                        "type": "embedding",
+                        "embedding_dim": 5
                     }
                 },
-                "dataset_reader": {"type": "sequence_tagging"},
-                "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
-                "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
-                "iterator": {"type": "basic", "batch_size": 2},
-                "trainer": {
-                    "cuda_device": -1,
-                    "num_epochs": 2,
-                    "optimizer": "adam"
+                "encoder": {
+                    "type": "lstm",
+                    "input_size": 5,
+                    "hidden_size": 7,
+                    "num_layers": 2
                 }
+            },
+            "dataset_reader": {"type": "sequence_tagging"},
+            "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+            "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+            "iterator": {"type": "basic", "batch_size": 2},
+            "trainer": {
+                "cuda_device": -1,
+                "num_epochs": 2,
+                "optimizer": "adam"
+            }
         })
         all_datasets = datasets_from_params(params)
         vocab = Vocabulary.from_params(
@@ -174,12 +201,12 @@ class TestSearchLearningRate(AllenNlpTestCase):
         serialization_dir = os.path.join(self.TEST_DIR, 'test_search_learning_rate')
 
         self.trainer = Trainer.from_params(model,
-                                      serialization_dir,
-                                      iterator,
-                                      train_data,
-                                      params=trainer_params,
-                                      validation_data=None,
-                                      validation_iterator=None)
+                                           serialization_dir,
+                                           iterator,
+                                           train_data,
+                                           params=trainer_params,
+                                           validation_data=None,
+                                           validation_iterator=None)
 
     def test_search_learning_rate_with_num_batches_less_than_ten(self):
         with pytest.raises(ConfigurationError):
@@ -190,6 +217,7 @@ class TestSearchLearningRate(AllenNlpTestCase):
         assert len(learning_rates_losses) > 1
 
     def test_search_learning_rate_without_stopping_factor(self):
-        learning_rates, losses = search_learning_rate(self.trainer, num_batches=100, stopping_factor=None)
+        learning_rates, losses = search_learning_rate(self.trainer, num_batches=100,
+                                                      stopping_factor=None)
         assert len(learning_rates) == 101
         assert len(losses) == 101

--- a/allennlp/tests/commands/find_learning_rate_test.py
+++ b/allennlp/tests/commands/find_learning_rate_test.py
@@ -20,31 +20,31 @@ class TestFindLearningRate(AllenNlpTestCase):
     def setUp(self):
         super().setUp()
         self.params = lambda: Params({
-            "model": {
-                "type": "simple_tagger",
-                "text_field_embedder": {
-                    "tokens": {
-                        "type": "embedding",
-                        "embedding_dim": 5
-                    }
-                },
-                "encoder": {
-                    "type": "lstm",
-                    "input_size": 5,
-                    "hidden_size": 7,
-                    "num_layers": 2
-                }
-            },
-            "dataset_reader": {"type": "sequence_tagging"},
-            "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
-            "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
-            "iterator": {"type": "basic", "batch_size": 2},
-            "trainer": {
-                "cuda_device": -1,
-                "num_epochs": 2,
-                "optimizer": "adam"
-            }
-        })
+                        "model": {
+                            "type": "simple_tagger",
+                            "text_field_embedder": {
+                                "tokens": {
+                                    "type": "embedding",
+                                    "embedding_dim": 5
+                                }
+                            },
+                            "encoder": {
+                                "type": "lstm",
+                                "input_size": 5,
+                                "hidden_size": 7,
+                                "num_layers": 2
+                            }
+                        },
+                        "dataset_reader": {"type": "sequence_tagging"},
+                        "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+                        "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+                        "iterator": {"type": "basic", "batch_size": 2},
+                        "trainer": {
+                            "cuda_device": -1,
+                            "num_epochs": 2,
+                            "optimizer": "adam"
+                        }
+                    })
 
     def test_find_learning_rate(self):
         find_learning_rate_model(self.params(),
@@ -162,31 +162,31 @@ class TestSearchLearningRate(AllenNlpTestCase):
     def setUp(self):
         super().setUp()
         params = Params({
-            "model": {
-                "type": "simple_tagger",
-                "text_field_embedder": {
-                    "tokens": {
-                        "type": "embedding",
-                        "embedding_dim": 5
+                "model": {
+                    "type": "simple_tagger",
+                    "text_field_embedder": {
+                        "tokens": {
+                            "type": "embedding",
+                            "embedding_dim": 5
+                        }
+                    },
+                    "encoder": {
+                        "type": "lstm",
+                        "input_size": 5,
+                        "hidden_size": 7,
+                        "num_layers": 2
                     }
                 },
-                "encoder": {
-                    "type": "lstm",
-                    "input_size": 5,
-                    "hidden_size": 7,
-                    "num_layers": 2
+                "dataset_reader": {"type": "sequence_tagging"},
+                "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+                "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+                "iterator": {"type": "basic", "batch_size": 2},
+                "trainer": {
+                    "cuda_device": -1,
+                    "num_epochs": 2,
+                    "optimizer": "adam"
                 }
-            },
-            "dataset_reader": {"type": "sequence_tagging"},
-            "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
-            "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
-            "iterator": {"type": "basic", "batch_size": 2},
-            "trainer": {
-                "cuda_device": -1,
-                "num_epochs": 2,
-                "optimizer": "adam"
-            }
-        })
+            })
         all_datasets = datasets_from_params(params)
         vocab = Vocabulary.from_params(
             params.pop("vocabulary", {}),

--- a/allennlp/tests/commands/find_learning_rate_test.py
+++ b/allennlp/tests/commands/find_learning_rate_test.py
@@ -3,6 +3,8 @@ import argparse
 import os
 import pytest
 
+import torch
+
 from allennlp.common import Params
 from allennlp.data import Vocabulary, DataIterator
 from allennlp.models import Model
@@ -204,7 +206,7 @@ class TestFindLearningRateForMultiGPU(AllenNlpTestCase):
                         "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
                         "iterator": {"type": "basic", "batch_size": 2},
                         "trainer": {
-                            "cuda_device": [0,1],
+                            "cuda_device": [0, 1],
                             "num_epochs": 2,
                             "optimizer": "adam"
                         }

--- a/allennlp/tests/commands/find_learning_rate_test.py
+++ b/allennlp/tests/commands/find_learning_rate_test.py
@@ -121,33 +121,9 @@ class TestFindLearningRate(AllenNlpTestCase):
     @pytest.mark.skipif(torch.cuda.device_count() < 2,
                         reason="Need multiple GPUs.")
     def test_find_learning_rate_multi_gpu(self):
-        multi_gpu_params = lambda: Params({
-            "model": {
-                "type": "simple_tagger",
-                "text_field_embedder": {
-                    "tokens": {
-                        "type": "embedding",
-                        "embedding_dim": 5
-                    }
-                },
-                "encoder": {
-                    "type": "lstm",
-                    "input_size": 5,
-                    "hidden_size": 7,
-                    "num_layers": 2
-                }
-            },
-            "dataset_reader": {"type": "sequence_tagging"},
-            "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
-            "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
-            "iterator": {"type": "basic", "batch_size": 2},
-            "trainer": {
-                "cuda_device": [0, 1],
-                "num_epochs": 2,
-                "optimizer": "adam"
-            }
-        })
-        find_learning_rate_model(multi_gpu_params(),
+        params = self.params()
+        params["trainer"]["cuda_device"] = [0, 1]
+        find_learning_rate_model(params,
                                  os.path.join(self.TEST_DIR, 'test_find_learning_rate_multi_gpu'),
                                  start_lr=1e-5,
                                  end_lr=1,

--- a/allennlp/tests/commands/find_learning_rate_test.py
+++ b/allennlp/tests/commands/find_learning_rate_test.py
@@ -178,3 +178,82 @@ class TestSearchLearningRate(AllenNlpTestCase):
         learning_rates, losses = search_learning_rate(self.trainer, num_batches=100, stopping_factor=None)
         assert len(learning_rates) == 101
         assert len(losses) == 101
+
+class TestFindLearningRateForMultiGPU(AllenNlpTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.params = lambda: Params({
+                        "model": {
+                            "type": "simple_tagger",
+                            "text_field_embedder": {
+                                "tokens": {
+                                    "type": "embedding",
+                                    "embedding_dim": 5
+                                }
+                            },
+                            "encoder": {
+                                "type": "lstm",
+                                "input_size": 5,
+                                "hidden_size": 7,
+                                "num_layers": 2
+                            }
+                        },
+                        "dataset_reader": {"type": "sequence_tagging"},
+                        "train_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+                        "validation_data_path": str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv'),
+                        "iterator": {"type": "basic", "batch_size": 2},
+                        "trainer": {
+                            "cuda_device": [0,1],
+                            "num_epochs": 2,
+                            "optimizer": "adam"
+                        }
+                    })
+
+    @pytest.mark.skipif(torch.cuda.device_count() < 2,
+                        reason="Need multiple GPUs.")
+    def test_find_learning_rate(self):
+        find_learning_rate_model(self.params(), os.path.join(self.TEST_DIR, 'test_find_learning_rate'),
+                                 start_lr=1e-5,
+                                 end_lr=1,
+                                 num_batches=100,
+                                 linear_steps=True,
+                                 stopping_factor=None,
+                                 force=False)
+
+        # It's OK if serialization dir exists but is empty:
+        serialization_dir2 = os.path.join(self.TEST_DIR, 'empty_directory')
+        assert not os.path.exists(serialization_dir2)
+        os.makedirs(serialization_dir2)
+        find_learning_rate_model(self.params(), serialization_dir2,
+                                 start_lr=1e-5,
+                                 end_lr=1,
+                                 num_batches=100,
+                                 linear_steps=True,
+                                 stopping_factor=None,
+                                 force=False)
+
+        # It's not OK if serialization dir exists and has junk in it non-empty:
+        serialization_dir3 = os.path.join(self.TEST_DIR, 'non_empty_directory')
+        assert not os.path.exists(serialization_dir3)
+        os.makedirs(serialization_dir3)
+        with open(os.path.join(serialization_dir3, 'README.md'), 'w') as f:
+            f.write("TEST")
+
+        with pytest.raises(ConfigurationError):
+            find_learning_rate_model(self.params(), serialization_dir3,
+                                     start_lr=1e-5,
+                                     end_lr=1,
+                                     num_batches=100,
+                                     linear_steps=True,
+                                     stopping_factor=None,
+                                     force=False)
+
+        # ... unless you use the --force flag.
+        find_learning_rate_model(self.params(), serialization_dir3,
+                                 start_lr=1e-5,
+                                 end_lr=1,
+                                 num_batches=100,
+                                 linear_steps=True,
+                                 stopping_factor=None,
+                                 force=True)


### PR DESCRIPTION
Modified checks  in find_learning_rate.py to add support for multi-gpu training from [#1944](https://github.com/allenai/allennlp/pull/1944/commits/6d0da18aa6abea2865229f7041d1a6e6221395da)