### PR TITLE
Fix broken model unit test function when using overrides

### DIFF
--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -81,7 +81,7 @@ class ModelTestCase(AllenNlpTestCase):
             assert_allclose(model.state_dict()[key].cpu().numpy(),
                             loaded_model.state_dict()[key].cpu().numpy(),
                             err_msg=key)
-        params = Params.from_file(param_file)
+        params = Params.from_file(param_file, params_overrides=overrides)
         reader = DatasetReader.from_params(params['dataset_reader'])
 
         # Need to duplicate params because Iterator.from_params will consume.


### PR DESCRIPTION
This was breaking for me when I wanted to create a unit test for a model, but also wanted to force certain parameter overrides as specified in the unit test. 

In this function, the model is instantiated from the params file with overrides.

But the second time params are created from file, it's missing the overrides argument, causing mismatches in the rest of the test.