### PR TITLE
make spacy word splitter return allennlp Tokens (now NamedTuples) by default

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -66,12 +66,12 @@ def sanitize(x: Any) -> Any:  # pylint: disable=invalid-name,too-many-return-sta
     elif isinstance(x, dict):
         # Dicts need their values sanitized
         return {key: sanitize(value) for key, value in x.items()}
-    elif isinstance(x, (list, tuple)):
-        # Lists and Tuples need their values sanitized
-        return [sanitize(x_i) for x_i in x]
     elif isinstance(x, (spacy.tokens.Token, allennlp.data.Token)):
         # Tokens get sanitized to just their text.
         return x.text
+    elif isinstance(x, (list, tuple)):
+        # Lists and Tuples need their values sanitized
+        return [sanitize(x_i) for x_i in x]
     elif x is None:
         return "None"
     elif hasattr(x, 'to_json'):

--- a/allennlp/data/dataset_readers/semantic_parsing/wikitables/wikitables.py
+++ b/allennlp/data/dataset_readers/semantic_parsing/wikitables/wikitables.py
@@ -409,7 +409,7 @@ class WikiTablesDatasetReader(DatasetReader):
 
     @staticmethod
     def _read_tokens_from_json_list(json_list) -> List[Token]:
-        return [Token(text=json_obj['text'], lemma=json_obj['lemma']) for json_obj in json_list]
+        return [Token(text=json_obj['text'], lemma_=json_obj['lemma']) for json_obj in json_list]
 
     @staticmethod
     def _should_keep_logical_form(logical_form: str) -> bool:

--- a/allennlp/data/tokenizers/token.py
+++ b/allennlp/data/tokenizers/token.py
@@ -1,4 +1,6 @@
-class Token:
+from typing import NamedTuple
+
+class Token(NamedTuple):
     """
     A simple token representation, keeping track of the token's text, offset in the passage it was
     taken from, POS tag, dependency relation, and similar information.  These fields match spacy's
@@ -10,15 +12,15 @@ class Token:
         The original text represented by this token.
     idx : ``int``, optional
         The character offset of this token into the tokenized passage.
-    lemma : ``str``, optional
+    lemma_ : ``str``, optional
         The lemma of this token.
-    pos : ``str``, optional
+    pos_ : ``str``, optional
         The coarse-grained part of speech of this token.
-    tag : ``str``, optional
+    tag_ : ``str``, optional
         The fine-grained part of speech of this token.
-    dep : ``str``, optional
+    dep_ : ``str``, optional
         The dependency relation for this token.
-    ent_type : ``str``, optional
+    ent_type_ : ``str``, optional
         The entity type (i.e., the NER tag) for this token.
     text_id : ``int``, optional
         If your tokenizer returns integers instead of strings (e.g., because you're doing byte
@@ -30,23 +32,14 @@ class Token:
         The other fields on ``Token`` follow the fields on spacy's ``Token`` object; this is one we
         added, similar to spacy's ``lex_id``.
     """
-    def __init__(self,
-                 text: str = None,
-                 idx: int = None,
-                 lemma: str = None,
-                 pos: str = None,
-                 tag: str = None,
-                 dep: str = None,
-                 ent_type: str = None,
-                 text_id: int = None) -> None:
-        self.text = text
-        self.idx = idx
-        self.lemma_ = lemma
-        self.pos_ = pos
-        self.tag_ = tag
-        self.dep_ = dep
-        self.ent_type_ = ent_type
-        self.text_id = text_id
+    text: str = None
+    idx: int = None
+    lemma_: str = None
+    pos_: str = None
+    tag_: str = None
+    dep_: str = None
+    ent_type_: str = None
+    text_id: int = None
 
     def __str__(self):
         return self.text

--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -138,24 +138,44 @@ def _remove_spaces(tokens: List[spacy.tokens.Token]) -> List[spacy.tokens.Token]
 class SpacyWordSplitter(WordSplitter):
     """
     A ``WordSplitter`` that uses spaCy's tokenizer.  It's fast and reasonable - this is the
-    recommended ``WordSplitter``.
+    recommended ``WordSplitter``. By default it will return allennlp Tokens,
+    which are small, efficient NamedTuples (and are serializable). If you want
+    to keep the original spaCy tokens, pass keep_spacy_tokens=True.
     """
     def __init__(self,
                  language: str = 'en_core_web_sm',
                  pos_tags: bool = False,
                  parse: bool = False,
-                 ner: bool = False) -> None:
+                 ner: bool = False,
+                 keep_spacy_tokens: bool = False) -> None:
         self.spacy = get_spacy_model(language, pos_tags, parse, ner)
+        self._keep_spacy_tokens = keep_spacy_tokens
+
+    def _sanitize(self, tokens: List[spacy.tokens.Token]) -> List[Token]:
+        """
+        Converts spaCy tokens to allennlp tokens. Is a no-op if
+        keep_spacy_tokens is True
+        """
+        if self._keep_spacy_tokens:
+            return tokens
+        else:
+            return [Token(token.text,
+                          token.idx,
+                          token.lemma,
+                          token.pos,
+                          token.tag,
+                          token.dep,
+                          token.ent_type) for token in tokens]
 
     @overrides
     def batch_split_words(self, sentences: List[str]) -> List[List[Token]]:
-        return [_remove_spaces(tokens)
+        return [self._sanitize(_remove_spaces(tokens))
                 for tokens in self.spacy.pipe(sentences, n_threads=-1)]
 
     @overrides
     def split_words(self, sentence: str) -> List[Token]:
         # This works because our Token class matches spacy's.
-        return _remove_spaces(self.spacy(sentence))
+        return self._sanitize(_remove_spaces(self.spacy(sentence)))
 
 
 @WordSplitter.register('openai')

--- a/allennlp/data/tokenizers/word_splitter.py
+++ b/allennlp/data/tokenizers/word_splitter.py
@@ -161,11 +161,11 @@ class SpacyWordSplitter(WordSplitter):
         else:
             return [Token(token.text,
                           token.idx,
-                          token.lemma,
-                          token.pos,
-                          token.tag,
-                          token.dep,
-                          token.ent_type) for token in tokens]
+                          token.lemma_,
+                          token.pos_,
+                          token.tag_,
+                          token.dep_,
+                          token.ent_type_) for token in tokens]
 
     @overrides
     def batch_split_words(self, sentences: List[str]) -> List[List[Token]]:

--- a/allennlp/data/tokenizers/word_stemmer.py
+++ b/allennlp/data/tokenizers/word_stemmer.py
@@ -47,9 +47,9 @@ class PorterStemmer(WordStemmer):
         new_text = self.stemmer.stem(word.text)
         return Token(text=new_text,
                      idx=word.idx,
-                     lemma=word.lemma_,
-                     pos=word.pos_,
-                     tag=word.tag_,
-                     dep=word.dep_,
-                     ent_type=word.ent_type_,
+                     lemma_=word.lemma_,
+                     pos_=word.pos_,
+                     tag_=word.tag_,
+                     dep_=word.dep_,
+                     ent_type_=word.ent_type_,
                      text_id=getattr(word, 'text_id', None))

--- a/allennlp/tests/data/token_indexers/ner_tag_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/ner_tag_indexer_test.py
@@ -43,9 +43,7 @@ class TestNerTagIndexer(AllenNlpTestCase):
         assert padded_tokens == {'key': [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]}
 
     def test_blank_ner_tag(self):
-        tokens = [Token(token) for token in "allennlp is awesome .".split(" ")]
-        for token in tokens:
-            token.ent_type_ = ""
+        tokens = [Token(token)._replace(ent_type_="") for token in "allennlp is awesome .".split(" ")]
         indexer = NerTagIndexer()
         counter = defaultdict(lambda: defaultdict(int))
         for token in tokens:

--- a/allennlp/tests/data/token_indexers/pos_tag_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pos_tag_indexer_test.py
@@ -61,9 +61,7 @@ class TestPosTagIndexer(AllenNlpTestCase):
         assert padded_tokens == {'key': [1, 2, 3, 4, 5, 0, 0, 0, 0, 0]}
 
     def test_blank_pos_tag(self):
-        tokens = [Token(token) for token in "allennlp is awesome .".split(" ")]
-        for token in tokens:
-            token.pos_ = ""
+        tokens = [Token(token)._replace(pos_="") for token in "allennlp is awesome .".split(" ")]
         indexer = PosTagIndexer()
         counter = defaultdict(lambda: defaultdict(int))
         for token in tokens:

--- a/allennlp/tests/data/tokenizers/word_splitter_test.py
+++ b/allennlp/tests/data/tokenizers/word_splitter_test.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-self-use,invalid-name
+import spacy
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data.tokenizers.token import Token
@@ -150,6 +151,20 @@ class TestSpacyWordSplitter(AllenNlpTestCase):
             assert len(batch_sentence) == len(separate_sentence)
             for batch_word, separate_word in zip(batch_sentence, separate_sentence):
                 assert batch_word.text == separate_word.text
+
+    def test_keep_spacy_tokens(self):
+        word_splitter = SpacyWordSplitter()
+        sentence = "This should be an allennlp Token"
+        tokens = word_splitter.split_words(sentence)
+        assert tokens
+        assert all(isinstance(token, Token) for token in tokens)
+
+        word_splitter = SpacyWordSplitter(keep_spacy_tokens=True)
+        sentence = "This should be a spacy Token"
+        tokens = word_splitter.split_words(sentence)
+        assert tokens
+        assert all(isinstance(token, spacy.tokens.Token) for token in tokens)
+
 
 class TestOpenAiWordSplitter(AllenNlpTestCase):
     def setUp(self):


### PR DESCRIPTION
largely fixes #2602, also fixes #1887 

the discussion at #2602 gives a lot of the justification for this, small-scale experiments suggest that it saves a lot of memory if you have a lot of text.

it is a breaking change in two (minor) ways:

1. the SpacyWordSplitter now by default returns allennlp Tokens instead of spacy Tokens. in theory everyone should be programming to the shared abstraction, but it's possible that someone somewhere is relying on having the actual spacy token, in which case they'll need to configure their word splitter to keep them.

2. a NamedTuple can't have different constructor parameters and field names. Our previous Token implementation used e.g. `pos` as the name of the constructor argument but then `pos_` as the name of the field. Converting this to a namedtuple meant that the constructor argument now also has to be `pos_`. This required a tiny change to the wikitables dataset reader; it's possible (but not all that likely) that other people could have dataset readers that rely on the old behavior. My guess is that most people are only creating tokens via our word splitters, in which case they won't notice the difference.

This could be avoided if we left `Token` as an actual class, but we'd get less memory improvement that way.