### PR TITLE
Fix docstring for PretrainedBertIndexer's pretrained_model param

### DIFF
--- a/allennlp/data/token_indexers/wordpiece_indexer.py
+++ b/allennlp/data/token_indexers/wordpiece_indexer.py
@@ -201,7 +201,7 @@ class PretrainedBertIndexer(WordpieceIndexer):
 
     Parameters
     ----------
-    pretrained_model: ``str``, optional (default = None)
+    pretrained_model: ``str``
         Either the name of the pretrained model to use (e.g. 'bert-base-uncased'),
         or the path to the .txt file with its vocabulary.
 


### PR DESCRIPTION
`pretrained_model` is not an optional param, as stated in `PretrainedBertIndexer` docs, so I removed the "optional" part from it.