### PR TITLE
Scope DeprecationWarning errors to just allennlp-internal stuff

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,21 +15,15 @@ filterwarnings =
 # how to explicitly test warns
 #  using `unittest`: https://docs.python.org/3/library/warnings.html#testing-warnings
 #  using `pytest`: https://docs.pytest.org/en/4.1.0/warnings.html#assertwarnings
-    # 1. transform all DeprecationWarnings and PendingDeprecationWarning to erros
-    #    when we _directly_ call deprecated methods (including internal methods in AllenNLP)
-    # 2. unless we explicitly _test_ these warns
-    error::DeprecationWarning
-    error::PendingDeprecationWarning
-    # 3. or _ignore_ them (usually caused by third-party modules)
-    #
-    # Those warns are caused by `nbconvert==5.4.0` (details see https://github.com/jupyter/nbconvert/pull/945)
-    #
-    ignore:`nbconvert.exporters.exporter_locator` is deprecated.*:DeprecationWarning:nbconvert\.exporters\.exporter_locator
-    ignore:@asynchronous is deprecated, use coroutines instead::tornado\.web
-    #
-    ignore:encoding is deprecated, Use raw=False instead.:PendingDeprecationWarning:msgpack_numpy
-    # For `spacy==2.0.11`
-    ignore:Direct calling implementation's unpack.*:PendingDeprecationWarning:msgpack_numpy
-    ignore:The binary mode of fromstring is deprecated.*:DeprecationWarning:msgpack_numpy
-    # 4. ignore these `ExperimentalFeatureWarning` for now, but record them once
+#
+# Our policy here is to ignore (silence) any deprecation warnings from _outside_ allennlp, but to
+# treat any _internal_ deprecation warnings as errors.  If we get a deprecation warning from things
+# we call in another library, we will just rely on seeing those outside of tests.  The purpose of
+# having these errors here is to make sure that we do not deprecate things lightly in allennlp.
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning
+    error::DeprecationWarning:allennlp.*:
+    error::PendingDeprecationWarning:allennlp.*:
+# For this particular warning, we don't want to cause an error for it, but we also don't want to
+# see it a whole bunch of times.
     once:This particular transformer implementation is a provisional feature.*::allennlp\.modules\.seq2seq_encoders\.bidirectional_language_model_transformer


### PR DESCRIPTION
A couple of people have mentioned test failures when running locally.  I just tried it myself and discovered that updates to other libraries added some deprecation warnings that are causing our tests to fail.  This was not the intent of the deprecation-warning-into-error stuff that we did - we just wanted to make sure we weren't adding deprecation warnings ourselves without fixing our own code first.  So this PR changes the policy to ignore all non-allennlp deprecation warnings, and fail only on allennlp ones (I confirmed that adding a deprecation warning inside of allennlp causes test failures, as intended).