### PR TITLE
Update pylint to 1.9.4

### DIFF
--- a/allennlp/semparse/domain_languages/domain_language.py
+++ b/allennlp/semparse/domain_languages/domain_language.py
@@ -27,13 +27,14 @@ def is_callable(type_: Type) -> bool:
         return getattr(type_, '_name', None) == 'Callable'
 
 
+# pylint: disable=no-name-in-module
 def is_generic(type_: Type) -> bool:
     if sys.version_info < (3, 7):
         from typing import GenericMeta  # type: ignore
         return isinstance(type_, GenericMeta)  # type: ignore
     else:
         # pylint: disable=protected-access
-        from typing import _GenericAlias  # pylint: disable=no-name-in-module
+        from typing import _GenericAlias
         return isinstance(type_, _GenericAlias) # type: ignore
 
 

--- a/allennlp/semparse/domain_languages/domain_language.py
+++ b/allennlp/semparse/domain_languages/domain_language.py
@@ -33,7 +33,7 @@ def is_generic(type_: Type) -> bool:
         return isinstance(type_, GenericMeta)  # type: ignore
     else:
         # pylint: disable=protected-access
-        from typing import _GenericAlias  # type: ignore
+        from typing import _GenericAlias  # pylint: disable=no-name-in-module
         return isinstance(type_, _GenericAlias) # type: ignore
 
 
@@ -325,7 +325,7 @@ class DomainLanguage:
         """
         # We'll strip off the first action, because it doesn't matter for execution.
         first_action = action_sequence[0]
-        left_side, right_side = first_action.split(' -> ')
+        left_side = first_action.split(' -> ')[0]
         if left_side != '@start@':
             raise ExecutionError('invalid action sequence')
         remaining_side_args = side_arguments[1:] if side_arguments else None
@@ -491,6 +491,7 @@ class DomainLanguage:
         nonterminal_productions = self.get_nonterminal_productions()
         return symbol in nonterminal_productions
 
+    # pylint: disable=inconsistent-return-statements
     def _execute_expression(self, expression: Any):
         """
         This does the bulk of the work of executing a logical form, recursively executing a single
@@ -512,7 +513,7 @@ class DomainLanguage:
             arguments = [self._execute_expression(arg) for arg in expression[1:]]
             try:
                 return function(*arguments)
-            except (TypeError, ValueError) as error:
+            except (TypeError, ValueError):
                 traceback.print_exc()
                 raise ExecutionError(f"Error executing expression {expression} (see stderr for stack trace)")
         elif isinstance(expression, str):
@@ -548,7 +549,7 @@ class DomainLanguage:
         first_action = action_sequence[0]
         remaining_actions = action_sequence[1:]
         remaining_side_args = side_arguments[1:] if side_arguments else None
-        left_side, right_side = first_action.split(' -> ')
+        right_side = first_action.split(' -> ')[1]
         if right_side in self._functions:
             function = self._functions[right_side]
             # mypy doesn't like this check, saying that Callable isn't a reasonable thing to pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,7 +106,7 @@ moto>=1.3.4
 #### TESTING-RELATED PACKAGES ####
 
 # Checks style, syntax, and other useful errors.
-pylint==1.8.1
+pylint==1.9.4
 
 # Static type checking
 mypy==0.521

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -4,7 +4,6 @@
 """
 
 import argparse
-
 import os
 import shutil
 from subprocess import run
@@ -57,16 +56,12 @@ def main(checks):
         sys.exit(1)
 
 if __name__ == "__main__":
-    checks = ['pytest', 'pylint', 'mypy', 'build-docs', 'check-docs', 'check-links', 'check-requirements', 'check-large-files']
+    checks = ['pytest', 'pylint', 'mypy', 'build-docs', 'check-docs', 'check-links', 'check-requirements',
+              'check-large-files']
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--checks', type=str, required=False, nargs='+', choices=checks)
+    parser.add_argument('--checks', default=checks, nargs='+', choices=checks)
 
     args = parser.parse_args()
 
-    if args.checks:
-        run_checks = args.checks
-    else:
-        run_checks = checks
-
-    main(run_checks)
+    main(args.checks)


### PR DESCRIPTION
Pinned pylint to the last 1.x version. Upgrading to 2.0 means much more changes.

This was motivated mostly because I realize that it was failing to check `allennlp/semparse/domain_languages/domain_language.py`, so it was ignoring checks there. I did the correspoding changes now that this file is checked. I also removed an unnecessary type ignore.

And I refactored `scripts/verify.py` a bit. This may be another PR, but I was wondering if the overhead it's worth it.