### PR TITLE
ensure regularizers are only computed for parameters requiring gradients

### DIFF
--- a/allennlp/nn/regularizers/regularizer_applicator.py
+++ b/allennlp/nn/regularizers/regularizer_applicator.py
@@ -30,14 +30,15 @@ class RegularizerApplicator:
             The module to regularize.
         """
         accumulator = 0.0
-        # For each parameter find the first matching regex.
         for name, parameter in module.named_parameters():
-            for regex, regularizer in self._regularizers:
-                if re.search(regex, name):
-                    penalty = regularizer(parameter)
-                    accumulator = accumulator + penalty
-                    break
-
+            # We first check if the parameter needs gradient updates or not
+            if parameter.requires_grad:
+                # For each parameter find the first matching regex.
+                for regex, regularizer in self._regularizers:
+                    if re.search(regex, name):
+                        penalty = regularizer(parameter)
+                        accumulator = accumulator + penalty
+                        break
         return accumulator
 
     # Requires custom from_params because of complex logic.


### PR DESCRIPTION
Fixes #2790 
Makes sure the regularizer doesn't include parameters that don't require gradients.