### PR TITLE
Fix TextField padding when there are no tokens

### DIFF
--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -105,8 +105,8 @@ class TextField(SequenceField[Dict[str, torch.Tensor]]):
                     # This is a padding edge case and occurs when we want to pad a ListField of
                     # TextFields. In order to pad the list field, we need to be able to have an
                     # _empty_ TextField, but if this is the case, token_lengths will be an empty
-                    # list, so we add the default empty padding dictionary to the list instead.
-                    token_lengths = [{}]
+                    # list, so we add the padding for a token of length 0 to the list instead.
+                    token_lengths = [indexer.get_padding_lengths([])]
                 # Iterate over the keys and find the maximum token length.
                 # It's fine to iterate over the keys of the first token since all tokens have the same keys.
                 for key in token_lengths[0]:

--- a/allennlp/tests/data/fields/text_field_test.py
+++ b/allennlp/tests/data/fields/text_field_test.py
@@ -216,6 +216,16 @@ class TestTextField(AllenNlpTestCase):
         numpy.testing.assert_array_almost_equal(tensor_dict["characters"].detach().cpu().numpy(),
                                                 expected_character_array)
 
+    def test_as_tensor_handles_characters_if_empty_field(self):
+        field = TextField([], token_indexers={"characters": TokenCharactersIndexer("characters",
+                                                                                   min_padding_length=1)})
+        field.index(self.vocab)
+        padding_lengths = field.get_padding_lengths()
+        tensor_dict = field.as_tensor(padding_lengths)
+        expected_character_array = numpy.array([])
+        numpy.testing.assert_array_almost_equal(tensor_dict["characters"].detach().cpu().numpy(),
+                                                expected_character_array)
+
     def test_as_tensor_handles_words_and_characters_with_longer_lengths(self):
         field = TextField([Token(t) for t in ["a", "sentence", "."]],
                           token_indexers={"words": SingleIdTokenIndexer("words"),


### PR DESCRIPTION
Related to (fixes?) #1591

The bug is about some `TextField` in some instance of the dataset that has no tokens and, at the same time, a `TokenCharactersIndexer` is used. When `to_tensor` is called it fails.