### PR TITLE
Ten times faster than before in GPU get_best_span of bidaf

### DIFF
--- a/allennlp/models/reading_comprehension/bidaf.py
+++ b/allennlp/models/reading_comprehension/bidaf.py
@@ -299,14 +299,26 @@ class BidirectionalAttentionFlow(Model):
 
     @staticmethod
     def get_best_span(span_start_logits: torch.Tensor, span_end_logits: torch.Tensor) -> torch.Tensor:
+        # We call the inputs "logits" - they could either be unnormalized logits or normalized log
+        # probabilities.  A log_softmax operation is a constant shifting of the entire logit
+        # vector, so taking an argmax over either one gives the same result.
         if span_start_logits.dim() != 2 or span_end_logits.dim() != 2:
             raise ValueError("Input shapes must be (batch_size, passage_length)")
         batch_size, passage_length = span_start_logits.size()
         device = span_start_logits.device
-        logits_add = span_start_logits.unsqueeze(2) + span_end_logits.unsqueeze(1)
-        logits_add_triu = logits_add + torch.triu(torch.ones((passage_length, passage_length),
-                                                             device=device)).log().unsqueeze(0)
-        res = logits_add_triu.view(batch_size, -1).argmax(-1)
-        span_start_idx = res // passage_length
-        span_end_idx = res % passage_length
-        return torch.stack([span_start_idx, span_end_idx], dim=-1)
+        # (batch_size, passage_length, passage_length)
+        span_log_probs = span_start_logits.unsqueeze(2) + span_end_logits.unsqueeze(1)
+        # Only the upper triangle of the span matrix is valid; the lower triangle has entries where
+        # the span ends before it starts.
+        span_log_mask = torch.triu(torch.ones((passage_length, passage_length),
+                                              device=device)).log().unsqueeze(0)
+        valid_span_log_probs = span_log_probs + span_log_mask
+
+        # Here we take the span matrix and flatten it, then find the best span using argmax.  We
+        # can recover the start and end indices from this flattened list using simple modular
+        # arithmetic.
+        # (batch_size, passage_length * passage_length)
+        best_spans = valid_span_log_probs.view(batch_size, -1).argmax(-1)
+        span_start_indices = best_spans // passage_length
+        span_end_indices = best_spans % passage_length
+        return torch.stack([span_start_indices, span_end_indices], dim=-1)


### PR DESCRIPTION
old version
- CPU 34.3 ms ± 973 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
- GPU 60.2 ms ± 1.33 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

new version
- CPU 47.4 ms ± 1.45 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
- GPU 5.04 ms ± 12.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

Ten times faster than before in GPU
