### PR TITLE
Fix Invalid Index Reference for labels in Vocabulary

### DIFF
--- a/allennlp/models/basic_classifier.py
+++ b/allennlp/models/basic_classifier.py
@@ -73,7 +73,7 @@ class BasicClassifier(Model):
         if num_labels:
             self._num_labels = num_labels
         else:
-            self._num_labels = vocab.get_vocab_size(namespace=label_namespace)
+            self._num_labels = vocab.get_vocab_size(namespace=self._label_namespace)
         self._classification_layer = torch.nn.Linear(self._classifier_input_dim, self._num_labels)
         self._accuracy = CategoricalAccuracy()
         self._loss = torch.nn.CrossEntropyLoss()
@@ -142,7 +142,7 @@ class BasicClassifier(Model):
         for prediction in predictions_list:
             label_idx = prediction.argmax(dim=-1).item()
             label_str = (self.vocab.get_index_to_token_vocabulary(self._label_namespace)
-                .get(label_idx, str(label_idx)))
+                         .get(label_idx, str(label_idx)))
             classes.append(label_str)
         output_dict["label"] = classes
         return output_dict

--- a/allennlp/models/basic_classifier.py
+++ b/allennlp/models/basic_classifier.py
@@ -73,7 +73,7 @@ class BasicClassifier(Model):
         if num_labels:
             self._num_labels = num_labels
         else:
-            self._num_labels = vocab.get_vocab_size(namespace=self._label_namespace)
+            self._num_labels = vocab.get_vocab_size(namespace=label_namespace)
         self._classification_layer = torch.nn.Linear(self._classifier_input_dim, self._num_labels)
         self._accuracy = CategoricalAccuracy()
         self._loss = torch.nn.CrossEntropyLoss()
@@ -141,8 +141,8 @@ class BasicClassifier(Model):
         classes = []
         for prediction in predictions_list:
             label_idx = prediction.argmax(dim=-1).item()
-            label_str = \
-                self.vocab.get_index_to_token_vocabulary(self._label_namespace).get(label_idx, str(label_idx))
+            label_str = (self.vocab.get_index_to_token_vocabulary(self._label_namespace)
+                .get(label_idx, str(label_idx)))
             classes.append(label_str)
         output_dict["label"] = classes
         return output_dict

--- a/allennlp/models/basic_classifier.py
+++ b/allennlp/models/basic_classifier.py
@@ -68,10 +68,12 @@ class BasicClassifier(Model):
         else:
             self._dropout = None
 
+        self._label_namespace = label_namespace
+
         if num_labels:
             self._num_labels = num_labels
         else:
-            self._num_labels = vocab.get_vocab_size(namespace=label_namespace)
+            self._num_labels = vocab.get_vocab_size(namespace=self._label_namespace)
         self._classification_layer = torch.nn.Linear(self._classifier_input_dim, self._num_labels)
         self._accuracy = CategoricalAccuracy()
         self._loss = torch.nn.CrossEntropyLoss()
@@ -139,7 +141,8 @@ class BasicClassifier(Model):
         classes = []
         for prediction in predictions_list:
             label_idx = prediction.argmax(dim=-1).item()
-            label_str = self.vocab.get_token_from_index(label_idx, namespace="labels")
+            label_str = \
+                self.vocab.get_index_to_token_vocabulary(self._label_namespace).get(label_idx, str(label_idx))
             classes.append(label_str)
         output_dict["label"] = classes
         return output_dict

--- a/allennlp/models/bert_for_classification.py
+++ b/allennlp/models/bert_for_classification.py
@@ -68,7 +68,7 @@ class BertForClassification(Model):
         if num_labels:
             out_features = num_labels
         else:
-            out_features = vocab.get_vocab_size(namespace=self._label_namespace)
+            out_features = vocab.get_vocab_size(namespace=label_namespace)
 
         self._dropout = torch.nn.Dropout(p=dropout)
 
@@ -141,8 +141,8 @@ class BertForClassification(Model):
         classes = []
         for prediction in predictions_list:
             label_idx = prediction.argmax(dim=-1).item()
-            label_str = \
-                self.vocab.get_index_to_token_vocabulary(self._label_namespace).get(label_idx, str(label_idx))
+            label_str = (self.vocab.get_index_to_token_vocabulary(self._label_namespace)
+                .get(label_idx, str(label_idx)))
             classes.append(label_str)
         output_dict["label"] = classes
         return output_dict

--- a/allennlp/models/bert_for_classification.py
+++ b/allennlp/models/bert_for_classification.py
@@ -68,7 +68,7 @@ class BertForClassification(Model):
         if num_labels:
             out_features = num_labels
         else:
-            out_features = vocab.get_vocab_size(self._label_namespace)
+            out_features = vocab.get_vocab_size(namespace=self._label_namespace)
 
         self._dropout = torch.nn.Dropout(p=dropout)
 
@@ -141,11 +141,8 @@ class BertForClassification(Model):
         classes = []
         for prediction in predictions_list:
             label_idx = prediction.argmax(dim=-1).item()
-            index_to_token_vocab = self.vocab.get_index_to_token_vocabulary(self._label_namespace)
-            if label_idx in index_to_token_vocab:
-                label_str = index_to_token_vocab[label_idx]
-            else:
-                label_str = str(label_idx)           
+            label_str = \
+                self.vocab.get_index_to_token_vocabulary(self._label_namespace).get(label_idx, str(label_idx))
             classes.append(label_str)
         output_dict["label"] = classes
         return output_dict

--- a/allennlp/models/bert_for_classification.py
+++ b/allennlp/models/bert_for_classification.py
@@ -68,7 +68,7 @@ class BertForClassification(Model):
         if num_labels:
             out_features = num_labels
         else:
-            out_features = vocab.get_vocab_size(namespace=label_namespace)
+            out_features = vocab.get_vocab_size(namespace=self._label_namespace)
 
         self._dropout = torch.nn.Dropout(p=dropout)
 
@@ -142,7 +142,7 @@ class BertForClassification(Model):
         for prediction in predictions_list:
             label_idx = prediction.argmax(dim=-1).item()
             label_str = (self.vocab.get_index_to_token_vocabulary(self._label_namespace)
-                .get(label_idx, str(label_idx)))
+                         .get(label_idx, str(label_idx)))
             classes.append(label_str)
         output_dict["label"] = classes
         return output_dict

--- a/allennlp/models/bert_for_classification.py
+++ b/allennlp/models/bert_for_classification.py
@@ -63,10 +63,12 @@ class BertForClassification(Model):
 
         in_features = self.bert_model.config.hidden_size
 
+        self._label_namespace = label_namespace
+
         if num_labels:
             out_features = num_labels
         else:
-            out_features = vocab.get_vocab_size(label_namespace)
+            out_features = vocab.get_vocab_size(self._label_namespace)
 
         self._dropout = torch.nn.Dropout(p=dropout)
 
@@ -139,7 +141,11 @@ class BertForClassification(Model):
         classes = []
         for prediction in predictions_list:
             label_idx = prediction.argmax(dim=-1).item()
-            label_str = self.vocab.get_token_from_index(label_idx, namespace="labels")
+            index_to_token_vocab = self.vocab.get_index_to_token_vocabulary(self._label_namespace)
+            if label_idx in index_to_token_vocab:
+                label_str = index_to_token_vocab[label_idx]
+            else:
+                label_str = str(label_idx)           
             classes.append(label_str)
         output_dict["label"] = classes
         return output_dict


### PR DESCRIPTION
This fixes an issue where `basic_classifier` and `bert_for_classification`, when used with integer labels (`LabelField` created with `skip_indexing=True`) run into an issue during prediction, where the `decode` method tries to look up labels for label indices. Sample stack trace:

```Traceback (most recent call last):
  File "allennlp_data_processor/run.py", line 14, in <module>
    main(prog="python -m allennlp.run")
  File "/Users/sumithrab/anaconda/envs/commonsense/lib/python3.6/site-packages/allennlp/commands/__init__.py", line 102, in main
    args.func(args)
  File "/Users/sumithrab/anaconda/envs/commonsense/lib/python3.6/site-packages/allennlp/commands/predict.py", line 204, in _predict
    manager.run()
  File "/Users/sumithrab/anaconda/envs/commonsense/lib/python3.6/site-packages/allennlp/commands/predict.py", line 178, in run
    for model_input_instance, result in zip(batch, self._predict_instances(batch)):
  File "/Users/sumithrab/anaconda/envs/commonsense/lib/python3.6/site-packages/allennlp/commands/predict.py", line 137, in _predict_instances
    results = [self._predictor.predict_instance(batch_data[0])]
  File "/Users/sumithrab/anaconda/envs/commonsense/lib/python3.6/site-packages/allennlp/predictors/predictor.py", line 95, in predict_instance
    outputs = self._model.forward_on_instance(instance)
  File "/Users/sumithrab/anaconda/envs/commonsense/lib/python3.6/site-packages/allennlp/models/model.py", line 124, in forward_on_instance
    return self.forward_on_instances([instance])[0]
  File "/Users/sumithrab/anaconda/envs/commonsense/lib/python3.6/site-packages/allennlp/models/model.py", line 153, in forward_on_instances
    outputs = self.decode(self(**model_input))
  File "/Users/sumithrab/anaconda/envs/commonsense/lib/python3.6/site-packages/allennlp/models/bert_for_classification.py", line 142, in decode
    label_str = self.vocab.get_token_from_index(label_idx, namespace="labels")
  File "/Users/sumithrab/anaconda/envs/commonsense/lib/python3.6/site-packages/allennlp/data/vocabulary.py", line 637, in get_token_from_index
    return self._index_to_token[namespace][index]
KeyError: 0
```

Tests Run:
`pytest allennlp/tests/models/basic_classifier_test.py` : ` 3 passed, 1 warnings`
`pytest allennlp/tests/models/bert_for_classification_test.py` : `4 passed, 1 warnings`
(Warnings are unrelated Deprecation warnings)

Note:

`git grep`'ing `get_token_from_index` it seems like there's a whole bunch of places that potentially have the same problem (below), but fixing just `basic_classifier` and `bert_for_classification` for now based on discussion with @joelgrus 

```basic_classifier.py:            label_str = self.vocab.get_token_from_index(label_idx, namespace="labels")
biaffine_dependency_parser.py:            labels = [self.vocab.get_token_from_index(label, "head_tags")
biattentive_classification_network.py:        labels = [self.vocab.get_token_from_index(x, namespace="labels")
bimpm.py:        labels = [self.vocab.get_token_from_index(x, namespace="labels")
constituency_parser.py:                               self.vocab.get_token_from_index(span.label_index, "labels")
crf_tagger.py:                [self.vocab.get_token_from_index(tag, namespace=self.label_namespace)
encoder_decoders/copynet_seq2seq.py:                        token = self.vocab.get_token_from_index(index, self._target_namespace)
encoder_decoders/simple_seq2seq.py:            predicted_tokens = [self.vocab.get_token_from_index(x, namespace=self._target_namespace)
event2mind.py:            predicted_tokens = [self.vocab.get_token_from_index(x, namespace=self._target_namespace)
graph_parser.py:                        edge_tags.append(self.vocab.get_token_from_index(tag, "labels"))
reading_comprehension/dialog_qa.py:        yesno_tags = [[self.vocab.get_token_from_index(x, namespace="yesno_labels") for x in yn_list] \
reading_comprehension/dialog_qa.py:        followup_tags = [[self.vocab.get_token_from_index(x, namespace="followup_labels") for x in followup_list] \
semantic_parsing/nlvr/nlvr_coverage_semantic_parser.py:            token = self.vocab.get_token_from_index(index=index, namespace='tokens')
semantic_parsing/nlvr/nlvr_coverage_semantic_parser.py:            if archived_vocab.get_token_from_index(archived_token_index, namespace="tokens") == token:
semantic_parsing/nlvr/nlvr_semantic_parser.py:                label_strings[-1].append(self.vocab.get_token_from_index(label_int, "denotations"))
semantic_parsing/wikitables/wikitables_erm_semantic_parser.py:            token = self.vocab.get_token_from_index(index=index, namespace='tokens')
semantic_parsing/wikitables/wikitables_erm_semantic_parser.py:            if archived_vocab.get_token_from_index(archived_token_index, namespace="tokens") == token:
semantic_role_labeler.py:            tags = [self.vocab.get_token_from_index(x, namespace="labels")
simple_tagger.py:            tags = [self.vocab.get_token_from_index(x, namespace="labels")```