### PR TITLE
fix a typo in tutorials/notebooks/embedding_tokens.ipynb

### DIFF
--- a/tutorials/notebooks/embedding_tokens.ipynb
+++ b/tutorials/notebooks/embedding_tokens.ipynb
@@ -26,7 +26,7 @@
     "- `TokenEmbedders`, which transform indexed tensors into embedded representations. At its most basic, this is just a standard `Embedding` layer you'd find in any neural network library. However, they can be more complex - for instance, AllenNLP has a `token_characters_encoder` which applies a CNN to character level representations.\n",
     "- `TextFieldEmbedders`, which are a wrapper around a set of `TokenEmbedders`. At it's most basic, this applies the `TokenEmbedders` which it is passed and concatenates their output.\n",
     "\n",
-    "Using this hierarchy allows you to easily compose different representations of a sentence together in modular ways. For instance, in the Bidaf model, we use this to concatenate a character level CNN encoding of the words in the sentence to the pretrained word embeddings. You can also specify this completely from a JSON file, making experimenation with different representations extremely easy.\n",
+    "Using this hierarchy allows you to easily compose different representations of a sentence together in modular ways. For instance, in the Bidaf model, we use this to concatenate a character level CNN encoding of the words in the sentence to the pretrained word embeddings. You can also specify this completely from a JSON file, making experimentation with different representations extremely easy.\n",
     " "
    ]
   },


### PR DESCRIPTION
change "experimenation" to "experimentation"