### PR TITLE
Make `load_archive` operate on serialization directories.

### DIFF
--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -49,7 +49,6 @@ and report any metrics calculated by the model.
     --include-package INCLUDE_PACKAGE
                             additional packages to include
 """
-import os
 from typing import Dict, Any
 import argparse
 import logging

--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -126,10 +126,6 @@ def evaluate_from_args(args: argparse.Namespace) -> Dict[str, Any]:
     logging.getLogger('allennlp.nn.initializers').disabled = True
     logging.getLogger('allennlp.modules.token_embedders.embedding').setLevel(logging.INFO)
 
-    if os.path.isdir(args.archive_file):
-        logger.warning(f"Attempting to load directory, {args.archive_file}, which may be missing "
-                       "critical files. You probably want to pass a path ending in .tar.gz.")
-
     # Load from archive
     archive = load_archive(args.archive_file, args.cuda_device, args.overrides, args.weights_file)
     config = archive.config

--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -49,6 +49,7 @@ and report any metrics calculated by the model.
     --include-package INCLUDE_PACKAGE
                             additional packages to include
 """
+import os
 from typing import Dict, Any
 import argparse
 import logging
@@ -124,6 +125,10 @@ def evaluate_from_args(args: argparse.Namespace) -> Dict[str, Any]:
     logging.getLogger('allennlp.common.params').disabled = True
     logging.getLogger('allennlp.nn.initializers').disabled = True
     logging.getLogger('allennlp.modules.token_embedders.embedding').setLevel(logging.INFO)
+
+    if os.path.isdir(args.archive_file):
+        logger.warning(f"Attempting to load directory, {args.archive_file}, which may be missing "
+                       "critical files. You probably want to pass a path ending in .tar.gz.")
 
     # Load from archive
     archive = load_archive(args.archive_file, args.cuda_device, args.overrides, args.weights_file)

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -175,10 +175,10 @@ def load_archive(archive_file: str,
         logger.info(f"loading archive file {archive_file} from cache at {resolved_archive_file}")
 
     if os.path.isdir(resolved_archive_file):
-        loading_dir = True
+        archive_is_directory = True
         serialization_dir = resolved_archive_file
     else:
-        loading_dir = False
+        archive_is_directory = False
         # Extract archive to temp dir
         tempdir = tempfile.mkdtemp()
         logger.info(f"extracting archive file {resolved_archive_file} to temp dir {tempdir}")
@@ -192,7 +192,7 @@ def load_archive(archive_file: str,
 
     # Check for supplemental files in archive
     fta_filename = os.path.join(serialization_dir, _FTA_NAME)
-    if not loading_dir and os.path.exists(fta_filename):
+    if not archive_is_directory and os.path.exists(fta_filename):
         with open(fta_filename, 'r') as fta_file:
             files_to_archive = json.loads(fta_file.read())
 
@@ -217,7 +217,7 @@ def load_archive(archive_file: str,
     if weights_file:
         weights_path = weights_file
     else:
-        if loading_dir:
+        if archive_is_directory:
             weights_path = os.path.join(serialization_dir, _DEFAULT_WEIGHTS)
         else:
             weights_path = os.path.join(serialization_dir, _WEIGHTS_NAME)

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -175,8 +175,10 @@ def load_archive(archive_file: str,
         logger.info(f"loading archive file {archive_file} from cache at {resolved_archive_file}")
 
     if os.path.isdir(resolved_archive_file):
+        loading_dir = True
         serialization_dir = resolved_archive_file
     else:
+        loading_dir = False
         # Extract archive to temp dir
         tempdir = tempfile.mkdtemp()
         logger.info(f"extracting archive file {resolved_archive_file} to temp dir {tempdir}")
@@ -190,18 +192,22 @@ def load_archive(archive_file: str,
 
     # Check for supplemental files in archive
     fta_filename = os.path.join(serialization_dir, _FTA_NAME)
-    if os.path.exists(fta_filename):
+    if not loading_dir and os.path.exists(fta_filename):
         with open(fta_filename, 'r') as fta_file:
             files_to_archive = json.loads(fta_file.read())
 
         # Add these replacements to overrides
         replacements_dict: Dict[str, Any] = {}
-        for key, _ in files_to_archive.items():
+        for key, original_filename in files_to_archive.items():
             replacement_filename = os.path.join(serialization_dir, f"fta/{key}")
+            if not os.path.exists(replacement_filename):
+                raise RuntimeError(f"Archived file {replacement_filename} not found! At train time "
+                                   f"this file was located at {original_filename}.")
+
             replacements_dict[key] = replacement_filename
 
         overrides_dict = parse_overrides(overrides)
-        combined_dict = with_fallback(preferred=unflatten(replacements_dict), fallback=overrides_dict)
+        combined_dict = with_fallback(preferred=overrides_dict, fallback=unflatten(replacements_dict))
         overrides = json.dumps(combined_dict)
 
     # Load config
@@ -211,7 +217,11 @@ def load_archive(archive_file: str,
     if weights_file:
         weights_path = weights_file
     else:
-        weights_path = os.path.join(serialization_dir, _WEIGHTS_NAME)
+        if loading_dir:
+            weights_path = os.path.join(serialization_dir, _DEFAULT_WEIGHTS)
+        else:
+            weights_path = os.path.join(serialization_dir, _WEIGHTS_NAME)
+
 
     # Instantiate model. Use a duplicate of the config, as it will get consumed.
     model = Model.load(config.duplicate(),

--- a/allennlp/tests/models/archival_test.py
+++ b/allennlp/tests/models/archival_test.py
@@ -9,6 +9,22 @@ from allennlp.common.testing import AllenNlpTestCase
 from allennlp.commands.train import train_model
 from allennlp.models.archival import load_archive, archive_model
 
+def assert_models_equal(model, model2):
+    # check that model weights are the same
+    keys = set(model.state_dict().keys())
+    keys2 = set(model2.state_dict().keys())
+
+    assert keys == keys2
+
+    for key in keys:
+        assert torch.equal(model.state_dict()[key], model2.state_dict()[key])
+
+    # check that vocabularies are the same
+    vocab = model.vocab
+    vocab2 = model2.vocab
+
+    assert vocab._token_to_index == vocab2._token_to_index  # pylint: disable=protected-access
+    assert vocab._index_to_token == vocab2._index_to_token  # pylint: disable=protected-access
 
 class ArchivalTest(AllenNlpTestCase):
     def setUp(self):
@@ -56,21 +72,7 @@ class ArchivalTest(AllenNlpTestCase):
         archive = load_archive(archive_path)
         model2 = archive.model
 
-        # check that model weights are the same
-        keys = set(model.state_dict().keys())
-        keys2 = set(model2.state_dict().keys())
-
-        assert keys == keys2
-
-        for key in keys:
-            assert torch.equal(model.state_dict()[key], model2.state_dict()[key])
-
-        # check that vocabularies are the same
-        vocab = model.vocab
-        vocab2 = model2.vocab
-
-        assert vocab._token_to_index == vocab2._token_to_index  # pylint: disable=protected-access
-        assert vocab._index_to_token == vocab2._index_to_token  # pylint: disable=protected-access
+        assert_models_equal(model, model2)
 
         # check that params are the same
         params2 = archive.config
@@ -111,3 +113,39 @@ class ArchivalTest(AllenNlpTestCase):
 
         # The validation data path should be the same though.
         assert params.get('validation_data_path') == str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv')
+
+    def test_loading_serialization_directory(self):
+        # copy params, since they'll get consumed during training
+        params_copy = copy.deepcopy(self.params.as_dict())
+
+        # `train_model` should create an archive
+        serialization_dir = self.TEST_DIR / 'serialization'
+        model = train_model(self.params, serialization_dir=serialization_dir)
+
+        # load from the serialization directory itself
+        archive = load_archive(serialization_dir)
+        model2 = archive.model
+
+        assert_models_equal(model, model2)
+
+        # check that params are the same
+        params2 = archive.config
+        assert params2.as_dict() == params_copy
+
+    def test_loading_serialization_directory_with_extra_files(self):
+
+        serialization_dir = self.TEST_DIR / 'serialization'
+
+        # Train a model
+        train_model(self.params, serialization_dir=serialization_dir)
+
+        # Archive model, and also archive the training data
+        original_train_data_path = str(self.FIXTURES_ROOT / 'data' / 'sequence_tagging.tsv')
+        files_to_archive = {"train_data_path": original_train_data_path}
+        archive_model(serialization_dir=serialization_dir, files_to_archive=files_to_archive)
+
+        archive = load_archive(serialization_dir)
+        params = archive.config
+
+        # We're loading from a directory, so retain the original path.
+        assert params.get('train_data_path') == original_train_data_path


### PR DESCRIPTION
- Fixes https://github.com/allenai/allennlp/issues/1052.
- Files like ELMo weight files aren't added to the serialization dir, but are added to the archive with `add_file_to_archive`.
- This results in misleading errors when using `load_archive` as it will attempt to load a serialization dir.
- Solution: Retain original paths when we're loading from a directory.
- Drive by fix for overrides not overriding.