### PR TITLE
Make DROP EM and F1 calculation length aware

### DIFF
--- a/allennlp/tests/tools/drop_eval_test.py
+++ b/allennlp/tests/tools/drop_eval_test.py
@@ -19,17 +19,21 @@ class TestDropEvalGetMetrics:
         assert get_metrics(["78"], ["78.0"]) == (1.0, 1.0)
 
     def test_metric_is_length_aware(self):
-        # EM is 0.0 here.
-        # F1 between gold[0] and predicted[0] is 1.0
-        # F1 between gold[1] and predicted[1] is 0.0 (since predicted[1] doesn't exist).
-        # So, overall F1 is 0.5 (the mean of [1.0, 0.0]).
+        # Overall F1 should be mean([1.0, 0.0])
         assert get_metrics(predicted=["td"], gold=["td", "td"]) == (0.0, 0.5)
         assert get_metrics("td", ["td", "td"]) == (0.0, 0.5)
-        # EM is 0.0 here.
-        # F1 between gold[0] and predicted[0] is 1.0.
-        # So, overall F1 is 1.0 (mean of [1.0]).
-        assert get_metrics(predicted=["td", "td"], gold=["td"]) == (0.0, 1.0)
-        assert get_metrics(predicted=["td", "td"], gold="td") == (0.0, 1.0)
+        # Overall F1 should be mean ([1.0, 0.0]) = 0.5
+        assert get_metrics(predicted=["td", "td"], gold=["td"]) == (0.0, 0.5)
+        assert get_metrics(predicted=["td", "td"], gold="td") == (0.0, 0.5)
+
+        # F1 score is mean([0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+        assert get_metrics(predicted=["the", "fat", "cat", "the fat", "fat cat", "the fat cat"],
+                           gold=["cat"]) == (0.0, 0.17)
+        assert get_metrics(predicted=["cat"],
+                           gold=["the", "fat", "cat", "the fat", "fat cat", "the fat cat"]) == (0.0, 0.17)
+        # F1 score is mean([1.0, 0.5, 0.0, 0.0, 0.0, 0.0])
+        assert get_metrics(predicted=["the", "fat", "cat", "the fat", "fat cat", "the fat cat"],
+                           gold=["cat", "cat dog"]) == (0.0, 0.25)
 
     def test_articles_are_ignored(self):
         assert get_metrics(["td"], ["the td"]) == (1.0, 1.0)
@@ -71,10 +75,12 @@ class TestDropEvalGetMetrics:
 
     def test_multi_span_overlap_in_incorrect_cases(self):
         # only consider bags with matching numbers if they are present
+        # F1 scores of:     1.0        2/3   0.0   0.0   0.0   0.0
+        # Average them to get F1 of 0.28
         assert get_metrics(["78-yard", "56", "28", "40", "44", "touchdown"],
-                           ["78-yard", "56 yard", "1 yard touchdown"]) == (0.0, 0.56)
+                           ["78-yard", "56 yard", "1 yard touchdown"]) == (0.0, 0.28)
 
-        # two copies of same value will account for only one match (using greedy 1-1 bag alignment)
+        # two copies of same value will account for only one match (using optimal 1-1 bag alignment)
         assert get_metrics(["23", "23 yard"],
                            ["23-yard", "56 yards"]) == (0.0, 0.5)
 

--- a/allennlp/tests/tools/drop_eval_test.py
+++ b/allennlp/tests/tools/drop_eval_test.py
@@ -18,6 +18,19 @@ class TestDropEvalGetMetrics:
     def test_float_numbers(self):
         assert get_metrics(["78"], ["78.0"]) == (1.0, 1.0)
 
+    def test_metric_is_length_aware(self):
+        # EM is 0.0 here.
+        # F1 between gold[0] and predicted[0] is 1.0
+        # F1 between gold[1] and predicted[1] is 0.0 (since predicted[1] doesn't exist).
+        # So, overall F1 is 0.5 (the mean of [1.0, 0.0]).
+        assert get_metrics(predicted=["td"], gold=["td", "td"]) == (0.0, 0.5)
+        assert get_metrics("td", ["td", "td"]) == (0.0, 0.5)
+        # EM is 0.0 here.
+        # F1 between gold[0] and predicted[0] is 1.0.
+        # So, overall F1 is 1.0 (mean of [1.0]).
+        assert get_metrics(predicted=["td", "td"], gold=["td"]) == (0.0, 1.0)
+        assert get_metrics(predicted=["td", "td"], gold="td") == (0.0, 1.0)
+
     def test_articles_are_ignored(self):
         assert get_metrics(["td"], ["the td"]) == (1.0, 1.0)
         assert get_metrics(["the a NOT an ARTICLE the an a"], ["NOT ARTICLE"]) == (1.0, 1.0)

--- a/allennlp/tools/drop_eval.py
+++ b/allennlp/tools/drop_eval.py
@@ -74,7 +74,7 @@ def _answer_to_bags(answer: Union[str, List[str], Tuple[str, ...]]) -> Tuple[Lis
 def _align_bags(predicted: List[Set[str]], gold: List[Set[str]]) -> List[float]:
     """
     Takes gold and predicted answer sets and first finds the optimal 1-1 alignment
-    between them and gets maximum metric values over all the answers
+    between them and gets maximum metric values over all the answers.
     """
     scores = np.zeros([len(gold), len(predicted)])
     for gold_index, gold_item in enumerate(gold):
@@ -83,7 +83,7 @@ def _align_bags(predicted: List[Set[str]], gold: List[Set[str]]) -> List[float]:
                 scores[gold_index, pred_index] = _compute_f1(pred_item, gold_item)
     row_ind, col_ind = linear_sum_assignment(-scores)
 
-    max_scores = np.zeros([len(gold)])
+    max_scores = np.zeros([max(len(gold), len(predicted))])
     for row, column in zip(row_ind, col_ind):
         max_scores[row] = max(max_scores[row], scores[row, column])
     return max_scores

--- a/allennlp/tools/drop_eval.py
+++ b/allennlp/tools/drop_eval.py
@@ -57,18 +57,18 @@ def _normalize_number(text: str) -> str:
         return text
 
 
-def _answer_to_bags(answer: Union[str, List[str], Tuple[str, ...]]) -> Tuple[Set[str], List[Set[str]]]:
+def _answer_to_bags(answer: Union[str, List[str], Tuple[str, ...]]) -> Tuple[List[str], List[Set[str]]]:
     if isinstance(answer, (list, tuple)):
         raw_spans = answer
     else:
         raw_spans = [answer]
-    span_bag: Set[str] = set()
-    token_bag = []
+    normalized_spans: List[str] = []
+    token_bags = []
     for raw_span in raw_spans:
-        span = _normalize_answer(raw_span)
-        span_bag.add(span)
-        token_bag.append(set(span.split()))
-    return span_bag, token_bag
+        normalized_span = _normalize_answer(raw_span)
+        normalized_spans.append(normalized_span)
+        token_bags.append(set(normalized_span.split()))
+    return normalized_spans, token_bags
 
 
 def _align_bags(predicted: List[Set[str]], gold: List[Set[str]]) -> List[float]:
@@ -129,7 +129,10 @@ def get_metrics(predicted: Union[str, List[str], Tuple[str, ...]],
     predicted_bags = _answer_to_bags(predicted)
     gold_bags = _answer_to_bags(gold)
 
-    exact_match = 1.0 if predicted_bags[0] == gold_bags[0] else 0
+    if set(predicted_bags[0]) == set(gold_bags[0]) and len(predicted_bags[0]) == len(gold_bags[0]):
+        exact_match = 1.0
+    else:
+        exact_match = 0.0
 
     f1_per_bag = _align_bags(predicted_bags[1], gold_bags[1])
     f1 = np.mean(f1_per_bag)


### PR DESCRIPTION
In short, the problems this fixes:

1) EM wasn't length-aware, since only the bags were being compared.
2) The F1 calculation was taking the average of the optimal alignments between the gold and the predicted. However, if there are more predicted answers than gold answers, the precision isn't penalized. In the case where there are more predicted answers, the excess answers are all given an F1 of 0.

## Examples:

Before this patch:

```
In [1]: from allennlp.tools.drop_eval import get_metrics

In [2]: get_metrics(predicted=["td"], gold=["td", "td"])
Out[2]: (1.0, 0.5)

In [3]: get_metrics(predicted=["td", "td"], gold=["td"])
Out[3]: (1.0, 1.0)

# Suppose the passage is ["the", "fat", "cat"]
In [4]: get_metrics(predicted=["the", "fat", "cat", "the fat", "fat cat", "the fat cat"], gold=["cat"])
Out[4]: (0, 1.0)
```

After this patch:

```
In [1]: from allennlp.tools.drop_eval import get_metrics

In [2]: get_metrics(predicted=["td"], gold=["td", "td"])
Out[2]: (0.0, 0.5)

In [3]: get_metrics(predicted=["td", "td"], gold=["td"])
Out[3]: (0.0, 0.5)

In [4]: get_metrics(predicted=["the", "fat", "cat", "the fat", "fat cat", "the fat cat"], gold=["cat"])
Out[4]: (0.0, 0.17)
```