### PR TITLE
add infer_type_and_cast flags to seq2seq and seq2vec modules

### DIFF
--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -85,7 +85,7 @@ class _Seq2SeqWrapper:
         if self._module_class in self.PYTORCH_MODELS:
             params['batch_first'] = True
         stateful = params.pop_bool('stateful', False)
-        module = self._module_class(**params.as_dict())
+        module = self._module_class(**params.as_dict(infer_type_and_cast=True))
         return PytorchSeq2SeqWrapper(module, stateful=stateful)
 
 # pylint: disable=protected-access

--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -71,7 +71,7 @@ class _Seq2VecWrapper:
             raise ConfigurationError("Our encoder semantics assumes batch is always first!")
         if self._module_class in self.PYTORCH_MODELS:
             params['batch_first'] = True
-        module = self._module_class(**params.as_dict())
+        module = self._module_class(**params.as_dict(infer_type_and_cast=True))
         return PytorchSeq2VecWrapper(module)
 
 # pylint: disable=protected-access


### PR DESCRIPTION
This PR adds the `infer_type_and_cast` flags to the seq2seq and seq2vec modules, so we can pass e.g. float param values as strings.