### PR TITLE
Add perplexity metric to LanguageModel

### DIFF
--- a/allennlp/models/language_model.py
+++ b/allennlp/models/language_model.py
@@ -11,6 +11,7 @@ from allennlp.modules.sampled_softmax_loss import SampledSoftmaxLoss
 from allennlp.modules.seq2seq_encoders import Seq2SeqEncoder
 from allennlp.nn.util import get_text_field_mask
 from allennlp.nn import InitializerApplicator
+from allennlp.training.metrics import Perplexity
 
 
 class _SoftmaxLoss(torch.nn.Module):
@@ -127,8 +128,10 @@ class LanguageModel(Model):
             self._softmax_loss = _SoftmaxLoss(num_words=vocab.get_vocab_size(),
                                               embedding_dim=self._forward_dim)
 
-        # TODO(brendanr): Output perplexity here. e^loss
+        # This buffer is now unused and exists only for backwards compatibility reasons.
         self.register_buffer('_last_average_loss', torch.zeros(1))
+
+        self._perplexity = Perplexity()
 
         if dropout:
             self._dropout = torch.nn.Dropout(dropout)
@@ -300,8 +303,8 @@ class LanguageModel(Model):
                     average_loss = forward_loss / num_targets.float()
             else:
                 average_loss = torch.tensor(0.0).to(forward_targets.device)  # pylint: disable=not-callable
-            # this is stored to compute perplexity if needed
-            self._last_average_loss[0] = average_loss.detach().item()
+
+            self._perplexity(average_loss)
 
             if num_targets > 0:
                 return_dict.update({
@@ -327,3 +330,6 @@ class LanguageModel(Model):
         })
 
         return return_dict
+
+    def get_metrics(self, reset: bool = False):
+        return {"perplexity": self._perplexity.get_metric(reset=reset)}

--- a/allennlp/training/metrics/__init__.py
+++ b/allennlp/training/metrics/__init__.py
@@ -18,6 +18,7 @@ from allennlp.training.metrics.mean_absolute_error import MeanAbsoluteError
 from allennlp.training.metrics.mention_recall import MentionRecall
 from allennlp.training.metrics.metric import Metric
 from allennlp.training.metrics.pearson_correlation import PearsonCorrelation
+from allennlp.training.metrics.perplexity import Perplexity
 from allennlp.training.metrics.sequence_accuracy import SequenceAccuracy
 from allennlp.training.metrics.span_based_f1_measure import SpanBasedF1Measure
 from allennlp.training.metrics.squad_em_and_f1 import SquadEmAndF1

--- a/allennlp/training/metrics/perplexity.py
+++ b/allennlp/training/metrics/perplexity.py
@@ -1,0 +1,32 @@
+from overrides import overrides
+import torch
+
+from allennlp.training.metrics.average import Average
+from allennlp.training.metrics.metric import Metric
+
+
+@Metric.register("perplexity")
+class Perplexity(Average):
+    """
+    Perplexity is a common metric used for evaluating how well a language model
+    predicts a sample.
+
+    Notes
+    -----
+    Assumes negative log likelihood loss of each batch (base e). Provides the
+    average perplexity of the batches.
+    """
+
+    @overrides
+    def get_metric(self, reset: bool = False) -> float:
+        """
+        Returns
+        -------
+        The accumulated perplexity.
+        """
+        average_loss = super().get_metric(reset)
+        if average_loss == 0:
+            return 0.
+
+        # Exponentiate the loss to compute perplexity
+        return float(torch.exp(average_loss))

--- a/doc/api/allennlp.training.metrics.rst
+++ b/doc/api/allennlp.training.metrics.rst
@@ -116,6 +116,12 @@ allennlp.training.metrics
    :undoc-members:
    :show-inheritance:
 
+.. _perplexity:
+.. automodule:: allennlp.training.metrics.perplexity
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. _sequence-accuracy:
 .. automodule:: allennlp.training.metrics.sequence_accuracy
    :members:


### PR DESCRIPTION
As discussed in #2400, this PR adds a `perplexity` metric to the `LanguageModel`. To do this, I created a `Perplexity` metric class which is updated with a negative log loss. @nelson-liu 

fixes #2400