### PR TITLE
Clean up temporary archive directory at exit

### DIFF
--- a/allennlp/tests/models/archival_test.py
+++ b/allennlp/tests/models/archival_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=invalid-name
 import copy
+import os
 
 import torch
 
@@ -92,6 +93,10 @@ class ArchivalTest(AllenNlpTestCase):
         # The param in the data should have been replaced with a temporary path
         # (which we don't know, but we know what it ends with).
         assert params.get('train_data_path').endswith('/fta/train_data_path')
+
+        # The temporary path should be accessible even after the load_archive
+        # function returns.
+        assert os.path.exists(params.get('train_data_path'))
 
         # The validation data path should be the same though.
         assert params.get('validation_data_path') == str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv')


### PR DESCRIPTION
Fixes the issue described in #2180 using the `atexit` hook proposed by @joelgrus.

Please let me know if there are any changes you'd like to see made and I'd be happy to make them.