### PR TITLE
experimental: add backoff

### DIFF
--- a/allennlp/predictors/wikitables_parser.py
+++ b/allennlp/predictors/wikitables_parser.py
@@ -3,7 +3,6 @@ import pathlib
 from subprocess import run
 from typing import List
 import shutil
-import requests
 
 from overrides import overrides
 import torch
@@ -40,6 +39,7 @@ class WikiTablesParserPredictor(Predictor):
         # Load auxiliary sempre files during startup for faster logical form execution.
         os.makedirs(SEMPRE_DIR, exist_ok=True)
         abbreviations_path = os.path.join(SEMPRE_DIR, 'abbreviations.tsv')
+        grammar_path = os.path.join(SEMPRE_DIR, 'grow.grammar')
 
         with session_with_backoff() as session:
             if not os.path.exists(abbreviations_path):
@@ -47,7 +47,6 @@ class WikiTablesParserPredictor(Predictor):
                 with open(abbreviations_path, 'wb') as downloaded_file:
                     downloaded_file.write(result.content)
 
-            grammar_path = os.path.join(SEMPRE_DIR, 'grow.grammar')
             if not os.path.exists(grammar_path):
                 result = session.get(GROW_FILE)
                 with open(grammar_path, 'wb') as downloaded_file:

--- a/allennlp/predictors/wikitables_parser.py
+++ b/allennlp/predictors/wikitables_parser.py
@@ -8,7 +8,7 @@ import requests
 from overrides import overrides
 import torch
 
-from allennlp.common.file_utils import cached_path
+from allennlp.common.file_utils import cached_path, session_with_backoff
 from allennlp.common.util import JsonDict, sanitize
 from allennlp.data import DatasetReader, Instance
 from allennlp.models import Model
@@ -40,16 +40,18 @@ class WikiTablesParserPredictor(Predictor):
         # Load auxiliary sempre files during startup for faster logical form execution.
         os.makedirs(SEMPRE_DIR, exist_ok=True)
         abbreviations_path = os.path.join(SEMPRE_DIR, 'abbreviations.tsv')
-        if not os.path.exists(abbreviations_path):
-            result = requests.get(ABBREVIATIONS_FILE)
-            with open(abbreviations_path, 'wb') as downloaded_file:
-                downloaded_file.write(result.content)
 
-        grammar_path = os.path.join(SEMPRE_DIR, 'grow.grammar')
-        if not os.path.exists(grammar_path):
-            result = requests.get(GROW_FILE)
-            with open(grammar_path, 'wb') as downloaded_file:
-                downloaded_file.write(result.content)
+        with session_with_backoff() as session:
+            if not os.path.exists(abbreviations_path):
+                result = session.get(ABBREVIATIONS_FILE)
+                with open(abbreviations_path, 'wb') as downloaded_file:
+                    downloaded_file.write(result.content)
+
+            grammar_path = os.path.join(SEMPRE_DIR, 'grow.grammar')
+            if not os.path.exists(grammar_path):
+                result = session.get(GROW_FILE)
+                with open(grammar_path, 'wb') as downloaded_file:
+                    downloaded_file.write(result.content)
 
     @overrides
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:

--- a/allennlp/semparse/executors/wikitables_sempre_executor.py
+++ b/allennlp/semparse/executors/wikitables_sempre_executor.py
@@ -4,7 +4,6 @@ import os
 import pathlib
 import shutil
 import subprocess
-import requests
 
 from allennlp.common.file_utils import cached_path, session_with_backoff
 from allennlp.common.checks import check_for_java
@@ -74,6 +73,7 @@ class WikiTablesSempreExecutor:
         # sure we put the files in that location.
         os.makedirs(SEMPRE_DIR, exist_ok=True)
         abbreviations_path = os.path.join(SEMPRE_DIR, 'abbreviations.tsv')
+        grammar_path = os.path.join(SEMPRE_DIR, 'grow.grammar')
 
         with session_with_backoff() as session:
             if not os.path.exists(abbreviations_path):
@@ -81,7 +81,6 @@ class WikiTablesSempreExecutor:
                 with open(abbreviations_path, 'wb') as downloaded_file:
                     downloaded_file.write(result.content)
 
-            grammar_path = os.path.join(SEMPRE_DIR, 'grow.grammar')
             if not os.path.exists(grammar_path):
                 result = session.get(GROW_FILE)
                 with open(grammar_path, 'wb') as downloaded_file:

--- a/allennlp/semparse/executors/wikitables_sempre_executor.py
+++ b/allennlp/semparse/executors/wikitables_sempre_executor.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import requests
 
-from allennlp.common.file_utils import cached_path
+from allennlp.common.file_utils import cached_path, session_with_backoff
 from allennlp.common.checks import check_for_java
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -74,16 +74,18 @@ class WikiTablesSempreExecutor:
         # sure we put the files in that location.
         os.makedirs(SEMPRE_DIR, exist_ok=True)
         abbreviations_path = os.path.join(SEMPRE_DIR, 'abbreviations.tsv')
-        if not os.path.exists(abbreviations_path):
-            result = requests.get(ABBREVIATIONS_FILE)
-            with open(abbreviations_path, 'wb') as downloaded_file:
-                downloaded_file.write(result.content)
 
-        grammar_path = os.path.join(SEMPRE_DIR, 'grow.grammar')
-        if not os.path.exists(grammar_path):
-            result = requests.get(GROW_FILE)
-            with open(grammar_path, 'wb') as downloaded_file:
-                downloaded_file.write(result.content)
+        with session_with_backoff() as session:
+            if not os.path.exists(abbreviations_path):
+                result = session.get(ABBREVIATIONS_FILE)
+                with open(abbreviations_path, 'wb') as downloaded_file:
+                    downloaded_file.write(result.content)
+
+            grammar_path = os.path.join(SEMPRE_DIR, 'grow.grammar')
+            if not os.path.exists(grammar_path):
+                result = session.get(GROW_FILE)
+                with open(grammar_path, 'wb') as downloaded_file:
+                    downloaded_file.write(result.content)
 
         if not check_for_java():
             raise RuntimeError('Java is not installed properly.')


### PR DESCRIPTION
Our tests have been consistently failing all day because of intermittent failed `requests.get` and `requests.head` calls to S3. It seems like these failures are rooted in AWS denying the requests (on account of volume / frequency?), so this PR implements retries with backoffs for all of our `requests` calls