### PR TITLE
Allow FromParams to construct Union types

### DIFF
--- a/allennlp/common/__init__.py
+++ b/allennlp/common/__init__.py
@@ -1,3 +1,4 @@
+from allennlp.common.from_params import FromParams
 from allennlp.common.params import Params
 from allennlp.common.registrable import Registrable
 from allennlp.common.tee_logger import TeeLogger

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -335,8 +335,7 @@ class FromParams:
                 # you've done the right thing in passing your parameters, and nothing else needs to
                 # be recursively constructed.
                 if not takes_arg(subclass, 'extras'):
-                    # Necessarily subclass.from_params is a custom implementation, so we need to
-                    # pass it only the args it's expecting.
+                    # We should only pass on the extras that the constructor actually expects.
                     extras = {k: v for k, v in extras.items() if takes_arg(subclass, k)}
                 constructor_args = {**params, **extras}
                 return subclass(**constructor_args)

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -96,8 +96,6 @@ def create_kwargs(cls: Type[T], params: Params, **extras) -> Dict[str, Any]:
     For instance, you might provide an existing `Vocabulary` this way.
     """
     # Get the signature of the constructor.
-    from allennlp.models.archival import load_archive  # import here to avoid circular imports
-
     signature = inspect.signature(cls.__init__)
     kwargs: Dict[str, Any] = {}
 
@@ -113,125 +111,169 @@ def create_kwargs(cls: Type[T], params: Params, **extras) -> Dict[str, Any]:
         # it will have an __origin__ field indicating `typing.Dict`
         # and an __args__ field indicating `(str, int)`. We capture both.
         annotation = remove_optional(param.annotation)
-        origin = getattr(annotation, '__origin__', None)
-        args = getattr(annotation, '__args__', [])
-
-        # The parameter is optional if its default value is not the "no default" sentinel.
-        default = param.default
-        optional = default != _NO_DEFAULT
-
-        # Some constructors expect extra non-parameter items, e.g. vocab: Vocabulary.
-        # We check the provided `extras` for these and just use them if they exist.
-        if name in extras:
-            kwargs[name] = extras[name]
-        # Next case is when argument should be loaded from pretrained archive.
-        elif name in params and isinstance(params.get(name), Params) and "_pretrained" in params.get(name):
-            load_module_params = params.pop(name).pop("_pretrained")
-            archive_file = load_module_params.pop("archive_file")
-            module_path = load_module_params.pop("module_path")
-            freeze = load_module_params.pop("freeze", True)
-            archive = load_archive(archive_file)
-            kwargs[name] = archive.extract_module(module_path, freeze) # pylint: disable=no-member
-            if not isinstance(kwargs[name], annotation):
-                raise ConfigurationError(f"The module from model at {archive_file} at path {module_path} "
-                                         f"was expected of type {annotation} but is of type {type(kwargs[name])}")
-        # # The next case is when the parameter type is itself constructible from_params.
-        elif hasattr(annotation, 'from_params'):
-            if name in params:
-                # Our params have an entry for this, so we use that.
-                subparams = params.pop(name)
-
-                if takes_arg(annotation.from_params, 'extras'):
-                    # If annotation.params accepts **extras, we need to pass them all along.
-                    # For example, `BasicTextFieldEmbedder.from_params` requires a Vocabulary
-                    # object, but `TextFieldEmbedder.from_params` does not.
-                    subextras = extras
-                else:
-                    # Otherwise, only supply the ones that are actual args; any additional ones
-                    # will cause a TypeError.
-                    subextras = {k: v for k, v in extras.items() if takes_arg(annotation.from_params, k)}
-
-                # In some cases we allow a string instead of a param dict, so
-                # we need to handle that case separately.
-                if isinstance(subparams, str):
-                    kwargs[name] = annotation.by_name(subparams)()
-                else:
-                    kwargs[name] = annotation.from_params(params=subparams, **subextras)
-            elif not optional:
-                # Not optional and not supplied, that's an error!
-                raise ConfigurationError(f"expected key {name} for {cls.__name__}")
-            else:
-                kwargs[name] = default
-
-        # If the parameter type is a Python primitive, just pop it off
-        # using the correct casting pop_xyz operation.
-        elif annotation == str:
-            kwargs[name] = (params.pop(name, default)
-                            if optional
-                            else params.pop(name))
-        elif annotation == int:
-            kwargs[name] = (params.pop_int(name, default)
-                            if optional
-                            else params.pop_int(name))
-        elif annotation == bool:
-            kwargs[name] = (params.pop_bool(name, default)
-                            if optional
-                            else params.pop_bool(name))
-        elif annotation == float:
-            kwargs[name] = (params.pop_float(name, default)
-                            if optional
-                            else params.pop_float(name))
-
-        # This is special logic for handling types like Dict[str, TokenIndexer],
-        # List[TokenIndexer], Tuple[TokenIndexer, Tokenizer], and Set[TokenIndexer],
-        # which it creates by instantiating each value from_params and returning the resulting structure.
-        elif origin in (Dict, dict) and len(args) == 2 and hasattr(args[-1], 'from_params'):
-            value_cls = annotation.__args__[-1]
-
-            value_dict = {}
-
-            for key, value_params in params.pop(name, Params({})).items():
-                value_dict[key] = value_cls.from_params(params=value_params, **extras)
-
-            kwargs[name] = value_dict
-
-        elif origin in (List, list) and len(args) == 1 and hasattr(args[0], 'from_params'):
-            value_cls = annotation.__args__[0]
-
-            value_list = []
-
-            for value_params in params.pop(name, Params({})):
-                value_list.append(value_cls.from_params(params=value_params, **extras))
-
-            kwargs[name] = value_list
-
-        elif origin in (Tuple, tuple) and all(hasattr(arg, 'from_params') for arg in args):
-            value_list = []
-
-            for value_cls, value_params in zip(annotation.__args__, params.pop(name, Params({}))):
-                value_list.append(value_cls.from_params(params=value_params, **extras))
-
-            kwargs[name] = tuple(value_list)
-
-        elif origin in (Set, set) and len(args) == 1 and hasattr(args[0], 'from_params'):
-            value_cls = annotation.__args__[0]
-
-            value_set = set()
-
-            for value_params in params.pop(name, Params({})):
-                value_set.add(value_cls.from_params(params=value_params, **extras))
-
-            kwargs[name] = value_set
-
-        else:
-            # Pass it on as is and hope for the best.   ¯\_(ツ)_/¯
-            if optional:
-                kwargs[name] = params.pop(name, default)
-            else:
-                kwargs[name] = params.pop(name)
+        kwargs[name] = construct_arg(cls, name, annotation, param.default, params, **extras)
 
     params.assert_empty(cls.__name__)
     return kwargs
+
+def construct_arg(cls: Type[T],
+                  param_name: str,
+                  annotation: Type,
+                  default: Any,
+                  params: Params,
+                  **extras) -> Any:
+    """
+    Does the work of actually constructing an individual argument for :func:`create_kwargs`.
+
+    Here we're in the inner loop of iterating over the parameters to a particular constructor,
+    trying to construct just one of them.  The information we get for that parameter is its name,
+    its type annotation, and its default value; we also get the full set of ``Params`` for
+    constructing the object (which we may mutate), and any ``extras`` that the constructor might
+    need.
+
+    We take the type annotation and default value here separately, instead of using an
+    ``inspect.Parameter`` object directly, so that we can handle ``Union`` types using recursion on
+    this method, trying the different annotation types in the union in turn.
+    """
+    from allennlp.models.archival import load_archive  # import here to avoid circular imports
+
+    # We used `param_name` as the method argument to avoid conflicts with 'name' being a key in
+    # `extras`, which isn't _that_ unlikely.  Now that we are inside the method, we can switch back
+    # to using `name`.
+    name = param_name
+    origin = getattr(annotation, '__origin__', None)
+    args = getattr(annotation, '__args__', [])
+
+    # The parameter is optional if its default value is not the "no default" sentinel.
+    optional = default != _NO_DEFAULT
+
+    # Some constructors expect extra non-parameter items, e.g. vocab: Vocabulary.
+    # We check the provided `extras` for these and just use them if they exist.
+    if name in extras:
+        return extras[name]
+    # Next case is when argument should be loaded from pretrained archive.
+    elif name in params and isinstance(params.get(name), Params) and "_pretrained" in params.get(name):
+        load_module_params = params.pop(name).pop("_pretrained")
+        archive_file = load_module_params.pop("archive_file")
+        module_path = load_module_params.pop("module_path")
+        freeze = load_module_params.pop("freeze", True)
+        archive = load_archive(archive_file)
+        result = archive.extract_module(module_path, freeze) # pylint: disable=no-member
+        if not isinstance(result, annotation):
+            raise ConfigurationError(f"The module from model at {archive_file} at path {module_path} "
+                                     f"was expected of type {annotation} but is of type {type(result)}")
+        return result
+    # The next case is when the parameter type is itself constructible from_params.
+    elif hasattr(annotation, 'from_params'):
+        if name in params:
+            # Our params have an entry for this, so we use that.
+            subparams = params.pop(name)
+
+            if takes_arg(annotation.from_params, 'extras'):
+                # If annotation.params accepts **extras, we need to pass them all along.
+                # For example, `BasicTextFieldEmbedder.from_params` requires a Vocabulary
+                # object, but `TextFieldEmbedder.from_params` does not.
+                subextras = extras
+            else:
+                # Otherwise, only supply the ones that are actual args; any additional ones
+                # will cause a TypeError.
+                subextras = {k: v for k, v in extras.items() if takes_arg(annotation.from_params, k)}
+
+            # In some cases we allow a string instead of a param dict, so
+            # we need to handle that case separately.
+            if isinstance(subparams, str):
+                return annotation.by_name(subparams)()
+            else:
+                return annotation.from_params(params=subparams, **subextras)
+        elif not optional:
+            # Not optional and not supplied, that's an error!
+            raise ConfigurationError(f"expected key {name} for {cls.__name__}")
+        else:
+            return default
+
+    # If the parameter type is a Python primitive, just pop it off
+    # using the correct casting pop_xyz operation.
+    elif annotation == str:
+        return (params.pop(name, default)
+                        if optional
+                        else params.pop(name))
+    elif annotation == int:
+        return (params.pop_int(name, default)
+                        if optional
+                        else params.pop_int(name))
+    elif annotation == bool:
+        return (params.pop_bool(name, default)
+                        if optional
+                        else params.pop_bool(name))
+    elif annotation == float:
+        return (params.pop_float(name, default)
+                        if optional
+                        else params.pop_float(name))
+
+    # This is special logic for handling types like Dict[str, TokenIndexer],
+    # List[TokenIndexer], Tuple[TokenIndexer, Tokenizer], and Set[TokenIndexer],
+    # which it creates by instantiating each value from_params and returning the resulting structure.
+    elif origin in (Dict, dict) and len(args) == 2 and hasattr(args[-1], 'from_params'):
+        value_cls = annotation.__args__[-1]
+
+        value_dict = {}
+
+        for key, value_params in params.pop(name, Params({})).items():
+            value_dict[key] = value_cls.from_params(params=value_params, **extras)
+
+        return value_dict
+
+    elif origin in (List, list) and len(args) == 1 and hasattr(args[0], 'from_params'):
+        value_cls = annotation.__args__[0]
+
+        value_list = []
+
+        for value_params in params.pop(name, Params({})):
+            value_list.append(value_cls.from_params(params=value_params, **extras))
+
+        return value_list
+
+    elif origin in (Tuple, tuple) and all(hasattr(arg, 'from_params') for arg in args):
+        value_list = []
+
+        for value_cls, value_params in zip(annotation.__args__, params.pop(name, Params({}))):
+            value_list.append(value_cls.from_params(params=value_params, **extras))
+
+        return tuple(value_list)
+
+    elif origin in (Set, set) and len(args) == 1 and hasattr(args[0], 'from_params'):
+        value_cls = annotation.__args__[0]
+
+        value_set = set()
+
+        for value_params in params.pop(name, Params({})):
+            value_set.add(value_cls.from_params(params=value_params, **extras))
+
+        return value_set
+
+    elif origin == Union:
+        # Storing this so we can recover it later if we need to.
+        param_value = params.get(name, Params({}))
+
+        # We'll try each of the given types in the union sequentially, returning the first one that
+        # succeeds.
+        for arg in args:
+            try:
+                return construct_arg(cls, name, arg, default, params, **extras)
+            except (ValueError, TypeError, ConfigurationError, AttributeError) as e:
+                # Our attempt to construct the argument may have popped `params[name]`, so we
+                # restore it here.
+                params[name] = param_value
+                continue
+
+        # If none of them succeeded, we crash.
+        raise ConfigurationError(f"Failed to construct argument {name} with type {annotation}")
+    else:
+        # Pass it on as is and hope for the best.   ¯\_(ツ)_/¯
+        if optional:
+            return params.pop(name, default)
+        else:
+            return params.pop(name)
 
 
 class FromParams:
@@ -275,18 +317,32 @@ class FromParams:
                                        default_to_first_choice=default_to_first_choice)
             subclass = registered_subclasses[choice]
 
-            # We want to call subclass.from_params. It's possible that it's just the "free"
-            # implementation here, in which case it accepts `**extras` and we are not able
-            # to make any assumptions about what extra parameters it needs.
-            #
-            # It's also possible that it has a custom `from_params` method. In that case it
-            # won't accept any **extra parameters and we'll need to filter them out.
-            if not takes_arg(subclass.from_params, 'extras'):
-                # Necessarily subclass.from_params is a custom implementation, so we need to
-                # pass it only the args it's expecting.
-                extras = {k: v for k, v in extras.items() if takes_arg(subclass.from_params, k)}
+            if hasattr(subclass, 'from_params'):
+                # We want to call subclass.from_params. It's possible that it's just the "free"
+                # implementation here, in which case it accepts `**extras` and we are not able
+                # to make any assumptions about what extra parameters it needs.
+                #
+                # It's also possible that it has a custom `from_params` method. In that case it
+                # won't accept any **extra parameters and we'll need to filter them out.
+                if not takes_arg(subclass.from_params, 'extras'):
+                    # Necessarily subclass.from_params is a custom implementation, so we need to
+                    # pass it only the args it's expecting.
+                    extras = {k: v for k, v in extras.items() if takes_arg(subclass.from_params, k)}
 
-            return subclass.from_params(params=params, **extras)
+                return subclass.from_params(params=params, **extras)
+            else:
+                # In some rare cases, we get a registered subclass that does _not_ have a
+                # from_params method (this happens with Activations, for instance, where we
+                # register pytorch modules directly).  This is a bit of a hack to make those work,
+                # instead of adding a `from_params` method for them somehow.  We just trust that
+                # you've done the right thing in passing your parameters, and nothing else needs to
+                # be recursively constructed.
+                if not takes_arg(subclass, 'extras'):
+                    # Necessarily subclass.from_params is a custom implementation, so we need to
+                    # pass it only the args it's expecting.
+                    extras = {k: v for k, v in extras.items() if takes_arg(subclass, k)}
+                kwargs = {**params, **extras}
+                return subclass(**kwargs)
         else:
             # This is not a base class, so convert our params and extras into a dict of kwargs.
 

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -116,7 +116,7 @@ def create_kwargs(cls: Type[T], params: Params, **extras) -> Dict[str, Any]:
     params.assert_empty(cls.__name__)
     return kwargs
 
-def construct_arg(cls: Type[T],
+def construct_arg(cls: Type[T], # pylint: disable=inconsistent-return-statements,too-many-return-statements
                   param_name: str,
                   annotation: Type,
                   default: Any,
@@ -135,7 +135,6 @@ def construct_arg(cls: Type[T],
     ``inspect.Parameter`` object directly, so that we can handle ``Union`` types using recursion on
     this method, trying the different annotation types in the union in turn.
     """
-    # pylint: disable=inconsistent-return-statements,too-many-return-statements
     from allennlp.models.archival import load_archive  # import here to avoid circular imports
 
     # We used `param_name` as the method argument to avoid conflicts with 'name' being a key in
@@ -195,13 +194,13 @@ def construct_arg(cls: Type[T],
     # If the parameter type is a Python primitive, just pop it off
     # using the correct casting pop_xyz operation.
     elif annotation == str:
-        return (params.pop(name, default) if optional else params.pop(name))
+        return params.pop(name, default) if optional else params.pop(name)
     elif annotation == int:
-        return (params.pop_int(name, default) if optional else params.pop_int(name))
+        return params.pop_int(name, default) if optional else params.pop_int(name)
     elif annotation == bool:
-        return (params.pop_bool(name, default) if optional else params.pop_bool(name))
+        return params.pop_bool(name, default) if optional else params.pop_bool(name)
     elif annotation == float:
-        return (params.pop_float(name, default) if optional else params.pop_float(name))
+        return params.pop_float(name, default) if optional else params.pop_float(name)
 
     # This is special logic for handling types like Dict[str, TokenIndexer],
     # List[TokenIndexer], Tuple[TokenIndexer, Tokenizer], and Set[TokenIndexer],

--- a/allennlp/modules/feedforward.py
+++ b/allennlp/modules/feedforward.py
@@ -1,16 +1,16 @@
 """
 A feed-forward neural network.
 """
-from typing import Sequence, Union
+from typing import List, Union
 
 import torch
 
-from allennlp.common import Params
+from allennlp.common import FromParams
 from allennlp.common.checks import ConfigurationError
 from allennlp.nn import Activation
 
 
-class FeedForward(torch.nn.Module):
+class FeedForward(torch.nn.Module, FromParams):
     """
     This ``Module`` is a feed-forward neural network, just a sequence of ``Linear`` layers with
     activation functions in between.
@@ -21,24 +21,24 @@ class FeedForward(torch.nn.Module):
         The dimensionality of the input.  We assume the input has shape ``(batch_size, input_dim)``.
     num_layers : ``int``
         The number of ``Linear`` layers to apply to the input.
-    hidden_dims : ``Union[int, Sequence[int]]``
+    hidden_dims : ``Union[int, List[int]]``
         The output dimension of each of the ``Linear`` layers.  If this is a single ``int``, we use
-        it for all ``Linear`` layers.  If it is a ``Sequence[int]``, ``len(hidden_dims)`` must be
+        it for all ``Linear`` layers.  If it is a ``List[int]``, ``len(hidden_dims)`` must be
         ``num_layers``.
-    activations : ``Union[Callable, Sequence[Callable]]``
+    activations : ``Union[Callable, List[Callable]]``
         The activation function to use after each ``Linear`` layer.  If this is a single function,
-        we use it after all ``Linear`` layers.  If it is a ``Sequence[Callable]``,
+        we use it after all ``Linear`` layers.  If it is a ``List[Callable]``,
         ``len(activations)`` must be ``num_layers``.
-    dropout : ``Union[float, Sequence[float]]``, optional
+    dropout : ``Union[float, List[float]]``, optional
         If given, we will apply this amount of dropout after each layer.  Semantics of ``float``
-        versus ``Sequence[float]`` is the same as with other parameters.
+        versus ``List[float]`` is the same as with other parameters.
     """
     def __init__(self,
                  input_dim: int,
                  num_layers: int,
-                 hidden_dims: Union[int, Sequence[int]],
-                 activations: Union[Activation, Sequence[Activation]],
-                 dropout: Union[float, Sequence[float]] = 0.0) -> None:
+                 hidden_dims: Union[int, List[int]],
+                 activations: Union[Activation, List[Activation]],
+                 dropout: Union[float, List[float]] = 0.0) -> None:
 
         super(FeedForward, self).__init__()
         if not isinstance(hidden_dims, list):
@@ -79,23 +79,3 @@ class FeedForward(torch.nn.Module):
         for layer, activation, dropout in zip(self._linear_layers, self._activations, self._dropout):
             output = dropout(activation(layer(output)))
         return output
-
-    # Requires custom logic around the activations (the automatic `from_params`
-    # method can't currently instatiate types like `Union[Activation, List[Activation]]`)
-    @classmethod
-    def from_params(cls, params: Params):
-        input_dim = params.pop_int('input_dim')
-        num_layers = params.pop_int('num_layers')
-        hidden_dims = params.pop('hidden_dims')
-        activations = params.pop('activations')
-        dropout = params.pop('dropout', 0.0)
-        if isinstance(activations, list):
-            activations = [Activation.by_name(name)() for name in activations]
-        else:
-            activations = Activation.by_name(activations)()
-        params.assert_empty(cls.__name__)
-        return cls(input_dim=input_dim,
-                   num_layers=num_layers,
-                   hidden_dims=hidden_dims,
-                   activations=activations,
-                   dropout=dropout)

--- a/allennlp/nn/activations.py
+++ b/allennlp/nn/activations.py
@@ -48,7 +48,7 @@ class Activation(Registrable):
         """
         raise NotImplementedError
 
-# There are no classes to decorate, so we hack these into Registrable._registry.from
+# There are no classes to decorate, so we hack these into Registrable._registry.
 # If you want to instantiate it, you can do like this:
 # Activation.by_name('relu')()
 # pylint: disable=protected-access

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -148,6 +148,12 @@ class TestFromParams(AllenNlpTestCase):
                 # this test we'll ignore that.
                 self.b = b
 
+        class C(FromParams):
+            def __init__(self, c: Union[A, B, Dict[str, A]]) -> None:
+                # Really you would want to be sure that `self.c` has a consistent type, but for
+                # this test we'll ignore that.
+                self.c = c
+
         params = Params({'a': 3})
         a = A.from_params(params)
         assert a.a == 3
@@ -166,6 +172,16 @@ class TestFromParams(AllenNlpTestCase):
         assert isinstance(b.b, list)
         assert b.b[0].a == 3
         assert b.b[1].a == [4, 5]
+
+        # This is a contrived, ugly example (why would you want to duplicate names in a nested
+        # structure like this??), but it demonstrates a potential bug when dealing with mutatable
+        # parameters.  If you're not careful about keeping the parameters un-mutated in two
+        # separate places, you'll end up with a B, or with a dict that's missing the 'b' key.
+        params = Params({'c': {'a': {'a': 3}, 'b': {'a': [4, 5]}}})
+        c = C.from_params(params)
+        assert isinstance(c.c, dict)
+        assert c.c['a'].a == 3
+        assert c.c['b'].a == [4, 5]
 
     def test_dict(self):
         # pylint: disable=unused-variable


### PR DESCRIPTION
This removes the need for custom `from_params` for `FeedForward` (and lets me more easily add some other modules that have similar behavior).