### PR TITLE
 Modify bioul_tags_to_spans for ill-formed spans 

### DIFF
--- a/allennlp/data/dataset_readers/dataset_utils/span_utils.py
+++ b/allennlp/data/dataset_readers/dataset_utils/span_utils.py
@@ -242,9 +242,11 @@ def bioul_tags_to_spans(tag_sequence: List[str],
     while index < len(tag_sequence):
         label = tag_sequence[index]
         if label[0] == 'U':
-            spans.append((label.partition('-')[2], (index, index)))
+            start_index = index
+            end_index = index
+            spans.append((label.partition('-')[2], (start_index, end_index)))
         elif label[0] == 'B':
-            start = index
+            start_index = index
             tag_type = label.partition('-')[2]
             index += 1
             label = tag_sequence[index]
@@ -253,13 +255,13 @@ def bioul_tags_to_spans(tag_sequence: List[str],
                 if index >= len(tag_sequence):
                     raise InvalidTagSequence(tag_sequence)
                 label = tag_sequence[index]
-                if not (label[0] == 'I' or label[0] == 'L'):
+                if not (label[0] == 'I' or label[0] == 'L' or label[0] == 'O'):
                     raise InvalidTagSequence(tag_sequence)
             if label.partition('-')[0] == 'L' and label.partition('-')[2] == tag_type:
-                spans.append((label.partition('-')[2], (start, index)))
-        else:
-            if label != 'O':
-                raise InvalidTagSequence(tag_sequence)
+                end_index = index
+                spans.append((label.partition('-')[2], (start_index, end_index)))
+            else:
+                index -= 1 #avoid start with "U"
         index += 1
     return [span for span in spans if span[0] not in classes_to_ignore]
 

--- a/allennlp/data/dataset_readers/dataset_utils/span_utils.py
+++ b/allennlp/data/dataset_readers/dataset_utils/span_utils.py
@@ -219,7 +219,7 @@ def bioul_tags_to_spans(tag_sequence: List[str],
     """
     Given a sequence corresponding to BIOUL tags, extracts spans.
     Spans are inclusive and can be of zero length, representing a single word span.
-    Ill-formed spans are not allowed and will raise ``InvalidTagSequence``.
+    Ill-formed spans will be ignored.
     This function works properly when the spans are unlabeled (i.e., your labels are
     simply "B", "I", "O", "U", and "L").
 
@@ -245,14 +245,18 @@ def bioul_tags_to_spans(tag_sequence: List[str],
             spans.append((label.partition('-')[2], (index, index)))
         elif label[0] == 'B':
             start = index
-            while label[0] != 'L':
+            tag_type = label.partition('-')[2]
+            index += 1
+            label = tag_sequence[index]
+            while label.partition('-')[0] == 'I' and label.partition('-')[2] == tag_type:
                 index += 1
                 if index >= len(tag_sequence):
                     raise InvalidTagSequence(tag_sequence)
                 label = tag_sequence[index]
                 if not (label[0] == 'I' or label[0] == 'L'):
                     raise InvalidTagSequence(tag_sequence)
-            spans.append((label.partition('-')[2], (start, index)))
+            if label.partition('-')[0] == 'L' and label.partition('-')[2] == tag_type:
+                spans.append((label.partition('-')[2], (start, index)))
         else:
             if label != 'O':
                 raise InvalidTagSequence(tag_sequence)

--- a/allennlp/tests/data/dataset_readers/dataset_utils/span_utils_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_utils/span_utils_test.py
@@ -109,19 +109,18 @@ class SpanUtilsTest(AllenNlpTestCase):
         tag_sequence = ['B-PER', 'I-PER', 'L-PER', 'U-PER', 'U-LOC', 'O']
         spans = span_utils.bioul_tags_to_spans(tag_sequence)
         assert spans == [('PER', (0, 2)), ('PER', (3, 3)), ('LOC', (4, 4))]
-
-        tag_sequence = ['B-PER', 'I-PER', 'O']
-        with self.assertRaises(span_utils.InvalidTagSequence):
-            spans = span_utils.bioul_tags_to_spans(tag_sequence)
+        
+        tag_sequence = ['B-PER', 'I-PER', 'O','L-PER', 'U-PER', 'B-LOC', 'L-LOC']
+        spans = span_utils.bioul_tags_to_spans(tag_sequence)
+        assert spans == [('PER', (4, 4)), ('LOC', (5, 6))
 
     def test_bioul_tags_to_spans_without_labels(self):
         tag_sequence = ['B', 'I', 'L', 'U', 'U', 'O']
         spans = span_utils.bioul_tags_to_spans(tag_sequence)
         assert spans == [('', (0, 2)), ('', (3, 3)), ('', (4, 4))]
 
-        tag_sequence = ['B', 'I', 'O']
-        with self.assertRaises(span_utils.InvalidTagSequence):
-            spans = span_utils.bioul_tags_to_spans(tag_sequence)
+        tag_sequence = ['B', 'U', 'O','B', 'I', 'L']
+        assert spans == [('', (1, 1)), ('', (3, 5))]
 
     def test_iob1_to_bioul(self):
         tag_sequence = ['I-ORG', 'O', 'I-MISC', 'O']


### PR DESCRIPTION
If a span is ill-formed, it will not be append to spans list instead of raise InvalidTagSequence.