### PR TITLE
Add caching functionality to the base DatasetReader class

### DIFF
--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -111,7 +111,9 @@ def train_model_from_args(args: argparse.Namespace):
                           args.overrides,
                           args.file_friendly_logging,
                           args.recover,
-                          args.force)
+                          args.force,
+                          args.cache_directory,
+                          args.cache_prefix)
 
 
 def train_model_from_file(parameter_filename: str,
@@ -150,7 +152,12 @@ def train_model_from_file(parameter_filename: str,
     """
     # Load the experiment config from a file and pass it to ``train_model``.
     params = Params.from_file(parameter_filename, overrides)
-    return train_model(params, serialization_dir, file_friendly_logging, recover, force)
+    return train_model(params,
+                       serialization_dir,
+                       file_friendly_logging,
+                       recover,
+                       force,
+                       cache_directory, cache_prefix)
 
 
 def train_model(params: Params,

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -86,6 +86,17 @@ class Train(Subcommand):
                                default=False,
                                help='outputs tqdm status on separate lines and slows tqdm refresh rate')
 
+        subparser.add_argument('--cache-directory',
+                               type=str,
+                               default='',
+                               help='Location to store cache of data preprocessing')
+
+        subparser.add_argument('--cache-prefix',
+                               type=str,
+                               default='',
+                               help='Prefix to use for data caching, giving current parameter '
+                               'settings a name in the cache, instead of computing a hash')
+
         subparser.set_defaults(func=train_model_from_args)
 
         return subparser
@@ -108,7 +119,9 @@ def train_model_from_file(parameter_filename: str,
                           overrides: str = "",
                           file_friendly_logging: bool = False,
                           recover: bool = False,
-                          force: bool = False) -> Model:
+                          force: bool = False,
+                          cache_directory: str = None,
+                          cache_prefix: str = None) -> Model:
     """
     A wrapper around :func:`train_model` which loads the params from a file.
 
@@ -130,6 +143,10 @@ def train_model_from_file(parameter_filename: str,
         of a run.  For continuing training a model on new data, see the ``fine-tune`` command.
     force : ``bool``, optional (default=False)
         If ``True``, we will overwrite the serialization directory if it already exists.
+    cache_directory : ``str``, optional
+        For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
+    cache_prefix : ``str``, optional
+        For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
     """
     # Load the experiment config from a file and pass it to ``train_model``.
     params = Params.from_file(parameter_filename, overrides)
@@ -140,7 +157,9 @@ def train_model(params: Params,
                 serialization_dir: str,
                 file_friendly_logging: bool = False,
                 recover: bool = False,
-                force: bool = False) -> Model:
+                force: bool = False,
+                cache_directory: str = None,
+                cache_prefix: str = None) -> Model:
     """
     Trains the model specified in the given :class:`Params` object, using the data and training
     parameters also specified in that object, and saves the results in ``serialization_dir``.
@@ -160,6 +179,10 @@ def train_model(params: Params,
         of a run.  For continuing training a model on new data, see the ``fine-tune`` command.
     force : ``bool``, optional (default=False)
         If ``True``, we will overwrite the serialization directory if it already exists.
+    cache_directory : ``str``, optional
+        For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
+    cache_prefix : ``str``, optional
+        For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
 
     Returns
     -------
@@ -181,7 +204,11 @@ def train_model(params: Params,
 
     if trainer_type == "default":
         # Special logic to instantiate backward-compatible trainer.
-        pieces = TrainerPieces.from_params(params, serialization_dir, recover)  # pylint: disable=no-member
+        pieces = TrainerPieces.from_params(params,  # pylint: disable=no-member
+                                           serialization_dir,
+                                           recover,
+                                           cache_directory,
+                                           cache_prefix)
         trainer = Trainer.from_params(
                 model=pieces.model,
                 serialization_dir=serialization_dir,

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -506,6 +506,14 @@ class Params(MutableMapping):
 
         return order_dict(params_dict, order_func)
 
+    def get_hash(self) -> str:
+        """
+        Returns a hash code representing the current state of this ``Params`` object.  We don't
+        want to implement ``__hash__`` because that has deeper python implications (and this is a
+        mutable object), but this will give you a representation of the current state.
+        """
+        return str(hash(json.dumps(self.params, sort_keys=True)))
+
 
 def pop_choice(params: Dict[str, Any],
                key: str,

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -421,3 +421,6 @@ def dump_metrics(file_path: str, metrics: Dict[str, Any], log: bool = False) -> 
         metrics_file.write(metrics_json)
     if log:
         logger.info("Metrics: %s", metrics_json)
+
+def flatten_filename(file_path: str) -> str:
+    return file_path.replace('/', '_SLASH_')

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -86,7 +86,7 @@ class DatasetReader(Registrable):
         unique cache directories.  If you don't use our commands, that is your responsibility.
         """
         self._cache_directory = pathlib.Path(cache_directory)
-        self._cache_directory.mkdir(exist_ok=True)
+        os.makedirs(self._cache_directory, exist_ok=True)
 
     def read(self, file_path: str) -> Iterable[Instance]:
         """

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -30,15 +30,15 @@ class _LazyInstances(Iterable):
     def __iter__(self) -> Iterator[Instance]:
         # Case 1: Use cached instances
         if self.cache_file is not None and os.path.exists(self.cache_file):
-            with open(self.cache_file) as f:
-                for line in f:
+            with open(self.cache_file) as data_file:
+                for line in data_file:
                     yield self.deserialize(line)
         # Case 2: Need to cache instances
         elif self.cache_file is not None:
-            with open(self.cache_file, 'w') as f:
+            with open(self.cache_file, 'w') as data_file:
                 for instance in self.instance_generator():
-                    f.write(self.serialize(instance))
-                    f.write("\n")
+                    data_file.write(self.serialize(instance))
+                    data_file.write("\n")
                     yield instance
         # Case 3: No cache
         else:

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -77,7 +77,7 @@ class DatasetReader(Registrable):
     """
     def __init__(self, lazy: bool = False) -> None:
         self.lazy = lazy
-        self._cache_directory = None
+        self._cache_directory: str = None
 
     def cache_data(self, cache_directory: str) -> None:
         """

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -1,6 +1,7 @@
 from typing import Iterable, Iterator, Callable
 import logging
 import os
+import pathlib
 
 import jsonpickle
 
@@ -66,7 +67,7 @@ class DatasetReader(Registrable):
     """
     def __init__(self, lazy: bool = False) -> None:
         self.lazy = lazy
-        self._cache_directory: str = None
+        self._cache_directory: pathlib.Path = None
 
     def cache_data(self, cache_directory: str) -> None:
         """
@@ -84,10 +85,8 @@ class DatasetReader(Registrable):
         is responsible for calling this method and ensuring that unique parameters correspond to
         unique cache directories.  If you don't use our commands, that is your responsibility.
         """
-        if not cache_directory.endswith('/'):
-            cache_directory += '/'
-        self._cache_directory = cache_directory
-        os.makedirs(self._cache_directory, exist_ok=True)
+        self._cache_directory = pathlib.Path(cache_directory)
+        self._cache_directory.mkdir(exist_ok=True)
 
     def read(self, file_path: str) -> Iterable[Instance]:
         """
@@ -146,7 +145,7 @@ class DatasetReader(Registrable):
             return instances
 
     def _get_cache_location_for_file_path(self, file_path: str) -> str:
-        return self._cache_directory + util.flatten_filename(str(file_path))
+        return str(self._cache_directory / util.flatten_filename(str(file_path)))
 
     def _read(self, file_path: str) -> Iterable[Instance]:
         """

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -1,5 +1,8 @@
 from typing import Iterable, Iterator, Callable
 import logging
+import os
+
+import jsonpickle
 
 from allennlp.data.instance import Instance
 from allennlp.common import Tqdm
@@ -23,6 +26,39 @@ class _LazyInstances(Iterable):
             raise ConfigurationError("For a lazy dataset reader, _read() must return a generator")
         return instances
 
+
+class _CachedLazyInstances(Iterable):
+    """
+    Like ``_LazyInstances``, but we take the actual input file that the instances come from, as
+    well as a cache file.  If the cache file exists, we read from that instead of from the main
+    file.  If the cache file `doesn't` exist, we create it on our first pass, and read it during
+    subsequent passes.
+    """
+    def __init__(self,
+                 read_from_file_method: Callable[[str], Iterator[Instance]],
+                 read_from_cache_method: Callable[[str], Iterator[Instance]],
+                 serialize_instance_method: Callable[[Instance], str],
+                 file_path: str,
+                 cache_file: str) -> None:
+        super().__init__()
+        self.read_from_file_method = read_from_file_method
+        self.read_from_cache_method = read_from_cache_method
+        self.serialize_instance_method = serialize_instance_method
+        self.file_path = file_path
+        self.cache_file = cache_file
+
+    def __iter__(self) -> Iterator[Instance]:
+        if os.path.exists(self.cache_file):
+            return self.read_from_cache_method(self.cache_file)
+        else:
+            def iterator():
+                with open(self.cache_file, 'w') as cache_file:
+                    for instance in self.read_from_file_method(self.file_path):
+                        cache_file.write(self.serialize_instance_method(instance) + '\n')
+                        yield instance
+            return iterator()
+
+
 class DatasetReader(Registrable):
     """
     A ``DatasetReader`` knows how to turn a file containing a dataset into a collection
@@ -38,9 +74,22 @@ class DatasetReader(Registrable):
     lazy : ``bool``, optional (default=False)
         If this is true, ``instances()`` will return an object whose ``__iter__`` method
         reloads the dataset each time it's called. Otherwise, ``instances()`` returns a list.
+    cache_suffix : ``str``, optional (default=None)
+        When provided, we add this suffix to each path passed to :func:`read` to get a location of
+        a file containing a cache of already-processed ``Instances`` in that path, serialized as
+        one string-formatted ``Instance`` per line.  If this file exists, we read the ``Instances``
+        from the cache instead of re-processing the data (using :func:`deserialize_instance`).  If
+        this file does `not` exist, we will `create` it on our first pass through the data (using
+        :func:`serialize_instance`).
+
+        IMPORTANT CAVEAT: if you change parameters in your dataset reader that are supposed to
+        affect how instances are processed, you `must` change this suffix, or clear the cache!
+        Otherwise you will think you are using your new parameters, but you are actually using
+        whatever parameters created the cache.
     """
-    def __init__(self, lazy: bool = False) -> None:
+    def __init__(self, lazy: bool = False, cache_suffix: str = None) -> None:
         self.lazy = lazy
+        self.cache_suffix = cache_suffix
 
     def read(self, file_path: str) -> Iterable[Instance]:
         """
@@ -61,6 +110,11 @@ class DatasetReader(Registrable):
         but if you do your result should likewise be repeatedly iterable.
         """
         lazy = getattr(self, 'lazy', None)
+        cache_suffix = getattr(self, 'cache_suffix', None)
+        if cache_suffix:
+            cache_file = str(file_path) + cache_suffix
+            return self._read_cached(file_path, cache_file, lazy)
+
         if lazy is None:
             logger.warning("DatasetReader.lazy is not set, "
                            "did you forget to call the superclass constructor?")
@@ -85,6 +139,42 @@ class DatasetReader(Registrable):
         """
         raise NotImplementedError
 
+    def _read_cached(self, file_path: str, cache_file: str, lazy: bool) -> Iterable[Instance]:
+        if lazy:
+            return _CachedLazyInstances(self._read,
+                                        self._instances_from_cache_file,
+                                        self.serialize_instance,
+                                        file_path,
+                                        cache_file)
+        if os.path.exists(cache_file):
+            # We already have cached instances; just read them.
+            logger.info(f"Reading cached instances from {cache_file}")
+            instances = self._instances_from_cache_file(cache_file)
+            if not isinstance(instances, list):
+                instances = [instance for instance in Tqdm.tqdm(instances)]
+            if not instances:
+                raise ConfigurationError("No instances were read from the given filepath {}. "
+                                         "Is the path correct?".format(cache_file))
+            return instances
+        else:
+            # We don't have any cached instances yet, so we create them before returning.
+            instances = self._read(file_path)
+            if not isinstance(instances, list):
+                instances = [instance for instance in Tqdm.tqdm(instances)]
+            if not instances:
+                raise ConfigurationError("No instances were read from the given filepath {}. "
+                                         "Is the path correct?".format(file_path))
+            logger.info(f"Caching instances to {cache_file}")
+            with open(cache_file, 'w') as cache_file:
+                for instance in Tqdm.tqdm(instances):
+                    cache_file.write(self.serialize_instance(instance) + '\n')
+            return instances
+
+    def _instances_from_cache_file(self, cache_filename: str) -> Iterable[Instance]:
+        with open(cache_filename, 'r') as cache_file:
+            for line in cache_file:
+                yield self.deserialize_instance(line.strip())
+
     def text_to_instance(self, *inputs) -> Instance:
         """
         Does whatever tokenization or processing is necessary to go from textual input to an
@@ -103,3 +193,22 @@ class DatasetReader(Registrable):
         to pass it the right information.
         """
         raise NotImplementedError
+
+    def serialize_instance(self, instance: Instance) -> str:
+        """
+        Serializes an ``Instance`` to a string.  We use this for caching the processed data.
+
+        The default implementation is to use ``jsonpickle``.  If you would like some other format
+        for your pre-processed data, override this method.
+        """
+        return jsonpickle.dumps(instance)
+
+    def deserialize_instance(self, string: str) -> Instance:
+        """
+        Deserializes an ``Instance`` from a string.  We use this when reading processed data from a
+        cache.
+
+        The default implementation is to use ``jsonpickle``.  If you would like some other format
+        for your pre-processed data, override this method.
+        """
+        return jsonpickle.loads(string)  # type: ignore

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -35,8 +35,8 @@ class _CachedLazyInstances(Iterable):
     subsequent passes.
     """
     def __init__(self,
-                 read_from_file_method: Callable[[str], Iterator[Instance]],
-                 read_from_cache_method: Callable[[str], Iterator[Instance]],
+                 read_from_file_method: Callable[[str], Iterable[Instance]],
+                 read_from_cache_method: Callable[[str], Iterable[Instance]],
                  serialize_instance_method: Callable[[Instance], str],
                  file_path: str,
                  cache_file: str) -> None:
@@ -176,9 +176,9 @@ class DatasetReader(Registrable):
                 raise ConfigurationError("No instances were read from the given filepath {}. "
                                          "Is the path correct?".format(file_path))
             logger.info(f"Caching instances to {cache_file}")
-            with open(cache_file, 'w') as cache_file:
+            with open(cache_file, 'w') as cache:
                 for instance in Tqdm.tqdm(instances):
-                    cache_file.write(self.serialize_instance(instance) + '\n')
+                    cache.write(self.serialize_instance(instance) + '\n')
             return instances
 
     def _instances_from_cache_file(self, cache_filename: str) -> Iterable[Instance]:
@@ -212,6 +212,7 @@ class DatasetReader(Registrable):
         The default implementation is to use ``jsonpickle``.  If you would like some other format
         for your pre-processed data, override this method.
         """
+        # pylint: disable=no-self-use
         return jsonpickle.dumps(instance)
 
     def deserialize_instance(self, string: str) -> Instance:
@@ -222,4 +223,5 @@ class DatasetReader(Registrable):
         The default implementation is to use ``jsonpickle``.  If you would like some other format
         for your pre-processed data, override this method.
         """
+        # pylint: disable=no-self-use
         return jsonpickle.loads(string)  # type: ignore

--- a/allennlp/data/dataset_readers/reading_comprehension/drop.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/drop.py
@@ -132,11 +132,10 @@ class DropReader(DatasetReader):
                                                  answer_annotations,
                                                  passage_tokens)
                 if instance is not None:
-                    instances.append(instance)
+                    yield instance
                 else:
                     skip_count += 1
         logger.info(f"Skipped {skip_count} questions, kept {len(instances)} questions.")
-        return instances
 
     @overrides
     def text_to_instance(self,  # type: ignore

--- a/allennlp/data/dataset_readers/reading_comprehension/drop.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/drop.py
@@ -111,7 +111,7 @@ class DropReader(DatasetReader):
         with open(file_path) as dataset_file:
             dataset = json.load(dataset_file)
         logger.info("Reading the dataset")
-        instances, skip_count = [], 0
+        kept_count, skip_count = 0, 0
         for passage_id, passage_info in dataset.items():
             passage_text = passage_info["passage"]
             passage_tokens = self._tokenizer.tokenize(passage_text)
@@ -132,10 +132,11 @@ class DropReader(DatasetReader):
                                                  answer_annotations,
                                                  passage_tokens)
                 if instance is not None:
+                    kept_count += 1
                     yield instance
                 else:
                     skip_count += 1
-        logger.info(f"Skipped {skip_count} questions, kept {len(instances)} questions.")
+        logger.info(f"Skipped {skip_count} questions, kept {kept_count} questions.")
 
     @overrides
     def text_to_instance(self,  # type: ignore

--- a/allennlp/data/dataset_readers/snli.py
+++ b/allennlp/data/dataset_readers/snli.py
@@ -34,8 +34,9 @@ class SnliReader(DatasetReader):
     def __init__(self,
                  tokenizer: Tokenizer = None,
                  token_indexers: Dict[str, TokenIndexer] = None,
-                 lazy: bool = False) -> None:
-        super().__init__(lazy)
+                 lazy: bool = False,
+                 cache_suffix: str = None) -> None:
+        super().__init__(lazy, cache_suffix)
         self._tokenizer = tokenizer or WordTokenizer()
         self._token_indexers = token_indexers or {'tokens': SingleIdTokenIndexer()}
 

--- a/allennlp/data/dataset_readers/snli.py
+++ b/allennlp/data/dataset_readers/snli.py
@@ -34,9 +34,8 @@ class SnliReader(DatasetReader):
     def __init__(self,
                  tokenizer: Tokenizer = None,
                  token_indexers: Dict[str, TokenIndexer] = None,
-                 lazy: bool = False,
-                 cache_suffix: str = None) -> None:
-        super().__init__(lazy, cache_suffix)
+                 lazy: bool = False) -> None:
+        super().__init__(lazy)
         self._tokenizer = tokenizer or WordTokenizer()
         self._token_indexers = token_indexers or {'tokens': SingleIdTokenIndexer()}
 

--- a/allennlp/data/fields/array_field.py
+++ b/allennlp/data/fields/array_field.py
@@ -55,6 +55,5 @@ class ArrayField(Field[numpy.ndarray]):
                           padding_value=self.padding_value,
                           dtype=self.dtype)
 
-
     def __str__(self) -> str:
         return f"ArrayField with shape: {self.array.shape} and dtype: {self.dtype}."

--- a/allennlp/data/fields/field.py
+++ b/allennlp/data/fields/field.py
@@ -109,3 +109,8 @@ class Field(Generic[DataArray]):
         """
         # pylint: disable=no-self-use
         return torch.stack(tensor_list)
+
+    def __eq__(self, other) -> bool:
+        if isinstance(self, other.__class__):
+            return self.__dict__ == other.__dict__
+        return NotImplemented

--- a/allennlp/data/instance.py
+++ b/allennlp/data/instance.py
@@ -97,7 +97,6 @@ class Instance(Mapping[str, Field]):
             tensors[field_name] = field.as_tensor(padding_lengths[field_name])
         return tensors
 
-
     def __str__(self) -> str:
         base_string = f"Instance with fields:\n"
         return " ".join([base_string] + [f"\t {name}: {field} \n"

--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -85,7 +85,6 @@ class DataIterator(Registrable):
         # we use their id() as the key.
         self._cursors: Dict[int, Iterator[Instance]] = {}
 
-
     def __call__(self,
                  instances: Iterable[Instance],
                  num_epochs: int = None,
@@ -228,7 +227,6 @@ class DataIterator(Registrable):
         else:
             yield list(iterator)
 
-
     def _ensure_batch_is_sufficiently_small(
             self,
             batch_instances: Iterable[Instance],
@@ -298,7 +296,6 @@ class DataIterator(Registrable):
 
         return batches
 
-
     def get_num_batches(self, instances: Iterable[Instance]) -> int:
         """
         Returns the number of batches that ``dataset`` will be split into; if you want to track
@@ -313,7 +310,6 @@ class DataIterator(Registrable):
         else:
             # Not lazy, so can compute the list length.
             return math.ceil(len(ensure_list(instances)) / self._batch_size)
-
 
     def _create_batches(self, instances: Iterable[Instance], shuffle: bool) -> Iterable[Batch]:
         """

--- a/allennlp/data/token_indexers/token_indexer.py
+++ b/allennlp/data/token_indexers/token_indexer.py
@@ -80,3 +80,8 @@ class TokenIndexer(Generic[TokenType], Registrable):
         """
         # pylint: disable=no-self-use
         return [index_name]
+
+    def __eq__(self, other) -> bool:
+        if isinstance(self, other.__class__):
+            return self.__dict__ == other.__dict__
+        return NotImplemented

--- a/allennlp/data/tokenizers/token.py
+++ b/allennlp/data/tokenizers/token.py
@@ -47,11 +47,6 @@ class Token(NamedTuple):
     def __repr__(self):
         return self.__str__()
 
-    def __eq__(self, other):
-        if isinstance(self, other.__class__):
-            return self.__dict__ == other.__dict__
-        return NotImplemented
-
 
 def show_token(token: Token) -> str:
     return (f"{token.text} "

--- a/allennlp/tests/commands/train_test.py
+++ b/allennlp/tests/commands/train_test.py
@@ -175,7 +175,7 @@ class LazyFakeReader(DatasetReader):
     # pylint: disable=abstract-method
     def __init__(self) -> None:
         super().__init__(lazy=True)
-        self.reader = DatasetReader.from_params(Params({'type': 'sequence_tagging'}))
+        self.reader = DatasetReader.from_params(Params({'type': 'sequence_tagging', 'lazy': True}))
 
     def _read(self, file_path: str) -> Iterable[Instance]:
         """

--- a/allennlp/tests/data/dataset_readers/dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_reader_test.py
@@ -1,0 +1,114 @@
+# pylint: disable=invalid-name,no-self-use,protected-access
+import os
+import shutil
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.dataset_readers import SnliReader
+from allennlp.data.dataset_readers.dataset_reader import _CachedLazyInstances
+
+
+class DatasetReaderTest(AllenNlpTestCase):
+    def test_read_creates_cache_file_when_not_present(self):
+        snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
+        suffix = ".cache"
+        cache_file = str(snli_file) + suffix
+        reader = SnliReader(cache_suffix=suffix)
+
+        try:
+            assert not os.path.exists(cache_file)
+            reader.read(snli_file)
+            assert os.path.exists(cache_file)
+        finally:
+            os.remove(cache_file)
+
+    def test_read_uses_existing_cache_file_when_present(self):
+        snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
+        snli_copy_file = str(snli_file) + ".copy"
+        shutil.copyfile(snli_file, snli_copy_file)
+        suffix = ".cache"
+        cache_file = snli_copy_file + suffix
+        reader = SnliReader(cache_suffix=suffix)
+
+        # The first read will create the cache.
+        instances = reader.read(snli_copy_file)
+        # Now we _remove_ the data file, to be sure we're reading from the cache.
+        os.remove(snli_copy_file)
+        cached_instances = reader.read(snli_copy_file)
+        try:
+            # We should get the same instances both times.
+            assert len(instances) == len(cached_instances)
+            for instance, cached_instance in zip(instances, cached_instances):
+                assert instance.fields == cached_instance.fields
+        finally:
+            os.remove(cache_file)
+
+    def test_read_only_creates_cache_file_once(self):
+        snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
+        suffix = ".cache"
+        cache_file = str(snli_file) + suffix
+        reader = SnliReader(cache_suffix=suffix)
+
+        try:
+            # The first read will create the cache.
+            reader.read(snli_file)
+            assert os.path.exists(cache_file)
+            with open(cache_file, 'r') as in_file:
+                cache_contents = in_file.read()
+            # The second and all subsequent reads should _use_ the cache, not modify it.  I looked
+            # into checking file modification times, but this test will probably be faster than the
+            # granularity of `os.path.getmtime()` (which only returns values in seconds).
+            reader.read(snli_file)
+            reader.read(snli_file)
+            reader.read(snli_file)
+            reader.read(snli_file)
+            with open(cache_file, 'r') as in_file:
+                final_cache_contents = in_file.read()
+            assert cache_contents == final_cache_contents
+        finally:
+            os.remove(cache_file)
+
+    def test_caching_works_with_lazy_reading(self):
+        snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
+        snli_copy_file = str(snli_file) + ".copy"
+        shutil.copyfile(snli_file, snli_copy_file)
+        suffix = ".cache"
+        cache_file = snli_copy_file + suffix
+        reader = SnliReader(lazy=True, cache_suffix=suffix)
+
+        try:
+            # The call to read() will give us an _iterator_.  We'll iterate over it multiple times,
+            # and the caching behavior should change as we go.
+            instances = reader.read(snli_copy_file)
+            assert isinstance(instances, _CachedLazyInstances)
+
+            # The first iteration will create the cache
+            assert not os.path.exists(cache_file)
+            first_pass_instances = []
+            for instance in instances:
+                first_pass_instances.append(instance)
+            assert os.path.exists(cache_file)
+
+            # Now we _remove_ the data file, to be sure we're reading from the cache.
+            os.remove(snli_copy_file)
+            second_pass_instances = []
+            for instance in instances:
+                second_pass_instances.append(instance)
+
+            # We should get the same instances both times.
+            assert len(first_pass_instances) == len(second_pass_instances)
+            for instance, cached_instance in zip(first_pass_instances, second_pass_instances):
+                assert instance.fields == cached_instance.fields
+
+            # And just to be super paranoid, in case the second pass somehow bypassed the cache
+            # because of a bug in `_CachedLazyInstance` that's hard to detect, we'll read the
+            # instances from the cache with a non-lazy iterator and make sure they're the same.
+            reader = SnliReader(lazy=False, cache_suffix=suffix)
+            cached_instances = reader.read(snli_copy_file)
+            assert len(first_pass_instances) == len(cached_instances)
+            for instance, cached_instance in zip(first_pass_instances, cached_instances):
+                assert instance.fields == cached_instance.fields
+        finally:
+            if os.path.exists(cache_file):
+                os.remove(cache_file)
+            if os.path.exists(snli_copy_file):
+                os.remove(snli_copy_file)

--- a/allennlp/tests/data/dataset_readers/dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_reader_test.py
@@ -10,7 +10,7 @@ from allennlp.data.dataset_readers.dataset_reader import _LazyInstances
 class DatasetReaderTest(AllenNlpTestCase):
     def setUp(self):
         super().setUp()
-        self.cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
+        self.cache_directory = str(self.FIXTURES_ROOT / "data_cache")
 
     def tearDown(self):
         super().tearDown()
@@ -19,8 +19,7 @@ class DatasetReaderTest(AllenNlpTestCase):
     def test_read_creates_cache_file_when_not_present(self):
         snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
         reader = SnliReader()
-        cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
-        reader.cache_data(cache_directory)
+        reader.cache_data(self.cache_directory)
         cache_file = reader._get_cache_location_for_file_path(snli_file)
         assert not os.path.exists(cache_file)
         reader.read(snli_file)
@@ -31,8 +30,7 @@ class DatasetReaderTest(AllenNlpTestCase):
         snli_copy_file = str(snli_file) + ".copy"
         shutil.copyfile(snli_file, snli_copy_file)
         reader = SnliReader()
-        cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
-        reader.cache_data(cache_directory)
+        reader.cache_data(self.cache_directory)
 
         # The first read will create the cache.
         instances = reader.read(snli_copy_file)
@@ -47,8 +45,7 @@ class DatasetReaderTest(AllenNlpTestCase):
     def test_read_only_creates_cache_file_once(self):
         snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
         reader = SnliReader()
-        cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
-        reader.cache_data(cache_directory)
+        reader.cache_data(self.cache_directory)
         cache_file = reader._get_cache_location_for_file_path(snli_file)
 
         # The first read will create the cache.
@@ -72,8 +69,7 @@ class DatasetReaderTest(AllenNlpTestCase):
         snli_copy_file = str(snli_file) + ".copy"
         shutil.copyfile(snli_file, snli_copy_file)
         reader = SnliReader(lazy=True)
-        cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
-        reader.cache_data(cache_directory)
+        reader.cache_data(self.cache_directory)
         cache_file = reader._get_cache_location_for_file_path(snli_copy_file)
 
         # The call to read() will give us an _iterator_.  We'll iterate over it multiple times,
@@ -103,7 +99,7 @@ class DatasetReaderTest(AllenNlpTestCase):
         # because of a bug in `_CachedLazyInstance` that's hard to detect, we'll read the
         # instances from the cache with a non-lazy iterator and make sure they're the same.
         reader = SnliReader(lazy=False)
-        reader.cache_data(cache_directory)
+        reader.cache_data(self.cache_directory)
         cached_instances = reader.read(snli_copy_file)
         assert len(first_pass_instances) == len(cached_instances)
         for instance, cached_instance in zip(first_pass_instances, cached_instances):

--- a/allennlp/tests/data/dataset_readers/dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_reader_test.py
@@ -4,7 +4,7 @@ import shutil
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data.dataset_readers import SnliReader
-from allennlp.data.dataset_readers.dataset_reader import _CachedLazyInstances
+from allennlp.data.dataset_readers.dataset_reader import _LazyInstances
 
 
 class DatasetReaderTest(AllenNlpTestCase):
@@ -79,7 +79,7 @@ class DatasetReaderTest(AllenNlpTestCase):
         # The call to read() will give us an _iterator_.  We'll iterate over it multiple times,
         # and the caching behavior should change as we go.
         instances = reader.read(snli_copy_file)
-        assert isinstance(instances, _CachedLazyInstances)
+        assert isinstance(instances, _LazyInstances)
 
         # The first iteration will create the cache
         assert not os.path.exists(cache_file)

--- a/allennlp/tests/data/dataset_readers/dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_reader_test.py
@@ -8,19 +8,23 @@ from allennlp.data.dataset_readers.dataset_reader import _CachedLazyInstances
 
 
 class DatasetReaderTest(AllenNlpTestCase):
+    def setUp(self):
+        super().setUp()
+        self.cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
+
+    def tearDown(self):
+        super().tearDown()
+        shutil.rmtree(self.cache_directory)
+
     def test_read_creates_cache_file_when_not_present(self):
         snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
         reader = SnliReader()
         cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
         reader.cache_data(cache_directory)
         cache_file = reader._get_cache_location_for_file_path(snli_file)
-
-        try:
-            assert not os.path.exists(cache_file)
-            reader.read(snli_file)
-            assert os.path.exists(cache_file)
-        finally:
-            shutil.rmtree(cache_directory)
+        assert not os.path.exists(cache_file)
+        reader.read(snli_file)
+        assert os.path.exists(cache_file)
 
     def test_read_uses_existing_cache_file_when_present(self):
         snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
@@ -29,20 +33,16 @@ class DatasetReaderTest(AllenNlpTestCase):
         reader = SnliReader()
         cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
         reader.cache_data(cache_directory)
-        cache_file = reader._get_cache_location_for_file_path(snli_copy_file)
 
         # The first read will create the cache.
         instances = reader.read(snli_copy_file)
         # Now we _remove_ the data file, to be sure we're reading from the cache.
         os.remove(snli_copy_file)
         cached_instances = reader.read(snli_copy_file)
-        try:
-            # We should get the same instances both times.
-            assert len(instances) == len(cached_instances)
-            for instance, cached_instance in zip(instances, cached_instances):
-                assert instance.fields == cached_instance.fields
-        finally:
-            shutil.rmtree(cache_directory)
+        # We should get the same instances both times.
+        assert len(instances) == len(cached_instances)
+        for instance, cached_instance in zip(instances, cached_instances):
+            assert instance.fields == cached_instance.fields
 
     def test_read_only_creates_cache_file_once(self):
         snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
@@ -51,24 +51,21 @@ class DatasetReaderTest(AllenNlpTestCase):
         reader.cache_data(cache_directory)
         cache_file = reader._get_cache_location_for_file_path(snli_file)
 
-        try:
-            # The first read will create the cache.
-            reader.read(snli_file)
-            assert os.path.exists(cache_file)
-            with open(cache_file, 'r') as in_file:
-                cache_contents = in_file.read()
-            # The second and all subsequent reads should _use_ the cache, not modify it.  I looked
-            # into checking file modification times, but this test will probably be faster than the
-            # granularity of `os.path.getmtime()` (which only returns values in seconds).
-            reader.read(snli_file)
-            reader.read(snli_file)
-            reader.read(snli_file)
-            reader.read(snli_file)
-            with open(cache_file, 'r') as in_file:
-                final_cache_contents = in_file.read()
-            assert cache_contents == final_cache_contents
-        finally:
-            os.remove(cache_file)
+        # The first read will create the cache.
+        reader.read(snli_file)
+        assert os.path.exists(cache_file)
+        with open(cache_file, 'r') as in_file:
+            cache_contents = in_file.read()
+        # The second and all subsequent reads should _use_ the cache, not modify it.  I looked
+        # into checking file modification times, but this test will probably be faster than the
+        # granularity of `os.path.getmtime()` (which only returns values in seconds).
+        reader.read(snli_file)
+        reader.read(snli_file)
+        reader.read(snli_file)
+        reader.read(snli_file)
+        with open(cache_file, 'r') as in_file:
+            final_cache_contents = in_file.read()
+        assert cache_contents == final_cache_contents
 
     def test_caching_works_with_lazy_reading(self):
         snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
@@ -79,41 +76,35 @@ class DatasetReaderTest(AllenNlpTestCase):
         reader.cache_data(cache_directory)
         cache_file = reader._get_cache_location_for_file_path(snli_copy_file)
 
-        try:
-            # The call to read() will give us an _iterator_.  We'll iterate over it multiple times,
-            # and the caching behavior should change as we go.
-            instances = reader.read(snli_copy_file)
-            assert isinstance(instances, _CachedLazyInstances)
+        # The call to read() will give us an _iterator_.  We'll iterate over it multiple times,
+        # and the caching behavior should change as we go.
+        instances = reader.read(snli_copy_file)
+        assert isinstance(instances, _CachedLazyInstances)
 
-            # The first iteration will create the cache
-            assert not os.path.exists(cache_file)
-            first_pass_instances = []
-            for instance in instances:
-                first_pass_instances.append(instance)
-            assert os.path.exists(cache_file)
+        # The first iteration will create the cache
+        assert not os.path.exists(cache_file)
+        first_pass_instances = []
+        for instance in instances:
+            first_pass_instances.append(instance)
+        assert os.path.exists(cache_file)
 
-            # Now we _remove_ the data file, to be sure we're reading from the cache.
-            os.remove(snli_copy_file)
-            second_pass_instances = []
-            for instance in instances:
-                second_pass_instances.append(instance)
+        # Now we _remove_ the data file, to be sure we're reading from the cache.
+        os.remove(snli_copy_file)
+        second_pass_instances = []
+        for instance in instances:
+            second_pass_instances.append(instance)
 
-            # We should get the same instances both times.
-            assert len(first_pass_instances) == len(second_pass_instances)
-            for instance, cached_instance in zip(first_pass_instances, second_pass_instances):
-                assert instance.fields == cached_instance.fields
+        # We should get the same instances both times.
+        assert len(first_pass_instances) == len(second_pass_instances)
+        for instance, cached_instance in zip(first_pass_instances, second_pass_instances):
+            assert instance.fields == cached_instance.fields
 
-            # And just to be super paranoid, in case the second pass somehow bypassed the cache
-            # because of a bug in `_CachedLazyInstance` that's hard to detect, we'll read the
-            # instances from the cache with a non-lazy iterator and make sure they're the same.
-            reader = SnliReader(lazy=False)
-            reader.cache_data(cache_directory)
-            cached_instances = reader.read(snli_copy_file)
-            assert len(first_pass_instances) == len(cached_instances)
-            for instance, cached_instance in zip(first_pass_instances, cached_instances):
-                assert instance.fields == cached_instance.fields
-        finally:
-            if os.path.exists(cache_file):
-                os.remove(cache_file)
-            if os.path.exists(snli_copy_file):
-                os.remove(snli_copy_file)
+        # And just to be super paranoid, in case the second pass somehow bypassed the cache
+        # because of a bug in `_CachedLazyInstance` that's hard to detect, we'll read the
+        # instances from the cache with a non-lazy iterator and make sure they're the same.
+        reader = SnliReader(lazy=False)
+        reader.cache_data(cache_directory)
+        cached_instances = reader.read(snli_copy_file)
+        assert len(first_pass_instances) == len(cached_instances)
+        for instance, cached_instance in zip(first_pass_instances, cached_instances):
+            assert instance.fields == cached_instance.fields

--- a/allennlp/tests/data/dataset_readers/dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_reader_test.py
@@ -10,24 +10,26 @@ from allennlp.data.dataset_readers.dataset_reader import _CachedLazyInstances
 class DatasetReaderTest(AllenNlpTestCase):
     def test_read_creates_cache_file_when_not_present(self):
         snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
-        suffix = ".cache"
-        cache_file = str(snli_file) + suffix
-        reader = SnliReader(cache_suffix=suffix)
+        reader = SnliReader()
+        cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
+        reader.cache_data(cache_directory)
+        cache_file = reader._get_cache_location_for_file_path(snli_file)
 
         try:
             assert not os.path.exists(cache_file)
             reader.read(snli_file)
             assert os.path.exists(cache_file)
         finally:
-            os.remove(cache_file)
+            shutil.rmtree(cache_directory)
 
     def test_read_uses_existing_cache_file_when_present(self):
         snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
         snli_copy_file = str(snli_file) + ".copy"
         shutil.copyfile(snli_file, snli_copy_file)
-        suffix = ".cache"
-        cache_file = snli_copy_file + suffix
-        reader = SnliReader(cache_suffix=suffix)
+        reader = SnliReader()
+        cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
+        reader.cache_data(cache_directory)
+        cache_file = reader._get_cache_location_for_file_path(snli_copy_file)
 
         # The first read will create the cache.
         instances = reader.read(snli_copy_file)
@@ -40,13 +42,14 @@ class DatasetReaderTest(AllenNlpTestCase):
             for instance, cached_instance in zip(instances, cached_instances):
                 assert instance.fields == cached_instance.fields
         finally:
-            os.remove(cache_file)
+            shutil.rmtree(cache_directory)
 
     def test_read_only_creates_cache_file_once(self):
         snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
-        suffix = ".cache"
-        cache_file = str(snli_file) + suffix
-        reader = SnliReader(cache_suffix=suffix)
+        reader = SnliReader()
+        cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
+        reader.cache_data(cache_directory)
+        cache_file = reader._get_cache_location_for_file_path(snli_file)
 
         try:
             # The first read will create the cache.
@@ -71,9 +74,10 @@ class DatasetReaderTest(AllenNlpTestCase):
         snli_file = self.FIXTURES_ROOT / "data" / "snli.jsonl"
         snli_copy_file = str(snli_file) + ".copy"
         shutil.copyfile(snli_file, snli_copy_file)
-        suffix = ".cache"
-        cache_file = snli_copy_file + suffix
-        reader = SnliReader(lazy=True, cache_suffix=suffix)
+        reader = SnliReader(lazy=True)
+        cache_directory = str(self.FIXTURES_ROOT / "data_cache") + '/'
+        reader.cache_data(cache_directory)
+        cache_file = reader._get_cache_location_for_file_path(snli_copy_file)
 
         try:
             # The call to read() will give us an _iterator_.  We'll iterate over it multiple times,
@@ -102,7 +106,8 @@ class DatasetReaderTest(AllenNlpTestCase):
             # And just to be super paranoid, in case the second pass somehow bypassed the cache
             # because of a bug in `_CachedLazyInstance` that's hard to detect, we'll read the
             # instances from the cache with a non-lazy iterator and make sure they're the same.
-            reader = SnliReader(lazy=False, cache_suffix=suffix)
+            reader = SnliReader(lazy=False)
+            reader.cache_data(cache_directory)
             cached_instances = reader.read(snli_copy_file)
             assert len(first_pass_instances) == len(cached_instances)
             for instance, cached_instance in zip(first_pass_instances, cached_instances):

--- a/allennlp/tests/data/dataset_readers/dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_reader_test.py
@@ -10,7 +10,7 @@ from allennlp.data.dataset_readers.dataset_reader import _LazyInstances
 class DatasetReaderTest(AllenNlpTestCase):
     def setUp(self):
         super().setUp()
-        self.cache_directory = str(self.FIXTURES_ROOT / "data_cache")
+        self.cache_directory = str(self.FIXTURES_ROOT / "data_cache" / "with_prefix")
 
     def tearDown(self):
         super().tearDown()

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -381,7 +381,6 @@ class TestTrainer(AllenNlpTestCase):
         assert new_trainer._momentum_scheduler.last_epoch == 3
         new_trainer.train()
 
-
     def test_trainer_can_run_with_lr_scheduler(self):
         lr_params = Params({"type": "reduce_on_plateau"})
         lr_scheduler = LearningRateScheduler.from_params(self.optimizer, lr_params)

--- a/allennlp/tests/training/util_test.py
+++ b/allennlp/tests/training/util_test.py
@@ -1,0 +1,39 @@
+# pylint: disable=invalid-name,too-many-public-methods,protected-access
+import os
+import shutil
+
+from allennlp.common import Params
+from allennlp.common import util as common_util
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.training import util
+
+
+class TestTrainerUtil(AllenNlpTestCase):
+    def test_datasets_from_params_uses_caching_correctly_in_simplest_case(self):
+        # We'll rely on the dataset reader tests to be sure of the functionality of this caching;
+        # we're just checking here that things get hooked up correctly to the right spots.
+        snli_file = str(self.FIXTURES_ROOT / "data" / "snli.jsonl")
+        params = Params({"dataset_reader": {"type": "snli"}, "train_data_path": snli_file})
+        cache_directory = str(self.FIXTURES_ROOT / "data_cache")
+        cache_prefix = "prefix"
+        datasets = util.datasets_from_params(params, cache_directory, cache_prefix)
+        expected_cache_file = f"{cache_directory}/{cache_prefix}/{common_util.flatten_filename(snli_file)}"
+        try:
+            assert os.path.exists(expected_cache_file)
+        finally:
+            shutil.rmtree(cache_directory)
+
+    def test_datasets_from_params_uses_caching_correctly_with_hashed_params(self):
+        # We'll rely on the dataset reader tests to be sure of the functionality of this caching;
+        # we're just checking here that things get hooked up correctly to the right spots.
+        snli_file = str(self.FIXTURES_ROOT / "data" / "snli.jsonl")
+        params = Params({"dataset_reader": {"type": "snli"}, "train_data_path": snli_file})
+        cache_directory = str(self.FIXTURES_ROOT / "data_cache")
+        datasets = util.datasets_from_params(params, cache_directory)
+
+        cache_prefix = util._dataset_reader_param_hash(Params({"type": "snli"}))
+        expected_cache_file = f"{cache_directory}/{cache_prefix}/{common_util.flatten_filename(snli_file)}"
+        try:
+            assert os.path.exists(expected_cache_file)
+        finally:
+            shutil.rmtree(cache_directory)

--- a/allennlp/tests/training/util_test.py
+++ b/allennlp/tests/training/util_test.py
@@ -1,40 +1,44 @@
 # pylint: disable=invalid-name,too-many-public-methods,protected-access
+import json
 import os
 import shutil
 
 from allennlp.common import Params
-from allennlp.common import util as common_util
+from allennlp.common.util import flatten_filename
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.training import util
 
 
 class TestTrainerUtil(AllenNlpTestCase):
+    def setUp(self):
+        super().setUp()
+        self.snli_file = str(self.FIXTURES_ROOT / "data" / "snli.jsonl")
+        self.params = Params({"dataset_reader": {"type": "snli"}, "train_data_path": self.snli_file})
+        self.cache_directory = str(self.FIXTURES_ROOT / "data_cache")
+
+    def tearDown(self):
+        super().tearDown()
+        shutil.rmtree(self.cache_directory)
+
     def test_datasets_from_params_uses_caching_correctly_in_simplest_case(self):
         # We'll rely on the dataset reader tests to be sure of the functionality of this caching;
         # we're just checking here that things get hooked up correctly to the right spots.
-        snli_file = str(self.FIXTURES_ROOT / "data" / "snli.jsonl")
-        params = Params({"dataset_reader": {"type": "snli"}, "train_data_path": snli_file})
-        cache_directory = str(self.FIXTURES_ROOT / "data_cache")
         cache_prefix = "prefix"
-        _ = util.datasets_from_params(params, cache_directory, cache_prefix)
+        _ = util.datasets_from_params(self.params.duplicate(), self.cache_directory, cache_prefix)
 
-        expected_cache_file = f"{cache_directory}/{cache_prefix}/{common_util.flatten_filename(snli_file)}"
-        try:
-            assert os.path.exists(expected_cache_file)
-        finally:
-            shutil.rmtree(cache_directory)
+        expected_cache_file = f"{self.cache_directory}/{cache_prefix}/{flatten_filename(self.snli_file)}"
+        expected_param_file = f"{self.cache_directory}/{cache_prefix}/params.json"
+        assert os.path.exists(expected_cache_file)
+        assert os.path.exists(expected_param_file)
+        with open(expected_param_file, 'r') as param_file:
+            saved_params = json.load(param_file)
+            assert saved_params == self.params.pop('dataset_reader').as_dict(quiet=True)
 
     def test_datasets_from_params_uses_caching_correctly_with_hashed_params(self):
         # We'll rely on the dataset reader tests to be sure of the functionality of this caching;
         # we're just checking here that things get hooked up correctly to the right spots.
-        snli_file = str(self.FIXTURES_ROOT / "data" / "snli.jsonl")
-        params = Params({"dataset_reader": {"type": "snli"}, "train_data_path": snli_file})
-        cache_directory = str(self.FIXTURES_ROOT / "data_cache")
-        _ = util.datasets_from_params(params, cache_directory)
+        _ = util.datasets_from_params(self.params, self.cache_directory)
 
         cache_prefix = util._dataset_reader_param_hash(Params({"type": "snli"}))
-        expected_cache_file = f"{cache_directory}/{cache_prefix}/{common_util.flatten_filename(snli_file)}"
-        try:
-            assert os.path.exists(expected_cache_file)
-        finally:
-            shutil.rmtree(cache_directory)
+        expected_cache_file = f"{self.cache_directory}/{cache_prefix}/{flatten_filename(self.snli_file)}"
+        assert os.path.exists(expected_cache_file)

--- a/allennlp/tests/training/util_test.py
+++ b/allennlp/tests/training/util_test.py
@@ -16,7 +16,8 @@ class TestTrainerUtil(AllenNlpTestCase):
         params = Params({"dataset_reader": {"type": "snli"}, "train_data_path": snli_file})
         cache_directory = str(self.FIXTURES_ROOT / "data_cache")
         cache_prefix = "prefix"
-        datasets = util.datasets_from_params(params, cache_directory, cache_prefix)
+        _ = util.datasets_from_params(params, cache_directory, cache_prefix)
+
         expected_cache_file = f"{cache_directory}/{cache_prefix}/{common_util.flatten_filename(snli_file)}"
         try:
             assert os.path.exists(expected_cache_file)
@@ -29,7 +30,7 @@ class TestTrainerUtil(AllenNlpTestCase):
         snli_file = str(self.FIXTURES_ROOT / "data" / "snli.jsonl")
         params = Params({"dataset_reader": {"type": "snli"}, "train_data_path": snli_file})
         cache_directory = str(self.FIXTURES_ROOT / "data_cache")
-        datasets = util.datasets_from_params(params, cache_directory)
+        _ = util.datasets_from_params(params, cache_directory)
 
         cache_prefix = util._dataset_reader_param_hash(Params({"type": "snli"}))
         expected_cache_file = f"{cache_directory}/{cache_prefix}/{common_util.flatten_filename(snli_file)}"

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -764,8 +764,12 @@ class TrainerPieces(NamedTuple):
     params: Params
 
     @staticmethod
-    def from_params(params: Params, serialization_dir: str, recover: bool = False) -> 'TrainerPieces':
-        all_datasets = training_util.datasets_from_params(params)
+    def from_params(params: Params,
+                    serialization_dir: str,
+                    recover: bool = False,
+                    cache_directory: str = None,
+                    cache_prefix: str = None) -> 'TrainerPieces':
+        all_datasets = training_util.datasets_from_params(params, cache_directory, cache_prefix)
         datasets_for_vocab_creation = set(params.pop("datasets_for_vocab_creation", all_datasets))
 
         for dataset in datasets_for_vocab_creation:

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -3,6 +3,7 @@ Helper functions for Trainers
 """
 from typing import Any, Union, Dict, Iterable, List, Optional
 import datetime
+import json
 import logging
 import os
 import shutil
@@ -174,6 +175,21 @@ def datasets_from_params(params: Params,
             cache_prefix += '/'
         if not validation_cache_prefix.endswith('/'):
             validation_cache_prefix += '/'
+
+        # For easy human inspection of what parameters were used to create the cache.  This will
+        # overwrite old files, but they should be identical.  This could bite someone who gave
+        # their own prefix instead of letting us compute it, and then _re-used_ that name with
+        # different parameters, without clearing the cache first.  But correctly handling that case
+        # is more work than it's worth.
+        os.makedirs(cache_directory + cache_prefix, exist_ok=True)
+        with open(cache_directory + cache_prefix + 'params.json', 'w') as param_file:
+            json.dump(dataset_reader_params.as_dict(quiet=True), param_file)
+        os.makedirs(cache_directory + validation_cache_prefix, exist_ok=True)
+        with open(cache_directory + validation_cache_prefix + 'params.json', 'w') as param_file:
+            if validation_dataset_reader_params:
+                json.dump(validation_dataset_reader_params.as_dict(quiet=True), param_file)
+            else:
+                json.dump(dataset_reader_params.as_dict(quiet=True), param_file)
 
     dataset_reader = DatasetReader.from_params(dataset_reader_params)
 

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -1,10 +1,11 @@
 """
 Helper functions for Trainers
 """
-from typing import Any, Union, Dict, Iterable, List, Optional
+from typing import Any, Union, Dict, Iterable, List, Optional, Tuple
 import datetime
 import json
 import logging
+import pathlib
 import os
 import shutil
 
@@ -156,40 +157,10 @@ def datasets_from_params(params: Params,
     """
     dataset_reader_params = params.pop('dataset_reader')
     validation_dataset_reader_params = params.pop('validation_dataset_reader', None)
-    if cache_directory:
-        if not cache_directory.endswith('/'):
-            cache_directory += '/'
-
-        # We need to compute the parameter hash before the parameters get destroyed when they're
-        # passed to `DatasetReader.from_params`.
-        if not cache_prefix:
-            cache_prefix = _dataset_reader_param_hash(dataset_reader_params)
-            if validation_dataset_reader_params:
-                validation_cache_prefix = _dataset_reader_param_hash(validation_dataset_reader_params)
-            else:
-                validation_cache_prefix = cache_prefix
-        else:
-            validation_cache_prefix = cache_prefix
-
-        if not cache_prefix.endswith('/'):
-            cache_prefix += '/'
-        if not validation_cache_prefix.endswith('/'):
-            validation_cache_prefix += '/'
-
-        # For easy human inspection of what parameters were used to create the cache.  This will
-        # overwrite old files, but they should be identical.  This could bite someone who gave
-        # their own prefix instead of letting us compute it, and then _re-used_ that name with
-        # different parameters, without clearing the cache first.  But correctly handling that case
-        # is more work than it's worth.
-        os.makedirs(cache_directory + cache_prefix, exist_ok=True)
-        with open(cache_directory + cache_prefix + 'params.json', 'w') as param_file:
-            json.dump(dataset_reader_params.as_dict(quiet=True), param_file)
-        os.makedirs(cache_directory + validation_cache_prefix, exist_ok=True)
-        with open(cache_directory + validation_cache_prefix + 'params.json', 'w') as param_file:
-            if validation_dataset_reader_params:
-                json.dump(validation_dataset_reader_params.as_dict(quiet=True), param_file)
-            else:
-                json.dump(dataset_reader_params.as_dict(quiet=True), param_file)
+    train_cache_dir, validation_cache_dir = _set_up_cache_files(dataset_reader_params,
+                                                                validation_dataset_reader_params,
+                                                                cache_directory,
+                                                                cache_prefix)
 
     dataset_reader = DatasetReader.from_params(dataset_reader_params)
 
@@ -198,9 +169,9 @@ def datasets_from_params(params: Params,
         logger.info("Using a separate dataset reader to load validation and test data.")
         validation_and_test_dataset_reader = DatasetReader.from_params(validation_dataset_reader_params)
 
-    if cache_directory:
-        dataset_reader.cache_data(cache_directory + cache_prefix)
-        validation_and_test_dataset_reader.cache_data(cache_directory + validation_cache_prefix)
+    if train_cache_dir:
+        dataset_reader.cache_data(train_cache_dir)
+        validation_and_test_dataset_reader.cache_data(validation_cache_dir)
 
     train_data_path = params.pop('train_data_path')
     logger.info("Reading training data from %s", train_data_path)
@@ -221,6 +192,44 @@ def datasets_from_params(params: Params,
         datasets["test"] = test_data
 
     return datasets
+
+
+def _set_up_cache_files(train_params: Params,
+                        validation_params: Params = None,
+                        cache_directory: str = None,
+                        cache_prefix: str = None) -> Tuple[str, str]:
+    if not cache_directory:
+        return None, None
+
+    # We need to compute the parameter hash before the parameters get destroyed when they're
+    # passed to `DatasetReader.from_params`.
+    if not cache_prefix:
+        cache_prefix = _dataset_reader_param_hash(train_params)
+        if validation_params:
+            validation_cache_prefix = _dataset_reader_param_hash(validation_params)
+        else:
+            validation_cache_prefix = cache_prefix
+    else:
+        validation_cache_prefix = cache_prefix
+
+    train_cache_dir = pathlib.Path(cache_directory) / cache_prefix
+    validation_cache_dir = pathlib.Path(cache_directory) / validation_cache_prefix
+
+    # For easy human inspection of what parameters were used to create the cache.  This will
+    # overwrite old files, but they should be identical.  This could bite someone who gave
+    # their own prefix instead of letting us compute it, and then _re-used_ that name with
+    # different parameters, without clearing the cache first.  But correctly handling that case
+    # is more work than it's worth.
+    os.makedirs(train_cache_dir, exist_ok=True)
+    with open(train_cache_dir / 'params.json', 'w') as param_file:
+        json.dump(train_params.as_dict(quiet=True), param_file)
+    os.makedirs(validation_cache_dir, exist_ok=True)
+    with open(validation_cache_dir / 'params.json', 'w') as param_file:
+        if validation_params:
+            json.dump(validation_params.as_dict(quiet=True), param_file)
+        else:
+            json.dump(train_params.as_dict(quiet=True), param_file)
+    return str(train_cache_dir), str(validation_cache_dir)
 
 
 def _dataset_reader_param_hash(params: Params) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,6 +65,9 @@ word2number>=1.1
 # To use the BERT model
 pytorch-pretrained-bert>=0.6.0
 
+# For caching processed data
+jsonpickle
+
 #### ESSENTIAL LIBRARIES USED IN SCRIPTS ####
 
 # Plot graphs for learning rate finder

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup(name='allennlp',
           'sqlparse>=0.2.4',
           'word2number>=1.1',
           'pytorch-pretrained-bert>=0.6.0',
+          'jsonpickle',
       ],
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
This adds a parameter that lets you specify a path to a cache file, where we will save already-constructed `Instances` for faster loading on subsequent reads of the data.  If you do a lot of processing, like running a tagger or expensive tokenizer or other things, this should save you a lot of time.  If you have only minimal pre-processing, this probably won't buy you much.