### PR TITLE
Fix MetadataField.batch_tensors

### DIFF
--- a/allennlp/data/fields/metadata_field.py
+++ b/allennlp/data/fields/metadata_field.py
@@ -58,9 +58,8 @@ class MetadataField(Field[DataArray], Mapping[str, Any]):
     def empty_field(self) -> 'MetadataField':
         return MetadataField(None)
 
-    @classmethod
     @overrides
-    def batch_tensors(cls, tensor_list: List[DataArray]) -> List[DataArray]:  # type: ignore
+    def batch_tensors(self, tensor_list: List[DataArray]) -> List[DataArray]:  # type: ignore
         return tensor_list
 
 


### PR DESCRIPTION
Unless I'm missing something, I think this was a typo: the overridden method `MetadataField.batch_tensors` was as annotated as a `classmethod` even though it should be a instance-bound method.