### PR TITLE
Adding bag_of_embeddings as an alternate name for the boe encoder

### DIFF
--- a/allennlp/modules/seq2vec_encoders/boe_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/boe_encoder.py
@@ -6,6 +6,7 @@ from allennlp.modules.seq2vec_encoders.seq2vec_encoder import Seq2VecEncoder
 from allennlp.nn.util import get_lengths_from_binary_sequence_mask
 
 @Seq2VecEncoder.register("boe")
+@Seq2VecEncoder.register("bag_of_embeddings")
 class BagOfEmbeddingsEncoder(Seq2VecEncoder):
     """
     A ``BagOfEmbeddingsEncoder`` is a simple :class:`Seq2VecEncoder` which simply sums the embeddings


### PR DESCRIPTION
Adding bag_of_embeddings as an alternate registered name for the boe encoder, as requested in issue #2268 and comment #2246 