### PR TITLE
Add __repr__ to Vocabulary

### DIFF
--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -615,6 +615,7 @@ class Vocabulary(Registrable):
         namespaces = [f"\tNamespace: {name}, Size: {self.get_vocab_size(name)} \n"
                       for name in self._index_to_token]
         return " ".join([base_string, non_padded_namespaces] + namespaces)
+    __repr__ = __str__
 
     def print_statistics(self) -> None:
         if self._retained_counter:

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -615,7 +615,14 @@ class Vocabulary(Registrable):
         namespaces = [f"\tNamespace: {name}, Size: {self.get_vocab_size(name)} \n"
                       for name in self._index_to_token]
         return " ".join([base_string, non_padded_namespaces] + namespaces)
-    __repr__ = __str__
+
+    def __repr__(self) -> str:
+        # This is essentially the same as __str__, but with no newlines
+        base_string = f"Vocabulary with namespaces: "
+        namespaces = [f"{name}, Size: {self.get_vocab_size(name)} ||"
+                      for name in self._index_to_token]
+        non_padded_namespaces = f"Non Padded Namespaces: {self._non_padded_namespaces}"
+        return " ".join([base_string] + namespaces + [non_padded_namespaces])
 
     def print_statistics(self) -> None:
         if self._retained_counter:


### PR DESCRIPTION
As it currently stands, the following is logged during training:

```
2019-01-06 10:46:21,832 - INFO - allennlp.common.from_params - instantiating class <class 'allennlp.model
s.language_model.LanguageModel'> from params {'bidirectional': False, 'contextualizer': {'bidirectional':
 False, 'dropout': 0.5, 'hidden_size': 200, 'input_size': 200, 'num_layers': 2, 'type': 'lstm'}, 'dropout
': 0.5, 'text_field_embedder': {'token_embedders': {'tokens': {'embedding_dim': 200, 'type': 'embedding'}
}}} and extras {'vocab': <allennlp.data.vocabulary.Vocabulary object at 0x7ff7811665f8>}
```

Note that the `Vocabulary` does not provide any useful information, since it doesn't have `__repr__` defined. This provides a fix.