### PR TITLE
Revert "Less restrictive token characters indexer"

### DIFF
--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -9,7 +9,7 @@ from allennlp.common.util import pad_sequence_to_length
 from allennlp.data.tokenizers.token import Token
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
 from allennlp.data.vocabulary import Vocabulary
-from allennlp.data.tokenizers import Tokenizer, CharacterTokenizer
+from allennlp.data.tokenizers.character_tokenizer import CharacterTokenizer
 
 
 @TokenIndexer.register("characters")
@@ -26,11 +26,7 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
         We use a :class:`CharacterTokenizer` to handle splitting tokens into characters, as it has
         options for byte encoding and other things.  The default here is to instantiate a
         ``CharacterTokenizer`` with its default parameters, which uses unicode characters and
-        retains casing.  Note: this argument is depreciated in favor of tokenizer and will be
-        removed before version 1.0.
-    tokenizer : ``Tokenizer``, optional (default=``None``)
-        If provided, it is used instead of character_tokenizer, otherwise we default to
-        character_tokenizer.
+        retains casing.
     start_tokens : ``List[str]``, optional (default=``None``)
         These are prepended to the tokens provided to ``tokens_to_indices``.
     end_tokens : ``List[str]``, optional (default=``None``)
@@ -43,7 +39,6 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
     def __init__(self,
                  namespace: str = 'token_characters',
                  character_tokenizer: CharacterTokenizer = CharacterTokenizer(),
-                 tokenizer: Tokenizer = None,
                  start_tokens: List[str] = None,
                  end_tokens: List[str] = None,
                  min_padding_length: int = 0) -> None:
@@ -56,16 +51,7 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
                           UserWarning)
         self._min_padding_length = min_padding_length
         self._namespace = namespace
-        self._character_tokenizer: Tokenizer = None
-        if tokenizer is None:
-            # NOTE: (matt-peters) when removing character_tokenizer in the future, the default
-            # value for tokenizer should change to CharacterTokenizer() from None.
-            warnings.warn("character_tokenizer is depreciated and will be "
-                          "removed before version 1.0.  Use tokenizer instead.",
-                          UserWarning)
-            self._character_tokenizer = character_tokenizer
-        else:
-            self._character_tokenizer = tokenizer
+        self._character_tokenizer = character_tokenizer
 
         self._start_tokens = [Token(st) for st in (start_tokens or [])]
         self._end_tokens = [Token(et) for et in (end_tokens or [])]

--- a/allennlp/tests/data/token_indexers/character_token_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/character_token_indexer_test.py
@@ -7,7 +7,6 @@ from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Token, Vocabulary
 from allennlp.data.token_indexers import TokenCharactersIndexer
 from allennlp.data.tokenizers.character_tokenizer import CharacterTokenizer
-from allennlp.data.tokenizers import WordTokenizer
 
 
 class CharacterTokenIndexerTest(AllenNlpTestCase):
@@ -105,15 +104,3 @@ class CharacterTokenIndexerTest(AllenNlpTestCase):
     def test_warn_min_padding_length(self):
         with pytest.warns(UserWarning, match=r"using the default value \(0\) of `min_padding_length`"):
             TokenCharactersIndexer("characters")
-
-    def test_warn_no_tokenizer(self):
-        with pytest.warns(UserWarning, match="depreciated"):
-            TokenCharactersIndexer("characters",
-                                   character_tokenizer=CharacterTokenizer(),
-                                   tokenizer=None)
-
-    def test_prefers_tokenizer_to_character_tokenizer(self):
-        indexer = TokenCharactersIndexer("characters",
-                                         character_tokenizer=CharacterTokenizer(),
-                                         tokenizer=WordTokenizer())
-        assert isinstance(indexer._character_tokenizer, WordTokenizer) # pylint: disable=protected-access


### PR DESCRIPTION
Reverts allenai/allennlp#2494

We just merged a huge involved PR to get rid of all of our warnings when we run tests (https://github.com/allenai/allennlp/pull/2479, https://github.com/allenai/allennlp/pull/2282).  I won't repeat the justification for this here - anyone interested can go back and read that history.  The bottom line: it is intentionally difficult to introduce new warnings into our code.  The original PR that introduces a warning must also do whatever cleanup is necessary for it, so that the cleanup has a clear owner and actually gets done.  This PR bypassed that by using a `UserWarning` instead of a `DeprecationWarning`, so I am reverting it.  I had a discussion with @joelgrus, who hadn't followed all of the discussion involved in #2282, and approved the PR without realizing that we were intentionally disallowing this.  Per @brendan-ai2's arguments, we are also intentionally slow at making API changes.

For @matt-peters, who made this change, there are three ways forward:
1. (Easiest) Just copy the code for the class you want and make the change, registering it as something else.  For a research project, this is generally the right thing to do.  Once you have a clear, compelling use case, we can consider an API change to handle it.
2. Make the change without adding a warning.  I don't much like this solution, because it makes the API muddy without giving a warning about the muddiness.
3. Use a `DeprecationWarning` instead of a `UserWarning`, and make all of the tests pass.