### PR TITLE
Disable requires_grad for Transformer ELMo parser.

### DIFF
--- a/training_config/constituency_parser_transformer_elmo.jsonnet
+++ b/training_config/constituency_parser_transformer_elmo.jsonnet
@@ -23,7 +23,7 @@
               "dropout": 0.2,
               "bos_eos_tokens": ["<S>", "</S>"],
               "remove_bos_eos": true,
-              "requires_grad": true
+              "requires_grad": false
             }
         }
       },


### PR DESCRIPTION
- Makes constituency_parser_transformer_elmo.jsonnet and constituency_parser_elmo.jsonnet comparable by default.