### PR TITLE
Use numpy's shuffle for reproducibility.

### DIFF
--- a/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
+++ b/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
@@ -59,6 +59,10 @@ class MultiprocessDatasetReader(DatasetReader):
     should be a glob, and that the dataset reader will return instances from all files
     matching the glob.
 
+    The order the files are processed in is a function of Numpy's random state
+    up to non-determinism caused by using multiple worker processes. This can
+    be avoided by setting ``num_workers`` to 1.
+
     Parameters
     ----------
     base_reader : ``DatasetReader``

--- a/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
+++ b/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
@@ -1,8 +1,8 @@
 from typing import List, Iterable, Iterator
 import glob
 import logging
-import random
 
+import numpy as np
 from torch.multiprocessing import Manager, Process, Queue, log_to_stderr
 
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
@@ -132,7 +132,7 @@ class MultiprocessDatasetReader(DatasetReader):
         # If we want multiple epochs per read, put shards in the queue multiple times.
         input_queue = manager.Queue(num_shards * self.epochs_per_read + self.num_workers)
         for _ in range(self.epochs_per_read):
-            random.shuffle(shards)
+            np.random.shuffle(shards)
             for shard in shards:
                 input_queue.put(shard)
 

--- a/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
+++ b/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
@@ -127,6 +127,8 @@ class MultiprocessDatasetReader(DatasetReader):
         ids into the queue).
         """
         shards = glob.glob(file_path)
+        # Ensure a consistent order before shuffling for testing.
+        shards.sort()
         num_shards = len(shards)
 
         # If we want multiple epochs per read, put shards in the queue multiple times.

--- a/allennlp/tests/data/dataset_readers/multiprocess_dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/multiprocess_dataset_reader_test.py
@@ -1,6 +1,9 @@
 # pylint: disable=no-self-use,invalid-name
+from multiprocessing import Queue, Process
 from typing import Tuple
 from collections import Counter
+
+import numpy as np
 
 from allennlp.data.dataset_readers import MultiprocessDatasetReader, SequenceTaggingDatasetReader
 from allennlp.data.instance import Instance
@@ -30,11 +33,21 @@ class TestMultiprocessDatasetReader(AllenNlpTestCase):
         # Make 100 copies of the data
         raw_data = open(base_file_path).read()
         for i in range(100):
-            file_path = self.TEST_DIR / f'sequence_tagging_{i}.tsv'
+            file_path = self.TEST_DIR / f'identical_{i}.tsv'
             with open(file_path, 'w') as f:
                 f.write(raw_data)
 
-        self.glob = str(self.TEST_DIR / 'sequence_tagging_*.tsv')
+        self.all_distinct_path = str(self.TEST_DIR / 'all_distinct.tsv')
+        with open(self.all_distinct_path, 'w') as all_distinct:
+            for i in range(100):
+                file_path = self.TEST_DIR / f'distinct_{i}.tsv'
+                line = f"This###DT\tis###VBZ\tsentence###NN\t{i}###CD\t.###.\n"
+                with open(file_path, 'w') as f:
+                    f.write(line)
+                all_distinct.write(line)
+
+        self.identical_files_glob = str(self.TEST_DIR / 'identical_*.tsv')
+        self.distinct_files_glob = str(self.TEST_DIR / 'distinct_*.tsv')
 
         # For some of the tests we need a vocab, we'll just use the base_reader for that.
         self.vocab = Vocabulary.from_instances(self.base_reader.read(str(base_file_path)))
@@ -44,7 +57,7 @@ class TestMultiprocessDatasetReader(AllenNlpTestCase):
 
         all_instances = []
 
-        for instance in reader.read(self.glob):
+        for instance in reader.read(self.identical_files_glob):
             all_instances.append(instance)
 
         # 100 files * 4 sentences / file
@@ -59,6 +72,37 @@ class TestMultiprocessDatasetReader(AllenNlpTestCase):
         assert counts[("snakes", "are", "animals", ".", "N", "V", "N", "N")] == 100
         assert counts[("birds", "are", "animals", ".", "N", "V", "N", "N")] == 100
 
+    def test_multiprocess_read_in_subprocess_is_deterministic(self):
+        reader = MultiprocessDatasetReader(base_reader=self.base_reader, num_workers=1)
+        q = Queue()
+        def read():
+            for instance in reader.read(self.distinct_files_glob):
+                q.put(fingerprint(instance))
+
+        # Ensure deterministic shuffling.
+        np.random.seed(0)
+        p = Process(target=read)
+        p.start()
+        p.join()
+
+        # Convert queue to list.
+        actual_fingerprints = []
+        while not q.empty():
+            actual_fingerprints.append(q.get(block=False))
+
+        assert len(actual_fingerprints) == 100
+
+        expected_fingerprints = []
+        for instance in self.base_reader.read(self.all_distinct_path):
+            expected_fingerprints.append(fingerprint(instance))
+
+        np.random.seed(0)
+        expected_fingerprints.sort()
+        # This should be shuffled into exactly the same order as actual_fingerprints.
+        np.random.shuffle(expected_fingerprints)
+
+        assert actual_fingerprints == expected_fingerprints
+
     def test_multiple_epochs(self):
         reader = MultiprocessDatasetReader(base_reader=self.base_reader,
                                            num_workers=2,
@@ -66,7 +110,7 @@ class TestMultiprocessDatasetReader(AllenNlpTestCase):
 
         all_instances = []
 
-        for instance in reader.read(self.glob):
+        for instance in reader.read(self.identical_files_glob):
             all_instances.append(instance)
 
         # 100 files * 4 sentences per file * 3 epochs
@@ -83,7 +127,7 @@ class TestMultiprocessDatasetReader(AllenNlpTestCase):
 
     def test_with_iterator(self):
         reader = MultiprocessDatasetReader(base_reader=self.base_reader, num_workers=2)
-        instances = reader.read(self.glob)
+        instances = reader.read(self.identical_files_glob)
 
         iterator = BasicIterator(batch_size=32)
         iterator.index_with(self.vocab)


### PR DESCRIPTION
- Fixes https://github.com/allenai/allennlp/issues/2620.
- Python resets the `random` library's seeds whenever a new process is spawned.
- Use numpy to avoid this.