### PR TITLE
Remove multiple GPU warning

### DIFF
--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -38,8 +38,6 @@ class TrainerBase(Registrable):
             raise ConfigurationError("Expected an int or list for cuda_device, got {}".format(cuda_device))
 
         if isinstance(cuda_device, list):
-            logger.warning(f"Multiple GPU support is experimental not recommended for use. "
-                           "In some cases it may lead to incorrect results or undefined behavior.")
             self._multiple_gpu = True
             self._cuda_devices = cuda_device
         else:


### PR DESCRIPTION
- This code is relatively stable.
- However, our support isn't ideal as it's based on `torch.nn.DataParallel`.
- We should really investigate using `torch.nn.parallel.DistributedDataParallel`.