### PR TITLE
Bugfix: stop BasicTextFieldEmbedder from crashing from mismatched token numbers

### DIFF
--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -273,7 +273,7 @@ class Model(torch.nn.Module, Registrable):
         model.extend_embedder_vocab()
 
         model_state = torch.load(weights_file, map_location=util.device_mapping(cuda_device))
-        model.load_state_dict(model_state, strict=False)
+        model.load_state_dict(model_state)
 
         # Force model to cpu or gpu, as appropriate, to make sure that the embeddings are
         # in sync with the weights

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -272,7 +272,7 @@ class Model(torch.nn.Module, Registrable):
         # If vocab and model embeddings are in sync, following would be just a no-op.
         model.extend_embedder_vocab()
 
-        model_state = torch.load(weights_file, map_location=util.device_mapping(cuda_device))
+        model_state = torch.load(weights_file, map_location=util.device_mapping(cuda_device), strict=False)
         model.load_state_dict(model_state)
 
         # Force model to cpu or gpu, as appropriate, to make sure that the embeddings are

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -272,8 +272,8 @@ class Model(torch.nn.Module, Registrable):
         # If vocab and model embeddings are in sync, following would be just a no-op.
         model.extend_embedder_vocab()
 
-        model_state = torch.load(weights_file, map_location=util.device_mapping(cuda_device), strict=False)
-        model.load_state_dict(model_state)
+        model_state = torch.load(weights_file, map_location=util.device_mapping(cuda_device))
+        model.load_state_dict(model_state, strict=False)
 
         # Force model to cpu or gpu, as appropriate, to make sure that the embeddings are
         # in sync with the weights

--- a/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
@@ -131,6 +131,8 @@ class BasicTextFieldEmbedder(TextFieldEmbedder):
             logger.warning(f"Mismatched token_vectors, truncating to shortest: {dims}")
             min_dim = min(dims)
             embedded_representations = [tv.narrow(1, 0, min_dim) for tv in embedded_representations]
+            dims = [tv.size()[1] for tv in embedded_representations]
+            logger.warning(f"Truncated to {dims}")
         return torch.cat(embedded_representations, dim=-1)
 
     # This is some unusual logic, it needs a custom from_params.

--- a/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
@@ -128,11 +128,9 @@ class BasicTextFieldEmbedder(TextFieldEmbedder):
         # Truncate to shortest token_vectors. Possible if one of the indexers truncated more than others.
         dims = [tv.size()[1] for tv in embedded_representations]
         if len(set(dims)) > 1:
-            logger.warning(f"Mismatched token_vectors, truncating to shortest: {dims}")
             min_dim = min(dims)
+            logger.warning(f"Mismatched token_vectors, truncating to {min_dim}: {dims}")
             embedded_representations = [tv.narrow(1, 0, min_dim) for tv in embedded_representations]
-            dims = [tv.size()[1] for tv in embedded_representations]
-            logger.warning(f"Truncated to {dims}")
         return torch.cat(embedded_representations, dim=-1)
 
     # This is some unusual logic, it needs a custom from_params.


### PR DESCRIPTION
When different token indexers return differing numbers of tokens, BasicTextFieldEmbedder crashes when concatenating their embeddings. 

For me this occurred because WordPieceIndexer truncated a text that was not truncated by another indexer. The WordPieceIndexer truncation happens here (note that this line is a TODO):
https://github.com/allenai/allennlp/blob/0f4175034f5d79f9415e47d915603cbba6af01a6/allennlp/data/token_indexers/wordpiece_indexer.py#L160

This PR prevents the crash in BasicTextFieldEmbedder by truncating to the shortest embedding. This solved my use case. But I'm not sure if it's the best solution, given that the original truncation is caused by the unresolved TODO above.