### PR TITLE
Restore tensorboard epoch metrics to pre-refactoring behavior

### DIFF
--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -64,10 +64,11 @@ class TensorboardWriter:
     def should_log_histograms_this_batch(self) -> bool:
         return self._histogram_interval is not None and self._get_batch_num_total() % self._histogram_interval == 0
 
-    def add_train_scalar(self, name: str, value: float) -> None:
+    def add_train_scalar(self, name: str, value: float, timestep: int = None) -> None:
+        timestep = timestep or self._get_batch_num_total()
         # get the scalar
         if self._train_log is not None:
-            self._train_log.add_scalar(name, self._item(value), self._get_batch_num_total())
+            self._train_log.add_scalar(name, self._item(value), timestep)
 
     def add_train_histogram(self, name: str, values: torch.Tensor) -> None:
         if self._train_log is not None:
@@ -75,9 +76,10 @@ class TensorboardWriter:
                 values_to_write = values.cpu().data.numpy().flatten()
                 self._train_log.add_histogram(name, values_to_write, self._get_batch_num_total())
 
-    def add_validation_scalar(self, name: str, value: float) -> None:
+    def add_validation_scalar(self, name: str, value: float, timestep: int = None) -> None:
+        timestep = timestep or self._get_batch_num_total()
         if self._validation_log is not None:
-            self._validation_log.add_scalar(name, self._item(value), self._get_batch_num_total())
+            self._validation_log.add_scalar(name, self._item(value), timestep)
 
     def log_parameter_and_gradient_statistics(self, # pylint: disable=invalid-name
                                               model: Model,
@@ -139,6 +141,7 @@ class TensorboardWriter:
     def log_metrics(self,
                     train_metrics: dict,
                     val_metrics: dict = None,
+                    epoch: int = None,
                     log_to_console: bool = False) -> None:
         """
         Sends all of the train metrics (and validation metrics, if provided) to tensorboard.
@@ -161,10 +164,10 @@ class TensorboardWriter:
             # Log to tensorboard
             train_metric = train_metrics.get(name)
             if train_metric is not None:
-                self.add_train_scalar(f"epoch_metrics/{name}", train_metric)
+                self.add_train_scalar(name, train_metric, timestep=epoch)
             val_metric = val_metrics.get(name)
             if val_metric is not None:
-                self.add_validation_scalar(f"epoch_metrics/{name}", val_metric)
+                self.add_validation_scalar(name, val_metric, timestep=epoch)
 
             # And maybe log to console
             if log_to_console and val_metric is not None and train_metric is not None:

--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -79,7 +79,6 @@ class TensorboardWriter:
         if self._validation_log is not None:
             self._validation_log.add_scalar(name, self._item(value), self._get_batch_num_total())
 
-
     def log_parameter_and_gradient_statistics(self, # pylint: disable=invalid-name
                                               model: Model,
                                               batch_grad_norm: float) -> None:
@@ -129,7 +128,6 @@ class TensorboardWriter:
                     effective_rate = rate * float(param.requires_grad)
                     self.add_train_scalar("learning_rate/" + names[param], effective_rate)
 
-
     def log_histograms(self, model: Model, histogram_parameters: Set[str]) -> None:
         """
         Send histograms of parameters to tensorboard.
@@ -163,10 +161,10 @@ class TensorboardWriter:
             # Log to tensorboard
             train_metric = train_metrics.get(name)
             if train_metric is not None:
-                self.add_train_scalar(name, train_metric)
+                self.add_train_scalar(f"epoch_metrics/{name}", train_metric)
             val_metric = val_metrics.get(name)
             if val_metric is not None:
-                self.add_validation_scalar(name, val_metric)
+                self.add_validation_scalar(f"epoch_metrics/{name}", val_metric)
 
             # And maybe log to console
             if log_to_console and val_metric is not None and train_metric is not None:
@@ -175,7 +173,6 @@ class TensorboardWriter:
                 logger.info(no_train_message_template, name.ljust(name_length), "N/A", val_metric)
             elif log_to_console and train_metric is not None:
                 logger.info(no_val_message_template, name.ljust(name_length), train_metric, "N/A")
-
 
     def enable_activation_logging(self, model: Model) -> None:
         if self._histogram_interval is not None:

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -353,7 +353,7 @@ class Trainer(TrainerBase):
                 self._tensorboard.log_learning_rates(self.model, self.optimizer)
 
                 self._tensorboard.add_train_scalar("loss/loss_train", metrics["loss"])
-                self._tensorboard.log_metrics({"epoch_metrics/" + k: v for k, v in metrics.items()})
+                self._tensorboard.log_metrics(metrics)
 
             if self._tensorboard.should_log_histograms_this_batch():
                 self._tensorboard.log_histograms(self.model, histogram_parameters)

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -353,7 +353,7 @@ class Trainer(TrainerBase):
                 self._tensorboard.log_learning_rates(self.model, self.optimizer)
 
                 self._tensorboard.add_train_scalar("loss/loss_train", metrics["loss"])
-                self._tensorboard.log_metrics(metrics)
+                self._tensorboard.log_metrics({"epoch_metrics/" + k: v for k, v in metrics.items()})
 
             if self._tensorboard.should_log_histograms_this_batch():
                 self._tensorboard.log_histograms(self.model, histogram_parameters)
@@ -380,7 +380,6 @@ class Trainer(TrainerBase):
         for (gpu_num, memory) in gpu_usage:
             metrics['gpu_'+str(gpu_num)+'_memory_MB'] = memory
         return metrics
-
 
     def _validation_loss(self) -> Tuple[float, int]:
         """
@@ -486,7 +485,10 @@ class Trainer(TrainerBase):
                         logger.info("Ran out of patience.  Stopping training.")
                         break
 
-            self._tensorboard.log_metrics(train_metrics, val_metrics=val_metrics, log_to_console=True)
+            self._tensorboard.log_metrics(train_metrics,
+                                          val_metrics=val_metrics,
+                                          log_to_console=True,
+                                          epoch=epoch + 1)  # +1 because tensorboard doesn't like 0
 
             # Create overall metrics dict
             training_elapsed_time = time.time() - training_start_time
@@ -634,7 +636,6 @@ class Trainer(TrainerBase):
             self._batch_num_total = batch_num_total
 
         return epoch_to_return
-
 
     # Requires custom from_params.
     @classmethod


### PR DESCRIPTION
Fixes #2529.

This changes the metrics that get logged to tensorboard at the end of every epoch to use the epoch number as its counter, instead of the batch number.  This is what the behavior was prior to the refactoring.

I think there are still some very confusing things in this behavior, which we may want to change: "epoch_metrics" isn't actually "the metrics at the end of every epoch", it's "train metrics shown at `summary_interval` steps during an epoch".  So I propose that we regroup things into two sections: (1) `epoch_metrics/`, which use the epoch number as their counter and are shown for both training and validation, and (2) `train_metrics/`, which use the batch number as their counter and are logged at `summary_interval`.  This is just renaming the current `epoch_metrics` to `train_metrics`, and grouping together the per-epoch metrics into a common prefix, so you don't have a top-level "loss", "accuracy", etc.  I'd probably also just remove "loss/loss_train" while doing this, because it's an exact duplicate of `train_metrics/loss`.

@fbrad, FYI.