### PR TITLE
WIP: Half precision training

### DIFF
--- a/allennlp/training/metrics/metric.py
+++ b/allennlp/training/metrics/metric.py
@@ -45,5 +45,8 @@ class Metric(Registrable):
         a huge memory leak, because it will prevent garbage collection for the computation
         graph. This method ensures that you're using tensors directly and that they are on
         the CPU.
+
+        In addition, all tensors are cast to float32 as torch does not
+        implement many operations for HalfTensor on CPU.
         """
-        return (x.detach().cpu() if isinstance(x, torch.Tensor) else x for x in tensors)
+        return (x.detach().cpu().float() if isinstance(x, torch.Tensor) else x for x in tensors)

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -144,6 +144,13 @@ Registrable._registry[Optimizer] = {   # pylint: disable=protected-access
         "bert_adam": BertAdam,
 }
 
+try:
+    from apex.optimizers import FusedAdam
+    Registrable._registry[Optimizer]["fused_adam"] = FusedAdam
+except ImportError:
+    pass
+
+
 def _safe_sparse_mask(tensor: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
     """
     In PyTorch 1.0, Tensor._sparse_mask was changed to Tensor.sparse_mask.

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -670,12 +670,14 @@ class Trainer(TrainerBase):
 
         # If fp16, need to wrap the optimizer
         try:
-            from apex.optimizers import FP16_Optimizer
+            from apex.optimizers import FP16_Optimizer, FusedAdam
         except ImportError:
             raise ImportError("Please install apex from https://www.github.com/nvidia/apex to use fp16 training.")
 
         optimizer = Optimizer.from_params(parameters, params.pop("optimizer"))
         if fp16:
+            if not isinstance(optimizer, FusedAdam):
+                raise ConfigurationError("fp16 training only supports 'fused_adam' optimizer")
             optimizer = FP16_Optimizer(optimizer, dynamic_loss_scale=True)
 
         if "moving_average" in params:


### PR DESCRIPTION
This is WIP, but is in a working state so will leave it here.  This adds half precision (16-bit) training to allennlp on GPU.  I was able to get about ~3X speedup and 50% less memory use on a V 100 when fine tuning BERT-base on for text classification (CoLA).  Here are some benchmarks from the third epoch of training (since allennlp overhead for indexing the dataset significantly slows down the first epoch):

fp32 without apex: 7.38it/s, 6342MiB memory
fp32 with apex: 7.93it/s, 6030MiB (the speedup comes from using their `FusedLayerNorm` which is an efficient implementation of layer norm)
fp16 with BertAdam optimizer: 7.42it/s, 4727MiB
fp16 with FusedAdam optimizer: 23.73it/s, 3721MiB  (`FusedAdam` is an efficient GPU implementation of Adam)

The caveats:

* I had to install CUDA 10.0 and cudnn 7.4.1
* It requires `apex` (https://github.com/nvidia/apex), which I had to fork to incorporate two open issues to get it to work with the Trainer (https://github.com/matt-peters/apex/tree/allennlp, see https://github.com/NVIDIA/apex/pull/123 and https://github.com/NVIDIA/apex/issues/131)
* ~~it requires master branch of https://github.com/huggingface/pytorch-pretrained-BERT~~
* It's only been tested in a very narrow use case, and I'm sure there are landmines elsewhere in allennlp (e.g. "grep -r "float()" * | wc" shows 146 potentially problematic lines)