### PR TITLE
Fix pearson correlation.py

### DIFF
--- a/allennlp/tests/training/metrics/pearson_correlation_test.py
+++ b/allennlp/tests/training/metrics/pearson_correlation_test.py
@@ -6,55 +6,82 @@ from numpy.testing import assert_allclose
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.training.metrics import PearsonCorrelation
 
+def pearson_corrcoef(predictions, labels, fweights=None):
+    covariance_matrices = np.cov(predictions, labels, fweights=fweights)
+    denominator = np.sqrt(covariance_matrices[0, 0] * covariance_matrices[1, 1])
+    if np.around(denominator, decimals=5) == 0:
+        expected_pearson_correlation = 0
+    else:
+        expected_pearson_correlation = covariance_matrices[0, 1] / denominator
+    return expected_pearson_correlation
+
 
 class PearsonCorrelationTest(AllenNlpTestCase):
     def test_pearson_correlation_unmasked_computation(self):
         pearson_correlation = PearsonCorrelation()
         batch_size = 100
         num_labels = 10
-        predictions = np.random.randn(batch_size, num_labels).astype("float32")
-        labels = 0.5 * predictions + np.random.randn(batch_size, num_labels).astype("float32")
+        predictions_1 = np.random.randn(batch_size, num_labels).astype("float32")
+        labels_1 = 0.5 * predictions_1 + np.random.randn(batch_size, num_labels).astype("float32")
+
+        predictions_2 = np.random.randn(1).repeat(num_labels).astype("float32")
+        predictions_2 = predictions_2[np.newaxis, :].repeat(batch_size, axis=0)
+        labels_2 = np.random.randn(1).repeat(num_labels).astype("float32")
+        labels_2 = 0.5 * predictions_2 + labels_2[np.newaxis, :].repeat(batch_size, axis=0)
+
+        predictions_labels = [(predictions_1, labels_1), (predictions_2, labels_2)]
 
         stride = 10
 
-        for i in range(batch_size // stride):
-            timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
-            timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
-            expected_pearson_correlation = np.corrcoef(predictions[:stride * (i + 1), :].reshape(-1),
-                                                       labels[:stride * (i + 1), :].reshape(-1))[0, 1]
-            pearson_correlation(timestep_predictions, timestep_labels)
-            assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
-        # Test reset
-        pearson_correlation.reset()
-        pearson_correlation(torch.FloatTensor(predictions), torch.FloatTensor(labels))
-        assert_allclose(np.corrcoef(predictions.reshape(-1), labels.reshape(-1))[0, 1],
-                        pearson_correlation.get_metric(), rtol=1e-5)
+        for predictions, labels in predictions_labels:
+            pearson_correlation.reset()
+            for i in range(batch_size // stride):
+                timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
+                timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
+                expected_pearson_correlation = pearson_corrcoef(predictions[:stride * (i + 1), :].reshape(-1),
+                                                           labels[:stride * (i + 1), :].reshape(-1))
+                pearson_correlation(timestep_predictions, timestep_labels)
+                assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
+            # Test reset
+            pearson_correlation.reset()
+            pearson_correlation(torch.FloatTensor(predictions), torch.FloatTensor(labels))
+            assert_allclose(pearson_corrcoef(predictions.reshape(-1), labels.reshape(-1)),
+                            pearson_correlation.get_metric(), rtol=1e-5)
 
     def test_pearson_correlation_masked_computation(self):
         pearson_correlation = PearsonCorrelation()
         batch_size = 100
         num_labels = 10
-        predictions = np.random.randn(batch_size, num_labels).astype("float32")
-        labels = 0.5 * predictions + np.random.randn(batch_size, num_labels).astype("float32")
+        predictions_1 = np.random.randn(batch_size, num_labels).astype("float32")
+        labels_1 = 0.5 * predictions_1 + np.random.randn(batch_size, num_labels).astype("float32")
+
+        predictions_2 = np.random.randn(1).repeat(num_labels).astype("float32")
+        predictions_2 = predictions_2[np.newaxis, :].repeat(batch_size, axis=0)
+        labels_2 = np.random.randn(1).repeat(num_labels).astype("float32")
+        labels_2 = 0.5 * predictions_2 + labels_2[np.newaxis, :].repeat(batch_size, axis=0)
+
+        predictions_labels = [(predictions_1, labels_1), (predictions_2, labels_2)]
+
         # Random binary mask
         mask = np.random.randint(0, 2, size=(batch_size, num_labels)).astype("float32")
         stride = 10
 
-        for i in range(batch_size // stride):
-            timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
-            timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
-            timestep_mask = torch.FloatTensor(mask[stride * i:stride * (i+1), :])
-            covariance_matrices = np.cov(predictions[:stride * (i + 1), :].reshape(-1),
-                                         labels[:stride * (i + 1), :].reshape(-1),
-                                         fweights=mask[:stride * (i + 1), :].reshape(-1))
-            expected_pearson_correlation = covariance_matrices[0, 1] / np.sqrt(covariance_matrices[0, 0] *
-                                                                               covariance_matrices[1, 1])
-            pearson_correlation(timestep_predictions, timestep_labels, timestep_mask)
+        for predictions, labels in predictions_labels:
+            pearson_correlation.reset()
+            for i in range(batch_size // stride):
+                timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
+                timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
+                timestep_mask = torch.FloatTensor(mask[stride * i:stride * (i+1), :])
+                expected_pearson_correlation = pearson_corrcoef(predictions[:stride * (i + 1), :].reshape(-1),
+                                             labels[:stride * (i + 1), :].reshape(-1),
+                                             fweights=mask[:stride * (i + 1), :].reshape(-1))
+
+                pearson_correlation(timestep_predictions, timestep_labels, timestep_mask)
+                assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
+            # Test reset
+            pearson_correlation.reset()
+            pearson_correlation(torch.FloatTensor(predictions), torch.FloatTensor(labels), torch.FloatTensor(mask))
+            expected_pearson_correlation = pearson_corrcoef(predictions.reshape(-1), labels.reshape(-1), fweights=mask.reshape(-1))
+
             assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
-        # Test reset
-        pearson_correlation.reset()
-        pearson_correlation(torch.FloatTensor(predictions), torch.FloatTensor(labels), torch.FloatTensor(mask))
-        covariance_matrices = np.cov(predictions.reshape(-1), labels.reshape(-1), fweights=mask.reshape(-1))
-        expected_pearson_correlation = covariance_matrices[0, 1] / np.sqrt(covariance_matrices[0, 0] *
-                                                                           covariance_matrices[1, 1])
-        assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
+

--- a/allennlp/tests/training/metrics/pearson_correlation_test.py
+++ b/allennlp/tests/training/metrics/pearson_correlation_test.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.training.metrics import PearsonCorrelation
 
+
 def pearson_corrcoef(predictions, labels, fweights=None):
     covariance_matrices = np.cov(predictions, labels, fweights=fweights)
     denominator = np.sqrt(covariance_matrices[0, 0] * covariance_matrices[1, 1])
@@ -28,7 +29,7 @@ class PearsonCorrelationTest(AllenNlpTestCase):
         predictions_2 = predictions_2[np.newaxis, :].repeat(batch_size, axis=0)
         labels_2 = np.random.randn(1).repeat(num_labels).astype("float32")
         labels_2 = 0.5 * predictions_2 + labels_2[np.newaxis, :].repeat(batch_size, axis=0)
-        
+
         # in most cases, the data is constructed like predictions_1, the data of such a batch different.
         # but in a few cases, for example, predictions_2, the data of such a batch is exactly the same.
         predictions_labels = [(predictions_1, labels_1), (predictions_2, labels_2)]
@@ -38,10 +39,10 @@ class PearsonCorrelationTest(AllenNlpTestCase):
         for predictions, labels in predictions_labels:
             pearson_correlation.reset()
             for i in range(batch_size // stride):
-                timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
-                timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
+                timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i + 1), :])
+                timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i + 1), :])
                 expected_pearson_correlation = pearson_corrcoef(predictions[:stride * (i + 1), :].reshape(-1),
-                                                           labels[:stride * (i + 1), :].reshape(-1))
+                                                                labels[:stride * (i + 1), :].reshape(-1))
                 pearson_correlation(timestep_predictions, timestep_labels)
                 assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
             # Test reset
@@ -71,18 +72,20 @@ class PearsonCorrelationTest(AllenNlpTestCase):
         for predictions, labels in predictions_labels:
             pearson_correlation.reset()
             for i in range(batch_size // stride):
-                timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
-                timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
-                timestep_mask = torch.FloatTensor(mask[stride * i:stride * (i+1), :])
+                timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i + 1), :])
+                timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i + 1), :])
+                timestep_mask = torch.FloatTensor(mask[stride * i:stride * (i + 1), :])
                 expected_pearson_correlation = pearson_corrcoef(predictions[:stride * (i + 1), :].reshape(-1),
-                                             labels[:stride * (i + 1), :].reshape(-1),
-                                             fweights=mask[:stride * (i + 1), :].reshape(-1))
+                                                                labels[:stride * (i + 1), :].reshape(-1),
+                                                                fweights=mask[:stride * (i + 1), :].reshape(-1))
 
                 pearson_correlation(timestep_predictions, timestep_labels, timestep_mask)
                 assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
             # Test reset
             pearson_correlation.reset()
-            pearson_correlation(torch.FloatTensor(predictions), torch.FloatTensor(labels), torch.FloatTensor(mask))
-            expected_pearson_correlation = pearson_corrcoef(predictions.reshape(-1), labels.reshape(-1), fweights=mask.reshape(-1))
+            pearson_correlation(torch.FloatTensor(predictions),
+                                torch.FloatTensor(labels), torch.FloatTensor(mask))
+            expected_pearson_correlation = pearson_corrcoef(predictions.reshape(-1), labels.reshape(-1),
+                                                            fweights=mask.reshape(-1))
 
             assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)

--- a/allennlp/tests/training/metrics/pearson_correlation_test.py
+++ b/allennlp/tests/training/metrics/pearson_correlation_test.py
@@ -28,7 +28,9 @@ class PearsonCorrelationTest(AllenNlpTestCase):
         predictions_2 = predictions_2[np.newaxis, :].repeat(batch_size, axis=0)
         labels_2 = np.random.randn(1).repeat(num_labels).astype("float32")
         labels_2 = 0.5 * predictions_2 + labels_2[np.newaxis, :].repeat(batch_size, axis=0)
-
+        
+        # in most cases, the data is constructed like predictions_1, the data of such a batch different.
+        # but in a few cases, for example, predictions_2, the data of such a batch is exactly the same.
         predictions_labels = [(predictions_1, labels_1), (predictions_2, labels_2)]
 
         stride = 10
@@ -84,4 +86,3 @@ class PearsonCorrelationTest(AllenNlpTestCase):
             expected_pearson_correlation = pearson_corrcoef(predictions.reshape(-1), labels.reshape(-1), fweights=mask.reshape(-1))
 
             assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
-

--- a/allennlp/training/metrics/pearson_correlation.py
+++ b/allennlp/training/metrics/pearson_correlation.py
@@ -30,7 +30,7 @@ class PearsonCorrelation(Metric):
     
     denominator = (sqrt(predictions_variance) * sqrt(labels_variance)) 
     denominator = 1 if denominator == 0 else denominator
-    r = covariance / (sqrt(predictions_variance) * sqrt(labels_variance))
+    r = covariance / denominator
     """
     def __init__(self) -> None:
         self._predictions_labels_covariance = Covariance()

--- a/allennlp/training/metrics/pearson_correlation.py
+++ b/allennlp/training/metrics/pearson_correlation.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import math
+import numpy as np
 
 from overrides import overrides
 import torch
@@ -27,10 +28,8 @@ class PearsonCorrelation(Metric):
     - ``covariance(labels, labels)``, i.e. variance of ``labels``
 
     If we have these values, the sample Pearson correlation coefficient is simply:
-    
-    denominator = (sqrt(predictions_variance) * sqrt(labels_variance)) 
-    denominator = 1 if denominator == 0 else denominator
-    r = covariance / denominator
+
+    r = covariance / (sqrt(predictions_variance) * sqrt(labels_variance))
     """
     def __init__(self) -> None:
         self._predictions_labels_covariance = Covariance()
@@ -68,8 +67,10 @@ class PearsonCorrelation(Metric):
         if reset:
             self.reset()
         denominator = (math.sqrt(predictions_variance) * math.sqrt(labels_variance))
-        denominator = 1 if denominator == 0 else denominator
-        pearson_r = covariance / denominator
+        if np.around(denominator, decimals=5) == 0:
+            pearson_r = 0
+        else:
+            pearson_r = covariance / denominator
         return pearson_r
 
     @overrides

--- a/allennlp/training/metrics/pearson_correlation.py
+++ b/allennlp/training/metrics/pearson_correlation.py
@@ -1,86 +1,82 @@
-# pylint: disable=no-self-use,invalid-name,protected-access
-import torch
+from typing import Optional
+import math
 import numpy as np
-from numpy.testing import assert_allclose
 
-from allennlp.common.testing import AllenNlpTestCase
-from allennlp.training.metrics import PearsonCorrelation
+from overrides import overrides
+import torch
 
-def pearson_corrcoef(predictions, labels, fweights=None):
-    covariance_matrices = np.cov(predictions, labels, fweights=fweights)
-    denominator = np.sqrt(covariance_matrices[0, 0] * covariance_matrices[1, 1])
-    if np.around(denominator, decimals=5) == 0:
-        expected_pearson_correlation = 0
-    else:
-        expected_pearson_correlation = covariance_matrices[0, 1] / denominator
-    return expected_pearson_correlation
+from allennlp.training.metrics.covariance import Covariance
+from allennlp.training.metrics.metric import Metric
 
 
-class PearsonCorrelationTest(AllenNlpTestCase):
-    def test_pearson_correlation_unmasked_computation(self):
-        pearson_correlation = PearsonCorrelation()
-        batch_size = 100
-        num_labels = 10
-        predictions_1 = np.random.randn(batch_size, num_labels).astype("float32")
-        labels_1 = 0.5 * predictions_1 + np.random.randn(batch_size, num_labels).astype("float32")
+@Metric.register("pearson_correlation")
+class PearsonCorrelation(Metric):
+    """
+    This ``Metric`` calculates the sample Pearson correlation coefficient (r)
+    between two tensors. Each element in the two tensors is assumed to be
+    a different observation of the variable (i.e., the input tensors are
+    implicitly flattened into vectors and the correlation is calculated
+    between the vectors).
 
-        predictions_2 = np.random.randn(1).repeat(num_labels).astype("float32")
-        predictions_2 = predictions_2[np.newaxis, :].repeat(batch_size, axis=0)
-        labels_2 = np.random.randn(1).repeat(num_labels).astype("float32")
-        labels_2 = 0.5 * predictions_2 + labels_2[np.newaxis, :].repeat(batch_size, axis=0)
+    This implementation is mostly modeled after the streaming_pearson_correlation function in Tensorflow. See
+    https://github.com/tensorflow/tensorflow/blob/v1.10.1/tensorflow/contrib/metrics/python/ops/metric_ops.py#L3267
 
-        predictions_labels = [(predictions_1, labels_1), (predictions_2, labels_2)]
+    This metric delegates to the Covariance metric the tracking of three [co]variances:
 
-        stride = 10
+    - ``covariance(predictions, labels)``, i.e. covariance
+    - ``covariance(predictions, predictions)``, i.e. variance of ``predictions``
+    - ``covariance(labels, labels)``, i.e. variance of ``labels``
 
-        for predictions, labels in predictions_labels:
-            pearson_correlation.reset()
-            for i in range(batch_size // stride):
-                timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
-                timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
-                expected_pearson_correlation = pearson_corrcoef(predictions[:stride * (i + 1), :].reshape(-1),
-                                                                labels[:stride * (i + 1), :].reshape(-1))
-                pearson_correlation(timestep_predictions, timestep_labels)
-                assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
-            # Test reset
-            pearson_correlation.reset()
-            pearson_correlation(torch.FloatTensor(predictions), torch.FloatTensor(labels))
-            assert_allclose(pearson_corrcoef(predictions.reshape(-1), labels.reshape(-1)),
-                            pearson_correlation.get_metric(), rtol=1e-5)
+    If we have these values, the sample Pearson correlation coefficient is simply:
 
-    def test_pearson_correlation_masked_computation(self):
-        pearson_correlation = PearsonCorrelation()
-        batch_size = 100
-        num_labels = 10
-        predictions_1 = np.random.randn(batch_size, num_labels).astype("float32")
-        labels_1 = 0.5 * predictions_1 + np.random.randn(batch_size, num_labels).astype("float32")
+    r = covariance / (sqrt(predictions_variance) * sqrt(labels_variance))
 
-        predictions_2 = np.random.randn(1).repeat(num_labels).astype("float32")
-        predictions_2 = predictions_2[np.newaxis, :].repeat(batch_size, axis=0)
-        labels_2 = np.random.randn(1).repeat(num_labels).astype("float32")
-        labels_2 = 0.5 * predictions_2 + labels_2[np.newaxis, :].repeat(batch_size, axis=0)
+    if predictions_variance or labels_variance is 0, r is 0
+    """
+    def __init__(self) -> None:
+        self._predictions_labels_covariance = Covariance()
+        self._predictions_variance = Covariance()
+        self._labels_variance = Covariance()
 
-        predictions_labels = [(predictions_1, labels_1), (predictions_2, labels_2)]
+    def __call__(self,
+                 predictions: torch.Tensor,
+                 gold_labels: torch.Tensor,
+                 mask: Optional[torch.Tensor] = None):
+        """
+        Parameters
+        ----------
+        predictions : ``torch.Tensor``, required.
+            A tensor of predictions of shape (batch_size, ...).
+        gold_labels : ``torch.Tensor``, required.
+            A tensor of the same shape as ``predictions``.
+        mask: ``torch.Tensor``, optional (default = None).
+            A tensor of the same shape as ``predictions``.
+        """
+        predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)
+        self._predictions_labels_covariance(predictions, gold_labels, mask)
+        self._predictions_variance(predictions, predictions, mask)
+        self._labels_variance(gold_labels, gold_labels, mask)
 
-        # Random binary mask
-        mask = np.random.randint(0, 2, size=(batch_size, num_labels)).astype("float32")
-        stride = 10
+    def get_metric(self, reset: bool = False):
+        """
+        Returns
+        -------
+        The accumulated sample Pearson correlation.
+        """
+        covariance = self._predictions_labels_covariance.get_metric(reset=reset)
+        predictions_variance = self._predictions_variance.get_metric(reset=reset)
+        labels_variance = self._labels_variance.get_metric(reset=reset)
+        if reset:
+            self.reset()
+        denominator = (math.sqrt(predictions_variance) * math.sqrt(labels_variance))
+        if np.around(denominator, decimals=5) == 0:
+            pearson_r = 0
+        else:
+            pearson_r = covariance / denominator
+        return pearson_r
 
-        for predictions, labels in predictions_labels:
-            pearson_correlation.reset()
-            for i in range(batch_size // stride):
-                timestep_predictions = torch.FloatTensor(predictions[stride * i:stride * (i+1), :])
-                timestep_labels = torch.FloatTensor(labels[stride * i:stride * (i+1), :])
-                timestep_mask = torch.FloatTensor(mask[stride * i:stride * (i+1), :])
-                expected_pearson_correlation = pearson_corrcoef(predictions[:stride * (i + 1), :].reshape(-1),
-                                                                labels[:stride * (i + 1), :].reshape(-1),
-                                                                fweights=mask[:stride * (i + 1), :].reshape(-1))
-
-                pearson_correlation(timestep_predictions, timestep_labels, timestep_mask)
-                assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
-            # Test reset
-            pearson_correlation.reset()
-            pearson_correlation(torch.FloatTensor(predictions), torch.FloatTensor(labels), torch.FloatTensor(mask))
-            expected_pearson_correlation = pearson_corrcoef(predictions.reshape(-1),
-                                                            labels.reshape(-1), fweights=mask.reshape(-1))
-            assert_allclose(expected_pearson_correlation, pearson_correlation.get_metric(), rtol=1e-5)
+    @overrides
+    def reset(self):
+        self._predictions_labels_covariance.reset()
+        self._predictions_variance.reset()
+        self._labels_variance.reset()

--- a/allennlp/training/metrics/pearson_correlation.py
+++ b/allennlp/training/metrics/pearson_correlation.py
@@ -27,7 +27,9 @@ class PearsonCorrelation(Metric):
     - ``covariance(labels, labels)``, i.e. variance of ``labels``
 
     If we have these values, the sample Pearson correlation coefficient is simply:
-
+    
+    denominator = (sqrt(predictions_variance) * sqrt(labels_variance)) 
+    denominator = 1 if denominator == 0 else denominator
     r = covariance / (sqrt(predictions_variance) * sqrt(labels_variance))
     """
     def __init__(self) -> None:
@@ -65,7 +67,9 @@ class PearsonCorrelation(Metric):
         labels_variance = self._labels_variance.get_metric(reset=reset)
         if reset:
             self.reset()
-        pearson_r = covariance / (math.sqrt(predictions_variance) * math.sqrt(labels_variance))
+        denominator = (math.sqrt(predictions_variance) * math.sqrt(labels_variance))
+        denominator = 1 if denominator == 0 else denominator
+        pearson_r = covariance / denominator
         return pearson_r
 
     @overrides


### PR DESCRIPTION
Fixes #3102. Since the input tensor may be, for example(a batch of label), a tensor ([[0.,0.,0.,0.],
[0.,0.,0.,0. ]), there will be a case where (math.sqrt(predictions_variance) or math.sqrt(labels_variance)) is zero, so a judgment is added here to prevent the denominator from being zero. If it is zero, the denominator is assigned a value of 1.