### PR TITLE
Update HTTP links to HTTPS where possible

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/MODELS.md
+++ b/MODELS.md
@@ -92,7 +92,7 @@ Based on [Dozat and Manning, 2017](https://arxiv.org/pdf/1611.01734.pdf)
 
 * [biaffine-dependency-parser-ptb-2018.08.23.tar.gz](https://allennlp.s3.amazonaws.com/models/biaffine-dependency-parser-ptb-2018.08.23.tar.gz) (69 MB) uses [Penn Treebank](https://catalog.ldc.upenn.edu/ldc99t42) style dependencies.
 
-* [biaffine-dependency-parser-ud-2018.08.23.tar.gz](https://allennlp.s3.amazonaws.com/models/biaffine-dependency-parser-ud-2018.08.23.tar.gz) (61 MB) uses [Universal Dependency](http://universaldependencies.org/) style depedencies.
+* [biaffine-dependency-parser-ud-2018.08.23.tar.gz](https://allennlp.s3.amazonaws.com/models/biaffine-dependency-parser-ud-2018.08.23.tar.gz) (61 MB) uses [Universal Dependency](https://universaldependencies.org/) style depedencies.
 
 ```
 f1: 0.941

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for developing state-of-the-art deep learning models on a wide variety of lingui
 
 ## Quick Links
 
-* [Website](http://www.allennlp.org/)
+* [Website](https://allennlp.org/)
 * [Tutorial](https://allennlp.org/tutorials)
 * [Documentation](https://allenai.github.io/allennlp-docs/)
 * [Contributing Guidelines](CONTRIBUTING.md)
@@ -96,7 +96,7 @@ AllenNLP installs a script when you install the python package, meaning you can 
 You can now test your installation with `allennlp test-install`.
 
 _`pip` currently installs Pytorch for CUDA 9 only (or no GPU). If you require an older version,
-please visit http://pytorch.org/ and install the relevant pytorch binary._
+please visit https://pytorch.org/ and install the relevant pytorch binary._
 
 ### Installing using Docker
 

--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -5,7 +5,7 @@ Given a pre-processed input text file, this command outputs the internal
 layers used to compute ELMo representations to a single (potentially large) file.
 
 The input file is previously tokenized, whitespace separated text, one sentence per line.
-The output is a hdf5 file (<http://docs.h5py.org/en/latest/>) where, with the --all flag, each
+The output is a hdf5 file (<https://h5py.readthedocs.io/en/latest/>) where, with the --all flag, each
 sentence is a size (3, num_tokens, 1024) array with the biLM representations.
 
 For information, see "Deep contextualized word representations", Peters et al 2018.

--- a/allennlp/data/dataset_readers/dataset_utils/ontonotes.py
+++ b/allennlp/data/dataset_readers/dataset_utils/ontonotes.py
@@ -85,7 +85,7 @@ class Ontonotes:
     This DatasetReader is designed to read in the English OntoNotes v5.0 data
     in the format used by the CoNLL 2011/2012 shared tasks. In order to use this
     Reader, you must follow the instructions provided `here (v12 release):
-    <http://cemantix.org/data/ontonotes.html>`_, which will allow you to download
+    <https://cemantix.org/data/ontonotes.html>`_, which will allow you to download
     the CoNLL style annotations for the  OntoNotes v5.0 release -- LDC2013T19.tgz
     obtained from LDC.
 

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -265,7 +265,7 @@ def write_to_conll_eval_file(prediction_file: TextIO,
     predicate in a sentence to two provided file references.
 
     The CoNLL SRL format is described in
-    `the shared task data README <http://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
+    `the shared task data README <https://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
 
     This function expects IOB2-formatted tags, where the B- tag is used in the beginning
     of every chunk (i.e. all chunks start with the B- tag).
@@ -309,7 +309,7 @@ def write_bio_formatted_tags_to_file(prediction_file: TextIO,
     predicate in a sentence to two provided file references.
 
     The CoNLL SRL format is described in
-    `the shared task data README <http://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
+    `the shared task data README <https://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
 
     This function expects IOB2-formatted tags, where the B- tag is used in the beginning
     of every chunk (i.e. all chunks start with the B- tag).
@@ -352,7 +352,7 @@ def write_conll_formatted_tags_to_file(prediction_file: TextIO,
     predicate in a sentence to two provided file references.
 
     The CoNLL SRL format is described in
-    `the shared task data README <http://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
+    `the shared task data README <https://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
 
     This function expects IOB2-formatted tags, where the B- tag is used in the beginning
     of every chunk (i.e. all chunks start with the B- tag).

--- a/allennlp/modules/__init__.py
+++ b/allennlp/modules/__init__.py
@@ -1,6 +1,6 @@
 """
 Custom PyTorch
-`Module <http://pytorch.org/docs/master/nn.html#torch.nn.Module>`_ s
+`Module <https://pytorch.org/docs/master/nn.html#torch.nn.Module>`_ s
 that are used as components in AllenNLP
 :class:`~allennlp.models.model.Model` s.
 """

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -6,9 +6,9 @@ others are AllenNLP modules.
 
 The available Seq2Seq encoders are
 
-* `"gru" <http://pytorch.org/docs/master/nn.html#torch.nn.GRU>`_
-* `"lstm" <http://pytorch.org/docs/master/nn.html#torch.nn.LSTM>`_
-* `"rnn" <http://pytorch.org/docs/master/nn.html#torch.nn.RNN>`_
+* `"gru" <https://pytorch.org/docs/master/nn.html#torch.nn.GRU>`_
+* `"lstm" <https://pytorch.org/docs/master/nn.html#torch.nn.LSTM>`_
+* `"rnn" <https://pytorch.org/docs/master/nn.html#torch.nn.RNN>`_
 * :class:`"augmented_lstm" <allennlp.modules.augmented_lstm.AugmentedLstm>`
 * :class:`"alternating_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`
 * :class:`"alternating_highway_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm> (GPU only)`

--- a/allennlp/modules/seq2seq_encoders/bidirectional_language_model_transformer.py
+++ b/allennlp/modules/seq2seq_encoders/bidirectional_language_model_transformer.py
@@ -1,6 +1,6 @@
 """
 The BidirectionalTransformerEncoder from Calypso.
-This is basically the transformer from http://nlp.seas.harvard.edu/2018/04/03/attention.html
+This is basically the transformer from https://nlp.seas.harvard.edu/2018/04/03/attention.html
 so credit to them.
 
 This code should be considered "private" in that we have several

--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -6,9 +6,9 @@ others are AllenNLP modules.
 
 The available Seq2Vec encoders are
 
-* `"gru" <http://pytorch.org/docs/master/nn.html#torch.nn.GRU>`_
-* `"lstm" <http://pytorch.org/docs/master/nn.html#torch.nn.LSTM>`_
-* `"rnn" <http://pytorch.org/docs/master/nn.html#torch.nn.RNN>`_
+* `"gru" <https://pytorch.org/docs/master/nn.html#torch.nn.GRU>`_
+* `"lstm" <https://pytorch.org/docs/master/nn.html#torch.nn.LSTM>`_
+* `"rnn" <https://pytorch.org/docs/master/nn.html#torch.nn.RNN>`_
 * :class:`"cnn" <allennlp.modules.seq2vec_encoders.cnn_encoder.CnnEncoder>`
 * :class:`"augmented_lstm" <allennlp.modules.augmented_lstm.AugmentedLstm>`
 * :class:`"alternating_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -272,7 +272,7 @@ class Embedding(TokenEmbedder):
 
               where ``archive_uri`` can be a file system path or a URL. For example::
 
-                    "(http://nlp.stanford.edu/data/glove.twitter.27B.zip)#glove.twitter.27B.200d.txt"
+                    "(https://nlp.stanford.edu/data/glove.twitter.27B.zip)#glove.twitter.27B.200d.txt"
         """
         # pylint: disable=arguments-differ
         num_embeddings = params.pop_int('num_embeddings', None)

--- a/allennlp/nn/activations.py
+++ b/allennlp/nn/activations.py
@@ -2,26 +2,26 @@
 An :class:`Activation` is just a function
 that takes some parameters and returns an element-wise activation function.
 For the most part we just use
-`PyTorch activations <http://pytorch.org/docs/master/nn.html#non-linear-activations>`_.
+`PyTorch activations <https://pytorch.org/docs/master/nn.html#non-linear-activations>`_.
 Here we provide a thin wrapper to allow registering them and instantiating them ``from_params``.
 
 The available activation functions are
 
 * "linear"
-* `"relu" <http://pytorch.org/docs/master/nn.html#torch.nn.ReLU>`_
-* `"relu6" <http://pytorch.org/docs/master/nn.html#torch.nn.ReLU6>`_
-* `"elu" <http://pytorch.org/docs/master/nn.html#torch.nn.ELU>`_
-* `"prelu" <http://pytorch.org/docs/master/nn.html#torch.nn.PReLU>`_
-* `"leaky_relu" <http://pytorch.org/docs/master/nn.html#torch.nn.LeakyReLU>`_
-* `"threshold" <http://pytorch.org/docs/master/nn.html#torch.nn.Threshold>`_
-* `"hardtanh" <http://pytorch.org/docs/master/nn.html#torch.nn.Hardtanh>`_
-* `"sigmoid" <http://pytorch.org/docs/master/nn.html#torch.nn.Sigmoid>`_
-* `"tanh" <http://pytorch.org/docs/master/nn.html#torch.nn.Tanh>`_
-* `"log_sigmoid" <http://pytorch.org/docs/master/nn.html#torch.nn.LogSigmoid>`_
-* `"softplus" <http://pytorch.org/docs/master/nn.html#torch.nn.Softplus>`_
-* `"softshrink" <http://pytorch.org/docs/master/nn.html#torch.nn.Softshrink>`_
-* `"softsign" <http://pytorch.org/docs/master/nn.html#torch.nn.Softsign>`_
-* `"tanhshrink" <http://pytorch.org/docs/master/nn.html#torch.nn.Tanhshrink>`_
+* `"relu" <https://pytorch.org/docs/master/nn.html#torch.nn.ReLU>`_
+* `"relu6" <https://pytorch.org/docs/master/nn.html#torch.nn.ReLU6>`_
+* `"elu" <https://pytorch.org/docs/master/nn.html#torch.nn.ELU>`_
+* `"prelu" <https://pytorch.org/docs/master/nn.html#torch.nn.PReLU>`_
+* `"leaky_relu" <https://pytorch.org/docs/master/nn.html#torch.nn.LeakyReLU>`_
+* `"threshold" <https://pytorch.org/docs/master/nn.html#torch.nn.Threshold>`_
+* `"hardtanh" <https://pytorch.org/docs/master/nn.html#torch.nn.Hardtanh>`_
+* `"sigmoid" <https://pytorch.org/docs/master/nn.html#torch.nn.Sigmoid>`_
+* `"tanh" <https://pytorch.org/docs/master/nn.html#torch.nn.Tanh>`_
+* `"log_sigmoid" <https://pytorch.org/docs/master/nn.html#torch.nn.LogSigmoid>`_
+* `"softplus" <https://pytorch.org/docs/master/nn.html#torch.nn.Softplus>`_
+* `"softshrink" <https://pytorch.org/docs/master/nn.html#torch.nn.Softshrink>`_
+* `"softsign" <https://pytorch.org/docs/master/nn.html#torch.nn.Softsign>`_
+* `"tanhshrink" <https://pytorch.org/docs/master/nn.html#torch.nn.Tanhshrink>`_
 """
 
 import torch

--- a/allennlp/nn/beam_search.py
+++ b/allennlp/nn/beam_search.py
@@ -28,7 +28,7 @@ class BeamSearch:
         If not given, this just defaults to ``beam_size``. Setting this parameter
         to a number smaller than ``beam_size`` may give better results, as it can introduce
         more diversity into the search. See `Beam Search Strategies for Neural Machine Translation.
-        Freitag and Al-Onaizan, 2017 <http://arxiv.org/abs/1702.01806>`_.
+        Freitag and Al-Onaizan, 2017 <https://arxiv.org/abs/1702.01806>`_.
     """
 
     def __init__(self,

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -14,7 +14,8 @@ The available initialization functions are
 * `"dirac" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.dirac_>`_
 * `"xavier_uniform" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.xavier_uniform_>`_
 * `"xavier_normal" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.xavier_normal_>`_
-* `"kaiming_uniform" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.kaiming_uniform_>`_
+* `"kaiming_uniform"
+  <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.kaiming_uniform_>`_
 * `"kaiming_normal" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.kaiming_normal_>`_
 * `"orthogonal" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.orthogonal_>`_
 * `"sparse" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.sparse_>`_

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -7,17 +7,17 @@ as named arguments to the constructor.
 
 The available initialization functions are
 
-* `"normal" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.normal_>`_
-* `"uniform" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.uniform_>`_
-* `"constant" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.constant_>`_
-* `"eye" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.eye_>`_
-* `"dirac" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.dirac_>`_
-* `"xavier_uniform" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.xavier_uniform_>`_
-* `"xavier_normal" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.xavier_normal_>`_
-* `"kaiming_uniform" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.kaiming_uniform_>`_
-* `"kaiming_normal" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.kaiming_normal_>`_
-* `"orthogonal" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.orthogonal_>`_
-* `"sparse" <http://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.sparse_>`_
+* `"normal" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.normal_>`_
+* `"uniform" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.uniform_>`_
+* `"constant" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.constant_>`_
+* `"eye" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.eye_>`_
+* `"dirac" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.dirac_>`_
+* `"xavier_uniform" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.xavier_uniform_>`_
+* `"xavier_normal" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.xavier_normal_>`_
+* `"kaiming_uniform" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.kaiming_uniform_>`_
+* `"kaiming_normal" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.kaiming_normal_>`_
+* `"orthogonal" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.orthogonal_>`_
+* `"sparse" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.sparse_>`_
 * :func:`"block_orthogonal" <block_orthogonal>`
 * :func:`"uniform_unit_scaling" <uniform_unit_scaling>`
 * :class:`"pretrained" <PretrainedModelInitializer>`

--- a/allennlp/service/server_simple.py
+++ b/allennlp/service/server_simple.py
@@ -1,5 +1,5 @@
 """
-A `Flask <http://flask.pocoo.org/>`_ server for serving predictions
+A `Flask <https://palletsprojects.com/p/flask/>`_ server for serving predictions
 from a single AllenNLP model. It also includes a very, very bare-bones
 web front-end for exploring predictions (or you can provide your own).
 

--- a/allennlp/tests/data/dataset_readers/universal_dependencies_dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/universal_dependencies_dataset_reader_test.py
@@ -48,7 +48,7 @@ class TestUniversalDependenciesDatasetReader(AllenNlpTestCase):
         assert fields["head_indices"].labels == [4, 4, 4, 0, 6, 4, 6, 6, 4]
 
         # This instance tests specifically for filtering of elipsis:
-        # http://universaldependencies.org/u/overview/specific-syntax.html#ellipsis
+        # https://universaldependencies.org/u/overview/specific-syntax.html#ellipsis
         # The original sentence is:
         # "Over 300 Iraqis are reported dead and 500 [reported] wounded in Fallujah alone."
         # But the second "reported" is elided, and as such isn't included in the syntax tree.

--- a/allennlp/tests/training/callback_trainer_test.py
+++ b/allennlp/tests/training/callback_trainer_test.py
@@ -207,7 +207,7 @@ class TestCallbackTrainer(ModelTestCase):
 
     @responses.activate
     def test_trainer_posts_to_url(self):
-        url = 'http://slack.com?webhook=ewifjweoiwjef'
+        url = 'https://slack.com?webhook=ewifjweoiwjef'
         responses.add(responses.POST, url)
         post_to_url = PostToUrl(url, message="only a test")
         callbacks = self.default_callbacks() + [post_to_url]

--- a/allennlp/tools/EVALB/LICENSE
+++ b/allennlp/tools/EVALB/LICENSE
@@ -21,4 +21,4 @@ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
-For more information, please refer to <http://unlicense.org/>
+For more information, please refer to <https://unlicense.org/>

--- a/allennlp/tools/EVALB/evalb.dSYM/Contents/Info.plist
+++ b/allennlp/tools/EVALB/evalb.dSYM/Contents/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
 		<key>CFBundleDevelopmentRegion</key>

--- a/allennlp/training/learning_rate_schedulers/__init__.py
+++ b/allennlp/training/learning_rate_schedulers/__init__.py
@@ -1,14 +1,14 @@
 """
 AllenNLP uses most
-`PyTorch learning rate schedulers <http://pytorch.org/docs/master/optim.html#how-to-adjust-learning-rate>`_,
+`PyTorch learning rate schedulers <https://pytorch.org/docs/master/optim.html#how-to-adjust-learning-rate>`_,
 with a thin wrapper to allow registering them and instantiating them ``from_params``.
 
 The available learning rate schedulers from PyTorch are
 
-* `"step" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.StepLR>`_
-* `"multi_step" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.MultiStepLR>`_
-* `"exponential" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.ExponentialLR>`_
-* `"reduce_on_plateau" <http://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.ReduceLROnPlateau>`_
+* `"step" <https://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.StepLR>`_
+* `"multi_step" <https://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.MultiStepLR>`_
+* `"exponential" <https://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.ExponentialLR>`_
+* `"reduce_on_plateau" <https://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.ReduceLROnPlateau>`_
 
 In addition, AllenNLP also provides `cosine with restarts <https://arxiv.org/abs/1608.03983>`_,
 a Noam schedule, and a slanted triangular schedule, which are registered as

--- a/allennlp/training/metrics/conll_coref_scores.py
+++ b/allennlp/training/metrics/conll_coref_scores.py
@@ -189,7 +189,7 @@ class Scorer:
         """
         Counts the mentions in each predicted cluster which need to be re-allocated in
         order for each predicted cluster to be contained by the respective gold cluster.
-        <http://aclweb.org/anthology/M/M95/M95-1005.pdf>
+        <https://aclweb.org/anthology/M/M95/M95-1005.pdf>
         """
         true_p, all_p = 0, 0
         for cluster in clusters:

--- a/allennlp/training/metrics/evalb_bracketing_scorer.py
+++ b/allennlp/training/metrics/evalb_bracketing_scorer.py
@@ -21,7 +21,7 @@ class EvalbBracketingScorer(Metric):
     """
     This class uses the external EVALB software for computing a broad range of metrics
     on parse trees. Here, we use it to compute the Precision, Recall and F1 metrics.
-    You can download the source for EVALB from here: <http://nlp.cs.nyu.edu/evalb/>.
+    You can download the source for EVALB from here: <https://nlp.cs.nyu.edu/evalb/>.
 
     Note that this software is 20 years old. In order to compile it on modern hardware,
     you may need to remove an ``include <malloc.h>`` statement in ``evalb.c`` before it

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -1,18 +1,18 @@
 """
 AllenNLP just uses
-`PyTorch optimizers <http://pytorch.org/docs/master/optim.html>`_ ,
+`PyTorch optimizers <https://pytorch.org/docs/master/optim.html>`_ ,
 with a thin wrapper to allow registering them and instantiating them ``from_params``.
 
 The available optimizers are
 
-* `"adadelta" <http://pytorch.org/docs/master/optim.html#torch.optim.Adadelta>`_
-* `"adagrad" <http://pytorch.org/docs/master/optim.html#torch.optim.Adagrad>`_
-* `"adam" <http://pytorch.org/docs/master/optim.html#torch.optim.Adam>`_
-* `"sparse_adam" <http://pytorch.org/docs/master/optim.html#torch.optim.SparseAdam>`_
-* `"sgd" <http://pytorch.org/docs/master/optim.html#torch.optim.SGD>`_
-* `"rmsprop <http://pytorch.org/docs/master/optim.html#torch.optim.RMSprop>`_
-* `"adamax <http://pytorch.org/docs/master/optim.html#torch.optim.Adamax>`_
-* `"averaged_sgd <http://pytorch.org/docs/master/optim.html#torch.optim.ASGD>`_
+* `"adadelta" <https://pytorch.org/docs/master/optim.html#torch.optim.Adadelta>`_
+* `"adagrad" <https://pytorch.org/docs/master/optim.html#torch.optim.Adagrad>`_
+* `"adam" <https://pytorch.org/docs/master/optim.html#torch.optim.Adam>`_
+* `"sparse_adam" <https://pytorch.org/docs/master/optim.html#torch.optim.SparseAdam>`_
+* `"sgd" <https://pytorch.org/docs/master/optim.html#torch.optim.SGD>`_
+* `"rmsprop <https://pytorch.org/docs/master/optim.html#torch.optim.RMSprop>`_
+* `"adamax <https://pytorch.org/docs/master/optim.html#torch.optim.Adamax>`_
+* `"averaged_sgd <https://pytorch.org/docs/master/optim.html#torch.optim.ASGD>`_
 """
 
 import logging
@@ -52,7 +52,7 @@ class Optimizer(Registrable):
             # e.g., {'params': [list of parameters], 'lr': 1e-3, ...}
             # Any config option not specified in the additional options (e.g.
             # for the default group) is inherited from the top level config.
-            # see: http://pytorch.org/docs/0.3.0/optim.html?#per-parameter-options
+            # see: https://pytorch.org/docs/0.3.0/optim.html?#per-parameter-options
             #
             # groups contains something like:
             #"parameter_groups": [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -123,7 +123,7 @@ html_logo = 'static/allennlp-logo-dark.png'
 # to template names.
 #
 # This is required for the alabaster theme
-# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
+# refs: https://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
     '**': [
         'about.html',
@@ -238,4 +238,4 @@ def linkcode_resolve(domain, info):
         linespec = ""
 
     filename = info['module'].replace('.', '/')
-    return "http://github.com/allenai/allennlp/blob/master/%s.py%s" % (filename, linespec)
+    return "https://github.com/allenai/allennlp/blob/master/%s.py%s" % (filename, linespec)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,7 +21,7 @@ following principles:
 
 AllenNLP includes reference implementations of high quality models for Semantic
 Role Labelling, Question and Answering (BiDAF), Entailment (decomposable
-attention), and more (see http://www.allennlp.org/models).
+attention), and more (see https://allennlp.org/models).
 
 AllenNLP is built and maintained by the Allen Institute for Artificial
 Intelligence, in close collaboration with researchers at the University of

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #### ESSENTIAL LIBRARIES FOR MAIN FUNCTIONALITY ####
 
 # This installs Pytorch for CUDA 8 only. If you are using a newer version,
-# please visit http://pytorch.org/ and install the relevant version.
+# please visit https://pytorch.org/ and install the relevant version.
 # For now AllenNLP works with both PyTorch 1.0 and 0.4.1. Expect that in
 # the future only >=1.0 will be supported.
 torch>=0.4.1,<1.2

--- a/scripts/compile_coref_data.sh
+++ b/scripts/compile_coref_data.sh
@@ -30,7 +30,7 @@ function compile_language() {
     compile_partition test test v4 _gold_conll $1
 }
 
-conll_url=http://conll.cemantix.org/2012/download
+conll_url=https://conll.cemantix.org/2012/download
 download_and_extract $conll_url conll-2012-train.v4.tar.gz
 download_and_extract $conll_url conll-2012-development.v4.tar.gz
 download_and_extract $conll_url/test conll-2012-test-key.tar.gz
@@ -38,7 +38,7 @@ download_and_extract $conll_url/test conll-2012-test-official.v9.tar.gz
 
 download_and_extract $conll_url conll-2012-scripts.v3.tar.gz
 
-download_and_extract http://conll.cemantix.org/download reference-coreference-scorers.v8.01.tar.gz
+download_and_extract https://conll.cemantix.org/download reference-coreference-scorers.v8.01.tar.gz
 mv reference-coreference-scorers conll-2012/scorer
 
 # Convert the ontonotes data into the CONLL format.

--- a/training_config/biattentive_classification_network_elmo.jsonnet
+++ b/training_config/biattentive_classification_network_elmo.jsonnet
@@ -1,6 +1,6 @@
 {
   // Slightly modified version of the bi-attentative classification model with ELMo
-  // from "Deep contextualized word representations" (http://www.aclweb.org/anthology/N18-1202),
+  // from "Deep contextualized word representations" (https://www.aclweb.org/anthology/N18-1202),
   // trained on 5-class Stanford Sentiment Treebank.
   // There is a trained model available at https://allennlp.s3.amazonaws.com/models/sst-5-elmo-biattentive-classification-network-2018.09.04.tar.gz
   // with test accuracy of 54.7%.

--- a/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt1.md
+++ b/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt1.md
@@ -50,8 +50,8 @@ decide if it was (or should be) published in a "natural language processing" ven
 learning" venue, or an "artificial intelligence" venue (all of those scare quotes are because this
 is a totally artificial task, and there aren't solid lines between these fields).
 
-We'll use the [open research corpus](http://labs.semanticscholar.org/corpus/) provided by the academic
-search engine [Semantic Scholar](http://semanticscholar.org), with a heuristically-edited "venue"
+We'll use the [open research corpus](https://labs.semanticscholar.org/corpus/) provided by the academic
+search engine [Semantic Scholar](https://www.semanticscholar.org/), with a heuristically-edited "venue"
 field.  You can follow the link to see the full specification of this data, but it's provided as a
 JSON-lines file, where each JSON blob has at least these fields:
 

--- a/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt2.md
+++ b/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt2.md
@@ -256,7 +256,7 @@ and saved `index.html` there. The original page had a lot of embedded CSS, which
 For our customization, we'll replace the ugly JSON output
 with a beautiful pie chart of the predicted class probabilities,
 using a library called
-[chart.js](http://www.chartjs.org/docs/latest/getting-started/usage.html).
+[chart.js](https://www.chartjs.org/docs/latest/getting-started/usage.html).
 
 To start with, we need to [add a `script` tag to load chart.js](https://github.com/allenai/allennlp-as-a-library-example/blob/master/static_html/index.html#L47).
 

--- a/tutorials/getting_started/semantic_parsing.md
+++ b/tutorials/getting_started/semantic_parsing.md
@@ -283,7 +283,7 @@ decoding_](https://github.com/allenai/acl2018-semantic-parsing-tutorial/blob/mas
 That is, instead of outputting tokens in the target language directly, we build an abstract syntax
 tree of the target program, linearize that tree, and produce it sequentially.  You can see an
 example of this in our [WikiTableQuestions parser
-demo](http://demo.allennlp.org/wikitables-parser), if you look at the predicted actions.  Each
+demo](https://demo.allennlp.org/wikitables-parser), if you look at the predicted actions.  Each
 action expands a non-terminal in the tree.  Constructing this grammar over abstract syntax trees is
 a bit messy.
 
@@ -439,7 +439,7 @@ general SQL grammar that we wrote with `parsimonious`.
   questions that require qualitative reasoning (paper and website coming soon).
 
 There are models implemented for most of these datasets, many of which you can see in our
-[demo](http://demo.allennlp.org).
+[demo](https://demo.allennlp.org).
 
 Is there a dataset or model that you really want to work on that's not here?  We'd love to hear
 about it, or to have contributions to add more capability to this framework.  Just open an issue or

--- a/tutorials/getting_started/using_pretrained_models.md
+++ b/tutorials/getting_started/using_pretrained_models.md
@@ -2,11 +2,11 @@
 
 In this tutorial, we show how to use run the pretrained models in AllenNLP to make predictions.
 This tutorial uses the Named Entity Recognition model, but the same procedure applies to any of
-the models [available on our website](http://allennlp.org/models).
+the models [available on our website](https://allennlp.org/models).
 
 ## Making Predictions on the Command Line
 
-[The models page on the website](http://allennlp.org/models) lists all the models in AllenNLP,
+[The models page on the website](https://allennlp.org/models) lists all the models in AllenNLP,
 as well as examples for how to run the model on the command line.  For example, under the
 [Named Entity Recognition model](https://allennlp.org/models#named-entity-recognition) there
 is a "Prediction" button that reveals the following example.

--- a/tutorials/getting_started/walk_through_allennlp/configuration.md
+++ b/tutorials/getting_started/walk_through_allennlp/configuration.md
@@ -15,10 +15,10 @@ each section of the configuration file in detail, explaining what all the parame
 ## A preliminary: Registrable and from_params
 
 Most AllenNLP classes inherit from the
-[`Registrable`](http://docs.allennlp.org/en/latest/api/allennlp.common.html#allennlp.common.registrable.Registrable)
+[`Registrable`](https://allenai.github.io/allennlp-docs/api/allennlp.common.registrable.html#allennlp.common.registrable.Registrable)
 base class,
 which gives them a named registry for their subclasses. This means that if we had
-a `Model(Registrable)` base class ([we do](http://docs.allennlp.org/en/latest/api/allennlp.models.html#allennlp.models.model.Model)),
+a `Model(Registrable)` base class ([we do](https://allenai.github.io/allennlp-docs/api/allennlp.models.model.html#allennlp.models.model.Model)),
 and we decorated a subclass like
 
 ```python
@@ -35,7 +35,7 @@ Model.by_name("custom")
 
 By convention, all such classes have a `from_params` factory method that
 allows you to instantiate instances from a
-[`Params`](http://docs.allennlp.org/en/latest/api/allennlp.common.html#allennlp.common.params.Params)
+[`Params`](https://allenai.github.io/allennlp-docs/api/allennlp.common.params.html#allennlp.common.params.Params)
 object, which is basically a `dict` of parameters
 with some added functionality that we won't get into here.
 
@@ -59,27 +59,27 @@ In particular, this means that once you start creating your own named models and
 the `allennlp` command will not be aware of them unless you specify them with `--include-package`.
 You can also create your own script that imports your custom classes and then calls `allennlp.commands.main()`.
 
-## Datasets and Instances and Fields
+## Batches and Instances and Fields
 
-We train and evaluate our models on `Dataset`s. A
-[`Dataset`](http://docs.allennlp.org/en/latest/api/allennlp.data.html#allennlp.data.dataset.Dataset)
+We train and evaluate our models on `Batch`es. A
+[`Batch`](https://allenai.github.io/allennlp-docs/api/allennlp.data.dataset.html#allennlp.data.dataset.Batch)
 is a collection of
-[`Instance`](http://docs.allennlp.org/en/latest/api/allennlp.data.html#allennlp.data.instance.Instance)s.
+[`Instance`](https://allenai.github.io/allennlp-docs/api/allennlp.data.instance.html#allennlp.data.instance.Instance)s.
 In our tagging experiment,
 each dataset is a collection of tagged sentences, and each instance is one of those tagged sentences.
 
 An instance consists of
-[`Field`](http://docs.allennlp.org/en/latest/api/allennlp.data.fields.html#allennlp.data.fields.field.Field)s,
+[`Field`](https://allenai.github.io/allennlp-docs/api/allennlp.data.fields.html#allennlp.data.fields.field.Field)s,
 each of which represents some part of the instance as arrays suitable for feeding into a model.
 
 In our tagging setup, each instance will contain a
-[`TextField`](http://docs.allennlp.org/en/latest/api/allennlp.data.fields.html#allennlp.data.fields.text_field.TextField)
+[`TextField`](https://allenai.github.io/allennlp-docs/api/allennlp.data.fields.html#allennlp.data.fields.text_field.TextField)
 representing the words/tokens of the sentence and a
-[`SequenceLabelField`](http://docs.allennlp.org/en/latest/api/allennlp.data.fields.html#allennlp.data.fields.sequence_label_field.SequenceLabelField)
+[`SequenceLabelField`](https://allenai.github.io/allennlp-docs/api/allennlp.data.fields.html#allennlp.data.fields.sequence_label_field.SequenceLabelField)
 representing the corresponding part-of-speech tags.
 
-How do we turn a text file full of sentences into a `Dataset`? With a
-[`DatasetReader`](http://docs.allennlp.org/en/latest/api/allennlp.data.dataset_readers.html#allennlp.data.dataset_readers.dataset_reader.DatasetReader)
+How do we turn a text file full of sentences into `Batches`? With a
+[`DatasetReader`](https://allenai.github.io/allennlp-docs/api/allennlp.data.dataset_readers.dataset_reader.html#allennlp.data.dataset_readers.dataset_reader.DatasetReader)
 specified by our configuration file.
 
 ## DatasetReaders
@@ -99,13 +99,12 @@ The first section of our configuration file defines the `dataset_reader`:
         "type": "characters"
       }
     }
-  },
-
+  }
 ```
 
 Here we've specified that we want to use the `DatasetReader` subclass that's registered
 under the name `"sequence_tagging"`. Unsurprisingly, this is the
-[`SequenceTaggingDatasetReader`](http://docs.allennlp.org/en/latest/api/allennlp.data.dataset_readers.html#allennlp.data.dataset_readers.sequence_tagging.SequenceTaggingDatasetReader)
+[`SequenceTaggingDatasetReader`](https://allenai.github.io/allennlp-docs/api/allennlp.data.dataset_readers.sequence_tagging.html#allennlp.data.dataset_readers.sequence_tagging.SequenceTaggingDatasetReader)
 subclass. This reader assumes a text file of newline-separated sentences, where each sentence looks like the following for some "word tag delimiter" `{wtd}` and some "token delimiter" `{td}`.
 
 ```
@@ -131,7 +130,7 @@ If you look at the code for `SequenceTaggingDatasetReader.read()`,
 it turns each sentence into a `TextField`
 of tokens and a `SequenceLabelField` of tags. The latter isn't
 really configurable, but the former wants a dictionary of
-[TokenIndexer](http://docs.allennlp.org/en/latest/api/allennlp.data.token_indexers.html#allennlp.data.token_indexers.token_indexer.TokenIndexer)s
+[TokenIndexer](https://allenai.github.io/allennlp-docs/api/allennlp.data.token_indexers.html#allennlp.data.token_indexers.token_indexer.TokenIndexer)s
 that indicate how to convert the tokens into arrays.
 
 Our configuration specifies two token indexers:
@@ -149,13 +148,13 @@ Our configuration specifies two token indexers:
 ```
 
 The first, `"tokens"`, is a
-[`SingleIdTokenIndexer`](http://docs.allennlp.org/en/latest/api/allennlp.data.token_indexers.html#allennlp.data.token_indexers.single_id_token_indexer.SingleIdTokenIndexer)
+[`SingleIdTokenIndexer`](https://allenai.github.io/allennlp-docs/api/allennlp.data.token_indexers.html#allennlp.data.token_indexers.single_id_token_indexer.SingleIdTokenIndexer)
 that just represents each token (word) as a single integer.
 The configuration also specifies that we *lowercase* the tokens before encoding;
 that is, that this token indexer should ignore case.
 
 The second, `"token_characters"`, is a
-[`TokenCharactersIndexer`](http://docs.allennlp.org/en/latest/api/allennlp.data.token_indexers.html#allennlp.data.token_indexers.token_characters_indexer.TokenCharactersIndexer)
+[`TokenCharactersIndexer`](https://allenai.github.io/allennlp-docs/api/allennlp.data.token_indexers.html#allennlp.data.token_indexers.token_characters_indexer.TokenCharactersIndexer)
 that represents each token as a list of int-encoded characters.
 
 Notice that this gives us two different encodings for each token.
@@ -186,12 +185,12 @@ The next section configures our model.
 
 This indicates we want to use the `Model` subclass that's registered as `"simple_tagger"`,
 which is the
-[`SimpleTagger`](http://docs.allennlp.org/en/latest/api/allennlp.models.html#allennlp.models.simple_tagger.SimpleTagger) model.
+[`SimpleTagger`](https://allenai.github.io/allennlp-docs/api/allennlp.models.simple_tagger.html#allennlp.models.simple_tagger.SimpleTagger) model.
 
 If you look at its code, you'll see it consists of a
-[`TextFieldEmbedder`](http://docs.allennlp.org/en/latest/api/allennlp.modules.text_field_embedders.html#allennlp.modules.text_field_embedders.text_field_embedder.TextFieldEmbedder)
+[`TextFieldEmbedder`](https://allenai.github.io/allennlp-docs/api/allennlp.modules.text_field_embedders.html#allennlp.modules.text_field_embedders.text_field_embedder.TextFieldEmbedder)
 that embeds the output of our text fields, a
-[`Seq2SeqEncoder`](http://docs.allennlp.org/en/latest/api/allennlp.modules.seq2seq_encoders.html#allennlp.modules.seq2seq_encoders.seq2seq_encoder.Seq2SeqEncoder)
+[`Seq2SeqEncoder`](https://allenai.github.io/allennlp-docs/api/allennlp.modules.seq2seq_encoders.html#allennlp.modules.seq2seq_encoders.seq2seq_encoder.Seq2SeqEncoder)
 that transforms that sequence into an output sequence,
 and a linear layer to convert the output sequences
 into logits representing the probabilities of predicted tags.
@@ -227,22 +226,22 @@ Let's first look at the text field embedder configuration:
 
 You can see that it has an entry for each of the named encodings in our `TextField`.
 Each entry specifies a
-[`TokenEmbedder`](http://docs.allennlp.org/en/latest/api/allennlp.modules.token_embedders.html?highlight=embedding#allennlp.modules.token_embedders.token_embedder.TokenEmbedder)
+[`TokenEmbedder`](https://allenai.github.io/allennlp-docs/api/allennlp.modules.token_embedders.html?highlight=embedding#allennlp.modules.token_embedders.token_embedder.TokenEmbedder)
 that indicates how to embed
 the tokens encoded with that name. The `TextFieldEmbedder`'s output is the concatenation
 of these embeddings.
 
 The `"tokens"` input (which consists of integer encodings of the lowercased words in the input)
 gets fed into an
-[`Embedding`](http://docs.allennlp.org/en/latest/api/allennlp.modules.token_embedders.html?highlight=embedding#allennlp.modules.token_embedders.embedding.Embedding)
+[`Embedding`](https://allenai.github.io/allennlp-docs/api/allennlp.modules.token_embedders.html?highlight=embedding#allennlp.modules.token_embedders.embedding.Embedding)
 module that embeds the vocabulary words in a 50-dimensional space, as specified by the `embedding_dim` parameter.
 
 The `"token_characters"` input (which consists of integer-sequence encodings of the characters in each word)
 gets fed into a
-[`TokenCharactersEncoder`](http://docs.allennlp.org/en/latest/api/allennlp.modules.token_embedders.html?highlight=embedding#allennlp.modules.token_embedders.token_characters_encoder.TokenCharactersEncoder),
+[`TokenCharactersEncoder`](https://allenai.github.io/allennlp-docs/api/allennlp.modules.token_embedders.html?highlight=embedding#allennlp.modules.token_embedders.token_characters_encoder.TokenCharactersEncoder),
 which embeds the characters in an 8-dimensional space
 and then applies a
-[`CnnEncoder`](http://docs.allennlp.org/en/latest/api/allennlp.modules.seq2vec_encoders.html#allennlp.modules.seq2vec_encoders.cnn_encoder.CnnEncoder)
+[`CnnEncoder`](https://allenai.github.io/allennlp-docs/api/allennlp.modules.seq2vec_encoders.html#allennlp.modules.seq2vec_encoders.cnn_encoder.CnnEncoder)
 that uses 50 filters and so also produces a 50-dimensional output. You can see that this encoder also uses a 20% dropout during training.
 
 The output of this `TextFieldEmbedder` is a 50-dimensional vector for `"tokens"`
@@ -259,7 +258,7 @@ code.
 
 The output of the `TextFieldEmbedder` is processed by the "stacked encoder",
 which needs to be a
-[`Seq2SeqEncoder`](http://docs.allennlp.org/en/latest/api/allennlp.modules.seq2seq_encoders.html#allennlp.modules.seq2seq_encoders.seq2seq_encoder.Seq2SeqEncoder):
+[`Seq2SeqEncoder`](https://allenai.github.io/allennlp-docs/api/allennlp.modules.seq2seq_encoders.html#allennlp.modules.seq2seq_encoders.seq2seq_encoder.Seq2SeqEncoder):
 
 ```js
     "encoder": {
@@ -273,7 +272,7 @@ which needs to be a
 ```
 
 Here the `"lstm"` encoder is just a thin wrapper around
-[`torch.nn.LSTM`](http://pytorch.org/docs/master/nn.html#torch.nn.LSTM),
+[`torch.nn.LSTM`](https://pytorch.org/docs/master/nn.html#torch.nn.LSTM),
 and its parameters are simply passed through to the PyTorch constructor.
 Its input size needs to match the 100-dimensional output size of the
 previous embedding layer.
@@ -290,7 +289,7 @@ The rest of the config file is dedicated to the training process.
 ```
 
 We'll iterate over our datasets using a
-[`BasicIterator`](http://docs.allennlp.org/en/latest/api/allennlp.data.iterators.html#allennlp.data.iterators.basic_iterator.BasicIterator)
+[`BasicIterator`](https://allenai.github.io/allennlp-docs/api/allennlp.data.iterators.html#allennlp.data.iterators.basic_iterator.BasicIterator)
 that pads our data and processes it in batches of size 32.
 
 
@@ -305,7 +304,7 @@ that pads our data and processes it in batches of size 32.
 ```
 
 Finally, we'll optimize using
-[`torch.optim.Adam`](http://pytorch.org/docs/master/optim.html#torch.optim.Adam)
+[`torch.optim.Adam`](https://pytorch.org/docs/master/optim.html#torch.optim.Adam)
 with its default parameters;
 we'll run the training for 40 epochs;
 we'll stop prematurely if we get no improvement for 10 epochs;

--- a/tutorials/getting_started/walk_through_allennlp/creating_a_model.md
+++ b/tutorials/getting_started/walk_through_allennlp/creating_a_model.md
@@ -10,7 +10,7 @@ subclass corresponding to the model you want to implement.
 (If there's already a `DatasetReader` for the dataset you want to use,
  of course you can reuse that one.)
 In this tutorial we'll also implement a custom PyTorch
-[`Module`](http://pytorch.org/docs/master/nn.html#torch.nn.Module),
+[`Module`](https://pytorch.org/docs/master/nn.html#torch.nn.Module),
 but you won't need to do that in general.
 
 Our [simple tagger](training_and_evaluating.md) model
@@ -31,7 +31,7 @@ on the validation dataset. We'd like to do better.
 One way to approach this is to add a [Conditional Random Field](https://en.wikipedia.org/wiki/Conditional_random_field)
 layer at the end of our tagging model.
 (If you're not familiar with conditional random fields, [this overview paper](https://arxiv.org/abs/1011.4088)
- is helpful, as is [this PyTorch tutorial](http://pytorch.org/tutorials/beginner/nlp/advanced_tutorial.html).)
+ is helpful, as is [this PyTorch tutorial](https://pytorch.org/tutorials/beginner/nlp/advanced_tutorial.html).)
 
 The "linear-chain" conditional random field we'll implement has a `num_tags` x `num_tags` matrix of transition costs,
 where `transitions[i, j]` represents the likelihood of transitioning
@@ -51,7 +51,7 @@ As the CRF is just a component of our model, we'll implement it as a [Module](ht
 
 ## Implementing the CRF Module
 
-To implement a PyTorch module, we just need to inherit from [`torch.nn.Module`](http://pytorch.org/docs/master/nn.html#torch.nn.Module)
+To implement a PyTorch module, we just need to inherit from [`torch.nn.Module`](https://pytorch.org/docs/master/nn.html#torch.nn.Module)
 and override
 
 ```python

--- a/tutorials/getting_started/walk_through_allennlp/training_and_evaluating.md
+++ b/tutorials/getting_started/walk_through_allennlp/training_and_evaluating.md
@@ -6,7 +6,7 @@ In this tutorial we'll train a simple part-of-speech tagger using AllenNLP.
 The model is defined in [allennlp/models/simple_tagger.py](../../../allennlp/models/simple_tagger.py).
 It consists of a word embedding layer followed by an LSTM.
 
-Our dataset will be a subset of the [Brown Corpus](http://www.nltk.org/nltk_data/).
+Our dataset will be a subset of the [Brown Corpus](https://www.nltk.org/nltk_data/).
 In particular, we will train a model on 4000 randomly chosen sentences (`sentences.small.train`) and use a different ~1000 randomly chosen sentences
 as the validation set (`sentences.small.dev`).
 

--- a/tutorials/how_to/elmo.md
+++ b/tutorials/how_to/elmo.md
@@ -8,7 +8,7 @@ semantic role labeling, classification, and syntactic parsing.
 This document describes how to add ELMo representations to your model using pytorch and `allennlp`.
 We also have a [tensorflow implementation](https://github.com/allenai/bilm-tf).
 
-For more detail about ELMo, please see the publication ["Deep contextualized word representations", NAACL 2018](http://www.aclweb.org/anthology/N18-1202) or the [ELMo section of the AllenNLP website](https://allennlp.org/elmo).
+For more detail about ELMo, please see the publication ["Deep contextualized word representations", NAACL 2018](https://www.aclweb.org/anthology/N18-1202) or the [ELMo section of the AllenNLP website](https://allennlp.org/elmo).
 
 Citations:
 
@@ -214,7 +214,7 @@ There are a few practical implications of this:
 # Reproducing the results from <i>Deep contextualized word representations</i>
 
 This section provides details on reproducing the results in Table 1
-of the [ELMo paper](http://www.aclweb.org/anthology/N18-1202).
+of the [ELMo paper](https://www.aclweb.org/anthology/N18-1202).
 
 For context, all of the experiments for the ELMo paper were done before AllenNLP existed, and almost all of the models in AllenNLP are re-implementations of things that were typically originally written in tensorflow code (the SRL model is the only exception).
 In some cases, we haven't had the resources to tune the AllenNLP implementations to match the existing performance numbers yet; if you are able to do this for some of the models and submit back a tuned model, we (and many others) would greatly appreciate it.

--- a/tutorials/how_to/training_transformer_elmo.md
+++ b/tutorials/how_to/training_transformer_elmo.md
@@ -4,7 +4,7 @@ This document describes how to train and use a transformer-based version of ELMo
 
 ## Training
 
-1. Obtain training data from http://www.statmt.org/lm-benchmark/1-billion-word-language-modeling-benchmark-r13output.tar.gz.
+1. Obtain training data from https://www.statmt.org/lm-benchmark/1-billion-word-language-modeling-benchmark-r13output.tar.gz.
     ```
     export BIDIRECTIONAL_LM_DATA_PATH=$PWD'/1-billion-word-language-modeling-benchmark-r13output'
     export BIDIRECTIONAL_LM_TRAIN_PATH=$BIDIRECTIONAL_LM_DATA_PATH'/training-monolingual.tokenized.shuffled/*'

--- a/tutorials/how_to/visualizing_model_internals.md
+++ b/tutorials/how_to/visualizing_model_internals.md
@@ -1,7 +1,7 @@
 # Visualizing model internals in a live demo
 
 We recently added an attention visualization to the live BiDAF demo on
-[allennlp.org](http://demo.allennlp.org/machine-comprehension).  Here's what it looks like:
+[allennlp.org](https://demo.allennlp.org/machine-comprehension).  Here's what it looks like:
 
 ![demo screenshot](visualization_images/bidaf_attention_demo.png)
 
@@ -58,7 +58,7 @@ visualize in the text output returned by the simple server you set up in the pre
 
 We've [set up a repository](https://github.com/allenai/allennlp-simple-server-visualization) with a
 stripped-down version of the code that runs the demo on
-[demo.allennlp.org](http://demo.allennlp.org).  Clone that repository and copy the `demo/`
+[demo.allennlp.org](https://demo.allennlp.org).  Clone that repository and copy the `demo/`
 directory to wherever you want.  `cd` to that directory, and run `npm install`, then `npm start`.
 That should show a screen in your terminal that says "Compiled successfully!", directing you to
 view your demo in a browser at `localhost:3000`.  If you go there, you should see a page that says


### PR DESCRIPTION
I changed the HTTP links to HTTPS where I saw the domain accepted it (I checked them). I also updated some sites' links that changed address such as Flask. And I changed the http://docs.allennlp.org/en/latest to https://allenai.github.io/allennlp-docs that I saw it changed, in which for some I needed to change the URL to add a missing module name.

Btw, I saw build.allennlp.org doesn't support HTTPS and that http://labs.semanticscholar.org/corpus/ is down.