### PR TITLE
fix get_output_dim() for ElmoTokenEmbedder

### DIFF
--- a/allennlp/modules/token_embedders/elmo_token_embedder.py
+++ b/allennlp/modules/token_embedders/elmo_token_embedder.py
@@ -65,11 +65,13 @@ class ElmoTokenEmbedder(TokenEmbedder):
                           scalar_mix_parameters=scalar_mix_parameters)
         if projection_dim:
             self._projection = torch.nn.Linear(self._elmo.get_output_dim(), projection_dim)
+            self.output_dim = projection_dim
         else:
             self._projection = None
-
-    def get_output_dim(self):
-        return self._projection.out_features
+            self.output_dim = self._elmo.get_output_dim()
+        
+    def get_output_dim(self) -> int:
+        return self.output_dim
 
     def forward(self, # pylint: disable=arguments-differ
                 inputs: torch.Tensor,

--- a/allennlp/modules/token_embedders/elmo_token_embedder.py
+++ b/allennlp/modules/token_embedders/elmo_token_embedder.py
@@ -69,7 +69,7 @@ class ElmoTokenEmbedder(TokenEmbedder):
         else:
             self._projection = None
             self.output_dim = self._elmo.get_output_dim()
-        
+
     def get_output_dim(self) -> int:
         return self.output_dim
 

--- a/allennlp/modules/token_embedders/elmo_token_embedder.py
+++ b/allennlp/modules/token_embedders/elmo_token_embedder.py
@@ -69,7 +69,7 @@ class ElmoTokenEmbedder(TokenEmbedder):
             self._projection = None
 
     def get_output_dim(self):
-        return self._elmo.get_output_dim()
+        return self._projection.out_features
 
     def forward(self, # pylint: disable=arguments-differ
                 inputs: torch.Tensor,

--- a/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
@@ -87,10 +87,13 @@ class TestElmoTokenEmbedder(ModelTestCase):
         word2[2] = 1
         word2[3] = 0
         embedding_layer = ElmoTokenEmbedder.from_params(vocab=None, params=params)
+        assert embedding_layer.get_output_dim == 20
+        
         input_tensor = torch.LongTensor([[word1, word2]])
         embedded = embedding_layer(input_tensor).data.numpy()
         assert embedded.shape == (1, 2, 20)
+        
 
         input_tensor = torch.LongTensor([[[word1]]])
         embedded = embedding_layer(input_tensor).data.numpy()
-        assert embedded.shape == (1, 1, 1, 20)
+        assert embedded.shape == (1, 1, 1, 20) 

--- a/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
@@ -88,11 +88,11 @@ class TestElmoTokenEmbedder(ModelTestCase):
         word2[3] = 0
         embedding_layer = ElmoTokenEmbedder.from_params(vocab=None, params=params)
         assert embedding_layer.get_output_dim() == 20
-        
+
         input_tensor = torch.LongTensor([[word1, word2]])
         embedded = embedding_layer(input_tensor).data.numpy()
         assert embedded.shape == (1, 2, 20)
-        
+
         input_tensor = torch.LongTensor([[[word1]]])
         embedded = embedding_layer(input_tensor).data.numpy()
         assert embedded.shape == (1, 1, 1, 20)

--- a/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
@@ -87,7 +87,7 @@ class TestElmoTokenEmbedder(ModelTestCase):
         word2[2] = 1
         word2[3] = 0
         embedding_layer = ElmoTokenEmbedder.from_params(vocab=None, params=params)
-        assert embedding_layer.get_output_dim == 20
+        assert embedding_layer.get_output_dim() == 20
         
         input_tensor = torch.LongTensor([[word1, word2]])
         embedded = embedding_layer(input_tensor).data.numpy()
@@ -96,4 +96,4 @@ class TestElmoTokenEmbedder(ModelTestCase):
 
         input_tensor = torch.LongTensor([[[word1]]])
         embedded = embedding_layer(input_tensor).data.numpy()
-        assert embedded.shape == (1, 1, 1, 20) 
+        assert embedded.shape == (1, 1, 1, 20)

--- a/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
@@ -93,7 +93,6 @@ class TestElmoTokenEmbedder(ModelTestCase):
         embedded = embedding_layer(input_tensor).data.numpy()
         assert embedded.shape == (1, 2, 20)
         
-
         input_tensor = torch.LongTensor([[[word1]]])
         embedded = embedding_layer(input_tensor).data.numpy()
         assert embedded.shape == (1, 1, 1, 20)


### PR DESCRIPTION
1. Fix get_output_dim() of ElmoTokenEmbedder with projection
2. Add test of get_output_dim() of ElmoTokenEmbedder with projection
 
#2227