### PR TITLE
Make `MultiLabelField.as_tensor` return `LongTensor`s.

### DIFF
--- a/allennlp/data/fields/multilabel_field.py
+++ b/allennlp/data/fields/multilabel_field.py
@@ -109,7 +109,7 @@ class MultiLabelField(Field[torch.Tensor]):
     def as_tensor(self, padding_lengths: Dict[str, int]) -> torch.Tensor:
         # pylint: disable=unused-argument
 
-        tensor = torch.zeros(self._num_labels)  # vector of zeros
+        tensor = torch.zeros(self._num_labels, dtype=torch.long)  # vector of zeros
         if self._label_ids:
             tensor.scatter_(0, torch.LongTensor(self._label_ids), 1)
 

--- a/allennlp/tests/data/fields/multilabel_field_test.py
+++ b/allennlp/tests/data/fields/multilabel_field_test.py
@@ -11,8 +11,9 @@ from allennlp.data.vocabulary import Vocabulary
 class TestMultiLabelField(AllenNlpTestCase):
     def test_as_tensor_returns_integer_tensor(self):
         f = MultiLabelField([2, 3], skip_indexing=True, label_namespace="test1", num_labels=5)
-        tensor = f.as_tensor(f.get_padding_lengths()).detach().cpu().numpy()
-        numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 0, 1, 1, 0]))
+        tensor = f.as_tensor(f.get_padding_lengths()).detach().cpu().tolist()
+        assert tensor == [0, 0, 1, 1, 0]
+        assert set([type(item) for item in tensor]) == set([int])
 
     def test_multilabel_field_can_index_with_vocab(self):
         vocab = Vocabulary()


### PR DESCRIPTION
fixes #2285 