### PR TITLE
Improve server_simple by adding predict_batch and adding GPU option

### DIFF
--- a/allennlp/tests/service/server_simple_test.py
+++ b/allennlp/tests/service/server_simple_test.py
@@ -88,7 +88,7 @@ class TestSimpleServer(AllenNlpTestCase):
         for data in data_list:
             assert 'best_span_str' in data
             assert 'span_start_logits' not in data
-            
+
     def test_static_dir(self):
         html = """<html><body>THIS IS A STATIC SITE</body></html>"""
         jpg = """something about a jpg"""

--- a/allennlp/tests/service/server_simple_test.py
+++ b/allennlp/tests/service/server_simple_test.py
@@ -58,6 +58,15 @@ class TestSimpleServer(AllenNlpTestCase):
         assert 'best_span_str' in data
         assert 'span_start_logits' in data
 
+        # Test the batch predictor
+        batch_size = 8
+        response = post_json(client, '/predict_batch', [PAYLOAD] * batch_size)
+        data_list = json.loads(response.get_data())
+        assert len(data_list) == batch_size
+        for data in data_list:
+            assert 'best_span_str' in data
+            assert 'span_start_logits' in data
+
     def test_sanitizer(self):
         def sanitize(result: JsonDict) -> JsonDict:
             return {key: value for key, value in result.items()
@@ -72,6 +81,14 @@ class TestSimpleServer(AllenNlpTestCase):
         assert 'best_span_str' in data
         assert 'span_start_logits' not in data
 
+        batch_size = 8
+        response = post_json(client, '/predict_batch', [PAYLOAD] * batch_size)
+        data_list = json.loads(response.get_data())
+        assert len(data_list) == batch_size
+        for data in data_list:
+            assert 'best_span_str' in data
+            assert 'span_start_logits' not in data
+            
     def test_static_dir(self):
         html = """<html><body>THIS IS A STATIC SITE</body></html>"""
         jpg = """something about a jpg"""


### PR DESCRIPTION
Some simple improvements to server_simple.py:
1. Add a predict_batch method so a client can send a list of items for prediction.
2. Add the command line option --cuda-device. 