### PR TITLE
Use the pytorch base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,6 @@ FROM pytorch/pytorch:1.1.0-cuda10.0-cudnn7.5-runtime
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-ENV PATH /usr/local/nvidia/bin/:$PATH
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
-
-# Tell nvidia-docker the driver spec that we need as well as to
-# use all available devices, which are mounted at /usr/local/nvidia.
-# The LABEL supports an older version of nvidia-docker, the env
-# variables a newer one.
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 
 WORKDIR /stage/allennlp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.8-stretch
+FROM pytorch/pytorch:1.1.0-cuda10.0-cudnn7.5-runtime
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8


### PR DESCRIPTION
The reason I attempted this was to get an image that could run as-is on our on-premise hardware (such as `allennlp-server-3`).  Currently `allennlp/allennlp:v0.8.4` will fail with a `CUDNN_STATUS_EXECUTION_FAILED` but this change will force `allennlp` to use the right version of CUDA (10.0).

I'm not sure this is a good idea.  It does increase the base image size, but only slightly.

```
allennlp/allennlp                                         v0.8.4                                     ed8b963a800a        2 months ago        3.93GB
pytorch/pytorch                                           1.1.0-cuda10.0-cudnn7.5-runtime            299bfb9e54db        3 months ago        4.17GB
```

For size (and build times) this is probably a net win because more is done (and cached) in the base image.  That said, we do have less control on what version of Python we're using (currently Python 3.6.8 from Anaconda) although we could regain that functionality by re-implementing https://github.com/pytorch/pytorch/blob/master/docker/pytorch/Dockerfile.