### PR TITLE
Pack batches more tightly with maximum_samples_per_batch.

### DIFF
--- a/allennlp/data/iterators/basic_iterator.py
+++ b/allennlp/data/iterators/basic_iterator.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Iterable
+from typing import Iterable, Deque
 import logging
 import random
 
@@ -24,7 +24,7 @@ class BasicIterator(DataIterator):
             if shuffle:
                 random.shuffle(instance_list)
             iterator = iter(instance_list)
-            excess: deque = deque()
+            excess: Deque[Instance] = deque()
             # Then break each memory-sized list into batches.
             for batch_instances in lazy_groups_of(iterator, self._batch_size):
                 for possibly_smaller_batches in self._ensure_batch_is_sufficiently_small(batch_instances, excess):

--- a/allennlp/data/iterators/basic_iterator.py
+++ b/allennlp/data/iterators/basic_iterator.py
@@ -1,3 +1,4 @@
+from collections import deque
 from typing import Iterable
 import logging
 import random
@@ -23,8 +24,11 @@ class BasicIterator(DataIterator):
             if shuffle:
                 random.shuffle(instance_list)
             iterator = iter(instance_list)
+            excess = deque()
             # Then break each memory-sized list into batches.
             for batch_instances in lazy_groups_of(iterator, self._batch_size):
-                for possibly_smaller_batches in self._ensure_batch_is_sufficiently_small(batch_instances):
+                for possibly_smaller_batches in self._ensure_batch_is_sufficiently_small(batch_instances, excess):
                     batch = Batch(possibly_smaller_batches)
                     yield batch
+            if excess:
+                yield Batch(excess)

--- a/allennlp/data/iterators/basic_iterator.py
+++ b/allennlp/data/iterators/basic_iterator.py
@@ -24,7 +24,7 @@ class BasicIterator(DataIterator):
             if shuffle:
                 random.shuffle(instance_list)
             iterator = iter(instance_list)
-            excess = deque()
+            excess: deque = deque()
             # Then break each memory-sized list into batches.
             for batch_instances in lazy_groups_of(iterator, self._batch_size):
                 for possibly_smaller_batches in self._ensure_batch_is_sufficiently_small(batch_instances, excess):

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -1,7 +1,7 @@
 import logging
 import random
 from collections import deque
-from typing import List, Tuple, Iterable, cast, Dict
+from typing import List, Tuple, Iterable, cast, Dict, Deque
 
 from overrides import overrides
 
@@ -117,7 +117,7 @@ class BucketIterator(DataIterator):
                                             self._padding_noise)
 
             batches = []
-            excess: deque = deque()
+            excess: Deque[Instance] = deque()
             for batch_instances in lazy_groups_of(iter(instance_list), self._batch_size):
                 for possibly_smaller_batches in self._ensure_batch_is_sufficiently_small(batch_instances, excess):
                     batches.append(Batch(possibly_smaller_batches))

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from collections import deque
 from typing import List, Tuple, Iterable, cast, Dict
 
 from overrides import overrides
@@ -116,9 +117,12 @@ class BucketIterator(DataIterator):
                                             self._padding_noise)
 
             batches = []
+            excess = deque()
             for batch_instances in lazy_groups_of(iter(instance_list), self._batch_size):
-                for possibly_smaller_batches in self._ensure_batch_is_sufficiently_small(batch_instances):
+                for possibly_smaller_batches in self._ensure_batch_is_sufficiently_small(batch_instances, excess):
                     batches.append(Batch(possibly_smaller_batches))
+            if excess:
+                batches.append(Batch(excess))
 
             move_to_front = self._biggest_batch_first and len(batches) > 1
             if move_to_front:

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -117,7 +117,7 @@ class BucketIterator(DataIterator):
                                             self._padding_noise)
 
             batches = []
-            excess = deque()
+            excess: deque = deque()
             for batch_instances in lazy_groups_of(iter(instance_list), self._batch_size):
                 for possibly_smaller_batches in self._ensure_batch_is_sufficiently_small(batch_instances, excess):
                     batches.append(Batch(possibly_smaller_batches))

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, Union, Iterable, Iterator, List, Optional, Tuple, Deque
-from collections import defaultdict, deque
+from collections import defaultdict
 import itertools
 import math
 import random

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Union, Iterable, Iterator, List, Optional, Tuple
+from typing import Dict, Union, Iterable, Iterator, List, Optional, Tuple, Deque
 from collections import defaultdict, deque
 import itertools
 import math
@@ -228,17 +228,25 @@ class DataIterator(Registrable):
     def _ensure_batch_is_sufficiently_small(
             self,
             batch_instances: Iterable[Instance],
-            excess: deque) -> List[List[Instance]]:
+            excess: Deque[Instance]) -> List[List[Instance]]:
         """
         If self._maximum_samples_per_batch is specified, then split the batch
         into smaller sub-batches if it exceeds the maximum size.
 
-        Any excess passed in will be used first. When the method returns excess
-        will have been populated with instances from the end of batch_instances
-        that do not consist of more than _maximum_samples_per_batch samples or
-        _batch_size instances. It is the caller's responsibility to output
-        these, which may, of course, be done in part with subsequent calls to
-        this method.
+        Parameters
+        ----------
+        batch_instances : ``Iterable[Instance]``
+            A candidate batch.
+        excess : ``Deque[Instance]``
+            Instances that were not sufficient to form an entire batch
+            previously. They will be used as part of the first sub-batch. This
+            will be populated with instances from the end of batch_instances
+            that do not consist of more than self._maximum_samples_per_batch
+            samples or self._batch_size instances. It is the caller's
+            responsibility to place these in a batch too, which may, of course,
+            be done in part with subsequent calls to this method.
+
+            WARNING: Mutated in place!
         """
         if self._maximum_samples_per_batch is None:
             assert not excess

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -49,10 +49,11 @@ class DataIterator(Registrable):
     track_epoch : ``bool``, optional, (default = False)
         If true, each instance will get a ``MetadataField`` containing the epoch number.
     maximum_samples_per_batch : ``Tuple[str, int]``, (default = None)
-        If specified, then is a tuple (padding_key, limit) and we will
-        shrink the batch size for very long sequences such that
-        batch_size * sequence_length <= limit where sequence_length is given
-        by the padding_key.
+        If specified, then is a tuple (padding_key, limit) and we will ensure
+        that every batch is such that batch_size * sequence_length <= limit
+        where sequence_length is given by the padding_key. This is done by
+        moving excess instances to the next batch (as opposed to dividing a
+        large batch evenly) and should result in a fairly tight packing.
     """
     default_implementation = 'bucket'
 

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -230,13 +230,15 @@ class DataIterator(Registrable):
             batch_instances: Iterable[Instance],
             excess: deque) -> List[List[Instance]]:
         """
-        If self._maximum_samples_per_batch is specified, then split the batch into smaller
-        sub-batches if it exceeds the maximum size.
+        If self._maximum_samples_per_batch is specified, then split the batch
+        into smaller sub-batches if it exceeds the maximum size.
 
-        Any excess passed in will be used first. When the method returns excess will have been populated with instances
-        from the end of batch_instances that do not consist of more than _maximum_samples_per_batch samples or
-        _batch_size instances. It is the caller's responsibility to output these, which may, of course, be done in part
-        with subsequent calls to this method.
+        Any excess passed in will be used first. When the method returns excess
+        will have been populated with instances from the end of batch_instances
+        that do not consist of more than _maximum_samples_per_batch samples or
+        _batch_size instances. It is the caller's responsibility to output
+        these, which may, of course, be done in part with subsequent calls to
+        this method.
         """
         if self._maximum_samples_per_batch is None:
             assert not excess

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -246,8 +246,8 @@ class DataIterator(Registrable):
 
         key, limit = self._maximum_samples_per_batch
 
-        batches = []
-        batch = []
+        batches: List[List[Instance]] = []
+        batch: List[Instance] = []
         padding_length = -1
 
         excess.extend(batch_instances)

--- a/allennlp/tests/data/iterators/basic_iterator_test.py
+++ b/allennlp/tests/data/iterators/basic_iterator_test.py
@@ -57,15 +57,15 @@ class IteratorTest(AllenNlpTestCase):
         sample_sizes = []
         for batch in batches:
             batch_sequence_length = max(
-                [instance.get_padding_lengths()['text']['num_tokens']
-                 for instance in batch.instances]
+                    [instance.get_padding_lengths()['text']['num_tokens']
+                     for instance in batch.instances]
             )
             sample_sizes.append(batch_sequence_length * len(batch.instances))
 
         return {
-            "batch_lengths": group_lengths,
-            "total_instances": sum(group_lengths),
-            "sample_sizes": sample_sizes
+                "batch_lengths": group_lengths,
+                "total_instances": sum(group_lengths),
+                "sample_sizes": sample_sizes
         }
 
     def assert_instances_are_correct(self, candidate_instances):
@@ -259,11 +259,12 @@ class TestBasicIterator(IteratorTest):
             assert stats['sample_sizes'] == [8, 3, 9, 1]
 
     def test_maximum_samples_per_batch_packs_tightly(self):
+        # pylint: disable=protected-access
         token_counts = [10, 4, 3]
         test_instances = self.create_instances_from_token_counts(token_counts)
 
         iterator = BasicIterator(
-            batch_size=3, maximum_samples_per_batch=['num_tokens', 11]
+                batch_size=3, maximum_samples_per_batch=['num_tokens', 11]
         )
         iterator.index_with(self.vocab)
         batches = list(iterator._create_batches(test_instances, shuffle=False))

--- a/allennlp/tests/data/iterators/bucket_iterator_test.py
+++ b/allennlp/tests/data/iterators/bucket_iterator_test.py
@@ -78,7 +78,8 @@ class TestBucketIterator(IteratorTest):
 
     def test_bucket_iterator_maximum_samples_per_batch(self):
         iterator = BucketIterator(
-                batch_size=3, padding_noise=0,
+                batch_size=3,
+                padding_noise=0,
                 sorting_keys=[('text', 'num_tokens')],
                 maximum_samples_per_batch=['num_tokens', 9]
         )
@@ -100,9 +101,10 @@ class TestBucketIterator(IteratorTest):
         test_instances = self.create_instances_from_token_counts(token_counts)
 
         iterator = BucketIterator(
-            batch_size=3, padding_noise=0,
-            sorting_keys=[('text', 'num_tokens')],
-            maximum_samples_per_batch=['num_tokens', 11]
+                batch_size=3,
+                padding_noise=0,
+                sorting_keys=[('text', 'num_tokens')],
+                maximum_samples_per_batch=['num_tokens', 11]
         )
         iterator.index_with(self.vocab)
         batches = list(iterator._create_batches(test_instances, shuffle=False))

--- a/allennlp/tests/data/iterators/bucket_iterator_test.py
+++ b/allennlp/tests/data/iterators/bucket_iterator_test.py
@@ -84,16 +84,35 @@ class TestBucketIterator(IteratorTest):
         )
         iterator.index_with(self.vocab)
         batches = list(iterator._create_batches(self.instances, shuffle=False))
+        stats = self.get_batches_stats(batches)
 
         # ensure all instances are in a batch
-        grouped_instances = [batch.instances for batch in batches]
-        num_instances = sum(len(group) for group in grouped_instances)
-        assert num_instances == len(self.instances)
+        assert stats['total_instances'] == len(self.instances)
 
-        # ensure all batches are sufficiently small
-        for batch in batches:
-            batch_sequence_length = max(
-                    [instance.get_padding_lengths()['text']['num_tokens']
-                     for instance in batch.instances]
-            )
-            assert batch_sequence_length * len(batch.instances) <= 9
+        # ensure correct batch sizes
+        assert stats['batch_lengths'] == [2, 2, 1]
+
+        # ensure correct sample sizes (<= 9)
+        assert stats['sample_sizes'] == [6, 8, 9]
+
+    def test_maximum_samples_per_batch_packs_tightly(self):
+        token_counts = [10, 4, 3]
+        test_instances = self.create_instances_from_token_counts(token_counts)
+
+        iterator = BucketIterator(
+            batch_size=3, padding_noise=0,
+            sorting_keys=[('text', 'num_tokens')],
+            maximum_samples_per_batch=['num_tokens', 11]
+        )
+        iterator.index_with(self.vocab)
+        batches = list(iterator._create_batches(test_instances, shuffle=False))
+        stats = self.get_batches_stats(batches)
+
+        # ensure all instances are in a batch
+        assert stats['total_instances'] == len(test_instances)
+
+        # ensure correct batch sizes
+        assert stats['batch_lengths'] == [2, 1]
+
+        # ensure correct sample sizes (<= 11)
+        assert stats['sample_sizes'] == [8, 10]


### PR DESCRIPTION
- Previously when maximum_samples_per_batch was used overly large batches would be split into equal sizes.
- This could lead to a certain degree of fragmentation.
- This change packs batches until just before maximum_samples_per_batch (or batch_size) is exceeded.