### PR TITLE
Add two optimize parameters for BeamSearch

### DIFF
--- a/allennlp/nn/beam_search.py
+++ b/allennlp/nn/beam_search.py
@@ -1,16 +1,14 @@
 from typing import List, Callable, Tuple, Dict
 import warnings
-
 import torch
 
 from allennlp.common.checks import ConfigurationError
-
 
 StateType = Dict[str, torch.Tensor]  # pylint: disable=invalid-name
 StepFunctionType = Callable[[torch.Tensor, StateType], Tuple[torch.Tensor, StateType]]  # pylint: disable=invalid-name
 
 
-class BeamSearch:
+class BeamSearchX:
     """
     Implements the beam search algorithm for decoding the most likely sequences.
 
@@ -29,17 +27,48 @@ class BeamSearch:
         to a number smaller than ``beam_size`` may give better results, as it can introduce
         more diversity into the search. See `Beam Search Strategies for Neural Machine Translation.
         Freitag and Al-Onaizan, 2017 <http://arxiv.org/abs/1702.01806>`_.
+
+    stochastic_beam_search : ``default``, optional (default = False)
+        The basic version of beam search can get stuck in local maximum as well.
+        To help avoid this, stochastic beam search picks children with probability relative to their values.
+    score_normalize : ``default``, optional (default = False)
+        Original beam search tends to choose shorter sequence ( cause the score will drop as the length rise).
+        So devide the score by their length may help avoid this.
+        To avoid the devide by 0, we set the intial length as 1
     """
 
     def __init__(self,
                  end_index: int,
                  max_steps: int = 50,
                  beam_size: int = 10,
-                 per_node_beam_size: int = None) -> None:
+                 per_node_beam_size: int = None,
+                 stochastic_beam_search: bool = False,
+                 score_normalize: bool = False) -> None:
         self._end_index = end_index
         self.max_steps = max_steps
         self.beam_size = beam_size
         self.per_node_beam_size = per_node_beam_size or beam_size
+        self.stochastic = stochastic_beam_search,
+        self.normalization = score_normalize
+
+    def _sample_topk(self, log_prob: torch.Tensor, sample_size: int):
+        """
+        Sample size items according to their probabilities.
+        Make the input and output style same as ``torch.topk``
+
+        :param log_prob: ``torch.Tensor``
+            Use ``torch.multinomial`` to sample items from input(specifically get their indexes).
+            But the log tensor is negative, so we use torch.exp to formalize it,
+            Then we could get them according the indexes
+        :param sample_size: num of items
+        :return:
+        """
+        original_prob = torch.exp(log_prob)
+        original_prob += 1e-30  # comfirm no zero tensors
+        sample_index = torch.multinomial(original_prob, sample_size)
+        sample_log_prob = log_prob.gather(dim=1, index=sample_index)
+
+        return sample_log_prob, sample_index
 
     def search(self,
                start_predictions: torch.Tensor,
@@ -117,10 +146,14 @@ class BeamSearch:
             raise ConfigurationError(f"Target vocab size ({num_classes:d}) too small "
                                      f"relative to per_node_beam_size ({self.per_node_beam_size:d}).\n"
                                      f"Please decrease beam_size or per_node_beam_size.")
-
-        # shape: (batch_size, beam_size), (batch_size, beam_size)
-        start_top_log_probabilities, start_predicted_classes = \
+        if self.stochastic:
+            start_top_log_probabilities, start_predicted_classes = \
+                self._sample_topk(start_class_log_probabilities, self.beam_size)
+        else:
+            # shape: (batch_size, beam_size), (batch_size, beam_size)
+            start_top_log_probabilities, start_predicted_classes = \
                 start_class_log_probabilities.topk(self.beam_size)
+
         if self.beam_size == 1 and (start_predicted_classes == self._end_index).all():
             warnings.warn("Empty sequences predicted. You may want to increase the beam size or ensure "
                           "your step function is working properly.",
@@ -137,8 +170,8 @@ class BeamSearch:
         # Log probability tensor that mandates that the end token is selected.
         # shape: (batch_size * beam_size, num_classes)
         log_probs_after_end = start_class_log_probabilities.new_full(
-                (batch_size * self.beam_size, num_classes),
-                float("-inf")
+            (batch_size * self.beam_size, num_classes),
+            float("-inf")
         )
         log_probs_after_end[:, self._end_index] = 0.
 
@@ -146,13 +179,14 @@ class BeamSearch:
         for key, state_tensor in state.items():
             _, *last_dims = state_tensor.size()
             # shape: (batch_size * beam_size, *)
-            state[key] = state_tensor.\
-                    unsqueeze(1).\
-                    expand(batch_size, self.beam_size, *last_dims).\
-                    reshape(batch_size * self.beam_size, *last_dims)
+            state[key] = state_tensor. \
+                unsqueeze(1). \
+                expand(batch_size, self.beam_size, *last_dims). \
+                reshape(batch_size * self.beam_size, *last_dims)
 
         for timestep in range(self.max_steps - 1):
             # shape: (batch_size * beam_size,)
+
             last_predictions = predictions[-1].reshape(batch_size * self.beam_size)
 
             # If every predicted token from the last step is `self._end_index`,
@@ -167,8 +201,8 @@ class BeamSearch:
 
             # shape: (batch_size * beam_size, num_classes)
             last_predictions_expanded = last_predictions.unsqueeze(-1).expand(
-                    batch_size * self.beam_size,
-                    num_classes
+                batch_size * self.beam_size,
+                num_classes
             )
 
             # Here we are finding any beams where we predicted the end token in
@@ -177,38 +211,46 @@ class BeamSearch:
             # this timestep as well.
             # shape: (batch_size * beam_size, num_classes)
             cleaned_log_probabilities = torch.where(
-                    last_predictions_expanded == self._end_index,
-                    log_probs_after_end,
-                    class_log_probabilities
+                last_predictions_expanded == self._end_index,
+                log_probs_after_end,
+                class_log_probabilities
             )
 
-            # shape (both): (batch_size * beam_size, per_node_beam_size)
-            top_log_probabilities, predicted_classes = \
-                cleaned_log_probabilities.topk(self.per_node_beam_size)
+            if self.stochastic:
+                top_log_probabilities, predicted_classes = \
+                    self._sample_topk(cleaned_log_probabilities, self.per_node_beam_size)
+            else:
+                # shape (both): (batch_size * beam_size, per_node_beam_size)
+                top_log_probabilities, predicted_classes = \
+                    cleaned_log_probabilities.topk(self.per_node_beam_size)
 
             # Here we expand the last log probabilities to (batch_size * beam_size, per_node_beam_size)
             # so that we can add them to the current log probs for this timestep.
             # This lets us maintain the log probability of each element on the beam.
             # shape: (batch_size * beam_size, per_node_beam_size)
-            expanded_last_log_probabilities = last_log_probabilities.\
-                    unsqueeze(2).\
-                    expand(batch_size, self.beam_size, self.per_node_beam_size).\
-                    reshape(batch_size * self.beam_size, self.per_node_beam_size)
+            expanded_last_log_probabilities = last_log_probabilities. \
+                unsqueeze(2). \
+                expand(batch_size, self.beam_size, self.per_node_beam_size). \
+                reshape(batch_size * self.beam_size, self.per_node_beam_size)
 
             # shape: (batch_size * beam_size, per_node_beam_size)
             summed_top_log_probabilities = top_log_probabilities + expanded_last_log_probabilities
 
             # shape: (batch_size, beam_size * per_node_beam_size)
-            reshaped_summed = summed_top_log_probabilities.\
-                    reshape(batch_size, self.beam_size * self.per_node_beam_size)
+            reshaped_summed = summed_top_log_probabilities. \
+                reshape(batch_size, self.beam_size * self.per_node_beam_size)
 
             # shape: (batch_size, beam_size * per_node_beam_size)
-            reshaped_predicted_classes = predicted_classes.\
-                    reshape(batch_size, self.beam_size * self.per_node_beam_size)
+            reshaped_predicted_classes = predicted_classes. \
+                reshape(batch_size, self.beam_size * self.per_node_beam_size)
 
             # Keep only the top `beam_size` beam indices.
             # shape: (batch_size, beam_size), (batch_size, beam_size)
-            restricted_beam_log_probs, restricted_beam_indices = reshaped_summed.topk(self.beam_size)
+            if self.stochastic:
+                restricted_beam_log_probs, restricted_beam_indices = \
+                    self._sample_topk(reshaped_summed, self.beam_size)
+            else:
+                restricted_beam_log_probs, restricted_beam_indices = reshaped_summed.topk(self.beam_size)
 
             # Use the beam indices to extract the corresponding classes.
             # shape: (batch_size, beam_size)
@@ -233,15 +275,15 @@ class BeamSearch:
             for key, state_tensor in state.items():
                 _, *last_dims = state_tensor.size()
                 # shape: (batch_size, beam_size, *)
-                expanded_backpointer = backpointer.\
-                        view(batch_size, self.beam_size, *([1] * len(last_dims))).\
-                        expand(batch_size, self.beam_size, *last_dims)
+                expanded_backpointer = backpointer. \
+                    view(batch_size, self.beam_size, *([1] * len(last_dims))). \
+                    expand(batch_size, self.beam_size, *last_dims)
 
                 # shape: (batch_size * beam_size, *)
-                state[key] = state_tensor.\
-                        reshape(batch_size, self.beam_size, *last_dims).\
-                        gather(1, expanded_backpointer).\
-                        reshape(batch_size * self.beam_size, *last_dims)
+                state[key] = state_tensor. \
+                    reshape(batch_size, self.beam_size, *last_dims). \
+                    gather(1, expanded_backpointer). \
+                    reshape(batch_size * self.beam_size, *last_dims)
 
         if not torch.isfinite(last_log_probabilities).all():
             warnings.warn("Infinite log probabilities encountered. Some final sequences may not make sense. "
@@ -272,5 +314,12 @@ class BeamSearch:
 
         # shape: (batch_size, beam_size, max_steps)
         all_predictions = torch.cat(list(reversed(reconstructed_predictions)), 2)
+        if self.normalization:
+            valid_length = all_predictions.ne(self._end_index)
+            valid_length = torch.sum(valid_length, dim=-1)
+            fill_value = torch.ones_like(valid_length)
+            valid_length = torch.where(valid_length == 0, fill_value, valid_length)  # confirm length is not 0
+            valid_length = valid_length.float()
+            last_log_probabilities = last_log_probabilities / valid_length
 
         return all_predictions, last_log_probabilities


### PR DESCRIPTION
###  1. stochastic_beam_search
The basic version of beam search can get stuck in local maximum as well. To help avoid this, stochastic beam search picks children with probability relative to their values. 
I "rewrite" a new class method `_sample_topk` and confirm the style same as `torch.topk`, if this parameter is True, use `_sample_topk` to replace `torch.topk`

### 2. score_normalize 
Original beam search tends to choose shorter sequence ( cause the score will drop as the length rise).So devide the score by their length may help avoid this. To avoid the devide by 0, we set the intial length as 1