### PR TITLE
Improve error message for "undocumented modules"

### DIFF
--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -71,4 +71,7 @@ if __name__ == "__main__":
             success = False
 
     if not success:
+        print("To pass this check, you must add a reference to undocumented modules in our API "
+              "documentation in the appropriate place under doc/api (typically, these are modules "
+              "that you added in this PR), and remove any reference to modules that you deleted.")
         sys.exit(1)


### PR DESCRIPTION
We've had a couple of people recently not understand what "undocumented module" meant in a CI failure.  This adds a nicer error message explaining what needs to happen for the check to pass.