### PR TITLE
disable tutorial test

### DIFF
--- a/allennlp/tests/tutorials/tagger/basic_allennlp_test.py
+++ b/allennlp/tests/tutorials/tagger/basic_allennlp_test.py
@@ -1,6 +1,9 @@
+import pytest
+
 from allennlp.common.testing import AllenNlpTestCase
 
 
+@pytest.mark.skip("makes test-install fail (and also takes 30 seconds)")
 class TestBasicAllenNlp(AllenNlpTestCase):
     @classmethod
     def test_run_as_script(cls):


### PR DESCRIPTION
it's breaking the master commit build (on account of the tutorial code not getting pip installed), and it's a really slow test, so I'm disabling it for now