### PR TITLE
Fix logging statement so it has the proper scope.

### DIFF
--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -95,7 +95,7 @@ class Elmo(torch.nn.Module):
                  module: torch.nn.Module = None) -> None:
         super(Elmo, self).__init__()
 
-        logging.info("Initializing ELMo")
+        logger.info("Initializing ELMo")
         if module is not None:
             if options_file is not None or weight_file is not None:
                 raise ConfigurationError(


### PR DESCRIPTION
I noticed some root-level log messages for ELMo in the demo logging.  After this change they will have the proper `__name__`.

```
INFO:__main__:loading coreference-resolution model
INFO:__main__:loading named-entity-recognition model
INFO:root:Initializing ELMo
```