### PR TITLE
Failing test case for multi-GPU ProductionRuleField

### DIFF
--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -17,7 +17,8 @@ from allennlp.data import Vocabulary
 from allennlp.common.params import Params
 from allennlp.models.simple_tagger import SimpleTagger
 from allennlp.data.iterators import BasicIterator
-from allennlp.data.dataset_readers import SequenceTaggingDatasetReader
+from allennlp.data.dataset_readers import SequenceTaggingDatasetReader, WikiTablesDatasetReader
+from allennlp.models.archival import load_archive
 from allennlp.models.model import Model
 
 
@@ -96,6 +97,11 @@ class TestTrainer(AllenNlpTestCase):
     @pytest.mark.skipif(torch.cuda.device_count() < 2,
                         reason="Need multiple GPUs.")
     def test_trainer_can_run_multiple_gpu(self):
+        wikitables_dir = 'allennlp/tests/fixtures/data/wikitables/'
+        wikitables_reader = WikiTablesDatasetReader(tables_directory=wikitables_dir,
+                                                    dpd_output_directory=wikitables_dir + 'dpd_output/')
+        wikitables_instances = wikitables_reader.read(self.FIXTURES_ROOT / 'data' / 'wikitables' /
+                                                      'sample_data.examples')
 
         class MetaDataCheckWrapper(Model):
             """
@@ -128,6 +134,21 @@ class TestTrainer(AllenNlpTestCase):
         assert isinstance(metrics['peak_gpu_0_memory_MB'], float)
         assert 'peak_gpu_1_memory_MB' in metrics
         assert isinstance(metrics['peak_gpu_1_memory_MB'], float)
+
+    @pytest.mark.skipif(torch.cuda.device_count() < 2,
+                        reason="Need multiple GPUs.")
+    def test_production_rule_field_with_multiple_gpus(self):
+        wikitables_dir = 'allennlp/tests/fixtures/data/wikitables/'
+        wikitables_reader = WikiTablesDatasetReader(tables_directory=wikitables_dir,
+                                                    dpd_output_directory=wikitables_dir + 'dpd_output/')
+        instances = wikitables_reader.read(wikitables_dir + 'sample_data.examples')
+        archive_path = self.FIXTURES_ROOT / 'semantic_parsing' / 'wikitables' / 'serialization' / 'model.tar.gz'
+        model = load_archive(archive_path).model
+
+        multigpu_iterator = BasicIterator(batch_size=4)
+        multigpu_iterator.index_with(model.vocab)
+        trainer = Trainer(model, self.optimizer, multigpu_iterator, instances, num_epochs=2, cuda_device=[0, 1])
+        metrics = trainer.train()
 
     def test_trainer_can_resume_training(self):
         trainer = Trainer(self.model, self.optimizer,


### PR DESCRIPTION
#1944 was supposed to handle complex scattering, but it doesn't work for the `ProductionRuleField`, as brought up in #2057.  I have reproduced this and made a failing test case, which is in this PR.

I'm afraid I'm not going to be able to actually fix the underlying problem, though, as I don't really understand the voodoo that @brendan-ai2 did to convert tensors to pointers and back, and why it doesn't work in this case.  The issue is that the `ProductionRuleField` produces a list of [`ProductionRules`](https://github.com/allenai/allennlp/blob/0663762960a4522d4740eea460f63a06eeba126d/allennlp/data/fields/production_rule_field.py#L10-L14), with tensors internal to the data structure that don't get sent to GPUs - they all remain on the CPU. 