### PR TITLE
Unfreeze layers when recovering with slanted triangular learning rate

### DIFF
--- a/allennlp/training/learning_rate_schedulers/slanted_triangular.py
+++ b/allennlp/training/learning_rate_schedulers/slanted_triangular.py
@@ -60,7 +60,6 @@ class SlantedTriangular(LearningRateScheduler):
         self.ratio = ratio
         self.gradual_unfreezing = gradual_unfreezing
         self.freezing_current = self.gradual_unfreezing
-        self.is_first_epoch = True
         # track the actual number of steps for each epoch
         self.batch_num_total_epoch_end: List[int] = []
         if self.gradual_unfreezing:
@@ -97,9 +96,8 @@ class SlantedTriangular(LearningRateScheduler):
             # epoch; so the first time, with epoch id -1, we want to set
             # up for epoch #1; the second time, with epoch id 0,
             # we want to set up for epoch #2, etc.
-            if self.is_first_epoch:
+            if epoch < 0:
                 num_layers_to_unfreeze = 1
-                self.is_first_epoch = False
             else:
                 num_layers_to_unfreeze = epoch + 2
             if num_layers_to_unfreeze >= len(self.optimizer.param_groups)-1:


### PR DESCRIPTION
`is_first_epoch` will always be true for one epoch regardless of the current epoch number. Instead, we should base the unfreezing on the epoch number to unfreeze the correct number of layers when recovering a training run.

Alternatively, could simplify the condition to

```python
num_layers_to_unfreeze = epoch + 2 if epoch > -1 else 1
```