### PR TITLE
change mislabeled variable in description

### DIFF
--- a/allennlp/modules/token_embedders/bert_token_embedder.py
+++ b/allennlp/modules/token_embedders/bert_token_embedder.py
@@ -117,7 +117,7 @@ class PretrainedBertEmbedder(BertEmbedder):
     """
     Parameters
     ----------
-    pretrained_model_name: ``str``
+    pretrained_model: ``str``
         Either the name of the pretrained model to use (e.g. 'bert-base-uncased'),
         or the path to the .tar.gz file with the model weights.
 


### PR DESCRIPTION
the required parameter "pretrained_model" was mislabeled as "pretrained_model_name" in the documentation