### PR TITLE
Upgrade pip inside Dockerfiles.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update --fix-missing && apt-get install -y \
 # Copy select files needed for installing requirements.
 # We only copy what we need here so small changes to the repository does not trigger re-installation of the requirements.
 COPY requirements.txt .
+# Ensure pip is new enough to install AllenNLP's dependencies.
+RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 COPY scripts/ scripts/

--- a/Dockerfile.pip
+++ b/Dockerfile.pip
@@ -22,6 +22,9 @@ WORKDIR /stage/allennlp
 ARG VERSION
 ARG SOURCE_COMMIT
 
+# Ensure pip is new enough to install AllenNLP's dependencies.
+RUN pip install --upgrade pip
+
 # Install the specified version of AllenNLP.
 RUN if [ ! -z "$VERSION" ]; \
     then echo "Installing allennlp==$VERSION."; pip install allennlp==$VERSION; \


### PR DESCRIPTION
- Torch was failing to install in Docker when I attempted to release.
  - It's pretty quiet about this, incidentally.
  - If you log into a running image and use the verbose flag, something like`pip -v install /allennlp-0.8.3-py3-none-any.whl`, you'll get better logging.
- Fixed with `pip install --upgrade pip`.