### PR TITLE
Allow checkpointer to be initialized from params

### DIFF
--- a/allennlp/tests/training/checkpointer_test.py
+++ b/allennlp/tests/training/checkpointer_test.py
@@ -1,0 +1,105 @@
+# pylint: disable=invalid-name
+import os
+import re
+import time
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.training.checkpointer import Checkpointer
+from allennlp.common.params import Params
+from allennlp.training.trainer import Trainer
+from allennlp.common.checks import ConfigurationError
+
+
+class TestCheckpointer(AllenNlpTestCase):
+    def retrieve_and_delete_saved(self):
+        serialization_files = os.listdir(self.TEST_DIR)
+        model_checkpoints = [x for x in serialization_files if "model_state_epoch" in x]
+        found_model_epochs = [int(re.search(r"model_state_epoch_([0-9\.\-]+)\.th", x).group(1))
+                              for x in model_checkpoints]
+        for f in model_checkpoints:
+            os.remove(os.path.join(self.TEST_DIR, f))
+        training_checkpoints = [x for x in serialization_files if "training_state_epoch" in x]
+        found_training_epochs = [int(re.search(r"training_state_epoch_([0-9\.\-]+)\.th", x).group(1))
+                                 for x in training_checkpoints]
+        for f in training_checkpoints:
+            os.remove(os.path.join(self.TEST_DIR, f))
+        return sorted(found_model_epochs), sorted(found_training_epochs)
+
+    def test_default(self):
+        """
+        Tests against Trainer's default values for num_to_keep
+        """
+        default_num_to_keep = 20
+        num_epochs = 30
+        target = list(range(num_epochs - default_num_to_keep, num_epochs))
+
+        checkpointer = Checkpointer(serialization_dir=self.TEST_DIR)
+
+        for e in range(num_epochs):
+            checkpointer.save_checkpoint(epoch=e,
+                                         model_state={"epoch": e},
+                                         training_states={"epoch": e},
+                                         is_best_so_far=False)
+        models, training = self.retrieve_and_delete_saved()
+        assert models == training == target
+
+    def test_with_time(self):
+        """
+        Tests consistent behavior for keep_serialized_model_every_num_seconds
+        """
+        num_to_keep = 10
+        num_epochs = 30
+        target = list(range(num_epochs - num_to_keep, num_epochs))
+        pauses = [5, 18, 26]
+        target = sorted(set(target + pauses))
+        checkpointer = Checkpointer(serialization_dir=self.TEST_DIR,
+                                    num_serialized_models_to_keep=num_to_keep,
+                                    keep_serialized_model_every_num_seconds=1)
+        for e in range(num_epochs):
+            if e in pauses:
+                time.sleep(2)
+            checkpointer.save_checkpoint(epoch=e,
+                                         model_state={"epoch": e},
+                                         training_states={"epoch": e},
+                                         is_best_so_far=False)
+        models, training = self.retrieve_and_delete_saved()
+        assert models == training == target
+
+    def test_configuration_error_when_passed_as_conflicting_argument_to_trainer(self):
+        with self.assertRaises(ConfigurationError):
+            Trainer(None, None, None, None,
+                    num_serialized_models_to_keep=30,
+                    keep_serialized_model_every_num_seconds=None,
+                    checkpointer=Checkpointer(serialization_dir=self.TEST_DIR,
+                                              num_serialized_models_to_keep=40,
+                                              keep_serialized_model_every_num_seconds=2))
+        with self.assertRaises(ConfigurationError):
+            Trainer(None, None, None, None,
+                    num_serialized_models_to_keep=20,
+                    keep_serialized_model_every_num_seconds=2,
+                    checkpointer=Checkpointer(serialization_dir=self.TEST_DIR,
+                                              num_serialized_models_to_keep=40,
+                                              keep_serialized_model_every_num_seconds=2))
+        try:
+            Trainer(None, None, None, None,
+                    checkpointer=Checkpointer(serialization_dir=self.TEST_DIR,
+                                              num_serialized_models_to_keep=40,
+                                              keep_serialized_model_every_num_seconds=2))
+        except ConfigurationError:
+            self.fail("Configuration Error raised for passed checkpointer")
+
+    def test_registered_subclass(self):
+        """
+        Tests that registering subclasses works correctly.
+        """
+
+        @Checkpointer.register("checkpointer_subclass")
+        class CheckpointerSubclass(Checkpointer):
+            def __init__(self, x: int, y: int) -> None:
+                super().__init__()
+                self.x = x
+                self.y = y
+
+        sub_inst = Checkpointer.from_params(Params({"type": "checkpointer_subclass", "x": 1, "y": 3}))
+        assert sub_inst.__class__ == CheckpointerSubclass
+        assert sub_inst.x == 1 and sub_inst.y == 3

--- a/allennlp/tests/training/checkpointer_test.py
+++ b/allennlp/tests/training/checkpointer_test.py
@@ -12,6 +12,11 @@ from allennlp.common.checks import ConfigurationError
 
 class TestCheckpointer(AllenNlpTestCase):
     def retrieve_and_delete_saved(self):
+        """
+        Helper function for the tests below. Finds the weight and training state files in
+        self.TEST_DIR, parses their names for the epochs that were saved, deletes them,
+        and returns the saved epochs as two lists of integers.
+        """
         serialization_files = os.listdir(self.TEST_DIR)
         model_checkpoints = [x for x in serialization_files if "model_state_epoch" in x]
         found_model_epochs = [int(re.search(r"model_state_epoch_([0-9\.\-]+)\.th", x).group(1))
@@ -27,7 +32,7 @@ class TestCheckpointer(AllenNlpTestCase):
 
     def test_default(self):
         """
-        Tests against Trainer's default values for num_to_keep
+        Tests that the default behavior keeps just the last 20 checkpoints.
         """
         default_num_to_keep = 20
         num_epochs = 30
@@ -45,7 +50,8 @@ class TestCheckpointer(AllenNlpTestCase):
 
     def test_with_time(self):
         """
-        Tests consistent behavior for keep_serialized_model_every_num_seconds
+        Tests that keep_serialized_model_every_num_seconds parameter causes a checkpoint to be saved
+        after enough time has elapsed between epochs.
         """
         num_to_keep = 10
         num_epochs = 30
@@ -66,6 +72,11 @@ class TestCheckpointer(AllenNlpTestCase):
         assert models == training == target
 
     def test_configuration_error_when_passed_as_conflicting_argument_to_trainer(self):
+        """
+        Users should initialize Trainer either with an instance of Checkpointer or by specifying
+        parameter values for num_serialized_models_to_keep and keep_serialized_model_every_num_seconds.
+        Check that Trainer raises a ConfigurationError if both methods are used at the same time.
+        """
         with self.assertRaises(ConfigurationError):
             Trainer(None, None, None, None,
                     num_serialized_models_to_keep=30,
@@ -90,7 +101,7 @@ class TestCheckpointer(AllenNlpTestCase):
 
     def test_registered_subclass(self):
         """
-        Tests that registering subclasses works correctly.
+        Tests that registering Checkpointer subclasses works correctly.
         """
 
         @Checkpointer.register("checkpointer_subclass")

--- a/allennlp/training/checkpointer.py
+++ b/allennlp/training/checkpointer.py
@@ -8,11 +8,12 @@ import time
 
 import torch
 
+from allennlp.common.registrable import Registrable
 from allennlp.nn import util as nn_util
 
 logger = logging.getLogger(__name__)
 
-class Checkpointer:
+class Checkpointer(Registrable):
     """
     This class implements the functionality for checkpointing your model and trainer state
     during training. It is agnostic as to what those states look like (they are typed as

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -50,6 +50,7 @@ class Trainer(TrainerBase):
                  serialization_dir: Optional[str] = None,
                  num_serialized_models_to_keep: int = 20,
                  keep_serialized_model_every_num_seconds: int = None,
+                 checkpointer: Checkpointer = None,
                  model_save_interval: float = None,
                  cuda_device: Union[int, List] = -1,
                  grad_norm: Optional[float] = None,
@@ -115,6 +116,11 @@ class Trainer(TrainerBase):
             To do so, specify keep_serialized_model_every_num_seconds as the number of seconds
             between permanently saved checkpoints.  Note that this option is only used if
             num_serialized_models_to_keep is not None, otherwise all checkpoints are kept.
+        checkpointer : ``Checkpointer``, optional (default=None)
+            An instance of class Checkpointer to use instead of the default. If a checkpointer is specified,
+            the arguments num_serialized_models_to_keep and keep_serialized_model_every_num_seconds should
+            not be specified. The caller is responsible for initializing the checkpointer so that it is
+            consistent with serialization_dir.
         model_save_interval : ``float``, optional (default=None)
             If provided, then serialize models every ``model_save_interval``
             seconds within single epochs.  In all cases, models are also saved
@@ -196,9 +202,19 @@ class Trainer(TrainerBase):
 
         self._num_epochs = num_epochs
 
-        self._checkpointer = Checkpointer(serialization_dir,
-                                          keep_serialized_model_every_num_seconds,
-                                          num_serialized_models_to_keep)
+        if checkpointer is not None:
+            # We can't easily check if these parameters were passed in, so check against their default values.
+            # We don't check against serialization_dir since it is also used by the parent class.
+            if num_serialized_models_to_keep != 20 or \
+                    keep_serialized_model_every_num_seconds is not None:
+                raise ConfigurationError(
+                        "When passing a custom Checkpointer, you may not also pass in separate checkpointer "
+                        "args 'num_serialized_models_to_keep' or 'keep_serialized_model_every_num_seconds'.")
+            self._checkpointer = checkpointer
+        else:
+            self._checkpointer = Checkpointer(serialization_dir,
+                                              keep_serialized_model_every_num_seconds,
+                                              num_serialized_models_to_keep)
 
         self._model_save_interval = model_save_interval
 
@@ -682,9 +698,22 @@ class Trainer(TrainerBase):
         else:
             momentum_scheduler = None
 
-        num_serialized_models_to_keep = params.pop_int("num_serialized_models_to_keep", 20)
-        keep_serialized_model_every_num_seconds = params.pop_int(
-                "keep_serialized_model_every_num_seconds", None)
+        if 'checkpointer' in params:
+            if 'keep_serialized_model_every_num_seconds' in params or \
+                    'num_serialized_models_to_keep' in params:
+                raise ConfigurationError(
+                        "Checkpointer may be initialized either from the 'checkpointer' key or from the "
+                        "keys 'num_serialized_models_to_keep' and 'keep_serialized_model_every_num_seconds'"
+                        " but the passed config uses both methods.")
+            checkpointer = Checkpointer.from_params(params.pop("checkpointer"))
+        else:
+            num_serialized_models_to_keep = params.pop_int("num_serialized_models_to_keep", 20)
+            keep_serialized_model_every_num_seconds = params.pop_int(
+                    "keep_serialized_model_every_num_seconds", None)
+            checkpointer = Checkpointer(
+                    serialization_dir=serialization_dir,
+                    num_serialized_models_to_keep=num_serialized_models_to_keep,
+                    keep_serialized_model_every_num_seconds=keep_serialized_model_every_num_seconds)
         model_save_interval = params.pop_float("model_save_interval", None)
         summary_interval = params.pop_int("summary_interval", 100)
         histogram_interval = params.pop_int("histogram_interval", None)
@@ -706,8 +735,7 @@ class Trainer(TrainerBase):
                    grad_clipping=grad_clipping,
                    learning_rate_scheduler=lr_scheduler,
                    momentum_scheduler=momentum_scheduler,
-                   num_serialized_models_to_keep=num_serialized_models_to_keep,
-                   keep_serialized_model_every_num_seconds=keep_serialized_model_every_num_seconds,
+                   checkpointer=checkpointer,
                    model_save_interval=model_save_interval,
                    summary_interval=summary_interval,
                    histogram_interval=histogram_interval,


### PR DESCRIPTION
Allows custom Checkpointer to be loaded from params.
Trainer now takes an optional `checkpointer` parameter. 
Also added some unit tests for Checkpointer