### PR TITLE
make mask arg optional

### DIFF
--- a/allennlp/modules/seq2seq_encoders/pytorch_seq2seq_wrapper.py
+++ b/allennlp/modules/seq2seq_encoders/pytorch_seq2seq_wrapper.py
@@ -66,7 +66,7 @@ class PytorchSeq2SeqWrapper(Seq2SeqEncoder):
     @overrides
     def forward(self,  # pylint: disable=arguments-differ
                 inputs: torch.Tensor,
-                mask: torch.Tensor,
+                mask: torch.Tensor = None,
                 hidden_state: torch.Tensor = None) -> torch.Tensor:
 
         if self.stateful and mask is None:


### PR DESCRIPTION
The implementation of the module implies that the `mask` parameter is optional, however it is not default to `none`.  It makes the `mask` compulsory, which is not intended.