### PR TITLE
LM dataset_reader fix

### DIFF
--- a/allennlp/tests/data/dataset_readers/language_modeling_dataset_test.py
+++ b/allennlp/tests/data/dataset_readers/language_modeling_dataset_test.py
@@ -15,17 +15,17 @@ class TestLanguageModelingDatasetReader:
         # in here, anyway.
         assert len(instances) == 5
 
-        assert [t.text for t in instances[0].fields["input_tokens"].tokens] == ["This", "is", "a"]
-        assert [t.text for t in instances[0].fields["output_tokens"].tokens] == ["is", "a", "sentence"]
+        assert [t.text for t in instances[0].fields["source_tokens"].tokens] == ["This", "is", "a"]
+        assert [t.text for t in instances[0].fields["target_tokens"].tokens] == ["is", "a", "sentence"]
 
-        assert [t.text for t in instances[1].fields["input_tokens"].tokens] == ["sentence", "for", "language"]
-        assert [t.text for t in instances[1].fields["output_tokens"].tokens] == ["for", "language", "modelling"]
+        assert [t.text for t in instances[1].fields["source_tokens"].tokens] == ["sentence", "for", "language"]
+        assert [t.text for t in instances[1].fields["target_tokens"].tokens] == ["for", "language", "modelling"]
 
-        assert [t.text for t in instances[2].fields["input_tokens"].tokens] == ["modelling", ".", "Here"]
-        assert [t.text for t in instances[2].fields["output_tokens"].tokens] == [".", "Here", "'s"]
+        assert [t.text for t in instances[2].fields["source_tokens"].tokens] == ["modelling", ".", "Here"]
+        assert [t.text for t in instances[2].fields["target_tokens"].tokens] == [".", "Here", "'s"]
 
-        assert [t.text for t in instances[3].fields["input_tokens"].tokens] == ["'s", "another", "one"]
-        assert [t.text for t in instances[3].fields["output_tokens"].tokens] == ["another", "one", "for"]
+        assert [t.text for t in instances[3].fields["source_tokens"].tokens] == ["'s", "another", "one"]
+        assert [t.text for t in instances[3].fields["target_tokens"].tokens] == ["another", "one", "for"]
 
-        assert [t.text for t in instances[4].fields["input_tokens"].tokens] == ["for", "extra", "language"]
-        assert [t.text for t in instances[4].fields["output_tokens"].tokens] == ["extra", "language", "modelling"]
+        assert [t.text for t in instances[4].fields["source_tokens"].tokens] == ["for", "extra", "language"]
+        assert [t.text for t in instances[4].fields["target_tokens"].tokens] == ["extra", "language", "modelling"]


### PR DESCRIPTION
[FIX] seq2seq models (simple_seq2seq.py) expect `source_tokens` and `target_tokens` naming, LM dataset readers are not aligned (passing input/output tokens)