### PR TITLE
Pad coreference model input to 5

### DIFF
--- a/allennlp/pretrained.py
+++ b/allennlp/pretrained.py
@@ -64,7 +64,7 @@ def neural_coreference_resolution_lee_2017() -> predictors.CorefPredictor:
         predictor = model.predictor()
         # pylint: disable=protected-access
         predictor._dataset_reader._token_indexers['token_characters']._min_padding_length = 5  # type: ignore
-        return predictor
+        return predictor  # type: ignore
 
 def named_entity_recognition_with_elmo_peters_2018() -> predictors.SentenceTaggerPredictor:
     with warnings.catch_warnings():

--- a/allennlp/pretrained.py
+++ b/allennlp/pretrained.py
@@ -61,7 +61,10 @@ def neural_coreference_resolution_lee_2017() -> predictors.CorefPredictor:
         warnings.simplefilter(action="ignore", category=DeprecationWarning)
         model = PretrainedModel('https://s3-us-west-2.amazonaws.com/allennlp/models/coref-model-2018.02.05.tar.gz',
                                 'coreference-resolution')
-        return model.predictor() # type: ignore
+        predictor = model.predictor()
+        # pylint: disable=protected-access
+        predictor._dataset_reader._token_indexers['token_characters']._min_padding_length = 5  # type: ignore
+        return predictor
 
 def named_entity_recognition_with_elmo_peters_2018() -> predictors.SentenceTaggerPredictor:
     with warnings.catch_warnings():


### PR DESCRIPTION
Fixes https://github.com/allenai/allennlp/issues/2930.

I've tested it manually with this code that failed before:

```python
In [1]: import allennlp.pretrained as pt                                                                                                                                 
In [2]: c = pt.neural_coreference_resolution_lee_2017()                                                                                                                  
In [3]: c.predict('I am Joe.')                                                                                                                                           
Out[3]: 
{'top_spans': [[0, 0]],
 'antecedent_indices': [0],
 'predicted_antecedents': [-1],
 'document': ['I', 'am', 'Joe', '.'],
 'clusters': []}
```