### PR TITLE
Multilabel bug

### DIFF
--- a/allennlp/data/fields/multilabel_field.py
+++ b/allennlp/data/fields/multilabel_field.py
@@ -60,7 +60,7 @@ class MultiLabelField(Field[torch.Tensor]):
         self._maybe_warn_for_namespace(label_namespace)
         self._num_labels = num_labels
 
-        if skip_indexing:
+        if skip_indexing and self.labels:
             if not all(isinstance(label, int) for label in labels):
                 raise ConfigurationError("In order to skip indexing, your labels must be integers. "
                                          "Found labels = {}".format(labels))

--- a/allennlp/tests/data/fields/multilabel_field_test.py
+++ b/allennlp/tests/data/fields/multilabel_field_test.py
@@ -55,7 +55,10 @@ class TestMultiLabelField(AllenNlpTestCase):
         f.index(vocab)
         tensor = f.as_tensor(f.get_padding_lengths()).detach().cpu().numpy()
         numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 0]))
-        f.empty_field()
+        g = f.empty_field()
+        g.index(vocab)
+        tensor = g.as_tensor(g.get_padding_lengths()).detach().cpu().numpy()
+        numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 0]))
 
     def test_class_variables_for_namespace_warnings_work_correctly(self):
         # pylint: disable=protected-access

--- a/allennlp/tests/data/fields/multilabel_field_test.py
+++ b/allennlp/tests/data/fields/multilabel_field_test.py
@@ -55,6 +55,7 @@ class TestMultiLabelField(AllenNlpTestCase):
         f.index(vocab)
         tensor = f.as_tensor(f.get_padding_lengths()).detach().cpu().numpy()
         numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 0]))
+        f.empty_field()
 
     def test_class_variables_for_namespace_warnings_work_correctly(self):
         # pylint: disable=protected-access


### PR DESCRIPTION
Fixes #2415
Basically we don't check the configuration errors if labels is empty