### PR TITLE
Extras checks

### DIFF
--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -73,7 +73,6 @@ def takes_arg(obj, arg: str) -> bool:
 
 
 def takes_kwargs(obj) -> bool:
-    # pylint: disable=protected-access,simplifiable-if-statement
     """
     Checks whether a provided object takes in any positional arguments.
     Similar to takes_arg, we do this for both the __init__ function of
@@ -86,7 +85,7 @@ def takes_kwargs(obj) -> bool:
         signature = inspect.signature(obj)
     else:
         raise ConfigurationError(f"object {obj} is not callable")
-    return bool(any([p.kind == inspect._ParameterKind.VAR_KEYWORD  # type: ignore
+    return bool(any([p.kind == inspect.Parameter.VAR_KEYWORD  # type: ignore
                      for p in signature.parameters.values()]))
 
 

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -73,6 +73,7 @@ def takes_arg(obj, arg: str) -> bool:
 
 
 def takes_kwargs(obj) -> bool:
+    # pylint: disable=protected-access,simplifiable-if-statement
     """
     Checks whether a provided object takes in any positional arguments.
     Similar to takes_arg, we do this for both the __init__ function of
@@ -85,11 +86,8 @@ def takes_kwargs(obj) -> bool:
         signature = inspect.signature(obj)
     else:
         raise ConfigurationError(f"object {obj} is not callable")
-    if any([p.kind == inspect._ParameterKind.VAR_KEYWORD  # type: ignore
-            for p in signature.parameters.values()]):
-        return True
-    else:
-        return False
+    return bool(any([p.kind == inspect._ParameterKind.VAR_KEYWORD  # type: ignore
+                     for p in signature.parameters.values()]))
 
 
 def remove_optional(annotation: type):

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -76,7 +76,7 @@ def takes_kwargs(obj) -> bool:
     """
     Checks whether a provided object takes in any positional arguments.
     Similar to takes_arg, we do this for both the __init__ function of
-    the classp or a function / method
+    the class or a function / method
     Otherwise, we raise an error
     """
     if inspect.isclass(obj):

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -143,7 +143,7 @@ def create_extras(cls: Type[T],
         # Otherwise, only supply the ones that are actual args; any additional ones
         # will cause a TypeError.
         subextras = {k: v for k, v in extras.items()
-                     if takes_arg(cls.from_params, k)}
+                     if takes_arg(from_params_method, k)}
     return subextras
 
 

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -55,6 +55,7 @@ T = TypeVar('T')
 # this is what the inspect module returns.
 _NO_DEFAULT = inspect.Parameter.empty  # pylint: disable=invalid-name
 
+
 def takes_arg(obj, arg: str) -> bool:
     """
     Checks whether the provided obj takes a certain arg.
@@ -84,7 +85,7 @@ def takes_kwargs(obj) -> bool:
         signature = inspect.signature(obj)
     else:
         raise ConfigurationError(f"object {obj} is not callable")
-    if any([p.kind._name_ == "VAR_KEYWORD"
+    if any([p.kind == inspect._ParameterKind.VAR_KEYWORD
             for p in signature.parameters.values()]):
         return True
     else:
@@ -147,7 +148,7 @@ def create_extras(cls: Type[T],
     """
     subextras: Dict[str, Any] = {}
     if hasattr(cls, "from_params"):
-        from_params_method = cls.from_params
+        from_params_method = cls.from_params  # type: ignore
     else:
         # In some rare cases, we get a registered subclass that does _not_ have a
         # from_params method (this happens with Activations, for instance, where we

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -85,7 +85,7 @@ def takes_kwargs(obj) -> bool:
         signature = inspect.signature(obj)
     else:
         raise ConfigurationError(f"object {obj} is not callable")
-    if any([p.kind == inspect._ParameterKind.VAR_KEYWORD
+    if any([p.kind == inspect._ParameterKind.VAR_KEYWORD  # type: ignore
             for p in signature.parameters.values()]):
         return True
     else:
@@ -157,7 +157,7 @@ def create_extras(cls: Type[T],
         # in the class constructor are what we are looking for, to pass on.
         from_params_method = cls
     if takes_kwargs(from_params_method):
-        # If annotation.params accepts **extras, we need to pass them all along.
+        # If annotation.params accepts **kwargs, we need to pass them all along.
         # For example, `BasicTextFieldEmbedder.from_params` requires a Vocabulary
         # object, but `TextFieldEmbedder.from_params` does not.
         subextras = extras

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -156,7 +156,7 @@ class TestFromParams(AllenNlpTestCase):
                 return self.b == other.b
 
             @classmethod
-            def from_params(cls, params: Params, a: int) -> 'A':
+            def from_params(cls, params: Params, a: int) -> 'A':  # type: ignore
                 # A custom from params
                 b = params.pop_int("b")
                 val = params.pop("val", "C")
@@ -170,7 +170,7 @@ class TestFromParams(AllenNlpTestCase):
                 self.b = b
 
             @classmethod
-            def from_params(cls, params: Params, c: int) -> 'B':
+            def from_params(cls, params: Params, c: int) -> 'B':  # type: ignore
                 b = params.pop_int("b")
                 params.assert_empty(cls.__name__)
                 return cls(c=c, b=b)
@@ -182,7 +182,7 @@ class TestFromParams(AllenNlpTestCase):
                 self.n = n
 
             @classmethod
-            def from_params(cls, params: Params, **extras2) -> 'E':
+            def from_params(cls, params: Params, **extras2) -> 'E':  # type: ignore
                 m = params.pop_int("m")
                 params.assert_empty(cls.__name__)
                 n = extras2["n"]
@@ -206,10 +206,16 @@ class TestFromParams(AllenNlpTestCase):
 
         vals = [1, 2, 3]
         params = Params({"type": "D",
-                         "arg1": [{"type": "A", "b": vals[0]}, {"type": "A", "b": vals[1]}, {"type": "A", "b": vals[2]}],
-                         "arg2": [{"type": "A", "b": vals[0]}, {"type": "B", "b": vals[0]}],
-                         "arg3": {"class_1": {"type": "A", "b": vals[0]}, "class_2": {"type": "A", "b": vals[1]}},
-                         "arg4": [{"type": "A", "b": vals[0], "val": "M"}, {"type": "A", "b": vals[1], "val": "N"}, {"type": "A", "b": vals[1], "val": "N"}],
+                         "arg1": [{"type": "A", "b": vals[0]},
+                                  {"type": "A", "b": vals[1]},
+                                  {"type": "A", "b": vals[2]}],
+                         "arg2": [{"type": "A", "b": vals[0]},
+                                  {"type": "B", "b": vals[0]}],
+                         "arg3": {"class_1": {"type": "A", "b": vals[0]},
+                                  "class_2": {"type": "A", "b": vals[1]}},
+                         "arg4": [{"type": "A", "b": vals[0], "val": "M"},
+                                  {"type": "A", "b": vals[1], "val": "N"},
+                                  {"type": "A", "b": vals[1], "val": "N"}],
                          "arg5": [{"type": "E", "m": 9}]})
         extra = C()
         tval1 = 5

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -193,8 +193,8 @@ class TestFromParams(AllenNlpTestCase):
 
         @BaseClass.register("D")
         class D(BaseClass):
-            def __init__(self, extra: C, a: int,
-                         arg1: List[BaseClass], arg2: Tuple[BaseClass, BaseClass2],
+            def __init__(self, arg1: List[BaseClass],
+                         arg2: Tuple[BaseClass, BaseClass2],
                          arg3: Dict[str, BaseClass], arg4: Set[BaseClass],
                          arg5: List[BaseClass]) -> None:
                 self.arg1 = arg1
@@ -202,7 +202,6 @@ class TestFromParams(AllenNlpTestCase):
                 self.arg3 = arg3
                 self.arg4 = arg4
                 self.arg5 = arg5
-                self.extra = extra
 
         vals = [1, 2, 3]
         params = Params({"type": "D",

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -134,7 +134,7 @@ class TestFromParams(AllenNlpTestCase):
 
     def test_extras_for_custom_classes(self):
         class A(FromParams):
-            def __init__(self, a: int, b: int, val: str):
+            def __init__(self, a: int, b: int, val: str) -> None:
                 self.a = a
                 self.b = b
                 self.val = val
@@ -146,7 +146,7 @@ class TestFromParams(AllenNlpTestCase):
                 return self.b == other.b
 
             @classmethod
-            def from_params(cls, a: int, params: Params):
+            def from_params(cls, a: int, params: Params) -> 'A':
                 # A custom from params
                 b = params.pop_int("b")
                 val = params.pop("val", "C")
@@ -154,30 +154,30 @@ class TestFromParams(AllenNlpTestCase):
                 return cls(a=a, b=b, val=val)
 
         class B(FromParams):
-            def __init__(self, c: int, b: int):
+            def __init__(self, c: int, b: int) -> None:
                 self.c = c
                 self.b = b
 
             @classmethod
-            def from_params(cls, c: int, params: Params):
+            def from_params(cls, c: int, params: Params) -> 'B':
                 b = params.pop_int("b")
                 params.assert_empty(cls.__name__)
                 return cls(c=c, b=b)
 
         class E(FromParams):
-            def __init__(self, m: int, n: int):
+            def __init__(self, m: int, n: int) -> None:
                 self.m = m
                 self.n = n
 
             @classmethod
-            def from_params(cls, params: Params, **extras2):
+            def from_params(cls, params: Params, **extras2) -> 'E':
                 m = params.pop_int("m")
                 params.assert_empty(cls.__name__)
                 n = extras2["n"]
                 return cls(m=m, n=n)
 
         class C(object):
-            def __init__(self):
+            def __init__(self) -> None:
                 pass
 
         class D(FromParams):
@@ -189,7 +189,7 @@ class TestFromParams(AllenNlpTestCase):
                 arg3: Dict[str, A],
                 arg4: Set[A],
                 arg5: List[E]
-            ):
+            ) -> None:
                 self.arg = arg
                 self.arg2 = arg2
                 self.arg3 = arg3
@@ -198,20 +198,11 @@ class TestFromParams(AllenNlpTestCase):
                 self.extra = extra
 
         vals = [1, 2, 3]
-        params = Params({
-            "arg": [{"b": vals[0]}, {"b": vals[1]}, {"b": vals[2]}],
-            "arg2": [{"b": vals[0]}, {"b": vals[0]}],
-            "arg3": {
-                "class_1": {"b": vals[0]},
-                "class_2": {"b": vals[1]}
-            },
-            "arg4": [
-                {"b": vals[0], "val": "M"},
-                {"b": vals[1], "val": "N"},
-                {"b": vals[1], "val": "N"}
-            ],
-            "arg5": [{"m": 9}]
-        })
+        params = Params({"arg": [{"b": vals[0]}, {"b": vals[1]}, {"b": vals[2]}],
+                         "arg2": [{"b": vals[0]}, {"b": vals[0]}],
+                         "arg3": {"class_1": {"b": vals[0]}, "class_2": {"b": vals[1]}},
+                         "arg4": [{"b": vals[0], "val": "M"}, {"b": vals[1], "val": "N"}, {"b": vals[1], "val": "N"}],
+                         "arg5": [{"m": 9}]})
         extra = C()
         tval1 = 5
         tval2 = 6

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -132,6 +132,30 @@ class TestFromParams(AllenNlpTestCase):
         assert c.name == "extra_c"
         assert c.size == 20
 
+    def test_extras_for_custom_classes(self):
+        class A(FromParams):
+            def __init__(self, a: int):
+                self.a = a
+
+            @classmethod
+            def from_params(cls, params: Params):
+                # A custom from params
+                a = params.pop_int("a")
+                params.assert_empty(cls.__name__)
+                return cls(a)
+
+        class B(FromParams):
+            def __init__(self, a: List[A]):
+                self.a = a
+        vals = [1, 2, 3]
+        params = Params({
+            "a": [{"a": vals[0]}, {"a": vals[1]}, {"a": vals[2]}]
+        })
+        b = B.from_params(params)
+
+        assert len(b.a) == len(vals)
+        assert all([x.a == y for x, y in zip(b.a, vals)])
+
     def test_no_constructor(self):
         params = Params({"type": "just_spaces"})
 

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -164,6 +164,18 @@ class TestFromParams(AllenNlpTestCase):
                 params.assert_empty(cls.__name__)
                 return cls(c=c, b=b)
 
+        class E(FromParams):
+            def __init__(self, m: int, n: int):
+                self.m = m
+                self.n = n
+
+            @classmethod
+            def from_params(cls, params: Params, **extras2):
+                m = params.pop_int("m")
+                params.assert_empty(cls.__name__)
+                n = extras2["n"]
+                return cls(m=m, n=n)
+
         class C(object):
             def __init__(self):
                 pass
@@ -175,12 +187,14 @@ class TestFromParams(AllenNlpTestCase):
                 arg: List[A],
                 arg2: Tuple[A, B],
                 arg3: Dict[str, A],
-                arg4: Set[A]
+                arg4: Set[A],
+                arg5: List[E]
             ):
                 self.arg = arg
                 self.arg2 = arg2
                 self.arg3 = arg3
                 self.arg4 = arg4
+                self.arg5 = arg5
                 self.extra = extra
 
         vals = [1, 2, 3]
@@ -195,12 +209,13 @@ class TestFromParams(AllenNlpTestCase):
                 {"b": vals[0], "val": "M"},
                 {"b": vals[1], "val": "N"},
                 {"b": vals[1], "val": "N"}
-            ]
+            ],
+            "arg5": [{"m": 9}]
         })
         extra = C()
         tval1 = 5
         tval2 = 6
-        d = D.from_params(params=params, extra=extra, a=tval1, c=tval2)
+        d = D.from_params(params=params, extra=extra, a=tval1, c=tval2, n=10)
 
         # Tests for List Parameters
         assert len(d.arg) == len(vals)
@@ -229,6 +244,12 @@ class TestFromParams(AllenNlpTestCase):
         assert len(d.arg4) == 2
         assert any(x.val == "M" for x in d.arg4)
         assert any(x.val == "N" for x in d.arg4)
+
+        # Tests for custom extras parameters
+        assert isinstance(d.arg5, list)
+        assert isinstance(d.arg5[0], E)
+        assert d.arg5[0].m == 9
+        assert d.arg5[0].n == 10
 
     def test_no_constructor(self):
         params = Params({"type": "just_spaces"})

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -164,7 +164,7 @@ class TestFromParams(AllenNlpTestCase):
                 return cls(a=a, b=b, val=val)
 
         @BaseClass2.register("B")
-        class B(BaseClass):
+        class B(BaseClass2):
             def __init__(self, c: int, b: int) -> None:
                 self.c = c
                 self.b = b

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -181,15 +181,10 @@ class TestFromParams(AllenNlpTestCase):
                 pass
 
         class D(FromParams):
-            def __init__(
-                self, extra: C,
-                a: int,
-                arg: List[A],
-                arg2: Tuple[A, B],
-                arg3: Dict[str, A],
-                arg4: Set[A],
-                arg5: List[E]
-            ) -> None:
+            def __init__(self, extra: C, a: int,
+                         arg: List[A], arg2: Tuple[A, B],
+                         arg3: Dict[str, A], arg4: Set[A],
+                         arg5: List[E]) -> None:
                 self.arg = arg
                 self.arg2 = arg2
                 self.arg3 = arg3


### PR DESCRIPTION
Fixes #2665.

This ensures only extras relevant to a class are passed to its from_params constructor for classes with custom from_params. Additionally, also handles the hacky scenario when the class does not have a from_params method, the assumption there being that we want to pass extras for the class itself (instead if its from_params method)