### PR TITLE
Stacked Bi-Directional LSTM to be compatible with the Seq2Vec wrapper

### DIFF
--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -27,6 +27,7 @@ from allennlp.modules.seq2vec_encoders.pytorch_seq2vec_wrapper import PytorchSeq
 from allennlp.modules.seq2vec_encoders.seq2vec_encoder import Seq2VecEncoder
 from allennlp.modules.augmented_lstm import AugmentedLstm
 from allennlp.modules.stacked_alternating_lstm import StackedAlternatingLstm
+from allennlp.modules.stacked_bidirectional_lstm import StackedBidirectionalLstm
 
 
 class _Seq2VecWrapper:
@@ -77,3 +78,4 @@ Seq2VecEncoder.register("lstm")(_Seq2VecWrapper(torch.nn.LSTM))
 Seq2VecEncoder.register("rnn")(_Seq2VecWrapper(torch.nn.RNN))
 Seq2VecEncoder.register("augmented_lstm")(_Seq2VecWrapper(AugmentedLstm))
 Seq2VecEncoder.register("alternating_lstm")(_Seq2VecWrapper(StackedAlternatingLstm))
+Seq2VecEncoder.register("stacked_bidirectional_lstm")(_Seq2VecWrapper(StackedBidirectionalLstm))

--- a/allennlp/modules/stacked_bidirectional_lstm.py
+++ b/allennlp/modules/stacked_bidirectional_lstm.py
@@ -25,6 +25,12 @@ class StackedBidirectionalLstm(torch.nn.Module):
         The dropout probability to be used in a dropout scheme as stated in
         `A Theoretically Grounded Application of Dropout in Recurrent Neural Networks
         <https://arxiv.org/abs/1512.05287>`_ .
+    use_highway: bool, optional (default = True)
+        Whether or not to use highway connections between layers. This effectively involves
+        reparameterising the normal output of an LSTM as::
+
+            gate = sigmoid(W_x1 * x_t + W_h * h_t)
+            output = gate * h_t  + (1 - gate) * (W_x2 * x_t)
     """
     def __init__(self,
                  input_size: int,

--- a/allennlp/tests/modules/stacked_bidirectional_lstm_test.py
+++ b/allennlp/tests/modules/stacked_bidirectional_lstm_test.py
@@ -5,6 +5,7 @@ from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
 
 from allennlp.modules.stacked_bidirectional_lstm import StackedBidirectionalLstm
 from allennlp.modules.seq2seq_encoders import Seq2SeqEncoder
+from allennlp.modules.seq2vec_encoders import Seq2VecEncoder
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.common.params import Params
 
@@ -33,3 +34,24 @@ class TestStackedBidirectionalLstm(AllenNlpTestCase):
         assert encoder.get_input_dim() == 5
         assert encoder.get_output_dim() == 18
         assert encoder.is_bidirectional
+
+    def test_stacked_bidirectional_lstm_can_build_from_params_seq2vec(self):
+        params = Params({"type": "stacked_bidirectional_lstm",
+                         "input_size": 5,
+                         "hidden_size": 9,
+                         "num_layers": 3})
+        encoder = Seq2VecEncoder.from_params(params)
+
+        assert encoder.get_input_dim() == 5
+        assert encoder.get_output_dim() == 18
+
+    def test_stacked_bidirectional_lstm_can_complete_forward_pass_seq2vec(self):
+        params = Params({"type": "stacked_bidirectional_lstm",
+                         "input_size": 3,
+                         "hidden_size": 9,
+                         "num_layers": 3})
+        encoder = Seq2VecEncoder.from_params(params)
+        input_tensor = torch.rand(4, 5, 3)
+        mask = torch.ones(4, 5)
+        output = encoder(input_tensor, mask)
+        assert output.detach().numpy().shape == (4, 18)


### PR DESCRIPTION
Fixes #2316 

I have also added an argument to the Doc String of the constructor to indicate that there is a `use_highway` argument, I have tested that the Sphinx of this documentation looks ok as well and a screenshot showing this:
![sphinx documentation](https://user-images.githubusercontent.com/13574854/50921185-4a169580-143f-11e9-9c35-ce2aa29ee755.png)

