### PR TITLE
Fix path issue for certain cases when using --include-package

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -305,6 +305,11 @@ def import_submodules(package_name: str) -> None:
     """
     importlib.invalidate_caches()
 
+    # For some reason, python doesn't always add this by default to your path, but you pretty much
+    # always want it when using `--include-package`.  And if it's already there, adding it again at
+    # the end won't hurt anything.
+    sys.path.append('.')
+
     # Import at top level
     module = importlib.import_module(package_name)
     path = getattr(module, '__path__', [])


### PR DESCRIPTION
I've run into this a few times myself, and @nitishgupta spent a lot of time on it today.  This fixes the problem.  I'm not sure if there's a better way to solve it, though.