### PR TITLE
Display default values in help message for allennlp command

### DIFF
--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -2,6 +2,8 @@ from typing import Dict
 import argparse
 import logging
 
+from overrides import overrides
+
 from allennlp import __version__
 from allennlp.commands.configure import Configure
 from allennlp.commands.elmo import Elmo
@@ -35,6 +37,7 @@ class ArgumentParserWithDefaults(argparse.ArgumentParser):
             return not bool(default)
         return False
 
+    @overrides
     def add_argument(self, *args, **kwargs):
         # pylint: disable=arguments-differ
         # Add default value to the help message when the default is meaningful.

--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -19,6 +19,32 @@ from allennlp.common.util import import_submodules
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
+class ArgumentParserWithDefaults(argparse.ArgumentParser):
+    """
+    Custom argument parser that will display the default value for an argument
+    in the help message.
+    """
+
+    _action_defaults_to_ignore = {"help", "store_true", "store_false", "store_const"}
+
+    @staticmethod
+    def _is_empty_default(default):
+        if default is None:
+            return True
+        if isinstance(default, (str, list, tuple, set)):
+            return not bool(default)
+        return False
+
+    def add_argument(self, *args, **kwargs):
+        # pylint: disable=arguments-differ
+        # Add default value to the help message when the default is meaningful.
+        default = kwargs.get("default")
+        if kwargs.get("action") not in self._action_defaults_to_ignore and not self._is_empty_default(default):
+            description = kwargs.get("help") or ""
+            kwargs["help"] = f"{description} (default = {default})"
+        super().add_argument(*args, **kwargs)
+
+
 def main(prog: str = None,
          subcommand_overrides: Dict[str, Subcommand] = {}) -> None:
     """
@@ -27,7 +53,7 @@ def main(prog: str = None,
     work for them, unless you use the ``--include-package`` flag.
     """
     # pylint: disable=dangerous-default-value
-    parser = argparse.ArgumentParser(description="Run AllenNLP", usage='%(prog)s', prog=prog)
+    parser = ArgumentParserWithDefaults(description="Run AllenNLP", usage='%(prog)s', prog=prog)
     parser.add_argument('--version', action='version', version='%(prog)s ' + __version__)
 
     subparsers = parser.add_subparsers(title='Commands', metavar='')

--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -98,7 +98,7 @@ class FindLearningRate(Subcommand):
         subparser.add_argument('--num-batches',
                                type=int,
                                default=100,
-                               help='number of mini-batches to run Learning rate finder')
+                               help='number of mini-batches to run learning rate finder')
         subparser.add_argument('--stopping-factor',
                                type=float,
                                default=None,


### PR DESCRIPTION
I thought it would be nice to display the default values in the help message when you do something like `allennlp find-lr --help`. This PR implements a custom `ArgumentParser` that just overrides the `add_argument` method to add any meaningful default values to the help description. Below is what the new output looks like:

![screen shot 2019-01-09 at 1 08 37 pm](https://user-images.githubusercontent.com/8812459/50928515-bed1db80-140f-11e9-9e0b-c1f62e22cf7e.png)
