### PR TITLE
allow "longest-sequences" to be zero-padded

### DIFF
--- a/allennlp/modules/lstm_cell_with_projection.py
+++ b/allennlp/modules/lstm_cell_with_projection.py
@@ -120,7 +120,7 @@ class LstmCellWithProjection(torch.nn.Module):
             ``memory`` has shape (1, batch_size, cell_size).
         """
         batch_size = inputs.size()[0]
-        total_timesteps = inputs.size()[1]
+        total_timesteps = batch_lengths.max()
 
         output_accumulator = inputs.new_zeros(batch_size, total_timesteps, self.hidden_size)
 


### PR DESCRIPTION
Up to now, `total_timesteps` is defined as the size of the second dimension (time-dimension). This makes sense as long as the longest sequence has exactly the same size. In most cases this is a valid assumption, but it does not allow shorter "longest-sequences". For example, if a single batch only contains shorter messages, one would have to use some functionality (e.g., `narrow`) to reduce the of the tensor's dimensionality. However, it would be easier to just use `batch_lenghts.max()` instead of `inputs.size()[1]`. In consequence, this patch allows batches where the longest sequences are shorter than the dimension of the tensor. This is maybe not ideal from an computational perspective, but more user-friendly and comes without computational burden if the longest sequence uses the whole space.