### PR TITLE
Fix edgecase of potentially missing best-val-metrics in metrics.json on training recovery

### DIFF
--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -140,7 +140,7 @@ class TestTrainer(AllenNlpTestCase):
                               validation_dataset=self.instances,
                               num_epochs=3, serialization_dir=self.TEST_DIR)
 
-        epoch, val_metrics_per_epoch = new_trainer._restore_checkpoint()  # pylint: disable=protected-access
+        epoch, val_metrics_per_epoch, _ = new_trainer._restore_checkpoint()  # pylint: disable=protected-access
         assert epoch == 1
         assert len(val_metrics_per_epoch) == 1
         assert isinstance(val_metrics_per_epoch[0], float)
@@ -272,7 +272,7 @@ class TestTrainer(AllenNlpTestCase):
                               train_dataset=self.instances,
                               validation_dataset=self.instances,
                               num_epochs=4, serialization_dir=self.TEST_DIR)
-        epoch, _ = new_trainer._restore_checkpoint()
+        epoch, _, _ = new_trainer._restore_checkpoint()
         assert epoch == 2
         assert new_trainer._learning_rate_scheduler.lr_scheduler.last_epoch == 1
         new_trainer.train()
@@ -408,7 +408,7 @@ class TestTrainer(AllenNlpTestCase):
                                   self.iterator, self.instances, num_epochs=2,
                                   serialization_dir=self.TEST_DIR,
                                   model_save_interval=0.0001)
-        epoch, _ = restore_trainer._restore_checkpoint()  # pylint: disable=protected-access
+        epoch, _, _ = restore_trainer._restore_checkpoint()  # pylint: disable=protected-access
         assert epoch == 2
         # One batch per epoch.
         assert restore_trainer._batch_num_total == 2  # pylint: disable=protected-access

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -421,7 +421,7 @@ class TestTrainer(AllenNlpTestCase):
                           num_epochs=1, serialization_dir=self.TEST_DIR)
         trainer.train()
         _, _, best_validation_metrics_epoch_1 = trainer._restore_checkpoint()  # pylint: disable=protected-access
-        # best_validation_metrics: {'accuracy': 0.75, 'accuracy3': 1.0, 'loss': 0.6243013441562653}
+        # best_validation_metrics_epoch_1: {'accuracy': 0.75, 'accuracy3': 1.0, 'loss': 0.6243013441562653}
         assert isinstance(best_validation_metrics_epoch_1, dict)
         assert "loss" in best_validation_metrics_epoch_1
 

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -996,7 +996,7 @@ class Trainer(Registrable):
 
         return (model_path, training_state_path)
 
-    def _restore_checkpoint(self) -> Tuple[int, List[float]]:
+    def _restore_checkpoint(self) -> Tuple[int, List[float], Dict[str, float]]:
         """
         Restores a model from a serialization_dir to the last saved checkpoint.
         This includes an epoch count and optimizer state, which is serialized separately

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -785,7 +785,10 @@ class Trainer(Registrable):
             best_validation_metrics = {}
 
         if validation_metric_per_epoch:
-            best_metric = min(validation_metric_per_epoch) if self._validation_metric_decreases else max(validation_metric_per_epoch)
+            if self._validation_metric_decreases:
+                best_metric = min(validation_metric_per_epoch)
+            else:
+                best_metric = max(validation_metric_per_epoch)
             metrics["best_epoch"] = validation_metric_per_epoch.index(best_metric)
         for name, value in best_validation_metrics.items():
             metrics["best_validation_" + name] = value
@@ -845,8 +848,7 @@ class Trainer(Registrable):
                 metrics['best_epoch'] = epoch
                 for key, value in val_metrics.items():
                     metrics["best_validation_" + key] = value
-                    if best_validation_metrics is not None:
-                        best_validation_metrics[key] = value
+                    best_validation_metrics[key] = value
 
             if self._serialization_dir:
                 dump_metrics(os.path.join(self._serialization_dir, f'metrics_epoch_{epoch}.json'), metrics)


### PR DESCRIPTION
Fixes #2024. Sorry for being very tardy to fix this!
It seems that this isn't a good time for this PR, because of the ongoing refactors (#2304).