### PR TITLE
Modify docstring to add example for initializing weights from a pretrained model

### DIFF
--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -230,7 +230,8 @@ class PretrainedModelInitializer(Initializer):
            {
                "type": "pretrained",
                "weights_file_path": "best.th",
-               "parameter_name_overrides": {}
+               "parameter_name_overrides": {
+               }
            }
        ]
 

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -226,13 +226,16 @@ class PretrainedModelInitializer(Initializer):
 
     To initialize weights for all the parameters from a pretrained model (assuming their names
     remain unchanged), use the following instead:
-       [".*",
-           {
-               "type": "pretrained",
-               "weights_file_path": "best.th",
-               "parameter_name_overrides": {}
-           }
-       ]
+
+        .. code-block:: js
+
+            [".*",
+                {
+                    "type": "pretrained",
+                    "weights_file_path": "best.th",
+                    "parameter_name_overrides": {}
+                }
+            ]
 
     Parameters
     ----------

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -230,8 +230,7 @@ class PretrainedModelInitializer(Initializer):
            {
                "type": "pretrained",
                "weights_file_path": "best.th",
-               "parameter_name_overrides": {
-               }
+               "parameter_name_overrides": {}
            }
        ]
 

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -224,6 +224,16 @@ class PretrainedModelInitializer(Initializer):
            }
        ]
 
+    To initialize weights for all the parameters from a pretrained model (assuming their names
+    remain unchanged), use the following instead:
+       [".*",
+           {
+               "type": "pretrained",
+               "weights_file_path": "best.th",
+               "parameter_name_overrides": {}
+           }
+       ]
+
     Parameters
     ----------
     weights_file_path : ``str``, required


### PR DESCRIPTION
In light of discussion on [this issue](https://github.com/allenai/allennlp/issues/3144), modified docstring to include example for initializing weights for all parameters using a pretrained checkpoint without passing named parameters.