### PR TITLE
Fix bug in QaNetEncoder, update pretrained model

### DIFF
--- a/allennlp/modules/seq2seq_encoders/qanet_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/qanet_encoder.py
@@ -74,7 +74,7 @@ class QaNetEncoder(Seq2SeqEncoder):
             self._input_projection_layer = lambda x: x
 
         self._encoder_blocks = ModuleList([])
-        for block_index in range(num_blocks):
+        for _ in range(num_blocks):
             encoder_block = QaNetEncoderBlock(hidden_dim,
                                               hidden_dim,
                                               attention_projection_dim,

--- a/allennlp/modules/seq2seq_encoders/qanet_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/qanet_encoder.py
@@ -86,7 +86,6 @@ class QaNetEncoder(Seq2SeqEncoder):
                                               dropout_prob,
                                               layer_dropout_undecayed_prob,
                                               attention_dropout_prob)
-            self.add_module(f"encoder_block_{block_index}", encoder_block)
             self._encoder_blocks.append(encoder_block)
 
         self._input_dim = input_dim

--- a/allennlp/pretrained.py
+++ b/allennlp/pretrained.py
@@ -40,7 +40,7 @@ def bidirectional_attention_flow_seo_2017() -> predictors.BidafPredictor:
 def naqanet_dua_2019() -> predictors.BidafPredictor:
     with warnings.catch_warnings():
         warnings.simplefilter(action="ignore", category=DeprecationWarning)
-        model = PretrainedModel('https://s3-us-west-2.amazonaws.com/allennlp/models/naqanet-2019.03.01.tar.gz',
+        model = PretrainedModel('https://s3-us-west-2.amazonaws.com/allennlp/models/naqanet-2019.04.29-fixed-weight-names.tar.gz',
                                 'machine-comprehension')
         return model.predictor()  # type: ignore
 


### PR DESCRIPTION
Fixes #2772.  `ModuleList` encodes it weight names differently, so I had to modify the saved model archive, and #2692 ended up adding each block twice, so I had to remove a line there.

We should figure out a better way to have sniff tests for all of our pretrained models, so we catch these things earlier...