### PR TITLE
Add a Contributions section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ You can run the image with `docker run --rm -it allennlp/allennlp:latest`.  The 
 
 You can test your installation by running  `allennlp test-install`.
 
+## Issues
+
+Everyone is welcome to file issues with either feature requests, bug reports, or general questions.  As a small team with our own internal goals, we may ask for contributions if a prompt fix doesn't fit into our roadmap.  We allow users a two week window to follow up on questions, after which we will close issues.  They can be re-opened if there is further discussion.
+
+## Contributions
+
+The AllenNLP team at AI2 (@allenai) welcomes contributions from the greater AllenNLP community, and, if you would like to get a change into the library, this is likely the fastest approach.  If you would like to contribute a larger feature, we recommend first creating an issue with a proposed design for discussion.  This will prevent you from spending significant time on an implementation which has a technical limitation someone could have pointed out early on.  Small contributions can be made directly in a pull request.
+
+Pull requests (PRs) must have one approving review and no requested changes before they are merged.  As AllenNLP is primarily driven by AI2 (@allenai) we reserve the right to reject or revert contributions that we don't think are good additions.
+
 ## Citing
 
 If you use AllenNLP in your research, please cite [AllenNLP: A Deep Semantic Natural Language Processing Platform](https://www.semanticscholar.org/paper/AllenNLP%3A-A-Deep-Semantic-Natural-Language-Platform-Gardner-Grus/a5502187140cdd98d76ae711973dbcdaf1fef46d).


### PR DESCRIPTION
 @matt-gardner here's a stab at a contributions section.  We can require a code owner to review, which we can manage in a [`CODEOWNERS` file](https://help.github.com/articles/about-codeowners/).  I don't think that's necessary presently.

If we want to grant others write access we could consider changing our code coverage tests, which often fail and require admin permissions to overwrite them.