### PR TITLE
Make `allennlp train --cache-directory` hashes consistent across program invocations.

### DIFF
--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -10,6 +10,7 @@ import copy
 import json
 import logging
 import os
+import zlib
 
 from overrides import overrides
 
@@ -511,8 +512,13 @@ class Params(MutableMapping):
         Returns a hash code representing the current state of this ``Params`` object.  We don't
         want to implement ``__hash__`` because that has deeper python implications (and this is a
         mutable object), but this will give you a representation of the current state.
+        We use `zlib.adler32` instead of Python's builtin `hash` because the random seed for the
+        latter is reset on each new program invocation, as discussed here:
+        https://stackoverflow.com/questions/27954892/deterministic-hashing-in-python-3.
         """
-        return str(hash(json.dumps(self.params, sort_keys=True)))
+        dumped = json.dumps(self.params, sort_keys=True)
+        hashed = zlib.adler32(dumped.encode())
+        return str(hashed)
 
 
 def pop_choice(params: Dict[str, Any],


### PR DESCRIPTION
When running `allennlp --cache-directory`, directory name hashes are not consistent across program invocations because Python's builtin `hash` function is initialized with a different random seed each time. An easy fix is to use a deterministic hash function, as discussed here: https://stackoverflow.com/questions/27954892/deterministic-hashing-in-python-3.
I'm not an expert on the properties of hash functions but it seems like this should do fine.