### PR TITLE
Fixes inconsistent resetting of metrics with Validate and TrackMetrics callbacks  (issue #3001)

### DIFF
--- a/allennlp/tests/training/callback_trainer_test.py
+++ b/allennlp/tests/training/callback_trainer_test.py
@@ -10,6 +10,7 @@ from typing import Dict, Iterable
 import torch
 import responses
 import pytest
+import numpy as np
 
 from allennlp.common.checks import ConfigurationError
 
@@ -348,7 +349,8 @@ class TestCallbackTrainer(ModelTestCase):
 
     def test_training_metrics_consistent_with_and_without_validation(self):
         default_callbacks = self.default_callbacks(serialization_dir=None)
-        default_callbacks_without_validation = [callback for callback in default_callbacks if type(callback).__name__ != 'Validate']
+        default_callbacks_without_validation = [callback for callback in default_callbacks
+                                                if not isinstance(callback, Validate)]
         trainer1 = CallbackTrainer(copy.deepcopy(self.model), copy.deepcopy(self.optimizer),
                                    callbacks=default_callbacks_without_validation,
                                    num_epochs=1, serialization_dir=None)
@@ -363,13 +365,13 @@ class TestCallbackTrainer(ModelTestCase):
         metrics1 = trainer1.train_metrics
         metrics2 = trainer2.train_metrics
         assert metrics1.keys() == metrics2.keys()
-        threshold = 1e-6
-        for key in metrics1:
-            assert abs(metrics1[key] - metrics2[key]) < threshold
+        for key in ['accuracy', 'accuracy3', 'loss']:
+            np.testing.assert_almost_equal(metrics1[key], metrics2[key])
 
     def test_validation_metrics_consistent_with_and_without_tracking(self):
         default_callbacks = self.default_callbacks(serialization_dir=None)
-        default_callbacks_without_tracking = [callback for callback in default_callbacks if type(callback).__name__ != 'TrackMetrics']
+        default_callbacks_without_tracking = [callback for callback in default_callbacks
+                                              if not isinstance(callback, TrackMetrics)]
         trainer1 = CallbackTrainer(copy.deepcopy(self.model), copy.deepcopy(self.optimizer),
                                    callbacks=default_callbacks_without_tracking,
                                    num_epochs=1, serialization_dir=None)
@@ -384,9 +386,8 @@ class TestCallbackTrainer(ModelTestCase):
         metrics1 = trainer1.val_metrics
         metrics2 = trainer2.val_metrics
         assert metrics1.keys() == metrics2.keys()
-        threshold = 1e-6
-        for key in metrics1:
-            assert abs(metrics1[key] - metrics2[key]) < threshold
+        for key in ['accuracy', 'accuracy3', 'loss']:
+            np.testing.assert_almost_equal(metrics1[key], metrics2[key])
 
     def test_metric_only_considered_best_so_far_when_strictly_better_than_those_before_it_increasing_metric(
             self):

--- a/allennlp/training/callbacks/track_metrics.py
+++ b/allennlp/training/callbacks/track_metrics.py
@@ -88,8 +88,8 @@ class TrackMetrics(Callback):
             logger.info(f"GPU {gpu} memory usage MB: {memory}")
 
 
-    @handle_event(Events.VALIDATE, priority=100)
-    def collect_metrics(self, trainer: 'CallbackTrainer'):
+    @handle_event(Events.VALIDATE, priority=-100)
+    def collect_train_metrics(self, trainer: 'CallbackTrainer'):
         trainer.train_metrics = training_util.get_metrics(trainer.model,
                                                           trainer.train_loss,
                                                           trainer.batches_this_epoch,
@@ -106,6 +106,8 @@ class TrackMetrics(Callback):
             if key.startswith('gpu_'):
                 trainer.metrics["peak_"+key] = max(trainer.metrics.get("peak_"+key, 0), value)
 
+    @handle_event(Events.VALIDATE, priority=100)
+    def collect_val_metrics(self, trainer: 'CallbackTrainer'):
         if trainer.validate:
             # Check validation metric for early stopping
             trainer.latest_val_metric = trainer.val_metrics[self.validation_metric]

--- a/allennlp/training/callbacks/track_metrics.py
+++ b/allennlp/training/callbacks/track_metrics.py
@@ -87,7 +87,7 @@ class TrackMetrics(Callback):
             self.gpu_usage.append((gpu, memory))
             logger.info(f"GPU {gpu} memory usage MB: {memory}")
 
-
+    # We want to collect training metrics before the actual validation happens
     @handle_event(Events.VALIDATE, priority=-100)
     def collect_train_metrics(self, trainer: 'CallbackTrainer'):
         trainer.train_metrics = training_util.get_metrics(trainer.model,
@@ -106,6 +106,7 @@ class TrackMetrics(Callback):
             if key.startswith('gpu_'):
                 trainer.metrics["peak_"+key] = max(trainer.metrics.get("peak_"+key, 0), value)
 
+    # We want to collect validation metrics after the validation happens
     @handle_event(Events.VALIDATE, priority=100)
     def collect_val_metrics(self, trainer: 'CallbackTrainer'):
         if trainer.validate:

--- a/allennlp/training/callbacks/train_supervised.py
+++ b/allennlp/training/callbacks/train_supervised.py
@@ -60,4 +60,6 @@ class TrainSupervised(Callback):
         trainer.optimizer.step()
 
         # Update the description with the latest metrics
-        trainer.train_metrics = training_util.get_metrics(trainer.model, trainer.train_loss, trainer.batches_this_epoch)
+        trainer.train_metrics = training_util.get_metrics(trainer.model, 
+                                                          trainer.train_loss, 
+                                                          trainer.batches_this_epoch)

--- a/allennlp/training/callbacks/train_supervised.py
+++ b/allennlp/training/callbacks/train_supervised.py
@@ -60,6 +60,6 @@ class TrainSupervised(Callback):
         trainer.optimizer.step()
 
         # Update the description with the latest metrics
-        trainer.train_metrics = training_util.get_metrics(trainer.model, 
-                                                          trainer.train_loss, 
+        trainer.train_metrics = training_util.get_metrics(trainer.model,
+                                                          trainer.train_loss,
                                                           trainer.batches_this_epoch)

--- a/allennlp/training/callbacks/train_supervised.py
+++ b/allennlp/training/callbacks/train_supervised.py
@@ -60,6 +60,4 @@ class TrainSupervised(Callback):
         trainer.optimizer.step()
 
         # Update the description with the latest metrics
-        trainer.train_metrics.update(
-                training_util.get_metrics(trainer.model, trainer.train_loss, trainer.batches_this_epoch)
-        )
+        trainer.train_metrics = training_util.get_metrics(trainer.model, trainer.train_loss, trainer.batches_this_epoch)


### PR DESCRIPTION
This is a workaround that I am currently using for issue #3001.
Just changed the priorities a bit to make it work.

Another minor fix that I added is to assign trainer.train_metrics instead of update in train_supervised.py.
Originally that was causing cpu memory information to appear in tqdm which made it too long