### PR TITLE
Flattening parameters for module in encoder_base.py

### DIFF
--- a/allennlp/modules/encoder_base.py
+++ b/allennlp/modules/encoder_base.py
@@ -112,6 +112,8 @@ class _EncoderBase(torch.nn.Module):
         else:
             initial_states = self._get_initial_states(batch_size, num_valid, sorting_indices)
 
+        # Recommended by PyTorch to save memory.
+        module.flatten_parameters()
         # Actually call the module on the sorted PackedSequence.
         module_output, final_states = module(packed_sequence_input, initial_states)
 


### PR DESCRIPTION
Adding in a line to avoid the PyTorch user warning and make this slightly more memory efficient:
```UserWarning: RNN module weights are not part of single contiguous chunk of memory. This means they need to be compacted at every call, possibly greately increasing memory usage. To compact weights again call flatten_parameters().```