### PR TITLE
Update the base image in the Dockerfiles.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.3-jessie
+FROM python:3.6.8-jessie
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/Dockerfile.pip
+++ b/Dockerfile.pip
@@ -1,7 +1,7 @@
 # This Dockerfile creates an environment suitable for downstream usage of AllenNLP.
 # It creates an environment that includes a pip installation of allennlp.
 
-FROM python:3.6.3-jessie
+FROM python:3.6.8-jessie
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8


### PR DESCRIPTION
This also upgrades `pip` from 9 to 18.1.  We've had `pip` warnings in our builds for a long time and few of our users likely use as old as a version as we have in our continuous build.