### PR TITLE
fix processes at 1 because python can't determine virtualised cpus correctly

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -22,8 +22,8 @@ persistent=yes
 # usually to register additional checkers.
 load-plugins=
 
-# Use multiple processes to speed up Pylint.
-jobs=4
+# Do not use multiple processes to speed up Pylint, because https://bugs.python.org/issue36054
+jobs=1
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -20,7 +20,7 @@ def main(checks):
 
         if "pylint" in checks:
             print("Linter (pylint):", flush=True)
-            run("pylint -d locally-disabled,locally-enabled -f colorized allennlp", shell=True, check=True)
+            run("pylint -d locally-disabled,locally-enabled -f colorized -j 1 allennlp", shell=True, check=True)
             print("pylint checks passed")
 
         if "mypy" in checks:


### PR DESCRIPTION
Test to see if this speeds up pylint.