### PR TITLE
Fixing BERT mask size

### DIFF
--- a/allennlp/data/token_indexers/wordpiece_indexer.py
+++ b/allennlp/data/token_indexers/wordpiece_indexer.py
@@ -160,7 +160,7 @@ class WordpieceIndexer(TokenIndexer[int]):
         # Our mask should correspond to the original tokens,
         # because calling util.get_text_field_mask on the
         # "wordpiece_id" tokens will produce the wrong shape.
-        mask = [1 for _ in tokens]
+        mask = [1 for _ in offsets]
 
         return {
                 index_name: wordpiece_ids,


### PR DESCRIPTION
Input tokens are truncated to <512 tokens long to fit into BERT. When this happens, the mask associated with that sample appears to not also be truncated. This edit is a fix for that issue, which can cause size mismatch errors downstream when the mask is used (See this [issue](https://github.com/allenai/allennlp/issues/2426)). @joelgrus 
