### PR TITLE
Fix issue #2669

### DIFF
--- a/allennlp/data/iterators/data_iterator.py
+++ b/allennlp/data/iterators/data_iterator.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 TensorDict = Dict[str, Union[torch.Tensor, Dict[str, torch.Tensor]]]  # pylint: disable=invalid-name
 
 
-def add_epoch_number(batch: Iterable[Instance], epoch: int) -> Iterable[Instance]:
+def add_epoch_number(batch: Iterable[Instance], epoch: int) -> None:
     """
     Add the epoch number to the batch instances as a MetadataField.
     """

--- a/allennlp/tests/data/iterators/basic_iterator_test.py
+++ b/allennlp/tests/data/iterators/basic_iterator_test.py
@@ -11,12 +11,14 @@ from allennlp.data.fields import TextField
 from allennlp.data.iterators import BasicIterator
 from allennlp.data.token_indexers import SingleIdTokenIndexer
 
+
 class LazyIterable:
     def __init__(self, instances):
         self._instances = instances
 
     def __iter__(self):
         return (instance for instance in self._instances)
+
 
 class IteratorTest(AllenNlpTestCase):
     def setUp(self):
@@ -165,7 +167,6 @@ class TestBasicIterator(IteratorTest):
                                          [self.instances[1], self.instances[2]],
                                          [self.instances[3]]]
 
-
     def test_epoch_tracking_when_one_epoch_at_a_time(self):
         iterator = BasicIterator(batch_size=2, track_epoch=True)
         iterator.index_with(self.vocab)
@@ -184,7 +185,6 @@ class TestBasicIterator(IteratorTest):
             epoch = i // 3
             assert all(epoch_num == epoch for epoch_num in batch['epoch_num'])
 
-
     def test_epoch_tracking_forever(self):
         iterator = BasicIterator(batch_size=2, track_epoch=True)
         iterator.index_with(self.vocab)
@@ -199,6 +199,19 @@ class TestBasicIterator(IteratorTest):
             epoch = i // 3
             assert all(epoch_num == epoch for epoch_num in batch['epoch_num'])
 
+    def test_epoch_tracking_forever_instances_per_epoch(self):
+        iterator = BasicIterator(batch_size=2, track_epoch=True, instances_per_epoch=4)
+        iterator.index_with(self.vocab)
+
+        it = iterator(self.instances, num_epochs=None)
+
+        all_batches = [next(it) for _ in range(30)]
+
+        assert len(all_batches) == 30
+        for i, batch in enumerate(all_batches):
+            # Should have 3 batches per epoch
+            epoch = i // 2
+            assert all(epoch_num == epoch for epoch_num in batch['epoch_num'])
 
     def test_shuffle(self):
         # pylint: disable=protected-access


### PR DESCRIPTION
The problem was described pretty well by @danieldeutsch, but I'll have to repeat its explaination in more details step by step.
1) `BasicIterator` is created with `instances_per_epoch` argument. Next `DataIterator.__call__` is used upon list of instances.
2) `BasicIterator._create_batches` is called, which in turns uses `DataIterator._memory_sized_lists`.
3) Finally control goes to `DataIterator._take_instances`, which yields amount of instances equal to  `instances_per_epoch` specified at step 1.
https://github.com/allenai/allennlp/blob/014fe3187d7314f2de3970943db5a8870ad5881b/allennlp/data/iterators/data_iterator.py#L173-L189
4) After that control comes back to `DataIterator.__call__`, epoch number metadata is added and the batch is yielded.
https://github.com/allenai/allennlp/blob/014fe3187d7314f2de3970943db5a8870ad5881b/allennlp/data/iterators/data_iterator.py#L143-L158
5) Next we return to `BasicIterator._create_batches` and create a Batch object from list of yielded instances https://github.com/allenai/allennlp/blob/014fe3187d7314f2de3970943db5a8870ad5881b/allennlp/data/iterators/basic_iterator.py#L31
6) During object creation a check conducted: https://github.com/allenai/allennlp/blob/014fe3187d7314f2de3970943db5a8870ad5881b/allennlp/data/dataset.py#L35-L44
That is precisely where the error occurs. In case without `instances_per_epoch` all instances get metadata field and thus they have no metadata field during first epoch, and have that field afterwards.
In case with `instances_per_epoch` some objects were not used during the first epoch and when they got mixed with objects that were used the check for equal fields fails.

I decided to call `add_epoch_batches` before Batch object is constructed and added a special unit test for it.