### PR TITLE
bug fix for default tokenization of knowledge graph entities

### DIFF
--- a/allennlp/tests/data/fields/knowledge_graph_field_test.py
+++ b/allennlp/tests/data/fields/knowledge_graph_field_test.py
@@ -152,3 +152,10 @@ class KnowledgeGraphFieldTest(AllenNlpTestCase):
         expected_linking_tensor = torch.stack([tensor_dict1['linking'], tensor_dict2['linking']])
         assert_almost_equal(batched_tensor_dict['linking'].detach().cpu().numpy(),
                             expected_linking_tensor.detach().cpu().numpy())
+
+    def test_tokenizer_exists(self):
+        try:
+            field = KnowledgeGraphField(self.graph, self.utterance, self.token_indexers, None)
+            assert (field._tokenizer is not None)
+        except AttributeError as e:
+            pytest.fail(str(e))

--- a/allennlp/tests/data/fields/knowledge_graph_field_test.py
+++ b/allennlp/tests/data/fields/knowledge_graph_field_test.py
@@ -153,9 +153,8 @@ class KnowledgeGraphFieldTest(AllenNlpTestCase):
         assert_almost_equal(batched_tensor_dict['linking'].detach().cpu().numpy(),
                             expected_linking_tensor.detach().cpu().numpy())
 
-    def test_tokenizer_exists(self):
+    def test_field_initialized_with_empty_constructor(self):
         try:
-            field = KnowledgeGraphField(self.graph, self.utterance, self.token_indexers, None)
-            assert (field._tokenizer is not None)
-        except AttributeError as e:
-            pytest.fail(str(e))
+            self.field.empty_field()
+        except AssertionError as e:
+            pytest.fail(str(e), pytrace=True)


### PR DESCRIPTION
This pull request handles the issue described in #3138 by adding a default tokenizer for the knowledge_graph_field and includes a test that catches this issue for future builds.