### PR TITLE
Ignore 2 root node types in PTB parsing reader

### DIFF
--- a/allennlp/data/dataset_readers/penn_tree_bank.py
+++ b/allennlp/data/dataset_readers/penn_tree_bank.py
@@ -69,7 +69,7 @@ class PennTreeBankConstituencySpanDatasetReader(DatasetReader):
             self._strip_functional_tags(parse)
             # This is un-needed and clutters the label space.
             # All the trees also contain a root S node.
-            if parse.label() == "VROOT":
+            if parse.label() == "VROOT" or parse.label() == "TOP":
                 parse = parse[0]
             pos_tags = [x[1] for x in parse.pos()] if self._use_pos_tags else None
             yield self.text_to_instance(parse.leaves(), pos_tags, parse)


### PR DESCRIPTION
Some variants of the PTB dataset use `TOP` as the root node, rather than `VROOT`. This lets the dataset reader handle both.