### PR TITLE
Made bz2 an optional dependency

### DIFF
--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -428,7 +428,7 @@ class EmbeddingsTextFile(Iterator[str]):
             extension = get_file_extension(main_file_uri)
             
             if ".bz2" in extension:
-	            import bz2 # import only when necessary
+	            import bz2  # import only when necessary
             
             package = {
                     '.txt': io,


### PR DESCRIPTION
bz2 was a **hard dependency** and it was throwing a "ModuleNotFoundError: No module named '_bz2'." error for me.  

I made it an optional dependency by moving the import to **function level** and made sure the dependency is **only imported when needed** by checking the file extension.

This fixes #2178 