### PR TITLE
Added Stacked Bi-Directional LSTM to list of Seq2Vec encoders in the documentation

### DIFF
--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -12,6 +12,7 @@ The available Seq2Vec encoders are
 * :class:`"cnn" <allennlp.modules.seq2vec_encoders.cnn_encoder.CnnEncoder>`
 * :class:`"augmented_lstm" <allennlp.modules.augmented_lstm.AugmentedLstm>`
 * :class:`"alternating_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`
+* :class:`"stacked_bidirectional_lstm" <allennlp.modules.stacked_bidirectional_lstm.StackedBidirectionalLstm>`
 """
 
 from typing import Type


### PR DESCRIPTION
I forgot to include in the following pull request #2318 to fix the following issue #2316 the [Stacked Bi-directional LSTM](https://github.com/allenai/allennlp/blob/master/allennlp/modules/stacked_bidirectional_lstm.py) in the list of available Seq2Vec encoders in the [Seq2Vec](https://github.com/allenai/allennlp/blob/master/allennlp/modules/seq2vec_encoders/__init__.py) doc string. This has now been added with this pull request and displays the doc string as shown in the figure below:
![stacked encoder doc](https://user-images.githubusercontent.com/13574854/51029915-ac7eab80-158f-11e9-8df3-63cb95bd1a4b.png)
