### PR TITLE
Add support of tokenized input for coref and srl predictors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 
 .envrc
 .python-version
+.idea
 
 
 # jupyter notebooks

--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -155,13 +155,6 @@ class SpacyWordSplitter(WordSplitter):
         # This works because our Token class matches spacy's.
         return _remove_spaces(self.spacy(sentence))
 
-    def tokens_from_list(self, words: List[str]) -> List[Token]:
-        spacy_doc = self.spacy.tokenizer.tokens_from_list(words)
-        for pipe in filter(None, self.spacy.pipeline):
-            pipe[1](spacy_doc)
-
-        return [token for token in spacy_doc]
-
 
 @WordSplitter.register('openai')
 class OpenAISplitter(WordSplitter):

--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -131,6 +131,7 @@ class JustSpacesWordSplitter(WordSplitter):
 def _remove_spaces(tokens: List[spacy.tokens.Token]) -> List[spacy.tokens.Token]:
     return [token for token in tokens if not token.is_space]
 
+
 @WordSplitter.register('spacy')
 class SpacyWordSplitter(WordSplitter):
     """
@@ -153,6 +154,14 @@ class SpacyWordSplitter(WordSplitter):
     def split_words(self, sentence: str) -> List[Token]:
         # This works because our Token class matches spacy's.
         return _remove_spaces(self.spacy(sentence))
+
+    def tokens_from_list(self, words: List[str]) -> List[Token]:
+        spacy_doc = self.spacy.tokenizer.tokens_from_list(words)
+        for pipe in filter(None, self.spacy.pipeline):
+            pipe[1](spacy_doc)
+
+        return [token for token in spacy_doc]
+
 
 @WordSplitter.register('openai')
 class OpenAISplitter(WordSplitter):

--- a/allennlp/predictors/coref.py
+++ b/allennlp/predictors/coref.py
@@ -1,7 +1,9 @@
+from typing import List
+
 from overrides import overrides
 
-from allennlp.common.util import get_spacy_model
 from allennlp.common.util import JsonDict
+from allennlp.common.util import get_spacy_model
 from allennlp.data import DatasetReader, Instance
 from allennlp.models import Model
 from allennlp.predictors.predictor import Predictor
@@ -52,6 +54,38 @@ class CorefPredictor(Predictor):
         A dictionary representation of the predicted coreference clusters.
         """
         return self.predict_json({"document" : document})
+
+    def predict_from_list(self, document_as_list: List[str]) -> JsonDict:
+        """
+        Predict the coreference clusters in the given document.
+
+        Parameters
+        ----------
+        document_as_list : ``List[str``
+            A list of words representation of a tokenized document.
+
+        Returns
+        -------
+        A dictionary representation of the predicted coreference clusters.
+        """
+        return self.predict_words_list(document_as_list)
+
+    def predict_words_list(self, words_list: List[str]) -> JsonDict:
+        instance = self._words_list_to_instance(words_list)
+        return self.predict_instance(instance)
+
+    def _words_list_to_instance(self, document_list: List[str]) -> Instance:
+        """
+        Create an instance from words list represent an already tokenized document,
+        for skipping tokenization when that information already exist for the user
+        """
+        spacy_document = self._spacy.tokenizer.tokens_from_list(document_list)
+        for pipe in filter(None, self._spacy.pipeline):
+            pipe[1](spacy_document)
+
+        sentences = [[token.text for token in sentence] for sentence in spacy_document.sents]
+        instance = self._dataset_reader.text_to_instance(sentences)
+        return instance
 
     @overrides
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:

--- a/allennlp/predictors/coref.py
+++ b/allennlp/predictors/coref.py
@@ -55,31 +55,28 @@ class CorefPredictor(Predictor):
         """
         return self.predict_json({"document" : document})
 
-    def predict_from_list(self, tokenized_document: List[str]) -> JsonDict:
+    def predict_tokenized(self, tokenized_document: List[str]) -> JsonDict:
         """
         Predict the coreference clusters in the given document.
 
         Parameters
         ----------
-        tokenized_document : ``List[str``
+        tokenized_document : ``List[str]``
             A list of words representation of a tokenized document.
 
         Returns
         -------
         A dictionary representation of the predicted coreference clusters.
         """
-        return self.predict_words_list(tokenized_document)
-
-    def predict_words_list(self, words_list: List[str]) -> JsonDict:
-        instance = self._words_list_to_instance(words_list)
+        instance = self._words_list_to_instance(tokenized_document)
         return self.predict_instance(instance)
 
-    def _words_list_to_instance(self, document_list: List[str]) -> Instance:
+    def _words_list_to_instance(self, words: List[str]) -> Instance:
         """
         Create an instance from words list represent an already tokenized document,
         for skipping tokenization when that information already exist for the user
         """
-        spacy_document = self._spacy.tokenizer.tokens_from_list(document_list)
+        spacy_document = self._spacy.tokenizer.tokens_from_list(words)
         for pipe in filter(None, self._spacy.pipeline):
             pipe[1](spacy_document)
 

--- a/allennlp/predictors/coref.py
+++ b/allennlp/predictors/coref.py
@@ -55,20 +55,20 @@ class CorefPredictor(Predictor):
         """
         return self.predict_json({"document" : document})
 
-    def predict_from_list(self, document_as_list: List[str]) -> JsonDict:
+    def predict_from_list(self, tokenized_document: List[str]) -> JsonDict:
         """
         Predict the coreference clusters in the given document.
 
         Parameters
         ----------
-        document_as_list : ``List[str``
+        tokenized_document : ``List[str``
             A list of words representation of a tokenized document.
 
         Returns
         -------
         A dictionary representation of the predicted coreference clusters.
         """
-        return self.predict_words_list(document_as_list)
+        return self.predict_words_list(tokenized_document)
 
     def predict_words_list(self, words_list: List[str]) -> JsonDict:
         instance = self._words_list_to_instance(words_list)

--- a/allennlp/predictors/semantic_role_labeler.py
+++ b/allennlp/predictors/semantic_role_labeler.py
@@ -41,8 +41,23 @@ class SemanticRoleLabelerPredictor(Predictor):
         -------
         A dictionary representation of the semantic roles in the sentence.
         """
-        return self.predict_json({"sentence" : sentence})
+        return self.predict_json({"sentence": sentence})
 
+    def predict_from_list(self, tokenized_sentence: List[str]) -> JsonDict:
+        """
+        Predicts the semantic roles of the supplied sentence tokens and returns a dictionary
+        with the results.
+
+        Parameters
+        ----------
+        tokenized_sentence, ``List[str]``
+            The sentence tokens to parse via semantic role labeling.
+
+        Returns
+        -------
+        A dictionary representation of the semantic roles in the sentence.
+        """
+        return self.predict_words_list(tokenized_sentence)
 
     @staticmethod
     def make_srl_string(words: List[str], tags: List[str]) -> str:
@@ -71,6 +86,17 @@ class SemanticRoleLabelerPredictor(Predictor):
     def _json_to_instance(self, json_dict: JsonDict):
         raise NotImplementedError("The SRL model uses a different API for creating instances.")
 
+    def tokens_to_instances(self, tokens):
+        words = [token.text for token in tokens]
+        instances: List[Instance] = []
+        for i, word in enumerate(tokens):
+            if word.pos_ == "VERB":
+                verb_labels = [0 for _ in words]
+                verb_labels[i] = 1
+                instance = self._dataset_reader.text_to_instance(tokens, verb_labels)
+                instances.append(instance)
+        return instances
+
     def _sentence_to_srl_instances(self, json_dict: JsonDict) -> List[Instance]:
         """
         The SRL model has a slightly different API from other models, as the model is run
@@ -92,15 +118,7 @@ class SemanticRoleLabelerPredictor(Predictor):
         """
         sentence = json_dict["sentence"]
         tokens = self._tokenizer.split_words(sentence)
-        words = [token.text for token in tokens]
-        instances: List[Instance] = []
-        for i, word in enumerate(tokens):
-            if word.pos_ == "VERB":
-                verb_labels = [0 for _ in words]
-                verb_labels[i] = 1
-                instance = self._dataset_reader.text_to_instance(tokens, verb_labels)
-                instances.append(instance)
-        return instances
+        return self.tokens_to_instances(tokens)
 
     @overrides
     def predict_batch_json(self, inputs: List[JsonDict]) -> List[JsonDict]:
@@ -178,6 +196,21 @@ class SemanticRoleLabelerPredictor(Predictor):
 
         return sanitize(return_dicts)
 
+    def predict_instances(self, instances: List[Instance]) -> JsonDict:
+        outputs = self._model.forward_on_instances(instances)
+
+        results = {"verbs": [], "words": outputs[0]["words"]}
+        for output in outputs:
+            tags = output['tags']
+            description = self.make_srl_string(output["words"], tags)
+            results["verbs"].append({
+                    "verb": output["verb"],
+                    "description": description,
+                    "tags": tags,
+            })
+
+        return sanitize(results)
+
     @overrides
     def predict_json(self, inputs: JsonDict) -> JsonDict:
         """
@@ -198,16 +231,17 @@ class SemanticRoleLabelerPredictor(Predictor):
         if not instances:
             return sanitize({"verbs": [], "words": self._tokenizer.split_words(inputs["sentence"])})
 
-        outputs = self._model.forward_on_instances(instances)
+        return self.predict_instances(instances)
 
-        results = {"verbs": [], "words": outputs[0]["words"]}
-        for output in outputs:
-            tags = output['tags']
-            description = self.make_srl_string(output["words"], tags)
-            results["verbs"].append({
-                    "verb": output["verb"],
-                    "description": description,
-                    "tags": tags,
-            })
+    def predict_words_list(self, words_list: List[str]) -> JsonDict:
+        """
+        Create an instance list of works document, for skipping tokenization when that
+        information already exist for the user
+        """
+        tokens = self._tokenizer.tokens_from_list(words_list)
+        instances = self.tokens_to_instances(tokens)
 
-        return sanitize(results)
+        if not instances:
+            return sanitize({"verbs": [], "words": tokens})
+
+        return self.predict_instances(instances)

--- a/allennlp/tests/predictors/coref_test.py
+++ b/allennlp/tests/predictors/coref_test.py
@@ -18,7 +18,8 @@ class TestCorefPredictor(AllenNlpTestCase):
         document = ['This', 'is', 'a', 'single', 'string',
                     'document', 'about', 'a', 'test', '.', 'Sometimes',
                     'it', 'contains', 'coreferent', 'parts', '.']
-        result_doc_words = predictor.predict_words_list(document)
+
+        result_doc_words = predictor.predict_tokenized(document)
         self.assert_predict_result(result_doc_words)
 
     @staticmethod

--- a/allennlp/tests/predictors/coref_test.py
+++ b/allennlp/tests/predictors/coref_test.py
@@ -13,12 +13,20 @@ class TestCorefPredictor(AllenNlpTestCase):
         predictor = Predictor.from_archive(archive, 'coreference-resolution')
 
         result = predictor.predict_json(inputs)
+        self.assert_predict_result(result)
 
+        document = ['This', 'is', 'a', 'single', 'string',
+                    'document', 'about', 'a', 'test', '.', 'Sometimes',
+                    'it', 'contains', 'coreferent', 'parts', '.']
+        result_doc_words = predictor.predict_words_list(document)
+        self.assert_predict_result(result_doc_words)
+
+    @staticmethod
+    def assert_predict_result(result):
         document = result["document"]
         assert document == ['This', 'is', 'a', 'single', 'string',
                             'document', 'about', 'a', 'test', '.', 'Sometimes',
                             'it', 'contains', 'coreferent', 'parts', '.']
-
         clusters = result["clusters"]
         assert isinstance(clusters, list)
         for cluster in clusters:

--- a/allennlp/tests/predictors/srl_test.py
+++ b/allennlp/tests/predictors/srl_test.py
@@ -19,7 +19,7 @@ class TestSrlPredictor(AllenNlpTestCase):
         words = ["The", "squirrel", "wrote", "a", "unit", "test",
                  "to", "make", "sure", "its", "nuts", "worked", "as", "designed", "."]
 
-        result_words = predictor.predict_words_list(words)
+        result_words = predictor.predict_tokenized(words)
         self.assert_predict_result(result_words)
 
     @staticmethod
@@ -27,6 +27,7 @@ class TestSrlPredictor(AllenNlpTestCase):
         words = result.get("words")
         assert words == ["The", "squirrel", "wrote", "a", "unit", "test",
                          "to", "make", "sure", "its", "nuts", "worked", "as", "designed", "."]
+
         num_words = len(words)
         verbs = result.get("verbs")
         assert verbs is not None

--- a/allennlp/tests/predictors/srl_test.py
+++ b/allennlp/tests/predictors/srl_test.py
@@ -13,21 +13,27 @@ class TestSrlPredictor(AllenNlpTestCase):
         archive = load_archive(self.FIXTURES_ROOT / 'srl' / 'serialization' / 'model.tar.gz')
         predictor = Predictor.from_archive(archive, 'semantic-role-labeling')
 
-        result = predictor.predict_json(inputs)
+        result_json = predictor.predict_json(inputs)
+        self.assert_predict_result(result_json)
 
+        words = ["The", "squirrel", "wrote", "a", "unit", "test",
+                 "to", "make", "sure", "its", "nuts", "worked", "as", "designed", "."]
+
+        result_words = predictor.predict_words_list(words)
+        self.assert_predict_result(result_words)
+
+    @staticmethod
+    def assert_predict_result(result):
         words = result.get("words")
         assert words == ["The", "squirrel", "wrote", "a", "unit", "test",
                          "to", "make", "sure", "its", "nuts", "worked", "as", "designed", "."]
         num_words = len(words)
-
         verbs = result.get("verbs")
         assert verbs is not None
         assert isinstance(verbs, list)
-
         assert any(v["verb"] == "wrote" for v in verbs)
         assert any(v["verb"] == "make" for v in verbs)
         assert any(v["verb"] == "worked" for v in verbs)
-
         for verb in verbs:
             tags = verb.get("tags")
             assert tags is not None


### PR DESCRIPTION
Adding method to support predicting on tokenized input in ``coref.py`` and ``semantic_role_labeler.py`` API methods.

Added methods:
``CorefPredictor.predict_from_list(self, tokenized_document: List[str]) -> JsonDict:``
``SemanticRoleLabelerPredictor.predict_from_list(self, tokenized_sentence: List[str]) -> JsonDict:``

This is very useful when user data is already tokenized (for example annotated corpus for some NLP task) and user would like to predict on that tokenized data without losing the original tokens ID's.. 

Avoid a workflow of: Creating document/sentence text from tokenized data -> input created text to predict method -> predict will tokenize the input text -> align output tokens with original tokens.

Usage code example in:
for coref: ``allennlp/tests/predictors/coref_test.py``, test: ``test_uses_named_inputs``
for srl:  ``allennlp/tests/predictors/srl_test.py``, test: ``test_uses_named_inputs``
