### PR TITLE
Close tensorboard's event files properly at the end of the training

### DIFF
--- a/allennlp/training/callbacks/log_to_tensorboard.py
+++ b/allennlp/training/callbacks/log_to_tensorboard.py
@@ -107,6 +107,10 @@ class LogToTensorboard(Callback):
                                      log_to_console=True,
                                      epoch=trainer.epoch_number + 1)
 
+    @handle_event(Events.TRAINING_END)
+    def training_end(self, trainer: 'CallbackTrainer'):
+        self.tensorboard.close()
+
     @classmethod
     def from_params(cls, serialization_dir: str, params: Params) -> 'LogToTensorboard':  # type: ignore
         log_batch_size_period = params.pop_int("log_batch_size_period", None)

--- a/allennlp/training/callbacks/log_to_tensorboard.py
+++ b/allennlp/training/callbacks/log_to_tensorboard.py
@@ -109,6 +109,7 @@ class LogToTensorboard(Callback):
 
     @handle_event(Events.TRAINING_END)
     def training_end(self, trainer: 'CallbackTrainer'):
+        # pylint: disable=unused-argument
         self.tensorboard.close()
 
     @classmethod

--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -214,7 +214,7 @@ class TensorboardWriter(FromParams):
 
     def close(self) -> None:
         """
-        Calls the `close` method of the `SummaryWriter`s which makes sure that pending
+        Calls the ``close`` method of the ``SummaryWriter`` s which makes sure that pending
         scalars are flushed to disk and the tensorboard event files are closed properly.
         """
         if self._train_log is not None:

--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -211,3 +211,13 @@ class TensorboardWriter(FromParams):
         else:
             # skip it
             pass
+
+    def close(self) -> None:
+        """
+        Calls the `close` method of the `SummaryWriter`s which makes sure that pending
+        scalars are flushed to disk and the tensorboard event files are closed properly.
+        """
+        if self._train_log is not None:
+            self._train_log.close()
+        if self._validation_log is not None:
+            self._validation_log.close()

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -549,6 +549,9 @@ class Trainer(TrainerBase):
 
             epochs_trained += 1
 
+        # make sure pending events are flushed to disk and files are closed properly
+        self._tensorboard.close()
+
         # Load the best model state before returning
         best_model_state = self._checkpointer.best_model_state()
         if best_model_state:


### PR DESCRIPTION
This PR addresses #3082 .
Issue: At the end of a training run, pending events are not flushed to disk and tensorboard's event files are not closed properly.

Solution: Call the `close` method of the `SummaryWriter` at the end of the training. I added this call to the "normal" trainer as well as to the callback trainer.

Not sure if the introduced `close` method in the `TensorboardWriter` needs a unit test though.