### PR TITLE
Adding a PretrainedTransformerTokenizer

### DIFF
--- a/allennlp/data/tokenizers/__init__.py
+++ b/allennlp/data/tokenizers/__init__.py
@@ -5,5 +5,6 @@ tokenization, stemming, and filtering.
 
 from allennlp.data.tokenizers.tokenizer import Token, Tokenizer
 from allennlp.data.tokenizers.word_tokenizer import WordTokenizer
+from allennlp.data.tokenizers.pretrained_transformer_tokenizer import PretrainedTransformerTokenizer
 from allennlp.data.tokenizers.character_tokenizer import CharacterTokenizer
 from allennlp.data.tokenizers.sentence_splitter import SentenceSplitter

--- a/allennlp/data/tokenizers/character_tokenizer.py
+++ b/allennlp/data/tokenizers/character_tokenizer.py
@@ -47,10 +47,6 @@ class CharacterTokenizer(Tokenizer):
         self._end_tokens = end_tokens or []
 
     @overrides
-    def batch_tokenize(self, texts: List[str]) -> List[List[Token]]:
-        return [self.tokenize(text) for text in texts]
-
-    @overrides
     def tokenize(self, text: str) -> List[Token]:
         if self._lowercase_characters:
             text = text.lower()

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -1,0 +1,65 @@
+import logging
+from typing import List, Tuple
+
+from overrides import overrides
+import pytorch_transformers
+from pytorch_transformers.tokenization_auto import AutoTokenizer
+
+from allennlp.data.tokenizers.token import Token
+from allennlp.data.tokenizers.tokenizer import Tokenizer
+
+logger = logging.getLogger(__name__)
+
+
+@Tokenizer.register("pretrained_transformer")
+class PretrainedTransformerTokenizer(Tokenizer):
+    """
+    A ``PretrainedTransformerTokenizer`` uses a model from HuggingFace's
+    ``pytorch_transformers`` library to tokenize some input text.  This often means wordpieces
+    (where ``'AllenNLP is awesome'`` might get split into ``['Allen', '##NL', '##P', 'is',
+    'awesome']``), but it could also use byte-pair encoding, or some other tokenization, depending
+    on the pretrained model that you're using.
+
+    We take a model name as an input parameter, which we will pass to
+    ``AutoTokenizer.from_pretrained``.
+
+    Parameters
+    ----------
+    model_name : ``str``
+        The name of the pretrained wordpiece tokenizer to use.
+    start_tokens : ``List[str]``, optional
+        If given, these tokens will be added to the beginning of every string we tokenize.  We try
+        to be a little bit smart about defaults here - e.g., if your model name contains ``bert``,
+        we by default add ``[CLS]`` at the beginning and ``[SEP]`` at the end.
+    end_tokens : ``List[str]``, optional
+        If given, these tokens will be added to the end of every string we tokenize.
+    """
+    def __init__(self,
+                 model_name: str,
+                 do_lowercase: bool = True,
+                 start_tokens: List[str] = None,
+                 end_tokens: List[str] = None) -> None:
+        if model_name.endswith("-cased") and do_lowercase:
+            logger.warning("Your wordpiece model appears to be cased, "
+                           "but your indexer is lowercasing tokens.")
+        elif model_name.endswith("-uncased") and not do_lowercase:
+            logger.warning("Your wordpiece model appears to be uncased, "
+                           "but your indexer is not lowercasing tokens.")
+        self._tokenizer = AutoTokenizer.from_pretrained(model_name, do_lower_case=do_lowercase)
+        default_start_tokens, default_end_tokens = _guess_start_and_end_token_defaults(model_name)
+        self._start_tokens = start_tokens if start_tokens is not None else default_start_tokens
+        self._end_tokens = end_tokens if end_tokens is not None else default_end_tokens
+
+    @overrides
+    def tokenize(self, text: str) -> List[Token]:
+        # TODO(mattg): track character offsets.  Might be too challenging to do it here, given that
+        # pytorch-transformers is dealing with the whitespace...
+        token_strings = self._start_tokens + self._tokenizer.tokenize(text) + self._end_tokens
+        return [Token(t) for t in token_strings]
+
+
+def _guess_start_and_end_token_defaults(model_name: str) -> Tuple[List[str], List[str]]:
+    if 'bert' in model_name:
+        return (['[CLS]'], ['[SEP]'])
+    else:
+        return ([], [])

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -35,15 +35,15 @@ class PretrainedTransformerTokenizer(Tokenizer):
     """
     def __init__(self,
                  model_name: str,
-                 do_lowercase: bool = True,
+                 do_lowercase: bool,
                  start_tokens: List[str] = None,
                  end_tokens: List[str] = None) -> None:
         if model_name.endswith("-cased") and do_lowercase:
-            logger.warning("Your wordpiece model appears to be cased, "
-                           "but your indexer is lowercasing tokens.")
+            logger.warning("Your pretrained model appears to be cased, "
+                           "but your tokenizer is lowercasing tokens.")
         elif model_name.endswith("-uncased") and not do_lowercase:
-            logger.warning("Your wordpiece model appears to be uncased, "
-                           "but your indexer is not lowercasing tokens.")
+            logger.warning("Your pretrained model appears to be uncased, "
+                           "but your tokenizer is not lowercasing tokens.")
         self._tokenizer = AutoTokenizer.from_pretrained(model_name, do_lower_case=do_lowercase)
         default_start_tokens, default_end_tokens = _guess_start_and_end_token_defaults(model_name)
         self._start_tokens = start_tokens if start_tokens is not None else default_start_tokens

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -2,7 +2,6 @@ import logging
 from typing import List, Tuple
 
 from overrides import overrides
-import pytorch_transformers
 from pytorch_transformers.tokenization_auto import AutoTokenizer
 
 from allennlp.data.tokenizers.token import Token

--- a/allennlp/data/tokenizers/tokenizer.py
+++ b/allennlp/data/tokenizers/tokenizer.py
@@ -27,8 +27,11 @@ class Tokenizer(Registrable):
         """
         Batches together tokenization of several texts, in case that is faster for particular
         tokenizers.
+
+        By default we just do this without batching.  Override this in your tokenizer if you have a
+        good way of doing batched computation.
         """
-        raise NotImplementedError
+        return [self.tokenize(text) for text in texts]
 
     def tokenize(self, text: str) -> List[Token]:
         """

--- a/allennlp/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -1,0 +1,12 @@
+# pylint: disable=no-self-use,invalid-name
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.tokenizers import PretrainedTransformerTokenizer
+
+class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
+    def test_splits_into_wordpieces(self):
+        tokenizer = PretrainedTransformerTokenizer('bert-base-cased', do_lowercase=False)
+        sentence = "A, [MASK] AllenNLP sentence."
+        tokens = [t.text for t in tokenizer.tokenize(sentence)]
+        expected_tokens = ["[CLS]", "A", ",", "[MASK]", "Allen", "##NL", "##P", "sentence", ".", "[SEP]"]
+        assert tokens == expected_tokens

--- a/doc/api/allennlp.data.tokenizers.rst
+++ b/doc/api/allennlp.data.tokenizers.rst
@@ -14,6 +14,7 @@ allennlp.data.tokenizers
 * :ref:`Tokenizer<tokenizer>`
 * :ref:`WordTokenizer<word-tokenizer>`
 * :ref:`CharacterTokenizer<character-tokenizer>`
+* :ref:`PretrainedTransformerTokenizer<pretrained-transformer-tokenizer>`
 * :ref:`WordFilter<word-filter>`
 * :ref:`WordSplitter<word-splitter>`
 * :ref:`WordStemmer<word-stemmer>`
@@ -32,6 +33,12 @@ allennlp.data.tokenizers
 
 .. _character-tokenizer:
 .. automodule:: allennlp.data.tokenizers.character_tokenizer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. _pretrained-transformer-tokenizer:
+.. automodule:: allennlp.data.tokenizers.pretrained_transformer_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,7 @@ word2number>=1.1
 
 # To use the BERT model
 pytorch-pretrained-bert>=0.6.0
+git+git://github.com/huggingface/pytorch-transformers.git@a7b4cfe9194bf93c7044a42c9f1281260ce6279e
 
 # For caching processed data
 jsonpickle

--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,7 @@ setup(name='allennlp',
           'sqlparse>=0.2.4',
           'word2number>=1.1',
           'pytorch-pretrained-bert>=0.6.0',
+          'pytorch-transformers @ https://api.github.com/repos/huggingface/pytorch-transformers/tarball/a7b4cfe9194bf93c7044a42c9f1281260ce6279e',
           'jsonpickle',
       ],
       entry_points={


### PR DESCRIPTION
First (of many) PRs merging our hackathon project into the main repo.  This one adds a dependency on the new `pytorch-transformers` repo, and grabs a tokenizer from there.

This also fills a gap that we had in our data processing API, where there was no good way to get native BERT (or GPT, etc.) tokenization as input to your model - you had to use words, then split them further into wordpieces or byte pairs.  With this tokenizer, you can have wordpieces or byte pairs be your base tokens, instead of words.