### PR TITLE
Switch SemanticRoleLabeler metric to SrlEvalScorer.

### DIFF
--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -159,7 +159,7 @@ class SemanticRoleLabeler(Model):
                                                       tags,
                                                       mask,
                                                       label_smoothing=self._label_smoothing)
-            if not self.ignore_span_metric:
+            if not self.ignore_span_metric and self.span_metric is not None and not self.training:
                 batch_verb_indices = [example_metadata["verb_index"] for example_metadata in metadata]
                 batch_sentences = [example_metadata["words"] for example_metadata in metadata]
                 # TODO (nfliu): This is kind of a hack, consider splitting out part

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -8,14 +8,14 @@ import torch.nn.functional as F
 
 from allennlp.common.checks import check_dimensions_match
 from allennlp.data import Vocabulary
+from allennlp.models.srl_util import convert_bio_tags_to_conll_format, write_bio_formatted_tags_to_file
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder
 from allennlp.modules.token_embedders import Embedding
 from allennlp.models.model import Model
 from allennlp.nn import InitializerApplicator, RegularizerApplicator
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 from allennlp.nn.util import get_lengths_from_binary_sequence_mask, viterbi_decode
-from allennlp.training.metrics import SpanBasedF1Measure
-
+from allennlp.training.metrics.srl_eval_scorer import SrlEvalScorer
 
 @Model.register("srl")
 class SemanticRoleLabeler(Model):
@@ -67,9 +67,7 @@ class SemanticRoleLabeler(Model):
         self.text_field_embedder = text_field_embedder
         self.num_classes = self.vocab.get_vocab_size("labels")
 
-        # For the span based evaluation, we don't want to consider labels
-        # for verb, because the verb index is provided to the model.
-        self.span_metric = SpanBasedF1Measure(vocab, tag_namespace="labels", ignore_classes=["V"])
+        self.span_metric = SrlEvalScorer()
 
         self.encoder = encoder
         # There are exactly 2 binary features for the verb predicate embedding.
@@ -144,19 +142,33 @@ class SemanticRoleLabeler(Model):
                                                                           sequence_length,
                                                                           self.num_classes])
         output_dict = {"logits": logits, "class_probabilities": class_probabilities}
+        # We need to retain the mask in the output dictionary
+        # so that we can crop the sequences to remove padding
+        # when we do viterbi inference in self.decode.
+        output_dict["mask"] = mask
+
         if tags is not None:
             loss = sequence_cross_entropy_with_logits(logits,
                                                       tags,
                                                       mask,
                                                       label_smoothing=self._label_smoothing)
             if not self.ignore_span_metric:
-                self.span_metric(class_probabilities, tags, mask)
+                batch_verb_indices = [example_metadata["verb_index"] for example_metadata in metadata]
+                batch_sentences = [example_metadata["words"] for example_metadata in metadata]
+                # TODO (nfliu): This is kind of a hack, consider splitting out part
+                # of decode() to a separate function.
+                batch_bio_predicted_tags = self.decode(output_dict).pop("tags")
+                batch_conll_predicted_tags = [convert_bio_tags_to_conll_format(tags) for
+                                              tags in batch_bio_predicted_tags]
+                batch_bio_gold_tags = [example_metadata["gold_tags"] for example_metadata in metadata]
+                batch_conll_gold_tags = [convert_bio_tags_to_conll_format(tags) for
+                                         tags in batch_bio_gold_tags]
+                # Get the BIO tags from decode()
+                self.span_metric(batch_verb_indices,
+                                 batch_sentences,
+                                 batch_conll_predicted_tags,
+                                 batch_conll_gold_tags)
             output_dict["loss"] = loss
-
-        # We need to retain the mask in the output dictionary
-        # so that we can crop the sequences to remove padding
-        # when we do viterbi inference in self.decode.
-        output_dict["mask"] = mask
 
         words, verbs = zip(*[(x["words"], x["verb"]) for x in metadata])
         if metadata is not None:
@@ -296,136 +308,3 @@ def write_to_conll_eval_file(prediction_file: TextIO,
                                      sentence,
                                      prediction,
                                      gold_labels)
-
-
-def write_bio_formatted_tags_to_file(prediction_file: TextIO,
-                                     gold_file: TextIO,
-                                     verb_index: Optional[int],
-                                     sentence: List[str],
-                                     prediction: List[str],
-                                     gold_labels: List[str]):
-    """
-    Prints predicate argument predictions and gold labels for a single verbal
-    predicate in a sentence to two provided file references.
-
-    The CoNLL SRL format is described in
-    `the shared task data README <https://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
-
-    This function expects IOB2-formatted tags, where the B- tag is used in the beginning
-    of every chunk (i.e. all chunks start with the B- tag).
-
-    Parameters
-    ----------
-    prediction_file : TextIO, required.
-        A file reference to print predictions to.
-    gold_file : TextIO, required.
-        A file reference to print gold labels to.
-    verb_index : Optional[int], required.
-        The index of the verbal predicate in the sentence which
-        the gold labels are the arguments for, or None if the sentence
-        contains no verbal predicate.
-    sentence : List[str], required.
-        The word tokens.
-    prediction : List[str], required.
-        The predicted BIO labels.
-    gold_labels : List[str], required.
-        The gold BIO labels.
-    """
-    conll_formatted_predictions = convert_bio_tags_to_conll_format(prediction)
-    conll_formatted_gold_labels = convert_bio_tags_to_conll_format(gold_labels)
-    write_conll_formatted_tags_to_file(prediction_file,
-                                       gold_file,
-                                       verb_index,
-                                       sentence,
-                                       conll_formatted_predictions,
-                                       conll_formatted_gold_labels)
-
-
-def write_conll_formatted_tags_to_file(prediction_file: TextIO,
-                                       gold_file: TextIO,
-                                       verb_index: Optional[int],
-                                       sentence: List[str],
-                                       conll_formatted_predictions: List[str],
-                                       conll_formatted_gold_labels: List[str]):
-    """
-    Prints predicate argument predictions and gold labels for a single verbal
-    predicate in a sentence to two provided file references.
-
-    The CoNLL SRL format is described in
-    `the shared task data README <https://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
-
-    This function expects IOB2-formatted tags, where the B- tag is used in the beginning
-    of every chunk (i.e. all chunks start with the B- tag).
-
-    Parameters
-    ----------
-    prediction_file : TextIO, required.
-        A file reference to print predictions to.
-    gold_file : TextIO, required.
-        A file reference to print gold labels to.
-    verb_index : Optional[int], required.
-        The index of the verbal predicate in the sentence which
-        the gold labels are the arguments for, or None if the sentence
-        contains no verbal predicate.
-    sentence : List[str], required.
-        The word tokens.
-    conll_formatted_predictions : List[str], required.
-        The predicted CoNLL-formatted labels.
-    conll_formatted_gold_labels : List[str], required.
-        The gold CoNLL-formatted labels.
-    """
-    verb_only_sentence = ["-"] * len(sentence)
-    if verb_index:
-        verb_only_sentence[verb_index] = sentence[verb_index]
-
-    for word, predicted, gold in zip(verb_only_sentence,
-                                     conll_formatted_predictions,
-                                     conll_formatted_gold_labels):
-        prediction_file.write(word.ljust(15))
-        prediction_file.write(predicted.rjust(15) + "\n")
-        gold_file.write(word.ljust(15))
-        gold_file.write(gold.rjust(15) + "\n")
-    prediction_file.write("\n")
-    gold_file.write("\n")
-
-
-def convert_bio_tags_to_conll_format(labels: List[str]):
-    """
-    Converts BIO formatted SRL tags to the format required for evaluation with the
-    official CONLL 2005 perl script. Spans are represented by bracketed labels,
-    with the labels of words inside spans being the same as those outside spans.
-    Beginning spans always have a opening bracket and a closing asterisk (e.g. "(ARG-1*" )
-    and closing spans always have a closing bracket (e.g. "*)" ). This applies even for
-    length 1 spans, (e.g "(ARG-0*)").
-
-    A full example of the conversion performed:
-
-    [B-ARG-1, I-ARG-1, I-ARG-1, I-ARG-1, I-ARG-1, O]
-    [ "(ARG-1*", "*", "*", "*", "*)", "*"]
-
-    Parameters
-    ----------
-    labels : List[str], required.
-        A list of BIO tags to convert to the CONLL span based format.
-
-    Returns
-    -------
-    A list of labels in the CONLL span based format.
-    """
-    sentence_length = len(labels)
-    conll_labels = []
-    for i, label in enumerate(labels):
-        if label == "O":
-            conll_labels.append("*")
-            continue
-        new_label = "*"
-        # Are we at the beginning of a new span, at the first word in the sentence,
-        # or is the label different from the previous one? If so, we are seeing a new label.
-        if label[0] == "B" or i == 0 or label[1:] != labels[i - 1][1:]:
-            new_label = "(" + label[2:] + new_label
-        # Are we at the end of the sentence, is the next word a new span, or is the next
-        # word not in a span? If so, we need to close the label span.
-        if i == sentence_length - 1 or labels[i + 1][0] == "B" or label[1:] != labels[i + 1][1:]:
-            new_label = new_label + ")"
-        conll_labels.append(new_label)
-    return conll_labels

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -164,6 +164,7 @@ class SemanticRoleLabeler(Model):
             if not self.ignore_span_metric and self.span_metric is not None and not self.training:
                 batch_verb_indices = [example_metadata["verb_index"] for example_metadata in metadata]
                 batch_sentences = [example_metadata["words"] for example_metadata in metadata]
+                # Get the BIO tags from decode()
                 # TODO (nfliu): This is kind of a hack, consider splitting out part
                 # of decode() to a separate function.
                 batch_bio_predicted_tags = self.decode(output_dict).pop("tags")
@@ -172,7 +173,6 @@ class SemanticRoleLabeler(Model):
                 batch_bio_gold_tags = [example_metadata["gold_tags"] for example_metadata in metadata]
                 batch_conll_gold_tags = [convert_bio_tags_to_conll_format(tags) for
                                          tags in batch_bio_gold_tags]
-                # Get the BIO tags from decode()
                 self.span_metric(batch_verb_indices,
                                  batch_sentences,
                                  batch_conll_predicted_tags,

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -72,6 +72,8 @@ class SemanticRoleLabeler(Model):
         self.num_classes = self.vocab.get_vocab_size("labels")
 
         if srl_eval_path is not None:
+            # For the span based evaluation, we don't want to consider labels
+            # for verb, because the verb index is provided to the model.
             self.span_metric = SrlEvalScorer(srl_eval_path, ignore_classes=["V"])
         else:
             self.span_metric = None

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -67,7 +67,7 @@ class SemanticRoleLabeler(Model):
         self.text_field_embedder = text_field_embedder
         self.num_classes = self.vocab.get_vocab_size("labels")
 
-        self.span_metric = SrlEvalScorer()
+        self.span_metric = SrlEvalScorer(ignore_classes=["V"])
 
         self.encoder = encoder
         # There are exactly 2 binary features for the verb predicate embedding.

--- a/allennlp/models/srl_util.py
+++ b/allennlp/models/srl_util.py
@@ -11,7 +11,7 @@ def write_bio_formatted_tags_to_file(prediction_file: TextIO,
     predicate in a sentence to two provided file references.
 
     The CoNLL SRL format is described in
-    `the shared task data README <http://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
+    `the shared task data README <https://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
 
     This function expects IOB2-formatted tags, where the B- tag is used in the beginning
     of every chunk (i.e. all chunks start with the B- tag).
@@ -54,7 +54,7 @@ def write_conll_formatted_tags_to_file(prediction_file: TextIO,
     predicate in a sentence to two provided file references.
 
     The CoNLL SRL format is described in
-    `the shared task data README <http://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
+    `the shared task data README <https://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
 
     This function expects IOB2-formatted tags, where the B- tag is used in the beginning
     of every chunk (i.e. all chunks start with the B- tag).

--- a/allennlp/models/srl_util.py
+++ b/allennlp/models/srl_util.py
@@ -1,0 +1,133 @@
+from typing import List, TextIO, Optional
+
+def write_bio_formatted_tags_to_file(prediction_file: TextIO,
+                                     gold_file: TextIO,
+                                     verb_index: Optional[int],
+                                     sentence: List[str],
+                                     prediction: List[str],
+                                     gold_labels: List[str]):
+    """
+    Prints predicate argument predictions and gold labels for a single verbal
+    predicate in a sentence to two provided file references.
+
+    The CoNLL SRL format is described in
+    `the shared task data README <http://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
+
+    This function expects IOB2-formatted tags, where the B- tag is used in the beginning
+    of every chunk (i.e. all chunks start with the B- tag).
+
+    Parameters
+    ----------
+    prediction_file : TextIO, required.
+        A file reference to print predictions to.
+    gold_file : TextIO, required.
+        A file reference to print gold labels to.
+    verb_index : Optional[int], required.
+        The index of the verbal predicate in the sentence which
+        the gold labels are the arguments for, or None if the sentence
+        contains no verbal predicate.
+    sentence : List[str], required.
+        The word tokens.
+    prediction : List[str], required.
+        The predicted BIO labels.
+    gold_labels : List[str], required.
+        The gold BIO labels.
+    """
+    conll_formatted_predictions = convert_bio_tags_to_conll_format(prediction)
+    conll_formatted_gold_labels = convert_bio_tags_to_conll_format(gold_labels)
+    write_conll_formatted_tags_to_file(prediction_file,
+                                       gold_file,
+                                       verb_index,
+                                       sentence,
+                                       conll_formatted_predictions,
+                                       conll_formatted_gold_labels)
+
+
+def write_conll_formatted_tags_to_file(prediction_file: TextIO,
+                                       gold_file: TextIO,
+                                       verb_index: Optional[int],
+                                       sentence: List[str],
+                                       conll_formatted_predictions: List[str],
+                                       conll_formatted_gold_labels: List[str]):
+    """
+    Prints predicate argument predictions and gold labels for a single verbal
+    predicate in a sentence to two provided file references.
+
+    The CoNLL SRL format is described in
+    `the shared task data README <http://www.lsi.upc.edu/~srlconll/conll05st-release/README>`_ .
+
+    This function expects IOB2-formatted tags, where the B- tag is used in the beginning
+    of every chunk (i.e. all chunks start with the B- tag).
+
+    Parameters
+    ----------
+    prediction_file : TextIO, required.
+        A file reference to print predictions to.
+    gold_file : TextIO, required.
+        A file reference to print gold labels to.
+    verb_index : Optional[int], required.
+        The index of the verbal predicate in the sentence which
+        the gold labels are the arguments for, or None if the sentence
+        contains no verbal predicate.
+    sentence : List[str], required.
+        The word tokens.
+    conll_formatted_predictions : List[str], required.
+        The predicted CoNLL-formatted labels.
+    conll_formatted_gold_labels : List[str], required.
+        The gold CoNLL-formatted labels.
+    """
+    verb_only_sentence = ["-"] * len(sentence)
+    if verb_index:
+        verb_only_sentence[verb_index] = sentence[verb_index]
+
+    for word, predicted, gold in zip(verb_only_sentence,
+                                     conll_formatted_predictions,
+                                     conll_formatted_gold_labels):
+        prediction_file.write(word.ljust(15))
+        prediction_file.write(predicted.rjust(15) + "\n")
+        gold_file.write(word.ljust(15))
+        gold_file.write(gold.rjust(15) + "\n")
+    prediction_file.write("\n")
+    gold_file.write("\n")
+
+
+def convert_bio_tags_to_conll_format(labels: List[str]):
+    """
+    Converts BIO formatted SRL tags to the format required for evaluation with the
+    official CONLL 2005 perl script. Spans are represented by bracketed labels,
+    with the labels of words inside spans being the same as those outside spans.
+    Beginning spans always have a opening bracket and a closing asterisk (e.g. "(ARG-1*" )
+    and closing spans always have a closing bracket (e.g. "*)" ). This applies even for
+    length 1 spans, (e.g "(ARG-0*)").
+
+    A full example of the conversion performed:
+
+    [B-ARG-1, I-ARG-1, I-ARG-1, I-ARG-1, I-ARG-1, O]
+    [ "(ARG-1*", "*", "*", "*", "*)", "*"]
+
+    Parameters
+    ----------
+    labels : List[str], required.
+        A list of BIO tags to convert to the CONLL span based format.
+
+    Returns
+    -------
+    A list of labels in the CONLL span based format.
+    """
+    sentence_length = len(labels)
+    conll_labels = []
+    for i, label in enumerate(labels):
+        if label == "O":
+            conll_labels.append("*")
+            continue
+        new_label = "*"
+        # Are we at the beginning of a new span, at the first word in the sentence,
+        # or is the label different from the previous one? If so, we are seeing a new label.
+        if label[0] == "B" or i == 0 or label[1:] != labels[i - 1][1:]:
+            new_label = "(" + label[2:] + new_label
+        # Are we at the end of the sentence, is the next word a new span, or is the next
+        # word not in a span? If so, we need to close the label span.
+        if i == sentence_length - 1 or labels[i + 1][0] == "B" or label[1:] != labels[i + 1][1:]:
+            new_label = new_label + ")"
+        conll_labels.append(new_label)
+    return conll_labels

--- a/allennlp/tests/models/semantic_role_labeler_test.py
+++ b/allennlp/tests/models/semantic_role_labeler_test.py
@@ -9,9 +9,9 @@ import numpy
 from allennlp.common.testing import ModelTestCase
 from allennlp.common.params import Params
 from allennlp.common.checks import ConfigurationError
-from allennlp.models.semantic_role_labeler import convert_bio_tags_to_conll_format
 from allennlp.models import Model
-from allennlp.models.semantic_role_labeler import write_bio_formatted_tags_to_file
+from allennlp.models.srl_util import (
+        convert_bio_tags_to_conll_format, write_bio_formatted_tags_to_file)
 from allennlp.nn.util import get_lengths_from_binary_sequence_mask
 
 from allennlp.data.dataset_readers.dataset_utils.span_utils import to_bioul

--- a/allennlp/tests/training/metrics/srl_eval_scorer_test.py
+++ b/allennlp/tests/training/metrics/srl_eval_scorer_test.py
@@ -2,7 +2,7 @@
 from numpy.testing import assert_allclose
 
 from allennlp.common.testing import AllenNlpTestCase
-from allennlp.models.semantic_role_labeler import convert_bio_tags_to_conll_format
+from allennlp.models.srl_util import convert_bio_tags_to_conll_format
 from allennlp.training.metrics import SrlEvalScorer
 
 

--- a/allennlp/tests/training/metrics/srl_eval_scorer_test.py
+++ b/allennlp/tests/training/metrics/srl_eval_scorer_test.py
@@ -34,13 +34,13 @@ class SrlEvalScorerTest(AllenNlpTestCase):
         batch_conll_gold_tags = [convert_bio_tags_to_conll_format(tags) for
                                  tags in batch_bio_gold_tags]
 
-        srl_scorer = SrlEvalScorer()
+        srl_scorer = SrlEvalScorer(ignore_classes=["V"])
         srl_scorer(batch_verb_indices,
                    batch_sentences,
                    batch_conll_predicted_tags,
                    batch_conll_gold_tags)
         metrics = srl_scorer.get_metric()
-        assert len(metrics) == 18
+        assert len(metrics) == 15
         assert_allclose(metrics['precision-ARG0'], 1.0)
         assert_allclose(metrics['recall-ARG0'], 1.0)
         assert_allclose(metrics['f1-measure-ARG0'], 1.0)
@@ -50,9 +50,6 @@ class SrlEvalScorerTest(AllenNlpTestCase):
         assert_allclose(metrics['precision-ARG2'], 1.0)
         assert_allclose(metrics['recall-ARG2'], 1.0)
         assert_allclose(metrics['f1-measure-ARG2'], 1.0)
-        assert_allclose(metrics['precision-V'], 1.0)
-        assert_allclose(metrics['recall-V'], 1.0)
-        assert_allclose(metrics['f1-measure-V'], 1.0)
         assert_allclose(metrics['precision-ARGM-TMP'], 1.0)
         assert_allclose(metrics['recall-ARGM-TMP'], 1.0)
         assert_allclose(metrics['f1-measure-ARGM-TMP'], 1.0)
@@ -70,23 +67,20 @@ class SrlEvalScorerTest(AllenNlpTestCase):
         batch_conll_gold_tags = [convert_bio_tags_to_conll_format(tags) for
                                  tags in batch_bio_gold_tags]
 
-        srl_scorer = SrlEvalScorer()
+        srl_scorer = SrlEvalScorer(ignore_classes=["V"])
         srl_scorer(batch_verb_indices,
                    batch_sentences,
                    batch_conll_predicted_tags,
                    batch_conll_gold_tags)
         metrics = srl_scorer.get_metric()
-        assert len(metrics) == 12
+        assert len(metrics) == 9
         assert_allclose(metrics['precision-ARG0'], 0.0)
         assert_allclose(metrics['recall-ARG0'], 0.0)
         assert_allclose(metrics['f1-measure-ARG0'], 0.0)
         assert_allclose(metrics['precision-ARG1'], 0.5)
         assert_allclose(metrics['recall-ARG1'], 1.0)
         assert_allclose(metrics['f1-measure-ARG1'], 2/3)
-        assert_allclose(metrics['precision-V'], 1.0)
-        assert_allclose(metrics['recall-V'], 1.0)
-        assert_allclose(metrics['f1-measure-V'], 1.0)
-        assert_allclose(metrics['precision-overall'], 1/2)
-        assert_allclose(metrics['recall-overall'], 2/3)
+        assert_allclose(metrics['precision-overall'], 1/3)
+        assert_allclose(metrics['recall-overall'], 1/2)
         assert_allclose(metrics['f1-measure-overall'],
-                        (2 * (2/3) * (1/2)) / ((2/3) + (1/2)))
+                        (2 * (1/3) * (1/2)) / ((1/3) + (1/2)))

--- a/allennlp/training/metrics/__init__.py
+++ b/allennlp/training/metrics/__init__.py
@@ -23,6 +23,6 @@ from allennlp.training.metrics.perplexity import Perplexity
 from allennlp.training.metrics.sequence_accuracy import SequenceAccuracy
 from allennlp.training.metrics.span_based_f1_measure import SpanBasedF1Measure
 from allennlp.training.metrics.squad_em_and_f1 import SquadEmAndF1
-from allennlp.training.metrics.srl_eval_scorer import SrlEvalScorer
+from allennlp.training.metrics.srl_eval_scorer import SrlEvalScorer, DEFAULT_SRL_EVAL_PATH
 from allennlp.training.metrics.unigram_recall import UnigramRecall
 from allennlp.training.metrics.auc import Auc

--- a/allennlp/training/metrics/srl_eval_scorer.py
+++ b/allennlp/training/metrics/srl_eval_scorer.py
@@ -33,10 +33,14 @@ class SrlEvalScorer(Metric):
     ----------
     srl_eval_path : ``str``, optional.
         The path to the srl-eval.pl script.
+    ignore_classes : ``List[str]``, optional (default=``None``).
+        A list of classes to ignore.
     """
     def __init__(self,
-                 srl_eval_path: str = DEFAULT_SRL_EVAL_PATH) -> None:
+                 srl_eval_path: str = DEFAULT_SRL_EVAL_PATH,
+                 ignore_classes: List[str] = None) -> None:
         self._srl_eval_path = srl_eval_path
+        self._ignore_classes = set(ignore_classes)
         # These will hold per label span counts.
         self._true_positives: Dict[str, int] = defaultdict(int)
         self._false_positives: Dict[str, int] = defaultdict(int)
@@ -95,7 +99,7 @@ class SrlEvalScorer(Metric):
             if len(stripped) == 7:
                 tag = stripped[0]
                 # Overall metrics are calculated in get_metric, skip them here.
-                if tag == "Overall":
+                if tag == "Overall" or tag in self._ignore_classes:
                     continue
                 # This line contains results for a span
                 num_correct = int(stripped[1])

--- a/allennlp/training/metrics/srl_eval_scorer.py
+++ b/allennlp/training/metrics/srl_eval_scorer.py
@@ -10,7 +10,7 @@ from overrides import overrides
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.training.metrics.metric import Metric
-from allennlp.models.semantic_role_labeler import write_conll_formatted_tags_to_file
+from allennlp.models.srl_util import write_conll_formatted_tags_to_file
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/doc/api/allennlp.models.rst
+++ b/doc/api/allennlp.models.rst
@@ -31,3 +31,4 @@ allennlp.models
   allennlp.models.language_model
   allennlp.models.simple_tagger
   allennlp.models.srl_bert
+  allennlp.models.srl_util

--- a/doc/api/allennlp.models.srl_util.rst
+++ b/doc/api/allennlp.models.srl_util.rst
@@ -1,0 +1,7 @@
+allennlp.models.srl_util
+========================
+
+.. automodule:: allennlp.models.srl_util
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
#2743 added the SrlEvalScorer, but I didn't actually change the metric used in the `SemanticRoleLabeler` 😅 

This PR has a few things:
- Fixes a circular import between SrlEvalMetric and SemanticRoleLabeler by moving the utility functions for converting between BIO / CoNLL tags to a separate `srl_utils.py` file. Let me know if you want them somewhere else.
- Switch `SemanticRoleLabeler.span_metric` from `SpanBasedF1` to `SrlEvalScorer`.

I'll try actually training this model in a bit, to make sure that nothing broke disastrously. The fact that the tests still work is somewhat promising, though...