### PR TITLE
Add output path to drop eval

### DIFF
--- a/allennlp/tools/drop_eval.py
+++ b/allennlp/tools/drop_eval.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from collections import defaultdict
-from typing import Any, Dict, List, Set, Tuple, Union
+from typing import Any, Dict, List, Set, Tuple, Union, Optional
 import json
 import argparse
 import string
@@ -217,7 +217,7 @@ def evaluate_json(annotations: Dict[str, Any], predicted_answers: Dict[str, Any]
     return global_em, global_f1
 
 
-def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: str) -> Tuple[float, float]:
+def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: Optional[str]) -> Tuple[float, float]:
     """
     Takes a prediction file and a gold file and evaluates the predictions for each question in the
     gold file.  Both files must be json formatted and must have query_id keys, which are used to
@@ -235,8 +235,9 @@ def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: 
     output_dict = {"global_em": global_em,
                    "global_f1": global_f1}
 
-    with open(output_path, "w", encoding="utf8") as outfile:
-        json.dump(output_dict, outfile)
+    if output_path is not None:
+        with open(output_path, "w", encoding="utf8") as outfile:
+            json.dump(output_dict, outfile)
 
     return (global_em, global_f1)
 
@@ -257,7 +258,7 @@ if __name__ == "__main__":
     parser.add_argument("--output_path",
                         type=str,
                         required=False,
-                        default=os.devnull,
+                        default=None,
                         help='location of the output metrics file')
 
     args = parser.parse_args()

--- a/allennlp/tools/drop_eval.py
+++ b/allennlp/tools/drop_eval.py
@@ -6,6 +6,7 @@ import json
 import argparse
 import string
 import re
+import os
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
@@ -216,18 +217,28 @@ def evaluate_json(annotations: Dict[str, Any], predicted_answers: Dict[str, Any]
     return global_em, global_f1
 
 
-def evaluate_prediction_file(prediction_path: str, gold_path: str) -> Tuple[float, float]:
+def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: str) -> Tuple[float, float]:
     """
     Takes a prediction file and a gold file and evaluates the predictions for each question in the
     gold file.  Both files must be json formatted and must have query_id keys, which are used to
     match predictions to gold annotations.  The gold file is assumed to have the format of the dev
     set in the DROP data release.  The prediction file must be a JSON dictionary keyed by query id,
     where the value is either a JSON dictionary with an "answer" key, or just a string (or list of
-    strings) that is the answer.
+    strings) that is the answer. Writes a json with global_em and global_f1 metrics to file at
+    the specified output path.
     """
     predicted_answers = json.load(open(prediction_path, encoding='utf-8'))
     annotations = json.load(open(gold_path, encoding='utf-8'))
-    return evaluate_json(annotations, predicted_answers)
+    global_em, global_f1 = evaluate_json(annotations, predicted_answers)
+
+    # Output predictions to file
+    output_dict = {"global_em": global_em,
+                   "global_f1": global_f1}
+
+    with open(output_path, "w", encoding = "utf8") as fout:
+        json.dump(output_dict, fout)
+
+    return (global_em, global_f1)
 
 
 if __name__ == "__main__":
@@ -243,5 +254,11 @@ if __name__ == "__main__":
                         required=False,
                         default="sample_predictions.json",
                         help='location of the prediction file')
+    parser.add_argument("--output_path",
+                        type=str,
+                        required=False,
+                        default=os.devnull,
+                        help='location of the output metrics file')
+
     args = parser.parse_args()
-    evaluate_prediction_file(args.prediction_path, args.gold_path)
+    evaluate_prediction_file(args.prediction_path, args.gold_path, args.output_path)

--- a/allennlp/tools/drop_eval.py
+++ b/allennlp/tools/drop_eval.py
@@ -6,7 +6,6 @@ import json
 import argparse
 import string
 import re
-import os
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
@@ -217,7 +216,8 @@ def evaluate_json(annotations: Dict[str, Any], predicted_answers: Dict[str, Any]
     return global_em, global_f1
 
 
-def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: Optional[str] = None) -> Tuple[float, float]:
+def evaluate_prediction_file(prediction_path: str, gold_path: str,
+                             output_path: Optional[str] = None) -> Tuple[float, float]:
     """
     Takes a prediction file and a gold file and evaluates the predictions for each question in the
     gold file.  Both files must be json formatted and must have query_id keys, which are used to

--- a/allennlp/tools/drop_eval.py
+++ b/allennlp/tools/drop_eval.py
@@ -217,7 +217,7 @@ def evaluate_json(annotations: Dict[str, Any], predicted_answers: Dict[str, Any]
     return global_em, global_f1
 
 
-def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: Optional[str]) -> Tuple[float, float]:
+def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: Optional[str] = None) -> Tuple[float, float]:
     """
     Takes a prediction file and a gold file and evaluates the predictions for each question in the
     gold file.  Both files must be json formatted and must have query_id keys, which are used to
@@ -225,17 +225,17 @@ def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: 
     set in the DROP data release.  The prediction file must be a JSON dictionary keyed by query id,
     where the value is either a JSON dictionary with an "answer" key, or just a string (or list of
     strings) that is the answer. Writes a json with global_em and global_f1 metrics to file at
-    the specified output path.
+    the specified output path, unless None is passed as output path.
     """
     predicted_answers = json.load(open(prediction_path, encoding='utf-8'))
     annotations = json.load(open(gold_path, encoding='utf-8'))
     global_em, global_f1 = evaluate_json(annotations, predicted_answers)
 
-    # Output predictions to file
-    output_dict = {"global_em": global_em,
-                   "global_f1": global_f1}
-
+    # Output predictions to file if an output path is given
     if output_path is not None:
+        output_dict = {"global_em": global_em,
+                       "global_f1": global_f1}
+
         with open(output_path, "w", encoding="utf8") as outfile:
             json.dump(output_dict, outfile)
 

--- a/allennlp/tools/drop_eval.py
+++ b/allennlp/tools/drop_eval.py
@@ -226,13 +226,6 @@ def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: 
     where the value is either a JSON dictionary with an "answer" key, or just a string (or list of
     strings) that is the answer. Writes a json with global_em and global_f1 metrics to file at
     the specified output path.
-    Takes a prediction file and a gold file and evaluates the predictions for each question in the
-    gold file.  Both files must be json formatted and must have query_id keys, which are used to
-    match predictions to gold annotations.  The gold file is assumed to have the format of the dev
-    set in the DROP data release.  The prediction file must be a JSON dictionary keyed by query id,
-    where the value is either a JSON dictionary with an "answer" key, or just a string (or list of
-    strings) that is the answer. Writes a json with global_em and global_f1 metrics to file at
-    the specified output path.
     """
     predicted_answers = json.load(open(prediction_path, encoding='utf-8'))
     annotations = json.load(open(gold_path, encoding='utf-8'))

--- a/allennlp/tools/drop_eval.py
+++ b/allennlp/tools/drop_eval.py
@@ -235,8 +235,8 @@ def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: 
     output_dict = {"global_em": global_em,
                    "global_f1": global_f1}
 
-    with open(output_path, "w", encoding = "utf8") as fout:
-        json.dump(output_dict, fout)
+    with open(output_path, "w", encoding = "utf8") as outfile:
+        json.dump(output_dict, outfile)
 
     return (global_em, global_f1)
 

--- a/allennlp/tools/drop_eval.py
+++ b/allennlp/tools/drop_eval.py
@@ -226,6 +226,13 @@ def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: 
     where the value is either a JSON dictionary with an "answer" key, or just a string (or list of
     strings) that is the answer. Writes a json with global_em and global_f1 metrics to file at
     the specified output path.
+    Takes a prediction file and a gold file and evaluates the predictions for each question in the
+    gold file.  Both files must be json formatted and must have query_id keys, which are used to
+    match predictions to gold annotations.  The gold file is assumed to have the format of the dev
+    set in the DROP data release.  The prediction file must be a JSON dictionary keyed by query id,
+    where the value is either a JSON dictionary with an "answer" key, or just a string (or list of
+    strings) that is the answer. Writes a json with global_em and global_f1 metrics to file at
+    the specified output path.
     """
     predicted_answers = json.load(open(prediction_path, encoding='utf-8'))
     annotations = json.load(open(gold_path, encoding='utf-8'))

--- a/allennlp/tools/drop_eval.py
+++ b/allennlp/tools/drop_eval.py
@@ -235,7 +235,7 @@ def evaluate_prediction_file(prediction_path: str, gold_path: str, output_path: 
     output_dict = {"global_em": global_em,
                    "global_f1": global_f1}
 
-    with open(output_path, "w", encoding = "utf8") as outfile:
+    with open(output_path, "w", encoding="utf8") as outfile:
         json.dump(output_dict, outfile)
 
     return (global_em, global_f1)


### PR DESCRIPTION
Leaderboard expects a json file with the evaluation metrics.
Having the evaluator code output a file that conforms to that format will simplify the maintenance of the DROP leaderboard, as the backend can just call 
`python -m allennlp.tools.drop_eval --gold_path path/to/gold --prediction_path path/to/predictions --output_path path/to/metrics`