### PR TITLE
Replace current default stopword list with nltk's.

### DIFF
--- a/allennlp/data/tokenizers/word_filter.py
+++ b/allennlp/data/tokenizers/word_filter.py
@@ -60,7 +60,7 @@ class RegexFilter(WordFilter):
 class StopwordFilter(WordFilter):
     """
     A ``StopwordFilter`` uses a list of stopwords to filter.
-    If no file is specified, a default list of stopwords is used.
+    If no file is specified, nltk's default list of stopwords is used.
     Words and stopwords are lowercased for comparison.
 
     Parameters
@@ -77,30 +77,28 @@ class StopwordFilter(WordFilter):
         if stopword_file is not None:
             self.stopwords = {token.lower() for token in read_set_from_file(stopword_file)}
         else:
-            self.stopwords = set([token.lower() for token in
-                                  ['I', 'a', 'aboard', 'about', 'above', 'accordance', 'according',
-                                   'across', 'after', 'against', 'along', 'alongside', 'also', 'am',
-                                   'amid', 'amidst', 'an', 'and', 'apart', 'are', 'around', 'as',
-                                   'aside', 'astride', 'at', 'atop', 'back', 'be', 'because', 'before',
-                                   'behind', 'below', 'beneath', 'beside', 'besides', 'between',
-                                   'beyond', 'but', 'by', 'concerning', 'do', 'down', 'due', 'during',
-                                   'either', 'except', 'exclusive', 'false', 'for', 'from', 'happen',
-                                   'he', 'her', 'hers', 'herself', 'him', 'himself', 'his', 'how',
-                                   'how many', 'how much', 'i', 'if', 'in', 'including', 'inside',
-                                   'instead', 'into', 'irrespective', 'is', 'it', 'its', 'itself',
-                                   'less', 'me', 'mine', 'minus', 'my', 'myself', 'neither', 'next',
-                                   'not', 'occur', 'of', 'off', 'on', 'onto', 'opposite', 'or', 'our',
-                                   'ours', 'ourselves', 'out', 'out of', 'outside', 'over', 'owing',
-                                   'per', 'prepatory', 'previous', 'prior', 'pursuant', 'regarding',
-                                   's', 'sans', 'she', 'subsequent', 'such', 'than', 'thanks', 'that',
-                                   'the', 'their', 'theirs', 'them', 'themselves', 'then', 'these',
-                                   'they', 'this', 'those', 'through', 'throughout', 'thru', 'till',
-                                   'to', 'together', 'top', 'toward', 'towards', 'true', 'under',
-                                   'underneath', 'unlike', 'until', 'up', 'upon', 'us', 'using',
-                                   'versus', 'via', 'was', 'we', 'were', 'what', 'when', 'where',
-                                   'which', 'who', 'why', 'will', 'with', 'within', 'without', 'you',
-                                   'your', 'yours', 'yourself', 'yourselves', ",", '.', ':', '!', ';',
-                                   "'", '"', '&', '$', '#', '@', '(', ')', '?']])
+            self.stopwords = {'i', 'me', 'my', 'myself', 'we', 'our', 'ours', 'ourselves', 'you',
+                              "you're", "you've", "you'll", "you'd", 'your', 'yours', 'yourself',
+                              'yourselves', 'he', 'him', 'his', 'himself', 'she', "she's", 'her',
+                              'hers', 'herself', 'it', "it's", 'its', 'itself', 'they', 'them',
+                              'their', 'theirs', 'themselves', 'what', 'which', 'who', 'whom',
+                              'this', 'that', "that'll", 'these', 'those', 'am', 'is', 'are', 'was',
+                              'were', 'be', 'been', 'being', 'have', 'has', 'had', 'having', 'do',
+                              'does', 'did', 'doing', 'a', 'an', 'the', 'and', 'but', 'if', 'or',
+                              'because', 'as', 'until', 'while', 'of', 'at', 'by', 'for', 'with',
+                              'about', 'against', 'between', 'into', 'through', 'during', 'before',
+                              'after', 'above', 'below', 'to', 'from', 'up', 'down', 'in', 'out',
+                              'on', 'off', 'over', 'under', 'again', 'further', 'then', 'once',
+                              'here', 'there', 'when', 'where', 'why', 'how', 'all', 'any', 'both',
+                              'each', 'few', 'more', 'most', 'other', 'some', 'such', 'no', 'nor',
+                              'not', 'only', 'own', 'same', 'so', 'than', 'too', 'very', 's', 't',
+                              'can', 'will', 'just', 'don', "don't", 'should', "should've", 'now',
+                              'd', 'll', 'm', 'o', 're', 've', 'y', 'ain', 'aren', "aren't",
+                              'couldn', "couldn't", 'didn', "didn't", 'doesn', "doesn't", 'hadn',
+                              "hadn't", 'hasn', "hasn't", 'haven', "haven't", 'isn', "isn't", 'ma',
+                              'mightn', "mightn't", 'mustn', "mustn't", 'needn', "needn't", 'shan',
+                              "shan't", 'shouldn', "shouldn't", 'wasn', "wasn't", 'weren',
+                              "weren't", 'won', "won't", 'wouldn', "wouldn't"}
         for token in self._tokens_to_add:
             self.stopwords.add(token.lower())
 


### PR DESCRIPTION
The current default stopword list has words like "prepatory", "irrespective", "accordance", "subsequent", etc. It's also missing words like "did", "so", "too", "can", and so on. I just replaced it with the current list from nltk.

The biggest differences, beyond what I just mentioned are 1) punctuation is no longer filtered, and 2) clitics like "re" and "ve" start getting filtered. Fwiw, I think both points are fine, because the goal here is just to provide a default that won't do something obviously wrong. But something to consider.