### PR TITLE
Extend evaluate to work with untrained models.

### DIFF
--- a/allennlp/tests/commands/evaluate_test.py
+++ b/allennlp/tests/commands/evaluate_test.py
@@ -72,6 +72,16 @@ class TestEvaluate(AllenNlpTestCase):
         metrics = evaluate_from_args(args)
         assert metrics.keys() == {'span_acc', 'end_acc', 'start_acc', 'em', 'f1', 'loss'}
 
+    def test_evaluate_from_args_untrained(self):
+        kebab_args = ["evaluate", str(self.FIXTURES_ROOT / "bidaf" / "experiment.json"),
+                      str(self.FIXTURES_ROOT / "data" / "squad.json"),
+                      "--cuda-device", "-1",
+                      "--load-config-only"]
+
+        args = self.parser.parse_args(kebab_args)
+        metrics = evaluate_from_args(args)
+        assert metrics.keys() == {'span_acc', 'end_acc', 'start_acc', 'em', 'f1', 'loss'}
+
     def test_output_file_evaluate_from_args(self):
         output_file = str(self.TEST_DIR / "metrics.json")
         kebab_args = ["evaluate", str(self.FIXTURES_ROOT / "bidaf" / "serialization" / "model.tar.gz"),


### PR DESCRIPTION
- Allow `allennlp evaluate` to operate on untrained models, i.e. `.jsonnet` config.
- Motivation: For the S2 salience work we're comparing against a number of untrained baselines like tf-idf. It's convenient to do this in AllenNLP to access the dataset readers and metrics.