### PR TITLE
Increase max_runs for NumericallyAugmentedQaNetTest.

### DIFF
--- a/allennlp/tests/models/reading_comprehension/naqanet_test.py
+++ b/allennlp/tests/models/reading_comprehension/naqanet_test.py
@@ -11,6 +11,6 @@ class NumericallyAugmentedQaNetTest(ModelTestCase):
         self.set_up_model(self.FIXTURES_ROOT / "naqanet" / "experiment.json",
                           self.FIXTURES_ROOT / "data" / "drop.json")
 
-    @flaky
+    @flaky(max_runs=3, min_passes=1)
     def test_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)


### PR DESCRIPTION
- This test has caused a couple failures of the "GPU Unit Tests" over the past few days due to flakiness.
- Examples:
http://build.allennlp.org/viewLog.html?buildId=14497&buildTypeId=AllenNLP_GpuUnitTests&tab=buildLog&_focus=2658
http://build.allennlp.org/viewLog.html?buildId=14313&buildTypeId=AllenNLP_GpuUnitTests&tab=buildLog&_focus=2600