### PR TITLE
[Feature Enhanced]Add FeedforwardEncoder for Sequences

### DIFF
--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -15,6 +15,7 @@ The available Seq2Seq encoders are
 * :class:`"stacked_self_attention" <allennlp.modules.stacked_self_attention.StackedSelfAttentionEncoder>`
 * :class:`"multi_head_self_attention" <allennlp.modules.multi_head_self_attention.MultiHeadSelfAttention>`
 * :class:`"pass_through" <allennlp.modules.pass_through_encoder.PassThroughEncoder>`
+* :class:`"feedforward" <allennlp.modules.feedforward_encoder.FeedforwardEncoder>`
 """
 
 from typing import Type
@@ -36,8 +37,10 @@ from allennlp.modules.stacked_bidirectional_lstm import StackedBidirectionalLstm
 from allennlp.modules.seq2seq_encoders.stacked_self_attention import StackedSelfAttentionEncoder
 from allennlp.modules.seq2seq_encoders.multi_head_self_attention import MultiHeadSelfAttention
 from allennlp.modules.seq2seq_encoders.pass_through_encoder import PassThroughEncoder
+from allennlp.modules.seq2seq_encoders.feedforward_encoder import FeedForwardEncoder
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
 
 class _Seq2SeqWrapper:
     """

--- a/allennlp/modules/seq2seq_encoders/feedforward_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/feedforward_encoder.py
@@ -45,5 +45,5 @@ class FeedForwardEncoder(Seq2SeqEncoder):
         if mask is None:
             return self._feedforward(inputs)
         else:
-            inputs = inputs * mask.unsqueeze(dim=-1).float()
-            return self._feedforward(inputs)
+            outputs = self._feedforward(inputs)
+            return outputs * mask.unsqueeze(dim=-1).float()

--- a/allennlp/modules/seq2seq_encoders/feedforward_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/feedforward_encoder.py
@@ -1,8 +1,8 @@
-from overrides import overrides
 import torch
+from overrides import overrides
 
-from allennlp.modules.seq2seq_encoders import Seq2SeqEncoder
-from allennlp.modules import FeedForward
+from allennlp.modules.feedforward import FeedForward
+from allennlp.modules.seq2seq_encoders.seq2seq_encoder import Seq2SeqEncoder
 
 
 @Seq2SeqEncoder.register("feedforward")
@@ -29,5 +29,21 @@ class FeedForwardEncoder(Seq2SeqEncoder):
     @overrides
     def forward(self,  # pylint: disable=arguments-differ
                 inputs: torch.Tensor,
-                mask: torch.LongTensor = None) -> torch.FloatTensor:
-        return self._feedforward(inputs)
+                mask: torch.LongTensor = None) -> torch.Tensor:
+        """
+        Parameters
+        ----------
+        inputs : ``torch.Tensor``, required.
+            A tensor of shape (batch_size, timesteps, input_dim)
+        mask : ``torch.LongTensor``, optional (default = None).
+            A tensor of shape (batch_size, timesteps).
+
+        Returns
+        -------
+        A tensor of shape (batch_size, timesteps, output_dim).
+        """
+        if mask is None:
+            return self._feedforward(inputs)
+        else:
+            inputs = inputs * mask.unsqueeze(dim=-1).float()
+            return self._feedforward(inputs)

--- a/allennlp/modules/seq2seq_encoders/feedforward_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/feedforward_encoder.py
@@ -1,0 +1,33 @@
+from overrides import overrides
+import torch
+
+from allennlp.modules.seq2seq_encoders import Seq2SeqEncoder
+from allennlp.modules import FeedForward
+
+
+@Seq2SeqEncoder.register("feedforward")
+class FeedForwardEncoder(Seq2SeqEncoder):
+    """
+    This class applies the `FeedForward` to each item in sequences.
+    """
+    def __init__(self, feedforward: FeedForward) -> None:
+        super().__init__()
+        self._feedforward = feedforward
+
+    @overrides
+    def get_input_dim(self) -> int:
+        return self._feedforward.get_input_dim()
+
+    @overrides
+    def get_output_dim(self) -> int:
+        return self._feedforward.get_output_dim()
+
+    @overrides
+    def is_bidirectional(self) -> bool:
+        return False
+
+    @overrides
+    def forward(self,  # pylint: disable=arguments-differ
+                inputs: torch.Tensor,
+                mask: torch.LongTensor = None) -> torch.FloatTensor:
+        return self._feedforward(inputs)

--- a/allennlp/tests/modules/seq2seq_encoders/feedforward_encoder_test.py
+++ b/allennlp/tests/modules/seq2seq_encoders/feedforward_encoder_test.py
@@ -1,0 +1,31 @@
+# pylint: disable=no-self-use,invalid-name
+import torch
+import numpy
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.modules import FeedForward
+from allennlp.modules.seq2seq_encoders import FeedForwardEncoder
+from allennlp.nn import Activation
+
+
+class TestFeedforwardEncoder(AllenNlpTestCase):
+    def test_get_dimension_is_correct(self):
+        feedforward = FeedForward(input_dim=10,
+                                  num_layers=1,
+                                  hidden_dims=10,
+                                  activations="linear")
+        encoder = FeedForwardEncoder(feedforward)
+        assert encoder.get_input_dim() == feedforward.get_input_dim()
+        assert encoder.get_output_dim() == feedforward.get_output_dim()
+
+    def test_feedforward_encoder_exactly_match_feedforward_each_item(self):
+        feedforward = FeedForward(input_dim=10,
+                                  num_layers=1,
+                                  hidden_dims=10,
+                                  activations=Activation.by_name("linear")())
+        encoder = FeedForwardEncoder(feedforward)
+        tensor = torch.randn([1, 2, 3, 10])
+        output = encoder(tensor)
+        target = feedforward(tensor)
+        numpy.testing.assert_array_almost_equal(target.detach().cpu().numpy(),
+                                                output.detach().cpu().numpy())

--- a/allennlp/tests/modules/seq2seq_encoders/feedforward_encoder_test.py
+++ b/allennlp/tests/modules/seq2seq_encoders/feedforward_encoder_test.py
@@ -4,7 +4,7 @@ import numpy
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.modules import FeedForward
-from allennlp.modules.seq2seq_encoders import FeedForwardEncoder
+from allennlp.modules.seq2seq_encoders.feedforward_encoder import FeedForwardEncoder
 from allennlp.nn import Activation
 
 
@@ -24,8 +24,15 @@ class TestFeedforwardEncoder(AllenNlpTestCase):
                                   hidden_dims=10,
                                   activations=Activation.by_name("linear")())
         encoder = FeedForwardEncoder(feedforward)
-        tensor = torch.randn([1, 2, 3, 10])
+        tensor = torch.randn([2, 3, 10])
         output = encoder(tensor)
         target = feedforward(tensor)
+        numpy.testing.assert_array_almost_equal(target.detach().cpu().numpy(),
+                                                output.detach().cpu().numpy())
+
+        # mask should work
+        mask = torch.LongTensor([[1, 1, 1], [1, 0, 0]])
+        output = encoder(tensor, mask)
+        target = feedforward(tensor * mask.unsqueeze(dim=-1).float())
         numpy.testing.assert_array_almost_equal(target.detach().cpu().numpy(),
                                                 output.detach().cpu().numpy())

--- a/allennlp/tests/modules/seq2seq_encoders/feedforward_encoder_test.py
+++ b/allennlp/tests/modules/seq2seq_encoders/feedforward_encoder_test.py
@@ -33,6 +33,6 @@ class TestFeedforwardEncoder(AllenNlpTestCase):
         # mask should work
         mask = torch.LongTensor([[1, 1, 1], [1, 0, 0]])
         output = encoder(tensor, mask)
-        target = feedforward(tensor * mask.unsqueeze(dim=-1).float())
+        target = feedforward(tensor)  * mask.unsqueeze(dim=-1).float()
         numpy.testing.assert_array_almost_equal(target.detach().cpu().numpy(),
                                                 output.detach().cpu().numpy())

--- a/doc/api/allennlp.modules.seq2seq_encoders.rst
+++ b/doc/api/allennlp.modules.seq2seq_encoders.rst
@@ -45,3 +45,8 @@ allennlp.modules.seq2seq_encoders
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. automodule:: allennlp.modules.seq2seq_encoders.feedforward_encoder
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
This new class (`FeedforwardEncoder`) applies the `FeedForward` to each item in sequences. So we can specify a feedforward network for sequences just by changing a configuation file now.