### PR TITLE
Ensure vocab is popped off params in recovery mode

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -688,6 +688,7 @@ class TrainerPieces(NamedTuple):
 
         if recover and os.path.exists(os.path.join(serialization_dir, "vocabulary")):
             vocab = Vocabulary.from_files(os.path.join(serialization_dir, "vocabulary"))
+            params.pop("vocabulary", {})
         else:
             vocab = Vocabulary.from_params(
                     params.pop("vocabulary", {}),


### PR DESCRIPTION
PR #2261 is incomplete. If we load an existing vocabulary, the key `vocabulary` still exists in `params`. This will cause the line `params.assert_empty('base train command')` in `commands/train.py` to raise an assertion later on.

This PR ensures that the key `vocab` is always popped off `params` in all cases.