### PR TITLE
changed log-to-console flags

### DIFF
--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -141,7 +141,7 @@ class TensorboardWriter:
     def log_metrics(self,
                     train_metrics: dict,
                     val_metrics: dict = None,
-                    log_to_console: bool = True) -> None:
+                    log_to_console: bool = False) -> None:
         """
         Sends all of the train metrics (and validation metrics, if provided) to tensorboard.
         """

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -437,7 +437,7 @@ class Trainer(TrainerBase):
                         logger.info("Ran out of patience.  Stopping training.")
                         break
 
-            self._tensorboard.log_metrics(train_metrics, val_metrics=val_metrics)
+            self._tensorboard.log_metrics(train_metrics, val_metrics=val_metrics, log_to_console=True)
 
             # Create overall metrics dict
             training_elapsed_time = time.time() - training_start_time


### PR DESCRIPTION
Tensorboard writer writes logs to console by default, resulting in unnecessary logging during training:

```
accuracy: 0.9264, loss: 0.2221 ||:  76%|#######5  | 2725/3593 [02:14<00:38, 22.53it/s]2019-01-17 18:16:12,176 - INFO - allennlp.training.tensorboard_writer -                            Training |  Validation
2019-01-17 18:16:12,177 - INFO - allennlp.training.tensorboard_writer - epoch_metrics/loss     |     0.222  |       N/A
2019-01-17 18:16:12,177 - INFO - allennlp.training.tensorboard_writer - epoch_metrics/accuracy |     0.926  |       N/A
accuracy: 0.9262, loss: 0.2230 ||:  79%|#######8  | 2827/3593 [02:19<00:33, 22.69it/s]2019-01-17 18:16:16,606 - INFO - allennlp.training.tensorboard_writer -                            Training |  Validation
2019-01-17 18:16:16,606 - INFO - allennlp.training.tensorboard_writer - epoch_metrics/loss     |     0.223  |       N/A
2019-01-17 18:16:16,606 - INFO - allennlp.training.tensorboard_writer - epoch_metrics/accuracy |     0.926  |       N/A
```

This fix sets console logging by tensorboard writer to False by default. Tensorboard writer will only log to console at the end of an epoch.