### PR TITLE
Unwrap masks to tensors as well in AUC metric

### DIFF
--- a/allennlp/training/metrics/auc.py
+++ b/allennlp/training/metrics/auc.py
@@ -37,7 +37,7 @@ class Auc(Metric):
             A one-dimensional label tensor of shape (batch_size).
         """
 
-        predictions, gold_labels = self.unwrap_to_tensors(predictions, gold_labels)
+        predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)
 
         # Sanity checks.
         if gold_labels.dim() != 1:


### PR DESCRIPTION
Masks were not unwrapped to tensors in AUC metric