### PR TITLE
pass cache_directory and cache_prefix to non-default trainers

### DIFF
--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -236,7 +236,7 @@ def train_model(params: Params,
                              "to evaluate at Events.TRAINING_END; otherwise you'll have "
                              "to run allennlp evaluate separately.")
 
-        trainer = TrainerBase.from_params(params, serialization_dir, recover)
+        trainer = TrainerBase.from_params(params, serialization_dir, recover, cache_directory, cache_prefix)
         evaluation_dataset = None
 
     params.assert_empty('base train command')

--- a/allennlp/tests/training/gan_trainer_test.py
+++ b/allennlp/tests/training/gan_trainer_test.py
@@ -274,7 +274,9 @@ class GanTestTrainer(TrainerBase):
     def from_params(cls,   # type: ignore
                     params: Params,
                     serialization_dir: str,
-                    recover: bool = False) -> 'GanTestTrainer':
+                    recover: bool = False,
+                    cache_directory: str = None,
+                    cache_prefix: str = None) -> 'GanTestTrainer':
         dataset_reader = DatasetReader.from_params(params.pop("data_reader"))
         data = dataset_reader.read("")
 

--- a/allennlp/tests/training/multi_task_trainer_test.py
+++ b/allennlp/tests/training/multi_task_trainer_test.py
@@ -234,7 +234,9 @@ class MultiTaskTrainer(TrainerBase):
     def from_params(cls,   # type: ignore
                     params: Params,
                     serialization_dir: str,
-                    recover: bool = False) -> 'MultiTaskTrainer':
+                    recover: bool = False,
+                    cache_directory: str = None,
+                    cache_prefix: str = None) -> 'MultiTaskTrainer':
         readers = {name: DatasetReader.from_params(reader_params)
                    for name, reader_params in params.pop("train_dataset_readers").items()}
         train_file_paths = params.pop("train_file_paths").as_dict()

--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -265,8 +265,10 @@ class CallbackTrainer(TrainerBase):
     def from_params(cls,  # type: ignore
                     params: Params,
                     serialization_dir: str,
-                    recover: bool = False) -> 'CallbackTrainer':
-        pieces = TrainerPieces.from_params(params, serialization_dir, recover)  # pylint: disable=no-member
+                    recover: bool = False,
+                    cache_directory: str = None,
+                    cache_prefix: str = None) -> 'CallbackTrainer':
+        pieces = TrainerPieces.from_params(params, serialization_dir, recover, cache_directory, cache_prefix)  # pylint: disable=no-member
         model = pieces.model
         params = pieces.params
         validation_iterator = pieces.validation_iterator or pieces.iterator

--- a/allennlp/training/no_op_trainer.py
+++ b/allennlp/training/no_op_trainer.py
@@ -23,9 +23,11 @@ class NoOpTrainer(TrainerBase):
     def from_params(cls,   # type: ignore
                     params: Params,
                     serialization_dir: str,
-                    recover: bool = False):
+                    recover: bool = False,
+                    cache_directory: str = None,
+                    cache_prefix: str = None):
         # pylint: disable=arguments-differ
-        pieces = TrainerPieces.from_params(params, serialization_dir, recover)  # pylint: disable=no-member
+        pieces = TrainerPieces.from_params(params, serialization_dir, recover, cache_directory, cache_prefix)  # pylint: disable=no-member
         return NoOpTrainer(serialization_dir, pieces.model)
 
     def train(self) -> Dict[str, Any]:

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -60,7 +60,9 @@ class TrainerBase(Registrable):
     def from_params(cls,   # type: ignore
                     params: Params,
                     serialization_dir: str,
-                    recover: bool = False):
+                    recover: bool = False,
+                    cache_directory: str = None,
+                    cache_prefix: str = None):
         # pylint: disable=arguments-differ
         typ3 = params.get("trainer", {}).pop("type", "default")
 
@@ -69,7 +71,7 @@ class TrainerBase(Registrable):
             from allennlp.training.trainer import Trainer
             from allennlp.training.trainer_pieces import TrainerPieces
 
-            pieces = TrainerPieces.from_params(params, serialization_dir, recover)  # pylint: disable=no-member
+            pieces = TrainerPieces.from_params(params, serialization_dir, recover, cache_directory, cache_prefix)  # pylint: disable=no-member
             return Trainer.from_params(model=pieces.model,
                                        serialization_dir=serialization_dir,
                                        iterator=pieces.iterator,
@@ -82,4 +84,4 @@ class TrainerBase(Registrable):
             # Explicit check to prevent recursion.
             is_overriden = klass.from_params.__func__ != TrainerBase.from_params.__func__ # type: ignore
             assert is_overriden, f"Class {klass.__name__} must override `from_params`."
-            return klass.from_params(params, serialization_dir, recover)
+            return klass.from_params(params, serialization_dir, recover, cache_directory, cache_prefix)


### PR DESCRIPTION
Currently the command line options `--cache-directory` and `--cache-prefix` are only utilized when using the default trainer, so they are ignored when using the callback trainer or any other custom trainer. This fixes that.