### PR TITLE
Add support for overriding list elements

### DIFF
--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -122,6 +122,24 @@ def with_fallback(preferred: Dict[str, Any], fallback: Dict[str, Any]) -> Dict[s
     """
     Deep merge two dicts, preferring values from `preferred`.
     """
+    def merge(preferred_value: Any, fallback_value: Any) -> Any:
+        if isinstance(preferred_value, dict) and isinstance(fallback_value, dict):
+            return with_fallback(preferred_value, fallback_value)
+        elif isinstance(preferred_value, dict) and isinstance(fallback_value, list):
+            # treat preferred_value as a sparse list, where each key is an index to be overridden
+            merged_list = fallback_value
+            for elem_key, preferred_element in preferred_value.items():
+                try:
+                    index = int(elem_key)
+                    merged_list[index] = merge(preferred_element, fallback_value[index])
+                except ValueError:
+                    raise ConfigurationError(f"could not merge dicts - the preferred dict contains invalid keys (key {elem_key} is not a valid list index)")
+                except IndexError:
+                    raise ConfigurationError(f"could not merge dicts - the preferred dict contains invalid keys (key {index} is out of bounds)")
+            return merged_list
+        else:
+            return copy.deepcopy(preferred_value)
+
     preferred_keys = set(preferred.keys())
     fallback_keys = set(fallback.keys())
     common_keys = preferred_keys & fallback_keys
@@ -137,16 +155,13 @@ def with_fallback(preferred: Dict[str, Any], fallback: Dict[str, Any]) -> Dict[s
         preferred_value = preferred[key]
         fallback_value = fallback[key]
 
-        if isinstance(preferred_value, dict) and isinstance(fallback_value, dict):
-            merged[key] = with_fallback(preferred_value, fallback_value)
-        else:
-            merged[key] = copy.deepcopy(preferred_value)
-
+        merged[key] = merge(preferred_value, fallback_value)
     return merged
 
 def parse_overrides(serialized_overrides: str) -> Dict[str, Any]:
     if serialized_overrides:
         ext_vars = _environment_variables()
+
         return unflatten(json.loads(evaluate_snippet("", serialized_overrides, ext_vars=ext_vars)))
     else:
         return {}
@@ -410,7 +425,7 @@ class Params(MutableMapping):
                           loading_from_archive=self.loading_from_archive,
                           files_to_archive=self.files_to_archive)
         if isinstance(value, list):
-            value = [self._check_is_dict(new_history + '.list', v) for v in value]
+            value = [self._check_is_dict(f"{new_history}.{i}", v) for i, v in enumerate(value)]
         return value
 
     @staticmethod

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -133,9 +133,11 @@ def with_fallback(preferred: Dict[str, Any], fallback: Dict[str, Any]) -> Dict[s
                     index = int(elem_key)
                     merged_list[index] = merge(preferred_element, fallback_value[index])
                 except ValueError:
-                    raise ConfigurationError(f"could not merge dicts - the preferred dict contains invalid keys (key {elem_key} is not a valid list index)")
+                    raise ConfigurationError("could not merge dicts - the preferred dict contains "
+                                             f"invalid keys (key {elem_key} is not a valid list index)")
                 except IndexError:
-                    raise ConfigurationError(f"could not merge dicts - the preferred dict contains invalid keys (key {index} is out of bounds)")
+                    raise ConfigurationError("could not merge dicts - the preferred dict contains "
+                                             f"invalid keys (key {index} is out of bounds)")
             return merged_list
         else:
             return copy.deepcopy(preferred_value)

--- a/allennlp/tests/common/params_test.py
+++ b/allennlp/tests/common/params_test.py
@@ -343,7 +343,7 @@ class TestParams(AllenNlpTestCase):
             @classmethod
             def from_params(cls, params: Params) -> 'A':
                 bs = params.pop("bs")
-                return cls(bs=[B.from_params(b_params) for b_params in bs] )
+                return cls(bs=[B.from_params(b_params) for b_params in bs])
 
         params = Params({
                 "a": {

--- a/allennlp/tests/common/params_test.py
+++ b/allennlp/tests/common/params_test.py
@@ -33,12 +33,13 @@ class TestParams(AllenNlpTestCase):
     def test_overrides(self):
         filename = self.FIXTURES_ROOT / 'bidaf' / 'experiment.json'
         overrides = '{ "train_data_path": "FOO", "model": { "type": "BAR" },'\
-                    '"model.text_field_embedder.tokens.type": "BAZ" }'
+                    '"model.text_field_embedder.tokens.type": "BAZ", "iterator.sorting_keys.0.0": "question"}'
         params = Params.from_file(filename, overrides)
 
         assert "dataset_reader" in params
         assert "trainer" in params
         assert params["train_data_path"] == "FOO"
+        assert params["iterator"]["sorting_keys"][0][0] == "question"
 
         model_params = params.pop("model")
         assert model_params.pop("type") == "BAR"
@@ -296,6 +297,75 @@ class TestParams(AllenNlpTestCase):
                 "a.b.filename": my_file,
                 "a.b.c.c_file": my_other_file
         }
+
+    def test_add_file_with_list_history_to_archive(self):
+        # Creates actual files since add_file_to_archive will throw an exception
+        # if the file does not exist.
+        tempdir = tempfile.mkdtemp()
+        my_file = os.path.join(tempdir, "my_file.txt")
+        my_other_file = os.path.join(tempdir, "my_other_file.txt")
+        open(my_file, 'w').close()
+        open(my_other_file, 'w').close()
+
+        # Some nested classes just to exercise the ``from_params``
+        # and ``add_file_to_archive`` methods.
+
+        class C:
+            def __init__(self, c_file: str) -> None:
+                self.c_file = c_file
+
+            @classmethod
+            def from_params(cls, params: Params) -> 'C':
+                params.add_file_to_archive("c_file")
+                c_file = params.pop("c_file")
+
+                return cls(c_file)
+
+        class B:
+            def __init__(self, filename: str, c) -> None:
+                self.filename = filename
+                self.c_dict = {"here": c}
+
+            @classmethod
+            def from_params(cls, params: Params) -> 'B':
+                params.add_file_to_archive("filename")
+
+                filename = params.pop("filename")
+                c_params = params.pop("c")
+                c = C.from_params(c_params)
+
+                return cls(filename, c)
+
+        class A:
+            def __init__(self, bs) -> None:
+                self.bs = bs
+
+            @classmethod
+            def from_params(cls, params: Params) -> 'A':
+                bs = params.pop("bs")
+                return cls(bs=[B.from_params(b_params) for b_params in bs] )
+
+        params = Params({
+                "a": {
+                        "bs": [
+                                {
+                                    "filename": my_file,
+                                    "c": {
+                                            "c_file": my_other_file
+                                    },
+                                },
+                            ],
+                }
+        })
+
+        # Construct ``A`` from params but then just throw it away.
+        A.from_params(params.pop("a"))
+
+        assert params.files_to_archive == {
+                "a.bs.0.filename": my_file,
+                "a.bs.0.c.c_file": my_other_file
+        }
+
 
     def test_as_ordered_dict(self):
         # keyD > keyC > keyE; keyDA > keyDB; Next all other keys alphabetically


### PR DESCRIPTION
Currently, when lists are popped off `Params`, `Params._check_is_dict()` will give each element in the list a history of `old_history.list.`. If this history is later intended to be used to construct an overrides dict (such as in`Params.add_file_to_archive()`) this will cause the overridden dict to be constructed incorrectly:

```python
from allennlp.common.params import with_fallback, unflatten

# dict resembling the one created by add_file_to_archive()
overrides_dict = {"old_history.list.some_value": 1}  

preferred = unflatten(overrides_dict) # => {"old_history": {"list": {"some_value": 1}}}
fallback = {"old_history": [{"some_value": 0}]}

config = with_fallback(preferred, fallback) # => {'old_history': {'list': {'some_value': 1}}}
```

## Motivation
We use allennlp's config system to compose simple transformations on data, and these transforms occasionally require adding files to the archive. 

Example (simplified, but hopefully illustrative):
```json
{
    "dataset_reader": {
        "type": "transforming",
        "transforms": [
            {"type": "lowercase"}
            {"type": "normalize_patterns", "pattern_file": "file_to_be_archived.json"}
        ]
    }
}
```


## Suggested fix
1. Change `Params._check_is_dict()` to give list elements a history of `old_history.{index}.`
2. Add the following case to `with_fallback()`: if a key exists in both the `preferred` and `fallback` dicts and `fallback[key]` is a list, treat `preferred[key]` as a sparsely represented list and use it to override selected indexes in `fallback[key]`.

What do you think?