### PR TITLE
Add missing requirement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(name='allennlp',
           'parsimonious==0.8.0',
           'ftfy',
           'sqlparse==0.2.4',
+          'word2number==1.1',
           'pytorch-pretrained-bert>=0.6.0',
       ],
       entry_points={


### PR DESCRIPTION
I figured out why the master commit was breaking - I added something to `requirements.txt` without adding a corresponding entry to `setup.py`.  I forgot that we had to do this.  I thought we had some check that made sure these were consistent?  Did that not actually happen?  Anyway, I'm going to merge this when tests pass, so I can get a demo deploy set up.