### PR TITLE
Fixed minor error while calculating span accuracy

### DIFF
--- a/allennlp/models/reading_comprehension/bidaf.py
+++ b/allennlp/models/reading_comprehension/bidaf.py
@@ -262,7 +262,7 @@ class BidirectionalAttentionFlow(Model):
             self._span_start_accuracy(span_start_logits, span_start.squeeze(-1))
             loss += nll_loss(util.masked_log_softmax(span_end_logits, passage_mask), span_end.squeeze(-1))
             self._span_end_accuracy(span_end_logits, span_end.squeeze(-1))
-            self._span_accuracy(best_span, torch.stack([span_start, span_end], -1))
+            self._span_accuracy(best_span, torch.cat([span_start, span_end], -1))
             output_dict["loss"] = loss
 
         # Compute the EM and F1 on SQuAD and add the tokenized input to the output.

--- a/allennlp/models/reading_comprehension/qanet.py
+++ b/allennlp/models/reading_comprehension/qanet.py
@@ -225,7 +225,7 @@ class QaNet(Model):
             self._span_start_accuracy(span_start_logits, span_start.squeeze(-1))
             loss += nll_loss(util.masked_log_softmax(span_end_logits, passage_mask), span_end.squeeze(-1))
             self._span_end_accuracy(span_end_logits, span_end.squeeze(-1))
-            self._span_accuracy(best_span, torch.stack([span_start, span_end], -1))
+            self._span_accuracy(best_span, torch.cat([span_start, span_end], -1))
             output_dict["loss"] = loss
 
         # Compute the EM and F1 on SQuAD and add the tokenized input to the output.

--- a/allennlp/tests/training/metrics/boolean_accuracy_test.py
+++ b/allennlp/tests/training/metrics/boolean_accuracy_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-self-use,invalid-name,protected-access
 import torch
+import pytest
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.training.metrics import BooleanAccuracy
@@ -48,3 +49,18 @@ class BooleanAccuracyTest(AllenNlpTestCase):
 
         # First example should be skipped, second is correct with mask, third is correct, fourth is wrong.
         assert accuracy.get_metric() == 2 / 3
+
+    def test_incorrect_gold_labels_shape_catches_exceptions(self):
+        accuracy = BooleanAccuracy()
+        predictions = torch.rand([5, 7])
+        incorrect_shape_labels = torch.rand([5, 8])
+        with pytest.raises(ValueError):
+            accuracy(predictions, incorrect_shape_labels)
+
+    def test_incorrect_mask_shape_catches_exceptions(self):
+        accuracy = BooleanAccuracy()
+        predictions = torch.rand([5, 7])
+        labels = torch.rand([5, 7])
+        incorrect_shape_mask = torch.rand([5, 8])
+        with pytest.raises(ValueError):
+            accuracy(predictions, labels, incorrect_shape_mask)

--- a/allennlp/tests/training/metrics/boolean_accuracy_test.py
+++ b/allennlp/tests/training/metrics/boolean_accuracy_test.py
@@ -61,6 +61,6 @@ class BooleanAccuracyTest(AllenNlpTestCase):
         accuracy = BooleanAccuracy()
         predictions = torch.rand([5, 7])
         labels = torch.rand([5, 7])
-        incorrect_shape_mask = torch.rand([5, 8])
+        incorrect_shape_mask = torch.randint(0, 2, [5, 8])
         with pytest.raises(ValueError):
             accuracy(predictions, labels, incorrect_shape_mask)

--- a/allennlp/training/metrics/boolean_accuracy.py
+++ b/allennlp/training/metrics/boolean_accuracy.py
@@ -41,6 +41,15 @@ class BooleanAccuracy(Metric):
             A tensor of the same shape as ``predictions``.
         """
         predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)
+
+        # Some sanity checks.
+        if gold_labels.size() != predictions.size():
+            raise ValueError("gold_labels must have shape == predictions.size() but "
+                             "found tensor of shape: {}".format(gold_labels.size()))
+        if mask is not None and mask.size() != predictions.size():
+            raise ValueError("mask must have shape == predictions.size() but "
+                             "found tensor of shape: {}".format(mask.size()))
+
         batch_size = predictions.size(0)
 
         if mask is not None:

--- a/allennlp/training/metrics/boolean_accuracy.py
+++ b/allennlp/training/metrics/boolean_accuracy.py
@@ -44,11 +44,11 @@ class BooleanAccuracy(Metric):
 
         # Some sanity checks.
         if gold_labels.size() != predictions.size():
-            raise ValueError("gold_labels must have shape == predictions.size() but "
-                             "found tensor of shape: {}".format(gold_labels.size()))
+            raise ValueError(f"gold_labels must have shape == predictions.size() but "
+                             f"found tensor of shape: {gold_labels.size()}")
         if mask is not None and mask.size() != predictions.size():
-            raise ValueError("mask must have shape == predictions.size() but "
-                             "found tensor of shape: {}".format(mask.size()))
+            raise ValueError(f"mask must have shape == predictions.size() but "
+                             f"found tensor of shape: {mask.size()}")
 
         batch_size = predictions.size(0)
 


### PR DESCRIPTION
Inputs to BooleanAccuracy must have the same dimensions. Here, the first argument has dimensions `(batch size, 2)`, while the second argument has dimensions `(batch size, 1, 2)`. Changing `torch.stack` to `torch.cat` makes the dimension of the second argument `(batch size, 2)`.

Note that span accuracy obtained earlier was not incorrect because of the way accuracy was being computed internally.