### PR TITLE
Corrected documentation

### DIFF
--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -56,20 +56,20 @@ class Elmo(torch.nn.Module):
         The number of ELMo representation layers to output.
     requires_grad: ``bool``, optional
         If True, compute gradient of ELMo parameters for fine tuning.
-    do_layer_norm : ``bool``, optional, (default=False).
+    do_layer_norm : ``bool``, optional, (default = False).
         Should we apply layer normalization (passed to ``ScalarMix``)?
     dropout : ``float``, optional, (default = 0.5).
         The dropout to be applied to the ELMo representations.
-    vocab_to_cache : ``List[str]``, optional, (default = 0.5).
+    vocab_to_cache : ``List[str]``, optional, (default = None).
         A list of words to pre-compute and cache character convolutions
         for. If you use this option, Elmo expects that you pass word
         indices of shape (batch_size, timesteps) to forward, instead
         of character indices. If you use this option and pass a word which
         wasn't pre-cached, this will break.
-    keep_sentence_boundaries : ``bool``, optional, (default=False)
+    keep_sentence_boundaries : ``bool``, optional, (default = False)
         If True, the representation of the sentence boundary tokens are
         not removed.
-    scalar_mix_parameters : ``List[int]``, optional, (default=None)
+    scalar_mix_parameters : ``List[int]``, optional, (default = None)
         If not ``None``, use these scalar mix parameters to weight the representations
         produced by different layers. These mixing weights are not updated during
         training.
@@ -274,7 +274,7 @@ class _ElmoCharacterEncoder(torch.nn.Module):
         ELMo JSON options file
     weight_file : ``str``
         ELMo hdf5 weight file
-    requires_grad: ``bool``, optional
+    requires_grad: ``bool``, optional, (default = False).
         If True, compute gradient of ELMo parameters for fine tuning.
 
     The relevant section of the options file is something like:
@@ -503,9 +503,9 @@ class _ElmoBiLm(torch.nn.Module):
         ELMo JSON options file
     weight_file : ``str``
         ELMo hdf5 weight file
-    requires_grad: ``bool``, optional
+    requires_grad: ``bool``, optional, (default = False).
         If True, compute gradient of ELMo parameters for fine tuning.
-    vocab_to_cache : ``List[str]``, optional, (default = 0.5).
+    vocab_to_cache : ``List[str]``, optional, (default = None).
         A list of words to pre-compute and cache character convolutions
         for. If you use this option, _ElmoBiLm expects that you pass word
         indices of shape (batch_size, timesteps) to forward, instead


### PR DESCRIPTION
Some default values were wrong or not present in the documentation.