### PR TITLE
Use self.array.dtype in ArrayField

### DIFF
--- a/allennlp/data/fields/array_field.py
+++ b/allennlp/data/fields/array_field.py
@@ -28,7 +28,7 @@ class ArrayField(Field[numpy.ndarray]):
                      for i in range(len(padding_lengths))]
 
         # Convert explicitly to an ndarray just in case it's an scalar (it'd end up not being an ndarray otherwise)
-        return_array = numpy.asarray(numpy.ones(max_shape, "float32") * self.padding_value)
+        return_array = numpy.asarray(numpy.ones(max_shape, dtype=self.array.dtype) * self.padding_value)
 
         # If the tensor has a different shape from the largest tensor, pad dimensions with zeros to
         # form the right shaped list of slices for insertion into the final tensor.
@@ -40,11 +40,12 @@ class ArrayField(Field[numpy.ndarray]):
         tensor = torch.from_numpy(return_array)
         return tensor
 
+
     @overrides
     def empty_field(self):  # pylint: disable=no-self-use
         # Pass the padding_value, so that any outer field, e.g., `ListField[ArrayField]` uses the
         # same padding_value in the padded ArrayFields
-        return ArrayField(numpy.array([], dtype="float32"), padding_value=self.padding_value)
+        return ArrayField(numpy.array([], dtype=self.array.dtype), padding_value=self.padding_value)
 
 
     def __str__(self) -> str:

--- a/allennlp/tests/data/fields/array_field_test.py
+++ b/allennlp/tests/data/fields/array_field_test.py
@@ -63,3 +63,9 @@ class TestArrayField(AllenNlpTestCase):
         returned_tensor = array.as_tensor(array.get_padding_lengths())
         current_tensor = numpy.asarray(42)
         numpy.testing.assert_array_equal(returned_tensor, current_tensor)
+
+    def test_padding_does_not_changes_array_dtype(self):
+        numpy_array = numpy.array([1, 2, 3])
+        array = ArrayField(numpy_array)
+        returned_tensor = array.as_tensor(array.get_padding_lengths()).numpy()
+        assert numpy_array.dtype == returned_tensor.dtype

--- a/allennlp/tests/data/fields/array_field_test.py
+++ b/allennlp/tests/data/fields/array_field_test.py
@@ -64,7 +64,7 @@ class TestArrayField(AllenNlpTestCase):
         current_tensor = numpy.asarray(42)
         numpy.testing.assert_array_equal(returned_tensor, current_tensor)
 
-    def test_padding_does_not_changes_array_dtype(self):
+    def test_padding_does_not_change_array_dtype(self):
         numpy_array = numpy.array([1, 2, 3])
         array = ArrayField(numpy_array)
         returned_tensor = array.as_tensor(array.get_padding_lengths()).numpy()


### PR DESCRIPTION
Simple fix for #2454.

I'd propose to use dtype of inner numpy array in ArrayField instead of float32.