### PR TITLE
Mark Atis Parser tests as flaky. Fix pylint.

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -60,7 +60,7 @@ def sanitize(x: Any) -> Any:  # pylint: disable=invalid-name,too-many-return-sta
     elif isinstance(x, numpy.ndarray):
         # array needs to be converted to a list
         return x.tolist()
-    elif isinstance(x, numpy.number):
+    elif isinstance(x, numpy.number):  # pylint: disable=no-member
         # NumPy numbers need to be converted to Python numbers
         return x.item()
     elif isinstance(x, dict):

--- a/allennlp/modules/sampled_softmax_loss.py
+++ b/allennlp/modules/sampled_softmax_loss.py
@@ -121,7 +121,7 @@ class SampledSoftmaxLoss(torch.nn.Module):
             num_words = self.softmax_w.size(0)
 
         self._num_words = num_words
-        self._log_num_words_p1 = np.log(num_words + 1)
+        self._log_num_words_p1 = np.log(num_words + 1)  # pylint: disable=assignment-from-no-return
 
         # compute the probability of each sampled id
         self._probs = (np.log(np.arange(num_words) + 2) -

--- a/allennlp/tests/nn/beam_search_test.py
+++ b/allennlp/tests/nn/beam_search_test.py
@@ -57,7 +57,7 @@ class BeamSearchTest(AllenNlpTestCase):
         )
 
         # This is what the log probs should look like for each item in the batch.
-        self.expected_log_probs = np.log(np.array([0.4, 0.3, 0.2]))
+        self.expected_log_probs = np.log(np.array([0.4, 0.3, 0.2]))  # pylint: disable=assignment-from-no-return
 
     def _check_results(self,
                        batch_size: int = 5,
@@ -129,7 +129,7 @@ class BeamSearchTest(AllenNlpTestCase):
     def test_greedy_search(self):
         beam_search = BeamSearch(self.end_index, beam_size=1)
         expected_top_k = np.array([[1, 2, 3, 4, 5]])
-        expected_log_probs = np.log(np.array([0.4]))
+        expected_log_probs = np.log(np.array([0.4]))  # pylint: disable=assignment-from-no-return
         self._check_results(expected_top_k=expected_top_k,
                             expected_log_probs=expected_log_probs,
                             beam_search=beam_search)
@@ -144,7 +144,7 @@ class BeamSearchTest(AllenNlpTestCase):
                  [2, 3, 4],
                  [3, 4, 5]]
         )
-        expected_log_probs = np.log(np.array([0.4, 0.3, 0.2]))
+        expected_log_probs = np.log(np.array([0.4, 0.3, 0.2]))  # pylint: disable=assignment-from-no-return
         self._check_results(expected_top_k=expected_top_k,
                             expected_log_probs=expected_log_probs,
                             beam_search=beam_search)

--- a/allennlp/tests/predictors/atis_parser_test.py
+++ b/allennlp/tests/predictors/atis_parser_test.py
@@ -1,9 +1,12 @@
 # pylint: disable=no-self-use,invalid-name
+from flaky import flaky
+
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
 
 class TestAtisParserPredictor(AllenNlpTestCase):
+    @flaky
     def test_atis_parser_uses_named_inputs(self):
         inputs = {
                 "utterance": "show me the flights to seattle",
@@ -24,6 +27,7 @@ class TestAtisParserPredictor(AllenNlpTestCase):
             predicted_sql_query = result.get("predicted_sql_query")
             assert predicted_sql_query is not None
 
+    @flaky
     def test_atis_parser_predicted_sql_present(self):
         inputs = {
                 "utterance": "show me flights to seattle"
@@ -37,6 +41,7 @@ class TestAtisParserPredictor(AllenNlpTestCase):
         predicted_sql_query = result.get("predicted_sql_query")
         assert predicted_sql_query is not None
 
+    @flaky
     def test_atis_parser_batch_predicted_sql_present(self):
         inputs = [{
                 "utterance": "show me flights to seattle",


### PR DESCRIPTION
- Tests appear to pull down a DB file from S3.
- Spurious network failures are common, so mark as flaky to ameliorate the problem.
- Alternative: Bring DB file into fixtures directory. However, as we're trying to keep the size of the library down, this probably isn't advisable.
- Also disables some `pylint` warnings that hit with `numpy==1.16.0`.