### PR TITLE
more informative message for BasicTextFieldEmbedder mismatched keys

### DIFF
--- a/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
@@ -73,9 +73,13 @@ class BasicTextFieldEmbedder(TextFieldEmbedder):
                 # token embedder keys are a strict subset of text field input keys.
                 message = (f"Your text field is generating more keys ({list(input_keys)}) "
                            f"than you have token embedders ({list(embedder_keys)}. "
-                           f"Most likely you need to add allow_unmatched_keys = True "
-                           f"(and possibly an embedder_to_indexer_map) to your "
-                           f"BasicTextFieldEmbedder configuration")
+                           f"If you are using a token embedder that requires multiple keys "
+                           f"(for example, the OpenAI Transformer embedder or the BERT embedder) "
+                           f"you need to add allow_unmatched_keys = True "
+                           f"(and likely an embedder_to_indexer_map) to your "
+                           f"BasicTextFieldEmbedder configuration. "
+                           f"Otherwise, you should check that there is a 1:1 embedding "
+                           f"between your token indexers and token embedders.")
                 raise ConfigurationError(message)
 
             elif self._token_embedders.keys() != text_field_input.keys():

--- a/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
+++ b/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
@@ -44,12 +44,22 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
         assert self.token_embedder.get_output_dim() == 10
 
     def test_forward_asserts_input_field_match(self):
+        # Total mismatch
         self.inputs['words4'] = self.inputs['words3']
         del self.inputs['words3']
-        with pytest.raises(ConfigurationError):
+        with pytest.raises(ConfigurationError) as exc:
             self.token_embedder(self.inputs)
+        assert exc.match("Mismatched token keys")
+
         self.inputs['words3'] = self.inputs['words4']
+
+        # Text field has too many inputs
+        with pytest.raises(ConfigurationError) as exc:
+            self.token_embedder(self.inputs)
+        assert exc.match("is generating more keys")
+
         del self.inputs['words4']
+
 
     def test_forward_concats_resultant_embeddings(self):
         assert self.token_embedder(self.inputs).size() == (1, 4, 10)


### PR DESCRIPTION
with BERT + ELMo + OpenAI embedders this becomes a very easy mistake to make, so I changed it to give a more informative error message in the case where the input has too many keys, and left the same error message in the case where there's a total mismatch