### PR TITLE
Allow the transition from M to M in the BMES constraint type

### DIFF
--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -140,7 +140,7 @@ def is_transition_allowed(constraint_type: str,
                 to_tag in ('B', 'S') and from_tag in ('E', 'S'),
                 # Can only transition to M-x from B-x, where
                 # x is the same tag.
-                to_tag == 'M' and from_tag == 'B' and from_entity == to_entity,
+                to_tag == 'M' and from_tag in ('B', 'M') and from_entity == to_entity,
                 # Can only transition to E-x from B-x or M-x, where
                 # x is the same tag.
                 to_tag == 'E' and from_tag in ('B', 'M') and from_entity == to_entity,

--- a/allennlp/tests/modules/conditional_random_field_test.py
+++ b/allennlp/tests/modules/conditional_random_field_test.py
@@ -238,11 +238,11 @@ class TestConditionalRandomField(AllenNlpTestCase):
         allowed = allowed_transitions("BMES", dict(enumerate(bmes_labels)))
         assert set(allowed) == {
                     (0, 1), (0, 2),
-                            (1, 2),                                         # Extra column for end tag.
+                    (1, 1), (1, 2),                                         # Extra column for end tag.
             (2, 0),                 (2, 3), (2, 4),                 (2, 7), (2, 9),
             (3, 0),                 (3, 3), (3, 4),                 (3, 7), (3, 9),
                                                     (4, 5), (4, 6),
-                                                            (5, 6),
+                                                    (5, 5), (5, 6),
             (6, 0),                 (6, 3), (6, 4),                 (6, 7), (6, 9),
             (7, 0),                 (7, 3), (7, 4),                 (7, 7), (7, 9),
             (8, 0),                 (8, 3), (8, 4),                 (8, 7),  # Extra row for start tag


### PR DESCRIPTION
Currently, the transition from M to M is not allowed for BMES label as shows in this sample:
```
In [1]: from allennlp.modules.conditional_random_field import allowed_transitions

In [2]: labels = {0: "B", 1: "M", 2: "E", 3: "S"}

In [3]: allowed_transitions("BMES", labels)
Out[3]:
[(0, 1),
 (0, 2),
 (1, 2),
 (2, 0),
 (2, 3),
 (2, 5),
 (3, 0),
 (3, 3),
 (3, 5),
 (4, 0),
 (4, 3)]
```
If target spans could be longer than 3 tokens, the transition between `M` should be valid, for example `B -> M -> M -> E`.

This pull request adds the transition and modify the corresponding test case.

What do you think?