### PR TITLE
Comparison operations return dtype torch.bool

### DIFF
--- a/allennlp/tests/data/fields/array_field_test.py
+++ b/allennlp/tests/data/fields/array_field_test.py
@@ -80,16 +80,16 @@ class TestArrayField(AllenNlpTestCase):
         returned_tensor1 = array_field1.as_tensor(array_field1.get_padding_lengths())
         assert returned_tensor1.dtype == torch.int64
 
-        # Setting dtype to numpy.uint8 should produce a torch.ByteTensor when field is converted to
+        # Setting dtype to numpy.bool should produce a torch.bool when field is converted to
         # a tensor
-        array_field2 = ArrayField(array, dtype=numpy.uint8)
+        array_field2 = ArrayField(array, dtype=numpy.bool)
         returned_tensor2 = array_field2.as_tensor(array_field2.get_padding_lengths())
-        assert returned_tensor2.dtype == torch.uint8
+        assert returned_tensor2.dtype == torch.bool
 
         # Padding should not affect dtype
         padding_lengths = {"dimension_" + str(i): 10 for i, _  in enumerate(shape)}
         padded_tensor = array_field2.as_tensor(padding_lengths)
-        assert padded_tensor.dtype == torch.uint8
+        assert padded_tensor.dtype == torch.bool
 
         # Empty fields should have the same dtype
         empty_field = array_field2.empty_field()

--- a/allennlp/training/metrics/bleu.py
+++ b/allennlp/training/metrics/bleu.py
@@ -106,7 +106,7 @@ class BLEU(Metric):
         return math.exp(1.0 - self._reference_lengths / self._prediction_lengths)
 
     def _get_valid_tokens_mask(self, tensor: torch.LongTensor) -> torch.ByteTensor:
-        valid_tokens_mask = torch.ones(tensor.size(), dtype=torch.uint8)
+        valid_tokens_mask = torch.ones(tensor.size(), dtype=torch.bool)
         for index in self._exclude_indices:
             valid_tokens_mask = valid_tokens_mask & (tensor != index)
         return valid_tokens_mask

--- a/allennlp/training/metrics/fbeta_measure.py
+++ b/allennlp/training/metrics/fbeta_measure.py
@@ -119,7 +119,7 @@ class FBetaMeasure(Metric):
 
         if mask is None:
             mask = torch.ones_like(gold_labels)
-        mask = mask.to(torch.uint8)
+        mask = mask.to(torch.bool)
         gold_labels = gold_labels.float()
 
         argmax_predictions = predictions.max(dim=-1)[1].float()


### PR DESCRIPTION
From [release note](https://github.com/pytorch/pytorch/releases) of torch:

> Comparison operations (lt (<), le (<=), gt (>), ge (>=), eq (==), ne, (!=) ) return dtype has changed from torch.uint8 to torch.bool (21113)

* Note:
Since I haven't made the correction for the other torch modification all the test faillure where there before my modification.

So feel free to reject it if this is unaceptable, just whant to help solve this problem since I got this error and managed to solved it.