### PR TITLE
 Add option in PytorchSeq2VecWrapper to return the state of all layers

### DIFF
--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -71,10 +71,10 @@ class _Seq2VecWrapper:
         if self._module_class in self.PYTORCH_MODELS:
             params['batch_first'] = True
         module = self._module_class(**params.as_dict())
-        return_only_last = params.pop('return_only_last', True)
-        return_tuple_if_state_is_tuple = params.pop('return_tuple_if_state_is_tuple', False)
-        return PytorchSeq2VecWrapper(module, return_only_last=return_only_last,
-                                     return_tuple_if_state_is_tuple=return_tuple_if_state_is_tuple)
+        return_all_layers = params.pop('return_all_layers', False)
+        return_all_hidden_states = params.pop('return_all_hidden_states', False)
+        return PytorchSeq2VecWrapper(module, return_all_layers=return_all_layers,
+                                     return_all_hidden_states=return_all_hidden_states)
 
 # pylint: disable=protected-access
 Seq2VecEncoder.register("gru")(_Seq2VecWrapper(torch.nn.GRU))

--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -71,7 +71,10 @@ class _Seq2VecWrapper:
         if self._module_class in self.PYTORCH_MODELS:
             params['batch_first'] = True
         module = self._module_class(**params.as_dict())
-        return PytorchSeq2VecWrapper(module)
+        return_only_last = params.pop('return_only_last', True)
+        return_tuple_if_state_is_tuple = params.pop('return_tuple_if_state_is_tuple', False)
+        return PytorchSeq2VecWrapper(module, return_only_last=return_only_last,
+                                     return_tuple_if_state_is_tuple=return_tuple_if_state_is_tuple)
 
 # pylint: disable=protected-access
 Seq2VecEncoder.register("gru")(_Seq2VecWrapper(torch.nn.GRU))

--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -70,9 +70,9 @@ class _Seq2VecWrapper:
             raise ConfigurationError("Our encoder semantics assumes batch is always first!")
         if self._module_class in self.PYTORCH_MODELS:
             params['batch_first'] = True
-        module = self._module_class(**params.as_dict())
         return_all_layers = params.pop('return_all_layers', False)
         return_all_hidden_states = params.pop('return_all_hidden_states', False)
+        module = self._module_class(**params.as_dict())
         return PytorchSeq2VecWrapper(module, return_all_layers=return_all_layers,
                                      return_all_hidden_states=return_all_hidden_states)
 

--- a/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
+++ b/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
@@ -1,3 +1,4 @@
+from overrides import overrides
 import torch
 
 from allennlp.common.checks import ConfigurationError
@@ -6,7 +7,7 @@ from allennlp.modules.seq2vec_encoders.seq2vec_encoder import Seq2VecEncoder
 
 class PytorchSeq2VecWrapper(Seq2VecEncoder):
     """
-    Pytorch's RNNs have two outputs: the hidden state for every time step, and the hidden state at
+    PyTorch's RNNs have two outputs: the hidden state for every time step, and the hidden state at
     the last time step for every layer.  We just want the second one as a single output.  This
     wrapper pulls out that output, and adds a :func:`get_output_dim` method, which is useful if you
     want to, e.g., define a linear + softmax layer on top of this to get some distribution over a
@@ -28,13 +29,14 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
           Tuple[PackedSequence, torch.Tensor]``.
         - ``self.bidirectional: bool`` (optional)
 
-    This is what pytorch's RNN's look like - just make sure your class looks like those, and it
+    This is what PyTorch's RNN's look like - just make sure your class looks like those, and it
     should work.
 
     Note that we *require* you to pass sequence lengths when you call this module, to avoid subtle
     bugs around masking.  If you already have a ``PackedSequence`` you can pass ``None`` as the
     second parameter.
     """
+
     def __init__(self,
                  module: torch.nn.modules.RNNBase,
                  return_all_layers: bool = False,
@@ -47,25 +49,56 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
         if not getattr(self._module, 'batch_first', True):
             raise ConfigurationError("Our encoder semantics assumes batch is always first!")
 
+    @property
+    def _bidirectional(self):
+        return getattr(self._module, 'bidirectional', False)
+
+    def _num_directions(self):
+        return 2 if self._bidirectional else 1
+
+    @property
+    def _num_layers(self):
+        return getattr(self._module, 'num_layers', 1)
+
+    @overrides
     def get_input_dim(self) -> int:
         return self._module.input_size
 
+    @overrides
     def get_output_dim(self) -> int:
-        is_bidirectional = getattr(self._module, 'bidirectional', False)
-        num_layers = getattr(self._module, 'num_layers', 1)
-        return self._module.hidden_size * (2 if is_bidirectional else 1) * num_layers
+        output_dim = self._module.hidden_size * self._num_directions()
 
+        if self._return_all_layers:
+            output_dim *= self._num_layers
+
+        return output_dim
+
+    @overrides
     def forward(self,  # pylint: disable=arguments-differ
                 inputs: torch.Tensor,
                 mask: torch.Tensor,
-                hidden_state: torch.Tensor = None) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-
+                hidden_state: torch.Tensor = None) -> torch.Tensor:
         if mask is None:
-            # If a mask isn't passed, there is no padding in the batch of instances, so we can just
-            # return the last sequence output as the state.  This doesn't work in the case of
-            # variable length sequences, as the last state for each element of the batch won't be
-            # at the end of the max sequence length, so we have to use the state of the RNN below.
-            return self._module(inputs, hidden_state)[0][:, -1, :]
+            if self._return_all_layers:
+                state = self._module(inputs, hidden_state)[1]  # FIXME: needs reshape?
+            else:
+                # If a mask isn't passed, there is no padding in the batch of instances, so we can just
+                # return the last sequence output as the state.  This doesn't work in the case of
+                # variable length sequences, as the last state for each element of the batch won't be
+                # at the end of the max sequence length, so we have to use the state of the RNN below.
+
+                # FIXME: take 1 instead of 0, to get (state, memory) if desired.
+                state = self._module(inputs, hidden_state)[0][:, -self._num_directions():, :]
+
+            if self._return_all_hidden_states:
+                if isinstance(state, tuple):
+                    return torch.stack(state)
+                else:
+                    return state.unsqueeze(0)
+            elif isinstance(state, tuple):
+                return state[0]
+            else:
+                return state
 
         batch_size = mask.size(0)
 
@@ -73,44 +106,48 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
             self.sort_and_run_forward(self._module, inputs, mask, hidden_state)
 
         # Deal with the fact the LSTM state is a tuple of (state, memory).
+        # For consistency, we always add one dimension to the state and later decide if to drop it.
         if isinstance(state, tuple) and self._return_all_hidden_states:
-            return self._restore_order_and_shape(batch_size, restoration_indices, state[0]), \
-                   self._restore_order_and_shape(batch_size, restoration_indices, state[1])
+            state = torch.stack(state)
         else:
-            return self._restore_order_and_shape(batch_size, restoration_indices, state)
+            if isinstance(state, tuple):
+                state = state[0]
+            state = state.unsqueeze(0)
+
+        return self._restore_order_and_shape(batch_size, restoration_indices, state)
 
     def _restore_order_and_shape(self,
                                  batch_size: int,
                                  restoration_indices: torch.LongTensor,
                                  state: torch.Tensor) -> torch.Tensor:
-        num_layers_times_directions, num_valid, encoding_dim = state.size()
+        # `state_len` is 2 if it's an LSTM and `self._return_all_hidden_states` is true.
+        state_len, num_layers_times_directions, num_valid, encoding_dim = state.size()
         # Add back invalid rows.
         if num_valid < batch_size:
-            # batch size is the second dimension here, because pytorch
-            # returns RNN state as a tensor of shape (num_layers * num_directions,
-            # batch_size, hidden_size)
-            zeros = state.new_zeros(num_layers_times_directions,
+            # batch size is the third dimension here, because PyTorch returns RNN state, which is possibly a tuple,
+            # as a tensor of shape (num_layers * num_directions, batch_size, hidden_size)
+            zeros = state.new_zeros(state_len,
+                                    num_layers_times_directions,
                                     batch_size - num_valid,
                                     encoding_dim)
-            state = torch.cat([state, zeros], 1)
+            state = torch.cat([state, zeros], 2)
 
         # Restore the original indices and return the final state of the
-        # top layer. Pytorch's recurrent layers return state in the form
+        # top layer. PyTorch's recurrent layers return state in the form
         # (num_layers * num_directions, batch_size, hidden_size) regardless
         # of the 'batch_first' flag, so we transpose, extract the relevant
         # layer state (both forward and backward if using bidirectional layers)
-        # and return them as a single (batch_size, self.get_output_dim()) tensor.
+        # and we combine the hidden states in the last dimension, just after the batch size.
 
-        # now of shape: (batch_size, num_layers * num_directions, hidden_size).
-        unsorted_state = state.transpose(0, 1).index_select(0, restoration_indices)
+        # now of shape: (state_len, batch_size, num_layers * num_directions, hidden_size).
+        unsorted_state = state.transpose(1, 2).index_select(1, restoration_indices)
 
         if not self._return_all_layers:
             # Extract the last hidden vector, including both forward and backward states
             # if the cell is bidirectional.
-            last_state_index = 2 if getattr(self._module, 'bidirectional', False) else 1
-            unsorted_state = unsorted_state[:, -last_state_index:, :]
+            unsorted_state = unsorted_state[:, :, -self._num_directions():, :]
 
-        # Reshape by concatenation (in the case we have bidirectional states) or just squash the 1st dimension in
-        # the non-bidirectional case. Return tensor has shape (batch_size, hidden_size * num_directions *
-        # num_layers).
-        return unsorted_state.contiguous().view([-1, self.get_output_dim()])
+        if self._return_all_hidden_states:
+            return unsorted_state.contiguous().view([state_len, -1, self.get_output_dim()])
+        else:
+            return unsorted_state[0].contiguous().view([-1, self.get_output_dim()])

--- a/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
+++ b/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
@@ -35,30 +35,30 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
     bugs around masking.  If you already have a ``PackedSequence`` you can pass ``None`` as the
     second parameter.
     """
-    def __init__(self, module: torch.nn.modules.RNNBase) -> None:
+    def __init__(self,
+                 module: torch.nn.modules.RNNBase,
+                 return_only_last: bool = True,
+                 return_tuple_if_state_is_tuple: bool = False) -> None:
         # Seq2VecEncoders cannot be stateful.
         super(PytorchSeq2VecWrapper, self).__init__(stateful=False)
         self._module = module
-        try:
-            if not self._module.batch_first:
-                raise ConfigurationError("Our encoder semantics assumes batch is always first!")
-        except AttributeError:
-            pass
+        self._return_only_last = return_only_last
+        self._return_tuple_if_state_is_tuple = return_tuple_if_state_is_tuple
+        if not getattr(self._module, 'batch_first', True):
+            raise ConfigurationError("Our encoder semantics assumes batch is always first!")
 
     def get_input_dim(self) -> int:
         return self._module.input_size
 
     def get_output_dim(self) -> int:
-        try:
-            is_bidirectional = self._module.bidirectional
-        except AttributeError:
-            is_bidirectional = False
-        return self._module.hidden_size * (2 if is_bidirectional else 1)
+        is_bidirectional = getattr(self._module, 'bidirectional', False)
+        num_layers = getattr(self._module, 'num_layers', 1)
+        return self._module.hidden_size * (2 if is_bidirectional else 1) * num_layers
 
     def forward(self,  # pylint: disable=arguments-differ
                 inputs: torch.Tensor,
                 mask: torch.Tensor,
-                hidden_state: torch.Tensor = None) -> torch.Tensor:
+                hidden_state: torch.Tensor = None) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
 
         if mask is None:
             # If a mask isn't passed, there is no padding in the batch of instances, so we can just
@@ -73,9 +73,16 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
             self.sort_and_run_forward(self._module, inputs, mask, hidden_state)
 
         # Deal with the fact the LSTM state is a tuple of (state, memory).
-        if isinstance(state, tuple):
-            state = state[0]
+        if isinstance(state, tuple) and self._return_tuple_if_state_is_tuple:
+            return self._restore_order_and_shape(batch_size, restoration_indices, state[0]), \
+                   self._restore_order_and_shape(batch_size, restoration_indices, state[1])
+        else:
+            return self._restore_order_and_shape(batch_size, restoration_indices, state)
 
+    def _restore_order_and_shape(self,
+                                 batch_size: int,
+                                 restoration_indices: torch.LongTensor,
+                                 state: torch.Tensor) -> torch.Tensor:
         num_layers_times_directions, num_valid, encoding_dim = state.size()
         # Add back invalid rows.
         if num_valid < batch_size:
@@ -97,13 +104,13 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
         # now of shape: (batch_size, num_layers * num_directions, hidden_size).
         unsorted_state = state.transpose(0, 1).index_select(0, restoration_indices)
 
-        # Extract the last hidden vector, including both forward and backward states
-        # if the cell is bidirectional. Then reshape by concatenation (in the case
-        # we have bidirectional states) or just squash the 1st dimension in the non-
-        # bidirectional case. Return tensor has shape (batch_size, hidden_size * num_directions).
-        try:
-            last_state_index = 2 if self._module.bidirectional else 1
-        except AttributeError:
-            last_state_index = 1
-        last_layer_state = unsorted_state[:, -last_state_index:, :]
-        return last_layer_state.contiguous().view([-1, self.get_output_dim()])
+        if self._return_only_last:
+            # Extract the last hidden vector, including both forward and backward states
+            # if the cell is bidirectional.
+            last_state_index = 2 if getattr(self._module, 'bidirectional', False) else 1
+            unsorted_state = unsorted_state[:, -last_state_index:, :]
+
+        # Reshape by concatenation (in the case we have bidirectional states) or just squash the 1st dimension in
+        # the non-bidirectional case. Return tensor has shape (batch_size, hidden_size * num_directions *
+        # num_layers).
+        return unsorted_state.contiguous().view([-1, self.get_output_dim()])


### PR DESCRIPTION
Add option in PytorchSeq2VecWrapper to return the state of all layers. Fixes #2411. Also, it adds an option to return all the states (e.g., in LSTMs also return the memory).

I addressed some comments from https://github.com/allenai/allennlp/commit/1d9464b11dc7c597a7a13b4cb36cfa54e55eb2d7

Pending stuff:

* [x] Implement the main thing.
* [ ] Review the case where `mask is None`
* [ ] Document
* [ ] Try to cover with tests the cases: {w/ mask, w/o mask} x {lstm, no lstm} x {all layers, last layer} x {return all hidden states, don't return all hidden states}

Where should the *params* `return_all_layers` and `return_all_hidden_states` be documented? Not the `PytorchSeq2VecWrapper` args but the supported params for RNNs and etc. I mean, where people should learn about them?