### PR TITLE
final_state_tuple is a Tuple

### DIFF
--- a/allennlp/modules/stacked_alternating_lstm.py
+++ b/allennlp/modules/stacked_alternating_lstm.py
@@ -3,7 +3,7 @@ A stacked LSTM with LSTM layers which alternate between going forwards over
 the sequence and going backwards.
 """
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 import torch
 from torch.nn.utils.rnn import PackedSequence
 from allennlp.modules.augmented_lstm import AugmentedLstm
@@ -72,7 +72,7 @@ class StackedAlternatingLstm(torch.nn.Module):
     def forward(self,  # pylint: disable=arguments-differ
                 inputs: PackedSequence,
                 initial_state: Optional[Tuple[torch.Tensor, torch.Tensor]] = None) -> \
-            Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+            Tuple[Union[torch.Tensor, PackedSequence], Tuple[torch.Tensor, torch.Tensor]]:
         """
         Parameters
         ----------
@@ -107,5 +107,5 @@ class StackedAlternatingLstm(torch.nn.Module):
             output_sequence, final_state = layer(output_sequence, state)
             final_states.append(final_state)
 
-        final_state_tuple = tuple(torch.cat(state_list, 0) for state_list in zip(*final_states))
-        return output_sequence, final_state_tuple
+        final_hidden_state, final_cell_state = tuple(torch.cat(state_list, 0) for state_list in zip(*final_states))
+        return output_sequence, (final_hidden_state, final_cell_state)

--- a/allennlp/modules/stacked_alternating_lstm.py
+++ b/allennlp/modules/stacked_alternating_lstm.py
@@ -106,5 +106,5 @@ class StackedAlternatingLstm(torch.nn.Module):
             output_sequence, final_state = layer(output_sequence, state)
             final_states.append(final_state)
 
-        final_state_tuple = (torch.cat(state_list, 0) for state_list in zip(*final_states))
+        final_state_tuple = tuple(torch.cat(state_list, 0) for state_list in zip(*final_states))
         return output_sequence, final_state_tuple

--- a/allennlp/modules/stacked_alternating_lstm.py
+++ b/allennlp/modules/stacked_alternating_lstm.py
@@ -71,7 +71,8 @@ class StackedAlternatingLstm(torch.nn.Module):
 
     def forward(self,  # pylint: disable=arguments-differ
                 inputs: PackedSequence,
-                initial_state: Optional[Tuple[torch.Tensor, torch.Tensor]] = None):
+                initial_state: Optional[Tuple[torch.Tensor, torch.Tensor]] = None) -> \
+            Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         """
         Parameters
         ----------
@@ -85,7 +86,7 @@ class StackedAlternatingLstm(torch.nn.Module):
         -------
         output_sequence : PackedSequence
             The encoded sequence of shape (batch_size, sequence_length, hidden_size)
-        final_states: torch.Tensor
+        final_states: Tuple[torch.Tensor, torch.Tensor]
             The per-layer final (state, memory) states of the LSTM, each with shape
             (num_layers, batch_size, hidden_size).
         """

--- a/allennlp/tests/modules/seq2vec_encoders/pytorch_seq2vec_wrapper_test.py
+++ b/allennlp/tests/modules/seq2vec_encoders/pytorch_seq2vec_wrapper_test.py
@@ -117,11 +117,11 @@ class TestPytorchSeq2VecWrapper(AllenNlpTestCase):
 
     def test_wrapper_works_with_alternating_lstm(self):
         model = PytorchSeq2VecWrapper(
-                StackedAlternatingLstm(input_size=100,
-                                       hidden_size=128,
+                StackedAlternatingLstm(input_size=4,
+                                       hidden_size=5,
                                        num_layers=3))
 
-        input_tensor = torch.randn(5, 7, 100)
-        mask = torch.ones(5, 7)
+        input_tensor = torch.randn(2, 3, 4)
+        mask = torch.ones(2, 3)
         output = model(input_tensor, mask)
-        assert tuple(output.size()) == (5, 128)
+        assert tuple(output.size()) == (2, 5)

--- a/allennlp/tests/modules/seq2vec_encoders/pytorch_seq2vec_wrapper_test.py
+++ b/allennlp/tests/modules/seq2vec_encoders/pytorch_seq2vec_wrapper_test.py
@@ -9,6 +9,7 @@ from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.modules.seq2vec_encoders import PytorchSeq2VecWrapper
 from allennlp.nn.util import sort_batch_by_length, get_lengths_from_binary_sequence_mask
+from allennlp.modules.stacked_alternating_lstm import StackedAlternatingLstm
 
 
 class TestPytorchSeq2VecWrapper(AllenNlpTestCase):
@@ -113,3 +114,16 @@ class TestPytorchSeq2VecWrapper(AllenNlpTestCase):
         with pytest.raises(ConfigurationError):
             lstm = LSTM(bidirectional=True, num_layers=3, input_size=3, hidden_size=7)
             _ = PytorchSeq2VecWrapper(lstm)
+
+    def test_wrapper_works_with_alternating_lstm(self):
+        model = PytorchSeq2VecWrapper(
+                StackedAlternatingLstm(recurrent_dropout_probability=0.44,
+                                       input_size=100,
+                                       hidden_size=128,
+                                       num_layers=3,
+                                       use_input_projection_bias=False))
+
+        input_tensor = torch.randn(5, 7, 100)
+        mask = torch.ones(5, 7)
+        output = model(input_tensor, mask)
+        assert tuple(output.size()) == (5, 128)

--- a/allennlp/tests/modules/seq2vec_encoders/pytorch_seq2vec_wrapper_test.py
+++ b/allennlp/tests/modules/seq2vec_encoders/pytorch_seq2vec_wrapper_test.py
@@ -117,11 +117,9 @@ class TestPytorchSeq2VecWrapper(AllenNlpTestCase):
 
     def test_wrapper_works_with_alternating_lstm(self):
         model = PytorchSeq2VecWrapper(
-                StackedAlternatingLstm(recurrent_dropout_probability=0.44,
-                                       input_size=100,
+                StackedAlternatingLstm(input_size=100,
                                        hidden_size=128,
-                                       num_layers=3,
-                                       use_input_projection_bias=False))
+                                       num_layers=3))
 
         input_tensor = torch.randn(5, 7, 100)
         mask = torch.ones(5, 7)


### PR DESCRIPTION
Fixes #2503. The `final_state_tuple` in the `StackedAlternatingLstm` was a generator instead of a tuple.