### PR TITLE
Replace current default stopword list with spaCy's.

### DIFF
--- a/allennlp/data/tokenizers/word_filter.py
+++ b/allennlp/data/tokenizers/word_filter.py
@@ -2,6 +2,8 @@ from typing import List
 import re
 from overrides import overrides
 
+from spacy.lang.en.stop_words import STOP_WORDS
+
 from allennlp.common import Registrable
 from allennlp.data.tokenizers.token import Token
 from allennlp.common.file_utils import read_set_from_file
@@ -60,7 +62,7 @@ class RegexFilter(WordFilter):
 class StopwordFilter(WordFilter):
     """
     A ``StopwordFilter`` uses a list of stopwords to filter.
-    If no file is specified, a default list of stopwords is used.
+    If no file is specified, spaCy's default list of English stopwords is used.
     Words and stopwords are lowercased for comparison.
 
     Parameters
@@ -77,30 +79,7 @@ class StopwordFilter(WordFilter):
         if stopword_file is not None:
             self.stopwords = {token.lower() for token in read_set_from_file(stopword_file)}
         else:
-            self.stopwords = set([token.lower() for token in
-                                  ['I', 'a', 'aboard', 'about', 'above', 'accordance', 'according',
-                                   'across', 'after', 'against', 'along', 'alongside', 'also', 'am',
-                                   'amid', 'amidst', 'an', 'and', 'apart', 'are', 'around', 'as',
-                                   'aside', 'astride', 'at', 'atop', 'back', 'be', 'because', 'before',
-                                   'behind', 'below', 'beneath', 'beside', 'besides', 'between',
-                                   'beyond', 'but', 'by', 'concerning', 'do', 'down', 'due', 'during',
-                                   'either', 'except', 'exclusive', 'false', 'for', 'from', 'happen',
-                                   'he', 'her', 'hers', 'herself', 'him', 'himself', 'his', 'how',
-                                   'how many', 'how much', 'i', 'if', 'in', 'including', 'inside',
-                                   'instead', 'into', 'irrespective', 'is', 'it', 'its', 'itself',
-                                   'less', 'me', 'mine', 'minus', 'my', 'myself', 'neither', 'next',
-                                   'not', 'occur', 'of', 'off', 'on', 'onto', 'opposite', 'or', 'our',
-                                   'ours', 'ourselves', 'out', 'out of', 'outside', 'over', 'owing',
-                                   'per', 'prepatory', 'previous', 'prior', 'pursuant', 'regarding',
-                                   's', 'sans', 'she', 'subsequent', 'such', 'than', 'thanks', 'that',
-                                   'the', 'their', 'theirs', 'them', 'themselves', 'then', 'these',
-                                   'they', 'this', 'those', 'through', 'throughout', 'thru', 'till',
-                                   'to', 'together', 'top', 'toward', 'towards', 'true', 'under',
-                                   'underneath', 'unlike', 'until', 'up', 'upon', 'us', 'using',
-                                   'versus', 'via', 'was', 'we', 'were', 'what', 'when', 'where',
-                                   'which', 'who', 'why', 'will', 'with', 'within', 'without', 'you',
-                                   'your', 'yours', 'yourself', 'yourselves', ",", '.', ':', '!', ';',
-                                   "'", '"', '&', '$', '#', '@', '(', ')', '?']])
+            self.stopwords = STOP_WORDS
         for token in self._tokens_to_add:
             self.stopwords.add(token.lower())
 

--- a/allennlp/tests/data/tokenizers/word_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/word_tokenizer_test.py
@@ -30,7 +30,7 @@ class TestWordTokenizer(AllenNlpTestCase):
     def test_stems_and_filters_stopwords_correctly(self):
         tokenizer = WordTokenizer.from_params(Params({'word_stemmer': {'type': 'porter'},
                                                       'word_filter': {'type': 'stopwords'}}))
-        sentence = "this (sentence) has 'crazy' \"punctuation\"."
-        expected_tokens = ["sentenc", "ha", "crazi", "punctuat"]
+        sentence = "this sentence has some stopwords, (but it doesn't have crazy \"punctuation\")."
+        expected_tokens = ["sentenc", "stopword", ",", "(", "crazi", '"', "punctuat", '"', ")", "."]
         tokens = [t.text for t in tokenizer.tokenize(sentence)]
         assert tokens == expected_tokens


### PR DESCRIPTION
The current default stopword list has some odd words like "prepatory", "irrespective", "accordance", "subsequent", etc. It's also missing words like "did", "so", "too", "can", and so on. This just replaces the hard-coded default list with one imported from spaCy, using the logic that since the default tokenizer uses spaCy, so should the default stopword list.

The biggest differences, beyond better word choices, are 1) punctuation is no longer filtered, 2) clitics like "'re" and "'ve" start getting filtered, and 3) potentially, a spaCy update could cause behavior to change. 

A regex filter could address (1); it seems odd to combine that behavior with stopword removal. (2), I think, is straightforwardly correct. Re: (3), the list looks like it's been pretty stable. The only changes in the past couple years have involved fixing issues with different kinds of apostrophes. But possibly people would prefer a hardcoded list? Not sure.