### PR TITLE
Fix `trainable` and `requires_grad` kwargs in `BertForClassification` and `BertPooler`

### DIFF
--- a/allennlp/models/bert_for_classification.py
+++ b/allennlp/models/bert_for_classification.py
@@ -59,7 +59,8 @@ class BertForClassification(Model):
         else:
             self.bert_model = bert_model
 
-        self.bert_model.requires_grad = trainable
+        for param in self.bert_model.parameters():
+            param.requires_grad = trainable
 
         in_features = self.bert_model.config.hidden_size
 

--- a/allennlp/modules/seq2vec_encoders/bert_pooler.py
+++ b/allennlp/modules/seq2vec_encoders/bert_pooler.py
@@ -39,7 +39,8 @@ class BertPooler(Seq2VecEncoder):
             model = pretrained_model
 
         self.pooler = model.pooler
-        self.pooler.requires_grad = requires_grad
+        for param in self.pooler.parameters():
+            param.requires_grad = requires_grad
         self._embedding_dim = model.config.hidden_size
 
     @overrides


### PR DESCRIPTION
The two kwargs `trainable` and `requires_grad` in `BertForClassification` and `BertPooler` have no effect as described in #2927.
This PR fixes #2927 by simply looping over the model parameters and freezing/unfreezing them. 