### PR TITLE
Remove the BasicTextFieldEmbedder warning

### DIFF
--- a/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
@@ -1,5 +1,4 @@
 from typing import Dict, List
-import warnings
 
 import torch
 from overrides import overrides

--- a/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
@@ -118,10 +118,25 @@ class BasicTextFieldEmbedder(TextFieldEmbedder):
             }
 
         else:
-            # Warn that the original behavior is deprecated
-            warnings.warn(DeprecationWarning("the token embedders for BasicTextFieldEmbedder should now "
-                                             "be specified as a dict under the 'token_embedders' key, "
-                                             "not as top-level key-value pairs"))
+            # While we would like to discourage the original behavior, we don't have a deprecation
+            # warning because we still follow it throughout our test fixtures and full models.
+            #
+            # The token embedders for BasicTextFieldEmbedder should now be specified as a dict
+            # under the 'token_embedders' key.  For example, instead of:
+            #
+            #     "tokens": {
+            #         "type": "embedding",
+            #         "embedding_dim": 50
+            #     }
+            #
+            # You should have:
+            #
+            #     "token_embedders": {
+            #         "tokens": {
+            #             "type": "embedding",
+            #             "embedding_dim": 50
+            #         }
+            #     }
 
             token_embedders = {}
             keys = list(params.keys())

--- a/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+import warnings
 
 import torch
 from overrides import overrides
@@ -117,25 +118,10 @@ class BasicTextFieldEmbedder(TextFieldEmbedder):
             }
 
         else:
-            # While we would like to discourage the original behavior, we don't have a deprecation
-            # warning because we still follow it throughout our test fixtures and full models.
-            #
-            # The token embedders for BasicTextFieldEmbedder should now be specified as a dict
-            # under the 'token_embedders' key.  For example, instead of:
-            #
-            #     "tokens": {
-            #         "type": "embedding",
-            #         "embedding_dim": 50
-            #     }
-            #
-            # You should have:
-            #
-            #     "token_embedders": {
-            #         "tokens": {
-            #             "type": "embedding",
-            #             "embedding_dim": 50
-            #         }
-            #     }
+            # Warn that the original behavior is deprecated
+            warnings.warn(DeprecationWarning("the token embedders for BasicTextFieldEmbedder should now "
+                                             "be specified as a dict under the 'token_embedders' key, "
+                                             "not as top-level key-value pairs"))
 
             token_embedders = {}
             keys = list(params.keys())

--- a/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
+++ b/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
@@ -108,7 +108,27 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
                 }
         token_embedder(inputs)
 
-    def test_new_from_params(self):
+    def test_old_from_params_new_from_params(self):
+        old_params = Params({
+                "token_embedders": {
+                        "words1": {
+                                "type": "embedding",
+                                "embedding_dim": 2
+                                },
+                        "words2": {
+                                "type": "embedding",
+                                "embedding_dim": 5
+                                },
+                        "words3": {
+                                "type": "embedding",
+                                "embedding_dim": 3
+                                }
+                        }
+                })
+
+        # Allow loading the parameters in the old format
+        old_embedder = BasicTextFieldEmbedder.from_params(params=old_params, vocab=self.vocab)
+
         new_params = Params({
                 "token_embedders": {
                         "words1": {
@@ -126,5 +146,8 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
                         }
                 })
 
-        token_embedder = BasicTextFieldEmbedder.from_params(params=new_params, vocab=self.vocab)
-        assert token_embedder(self.inputs).size() == (1, 4, 10)
+        # But also allow loading the parameters in the new format
+        new_embedder = BasicTextFieldEmbedder.from_params(params=new_params, vocab=self.vocab)
+        assert old_embedder._token_embedders.keys() == new_embedder._token_embedders.keys()
+
+        assert new_embedder(self.inputs).size() == (1, 4, 10)

--- a/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
+++ b/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
@@ -18,17 +18,19 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
         self.vocab.add_token_to_namespace("3")
         self.vocab.add_token_to_namespace("4")
         params = Params({
-                "words1": {
-                        "type": "embedding",
-                        "embedding_dim": 2
-                        },
-                "words2": {
-                        "type": "embedding",
-                        "embedding_dim": 5
-                        },
-                "words3": {
-                        "type": "embedding",
-                        "embedding_dim": 3
+                "token_embedders": {
+                        "words1": {
+                                "type": "embedding",
+                                "embedding_dim": 2
+                                },
+                        "words2": {
+                                "type": "embedding",
+                                "embedding_dim": 5
+                                },
+                        "words3": {
+                                "type": "embedding",
+                                "embedding_dim": 3
+                                }
                         }
                 })
         self.token_embedder = BasicTextFieldEmbedder.from_params(vocab=self.vocab, params=params)
@@ -54,23 +56,25 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
 
     def test_forward_works_on_higher_order_input(self):
         params = Params({
-                "words": {
-                        "type": "embedding",
-                        "num_embeddings": 20,
-                        "embedding_dim": 2,
-                        },
-                "characters": {
-                        "type": "character_encoding",
-                        "embedding": {
-                                "embedding_dim": 4,
-                                "num_embeddings": 15,
+                "token_embedders": {
+                        "words": {
+                                "type": "embedding",
+                                "num_embeddings": 20,
+                                "embedding_dim": 2,
                                 },
-                        "encoder": {
-                                "type": "cnn",
-                                "embedding_dim": 4,
-                                "num_filters": 10,
-                                "ngram_filter_sizes": [3],
-                                },
+                        "characters": {
+                                "type": "character_encoding",
+                                "embedding": {
+                                        "embedding_dim": 4,
+                                        "num_embeddings": 15,
+                                        },
+                                "encoder": {
+                                        "type": "cnn",
+                                        "embedding_dim": 4,
+                                        "num_filters": 10,
+                                        "ngram_filter_sizes": [3],
+                                        },
+                                }
                         }
                 })
         token_embedder = BasicTextFieldEmbedder.from_params(vocab=self.vocab, params=params)
@@ -85,17 +89,19 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
         options_file = str(elmo_fixtures_path / 'options.json')
         weight_file = str(elmo_fixtures_path / 'lm_weights.hdf5')
         params = Params({
-                "words": {
-                        "type": "embedding",
-                        "num_embeddings": 20,
-                        "embedding_dim": 2,
-                        },
-                "elmo": {
-                        "type": "elmo_token_embedder",
-                        "options_file": options_file,
-                        "weight_file": weight_file
-                        },
-                "embedder_to_indexer_map": {"words": ["words"], "elmo": ["elmo", "words"]}
+                "token_embedders": {
+                        "words": {
+                                "type": "embedding",
+                                "num_embeddings": 20,
+                                "embedding_dim": 2,
+                                },
+                        "elmo": {
+                                "type": "elmo_token_embedder",
+                                "options_file": options_file,
+                                "weight_file": weight_file
+                                },
+                        "embedder_to_indexer_map": {"words": ["words"], "elmo": ["elmo", "words"]}
+                        }
                 })
         token_embedder = BasicTextFieldEmbedder.from_params(self.vocab, params)
         inputs = {
@@ -107,17 +113,19 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
     def test_old_from_params_new_from_params(self):
 
         old_params = Params({
-                "words1": {
-                        "type": "embedding",
-                        "embedding_dim": 2
-                        },
-                "words2": {
-                        "type": "embedding",
-                        "embedding_dim": 5
-                        },
-                "words3": {
-                        "type": "embedding",
-                        "embedding_dim": 3
+                "token_embedders": {
+                        "words1": {
+                                "type": "embedding",
+                                "embedding_dim": 2
+                                },
+                        "words2": {
+                                "type": "embedding",
+                                "embedding_dim": 5
+                                },
+                        "words3": {
+                                "type": "embedding",
+                                "embedding_dim": 3
+                                }
                         }
                 })
 

--- a/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
+++ b/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
@@ -89,19 +89,17 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
         options_file = str(elmo_fixtures_path / 'options.json')
         weight_file = str(elmo_fixtures_path / 'lm_weights.hdf5')
         params = Params({
-                "token_embedders": {
-                        "words": {
-                                "type": "embedding",
-                                "num_embeddings": 20,
-                                "embedding_dim": 2,
-                                },
-                        "elmo": {
-                                "type": "elmo_token_embedder",
-                                "options_file": options_file,
-                                "weight_file": weight_file
-                                },
-                        "embedder_to_indexer_map": {"words": ["words"], "elmo": ["elmo", "words"]}
-                        }
+                "words": {
+                        "type": "embedding",
+                        "num_embeddings": 20,
+                        "embedding_dim": 2,
+                        },
+                "elmo": {
+                        "type": "elmo_token_embedder",
+                        "options_file": options_file,
+                        "weight_file": weight_file
+                        },
+                "embedder_to_indexer_map": {"words": ["words"], "elmo": ["elmo", "words"]}
                 })
         token_embedder = BasicTextFieldEmbedder.from_params(self.vocab, params)
         inputs = {
@@ -110,28 +108,7 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
                 }
         token_embedder(inputs)
 
-    def test_old_from_params_new_from_params(self):
-
-        old_params = Params({
-                "token_embedders": {
-                        "words1": {
-                                "type": "embedding",
-                                "embedding_dim": 2
-                                },
-                        "words2": {
-                                "type": "embedding",
-                                "embedding_dim": 5
-                                },
-                        "words3": {
-                                "type": "embedding",
-                                "embedding_dim": 3
-                                }
-                        }
-                })
-
-        with pytest.warns(DeprecationWarning):
-            BasicTextFieldEmbedder.from_params(params=old_params, vocab=self.vocab)
-
+    def test_new_from_params(self):
         new_params = Params({
                 "token_embedders": {
                         "words1": {

--- a/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
+++ b/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
@@ -110,24 +110,23 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
 
     def test_old_from_params_new_from_params(self):
         old_params = Params({
-                "token_embedders": {
-                        "words1": {
-                                "type": "embedding",
-                                "embedding_dim": 2
-                                },
-                        "words2": {
-                                "type": "embedding",
-                                "embedding_dim": 5
-                                },
-                        "words3": {
-                                "type": "embedding",
-                                "embedding_dim": 3
-                                }
-                        }
+                    "words1": {
+                            "type": "embedding",
+                            "embedding_dim": 2
+                            },
+                    "words2": {
+                            "type": "embedding",
+                            "embedding_dim": 5
+                            },
+                    "words3": {
+                            "type": "embedding",
+                            "embedding_dim": 3
+                            }
                 })
 
         # Allow loading the parameters in the old format
-        old_embedder = BasicTextFieldEmbedder.from_params(params=old_params, vocab=self.vocab)
+        with pytest.warns(DeprecationWarning):
+            old_embedder = BasicTextFieldEmbedder.from_params(params=old_params, vocab=self.vocab)
 
         new_params = Params({
                 "token_embedders": {

--- a/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
+++ b/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
@@ -148,6 +148,6 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
 
         # But also allow loading the parameters in the new format
         new_embedder = BasicTextFieldEmbedder.from_params(params=new_params, vocab=self.vocab)
-        assert old_embedder._token_embedders.keys() == new_embedder._token_embedders.keys()
+        assert old_embedder._token_embedders.keys() == new_embedder._token_embedders.keys() #pylint: disable=protected-access
 
         assert new_embedder(self.inputs).size() == (1, 4, 10)

--- a/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
+++ b/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
@@ -110,18 +110,18 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
 
     def test_old_from_params_new_from_params(self):
         old_params = Params({
-                    "words1": {
-                            "type": "embedding",
-                            "embedding_dim": 2
-                            },
-                    "words2": {
-                            "type": "embedding",
-                            "embedding_dim": 5
-                            },
-                    "words3": {
-                            "type": "embedding",
-                            "embedding_dim": 3
-                            }
+                "words1": {
+                        "type": "embedding",
+                        "embedding_dim": 2
+                        },
+                "words2": {
+                        "type": "embedding",
+                        "embedding_dim": 5
+                        },
+                "words3": {
+                        "type": "embedding",
+                        "embedding_dim": 3
+                        }
                 })
 
         # Allow loading the parameters in the old format

--- a/allennlp/tests/training/optimizer_test.py
+++ b/allennlp/tests/training/optimizer_test.py
@@ -16,9 +16,11 @@ class TestOptimizer(AllenNlpTestCase):
         vocab = Vocabulary.from_instances(self.instances)
         self.model_params = Params({
                 "text_field_embedder": {
-                        "tokens": {
-                                "type": "embedding",
-                                "embedding_dim": 5
+                        "token_embedders": {
+                                "tokens": {
+                                        "type": "embedding",
+                                        "embedding_dim": 5
+                                        }
                                 }
                         },
                 "encoder": {

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -29,9 +29,11 @@ class TestTrainer(AllenNlpTestCase):
         self.vocab = vocab
         self.model_params = Params({
                 "text_field_embedder": {
-                        "tokens": {
-                                "type": "embedding",
-                                "embedding_dim": 5
+                        "token_embedders": {
+                                "tokens": {
+                                        "type": "embedding",
+                                        "embedding_dim": 5
+                                        }
                                 }
                         },
                 "encoder": {


### PR DESCRIPTION
While we would like to discourage the original behavior, we would like to remove the deprecation warning because we still follow it throughout our test fixtures and full models.  We can formally deprecate this behavior when AllenNLP gets off it.