### PR TITLE
Avoid divide by zero in boolean_accuracy.py

### DIFF
--- a/allennlp/training/metrics/boolean_accuracy.py
+++ b/allennlp/training/metrics/boolean_accuracy.py
@@ -84,7 +84,10 @@ class BooleanAccuracy(Metric):
         -------
         The accumulated accuracy.
         """
-        accuracy = float(self._correct_count) / float(self._total_count)
+        if self.total_count > 1e-12:
+            accuracy = float(self.correct_count) / float(self.total_count)
+        else:
+            accuracy = 0.0
         if reset:
             self.reset()
         return accuracy

--- a/allennlp/training/metrics/boolean_accuracy.py
+++ b/allennlp/training/metrics/boolean_accuracy.py
@@ -84,8 +84,8 @@ class BooleanAccuracy(Metric):
         -------
         The accumulated accuracy.
         """
-        if self.total_count > 1e-12:
-            accuracy = float(self.correct_count) / float(self.total_count)
+        if self._total_count > 1e-12:
+            accuracy = float(self.correct_count) / float(self._total_count)
         else:
             accuracy = 0.0
         if reset:

--- a/allennlp/training/metrics/boolean_accuracy.py
+++ b/allennlp/training/metrics/boolean_accuracy.py
@@ -85,7 +85,7 @@ class BooleanAccuracy(Metric):
         The accumulated accuracy.
         """
         if self._total_count > 1e-12:
-            accuracy = float(self.correct_count) / float(self._total_count)
+            accuracy = float(self._correct_count) / float(self._total_count)
         else:
             accuracy = 0.0
         if reset:


### PR DESCRIPTION
If you call model.get_metrics(reset=True) before saving any metric this function throws an error.