### PR TITLE
Fix CORS error for react in config explorer

### DIFF
--- a/allennlp/service/config_explorer.html
+++ b/allennlp/service/config_explorer.html
@@ -193,8 +193,8 @@
 
     <div id="app"></div>
 
-    <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
+    <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.8.2/immutable.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/6.26.0/babel.js"></script>
     <script src="https://unpkg.com/tippy.js@2.5.2/dist/tippy.all.min.js"></script>


### PR DESCRIPTION
The config explorer is currently broken on master due to https://github.com/unpkg/unpkg.com/issues/176 . Here's a screenshot of what I see:

<img width="1280" alt="screen shot 2019-02-02 at 3 35 10 pm" src="https://user-images.githubusercontent.com/7272031/52170492-2e31a700-2700-11e9-94bf-f94bd2359991.png">

The fix seems to be to remove the `crossorigin` attribute on the `<script>` tag. Things seems to load fine after doing so (also recommended in https://github.com/unpkg/unpkg.com/issues/176#issuecomment-459252472 ).