### PR TITLE
Changing model name in config file to match registered name

### DIFF
--- a/training_config/naqanet.jsonnet
+++ b/training_config/naqanet.jsonnet
@@ -45,7 +45,7 @@
     "train_data_path": "drop_dataset_train.json",
     "validation_data_path": "drop_dataset_dev.json",
     "model": {
-        "type": "augmented_qanet",
+        "type": "naqanet",
         "text_field_embedder": {
             "token_embedders": {
                 "tokens": {


### PR DESCRIPTION
It seems that there's a discrepancy between the registered model name for NAQANet (naqanet.py) and the name in the config file