### PR TITLE
Expose the spacy language model for the word splitter in the semantic role label predictor. 

### DIFF
--- a/allennlp/predictors/semantic_role_labeler.py
+++ b/allennlp/predictors/semantic_role_labeler.py
@@ -15,9 +15,9 @@ class SemanticRoleLabelerPredictor(Predictor):
     """
     Predictor for the :class:`~allennlp.models.bidaf.SemanticRoleLabeler` model.
     """
-    def __init__(self, model: Model, dataset_reader: DatasetReader) -> None:
+    def __init__(self, model: Model, dataset_reader: DatasetReader, language: str = 'en_core_web_sm') -> None:
         super().__init__(model, dataset_reader)
-        self._tokenizer = SpacyWordSplitter(language='en_core_web_sm', pos_tags=True)
+        self._tokenizer = SpacyWordSplitter(language=language, pos_tags=True)
 
     def predict(self, sentence: str) -> JsonDict:
         """


### PR DESCRIPTION
This change exposes the Spacy model string in the constructor for the Semantic Role Labeler predictor. 

We currently monkey patch this as we use the large model in spacy and need the tokenization to be consistent. 