### PR TITLE
WIP / experimental: expose model internals to predictor

### DIFF
--- a/allennlp/common/introspection.py
+++ b/allennlp/common/introspection.py
@@ -1,0 +1,29 @@
+import inspect
+from functools import wraps
+
+_FLAGS = {'STORE_FUNCTION_RESULTS': False}
+
+def store_function_results(flag: bool) -> None:
+    _FLAGS['STORE_FUNCTION_RESULTS'] = flag
+
+def store_result(func):
+    @wraps(func)
+    def inner(*args, **kwargs):
+        result = func(*args, **kwargs)
+
+        if _FLAGS['STORE_FUNCTION_RESULTS']:
+            # Import here to avoid circularity
+            from allennlp.models.model import Model
+
+            stack = inspect.stack()
+
+            calling_module = stack[1].frame.f_locals['self']
+
+            if isinstance(calling_module, Model):
+                secret_functions = getattr(calling_module, '_stored_function_results', [])
+                secret_functions.append([func.__name__, result])
+                setattr(calling_module, '_stored_function_results', secret_functions)
+
+        return result
+
+    return inner

--- a/allennlp/common/introspection.py
+++ b/allennlp/common/introspection.py
@@ -1,11 +1,15 @@
 import inspect
 from functools import wraps
 
+# A global flag that indicates whether function results
+# should be stored as part of the containing model.
 _FLAGS = {'STORE_FUNCTION_RESULTS': False}
 
+# Helper function to update the flag
 def store_function_results(flag: bool) -> None:
     _FLAGS['STORE_FUNCTION_RESULTS'] = flag
 
+# Decorator for storing function results with the containing model.
 def store_result(func):
     @wraps(func)
     def inner(*args, **kwargs):

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -12,6 +12,7 @@ import warnings
 import torch
 
 from allennlp.common.checks import ConfigurationError
+from allennlp.common.introspection import store_result
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -213,7 +214,7 @@ def get_dropout_mask(dropout_probability: float, tensor_for_masking: torch.Tenso
     dropout_mask = binary_mask.float().div(1.0 - dropout_probability)
     return dropout_mask
 
-
+@store_result
 def masked_softmax(vector: torch.Tensor, mask: torch.Tensor, dim: int = -1) -> torch.Tensor:
     """
     ``torch.nn.functional.softmax(vector)`` does not work if some elements of ``vector`` should be

--- a/allennlp/predictors/predictor.py
+++ b/allennlp/predictors/predictor.py
@@ -41,10 +41,6 @@ class Predictor(Registrable):
         self._dataset_reader = dataset_reader
         self._return_model_internals = return_model_internals
 
-        if return_model_internals:
-            # Set global flag
-            store_function_results(True)
-
     def load_line(self, line: str) -> JsonDict:  # pylint: disable=no-self-use
         """
         If your inputs are not in JSON-lines format (e.g. you have a CSV)
@@ -68,6 +64,8 @@ class Predictor(Registrable):
         hooks = []
 
         if self._return_model_internals:
+            store_function_results(True)
+
             def add_output(idx: int):
                 def _add_output(mod, _, outputs):
                     model_internals[idx] = {"name": str(mod), "output": outputs}
@@ -86,6 +84,7 @@ class Predictor(Registrable):
             if internal_function_results:
                 outputs['_internal_function_results'] = internal_function_results[:]
             internal_function_results.clear()
+            store_function_results(False)
 
         # Remove hooks
         for hook in hooks:

--- a/allennlp/tests/predictors/bidaf_test.py
+++ b/allennlp/tests/predictors/bidaf_test.py
@@ -37,7 +37,6 @@ class TestBidafPredictor(AllenNlpTestCase):
             assert sum(probs) == approx(1.0)
 
     def test_model_internals(self):
-        store_function_results(True)
         archive = load_archive(self.FIXTURES_ROOT / 'bidaf' / 'serialization' / 'model.tar.gz')
         predictor = Predictor.from_archive(archive, 'machine-comprehension', return_model_internals=True)
 
@@ -58,8 +57,6 @@ class TestBidafPredictor(AllenNlpTestCase):
 
         ifr = result.get('_internal_function_results')
         assert any(name == 'masked_softmax' for name, value in ifr)
-
-        store_function_results(False)
 
     def test_batch_prediction(self):
         inputs = [


### PR DESCRIPTION
**this is a proof of concept, not a proposed design**

basically, any predictor can now take a third argument `return_model_internals`. If you specify true, two things happen in `forward_on_instance`:

(1) as a pytorch module, the `Model` knows all of its submodules, so we register a forward hook for each of them that sticks its output in a dict owned by the predictor. that means when the model runs forward, the predictor gets all of the intermediate model results for free. after the single prediction, the hooks all get deleted.

(2) a fair amount of stuff that happens internal to models is not done by pytorch modules but by functions. insofar as we own the functions, we can add a `store_results` decorator to them that

* checks a global flag indicating that we want to save these results
* if so, when the function is called it checks whether it is being called by an allennlp.Model
* if that's the case, it appends its result to a private accumulator on the model instance
* the predictor can then collect those results, add them to its output, and clear the accumulator

(I know this is really ugly)

(3) this still doesn't solve the problem of getting the results of other people's functions (in particular, of functions in torch.nn.functional). So far I don't have a great solution for this, other than to explicitly apply the store_results decorator (which is a no-op when the global store_results flag is not set).

```
probs = store_results(torch.nn.functional.log_softmax)(
                torch.matmul(embeddings, self.softmax_w) + self.softmax_b,
                dim=-1
        )
```

but that's ugly and requires changing model code