### PR TITLE
Add top-k sequence decoding

### DIFF
--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -64,7 +64,7 @@ class CrfTagger(Model):
     top_k : ``int``, optional (default=``None``)
         If provided, the number of parses to return from the crf in output_dict['top_k_tags'].
         Top k parses are returned as a list of dicts, where each dictionary is of the form:
-            {"tags": List, "score": float}.
+        {"tags": List, "score": float}.
         The "tags" value for the first dict in the list for each data_item will be the top
         choice, and will equal the corresponding item in output_dict['tags']
     """

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -61,6 +61,12 @@ class CrfTagger(Model):
         Used to initialize the model parameters.
     regularizer : ``RegularizerApplicator``, optional (default=``None``)
         If provided, will be used to calculate the regularization penalty during training.
+    top_k : ``int``, optional (default=``None``)
+        If provided, the number of parses to return from the crf in output_dict['top_k_tags'].
+        Top k parses are returned as a list of dicts, where each dictionary is of the form:
+            {"tags": List, "score": float}.
+        The "tags" value for the first dict in the list for each data_item will be the top
+        choice, and will equal the corresponding item in output_dict['tags']
     """
 
     def __init__(
@@ -78,6 +84,7 @@ class CrfTagger(Model):
         verbose_metrics: bool = False,
         initializer: InitializerApplicator = InitializerApplicator(),
         regularizer: Optional[RegularizerApplicator] = None,
+        top_k: int = 1
     ) -> None:
         super().__init__(vocab, regularizer)
 
@@ -85,6 +92,7 @@ class CrfTagger(Model):
         self.text_field_embedder = text_field_embedder
         self.num_tags = self.vocab.get_vocab_size(label_namespace)
         self.encoder = encoder
+        self.top_k = top_k
         self._verbose_metrics = verbose_metrics
         if dropout:
             self.dropout = torch.nn.Dropout(dropout)
@@ -206,12 +214,15 @@ class CrfTagger(Model):
             encoded_text = self._feedforward(encoded_text)
 
         logits = self.tag_projection_layer(encoded_text)
-        best_paths = self.crf.viterbi_tags(logits, mask)
+        best_paths = self.crf.viterbi_tags(logits, mask, top_k=self.top_k)
 
-        # Just get the tags and ignore the score.
-        predicted_tags = [x for x, y in best_paths]
+        # Just get the top tags and ignore the scores.
+        predicted_tags = [x[0][0] for x in best_paths]
 
         output = {"logits": logits, "mask": mask, "tags": predicted_tags}
+
+        if self.top_k > 1:
+            output["top_k_tags"] = best_paths
 
         if tags is not None:
             # Add negative log-likelihood as loss
@@ -241,13 +252,16 @@ class CrfTagger(Model):
         ``output_dict["tags"]`` is a list of lists of tag_ids,
         so we use an ugly nested list comprehension.
         """
-        output_dict["tags"] = [
-            [
-                self.vocab.get_token_from_index(tag, namespace=self.label_namespace)
-                for tag in instance_tags
-            ]
-            for instance_tags in output_dict["tags"]
-        ]
+        def decode_tags(tags):
+            return [self.vocab.get_token_from_index(tag, namespace=self.label_namespace) for tag in tags]
+
+        def decode_top_k_tags(top_k_tags):
+            return [{"tags": decode_tags(scored_path[0]), "score": scored_path[1]} for scored_path in top_k_tags]
+
+        output_dict["tags"] = [decode_tags(t) for t in output_dict["tags"]]
+
+        if "top_k_tags" in output_dict:
+            output_dict["top_k_tags"] = [decode_top_k_tags(t) for t in output_dict["top_k_tags"]]
 
         return output_dict
 

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -84,7 +84,7 @@ class CrfTagger(Model):
         verbose_metrics: bool = False,
         initializer: InitializerApplicator = InitializerApplicator(),
         regularizer: Optional[RegularizerApplicator] = None,
-        top_k: int = 1
+        top_k: int = 1,
     ) -> None:
         super().__init__(vocab, regularizer)
 

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -252,11 +252,17 @@ class CrfTagger(Model):
         ``output_dict["tags"]`` is a list of lists of tag_ids,
         so we use an ugly nested list comprehension.
         """
+
         def decode_tags(tags):
-            return [self.vocab.get_token_from_index(tag, namespace=self.label_namespace) for tag in tags]
+            return [
+                self.vocab.get_token_from_index(tag, namespace=self.label_namespace) for tag in tags
+            ]
 
         def decode_top_k_tags(top_k_tags):
-            return [{"tags": decode_tags(scored_path[0]), "score": scored_path[1]} for scored_path in top_k_tags]
+            return [
+                {"tags": decode_tags(scored_path[0]), "score": scored_path[1]}
+                for scored_path in top_k_tags
+            ]
 
         output_dict["tags"] = [decode_tags(t) for t in output_dict["tags"]]
 

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -61,7 +61,7 @@ class CrfTagger(Model):
         Used to initialize the model parameters.
     regularizer : ``RegularizerApplicator``, optional (default=``None``)
         If provided, will be used to calculate the regularization penalty during training.
-    top_k : ``int``, optional (default=``None``)
+    top_k : ``int``, optional (default=``1``)
         If provided, the number of parses to return from the crf in output_dict['top_k_tags'].
         Top k parses are returned as a list of dicts, where each dictionary is of the form:
         {"tags": List, "score": float}.

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -217,7 +217,7 @@ class CrfTagger(Model):
         best_paths = self.crf.viterbi_tags(logits, mask, top_k=self.top_k)
 
         # Just get the top tags and ignore the scores.
-        predicted_tags = cast(List[int], [x[0][0] for x in best_paths])
+        predicted_tags = cast(List[List[int]], [x[0][0] for x in best_paths])
 
         output = {"logits": logits, "mask": mask, "tags": predicted_tags}
 

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List, Any
+from typing import Dict, Optional, List, Any, cast
 
 from overrides import overrides
 import torch
@@ -217,7 +217,7 @@ class CrfTagger(Model):
         best_paths = self.crf.viterbi_tags(logits, mask, top_k=self.top_k)
 
         # Just get the top tags and ignore the scores.
-        predicted_tags = [x[0][0] for x in best_paths]
+        predicted_tags = cast(List[int], [x[0][0] for x in best_paths])
 
         output = {"logits": logits, "mask": mask, "tags": predicted_tags}
 

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -331,9 +331,7 @@ class ConditionalRandomField(torch.nn.Module):
         return torch.sum(log_numerator - log_denominator)
 
     def viterbi_tags(
-        self,
-        logits: torch.Tensor, mask: torch.Tensor,
-        top_k: int = None,
+        self, logits: torch.Tensor, mask: torch.Tensor, top_k: int = None
     ) -> Union[List[VITERBI_DECODING], List[List[VITERBI_DECODING]]]:
         """
         Uses viterbi algorithm to find most likely tags for the given inputs.
@@ -405,9 +403,10 @@ class ConditionalRandomField(torch.nn.Module):
 
             # We pass the tags and the transitions to ``viterbi_decode``.
             viterbi_paths, viterbi_scores = util.viterbi_decode(
-                tag_sequence=tag_sequence[:(sequence_length + 2)],
+                tag_sequence=tag_sequence[: (sequence_length + 2)],
                 transition_matrix=transitions,
-                top_k=top_k)
+                top_k=top_k,
+            )
             top_k_paths = []
             for viterbi_path, viterbi_score in zip(viterbi_paths, viterbi_scores):
                 # Get rid of START and END sentinels and append.

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -1,12 +1,14 @@
 """
 Conditional random field
 """
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Union
 
 import torch
 
 from allennlp.common.checks import ConfigurationError
 import allennlp.nn.util as util
+
+VITERBI_DECODING = Tuple[List[int], float]  # a list of tags, and a viterbi score
 
 
 def allowed_transitions(constraint_type: str, labels: Dict[int, str]) -> List[Tuple[int, int]]:
@@ -330,11 +332,25 @@ class ConditionalRandomField(torch.nn.Module):
 
     def viterbi_tags(
         self, logits: torch.Tensor, mask: torch.Tensor
-    ) -> List[Tuple[List[int], float]]:
+    ,
+                     top_k: int = None) -> Union[List[VITERBI_DECODING], List[List[VITERBI_DECODING]]]:
         """
         Uses viterbi algorithm to find most likely tags for the given inputs.
         If constraints are applied, disallows all other transitions.
+
+        Returns a list of results, of the same size as the batch (one result per batch member)
+        Each result is a List of length top_k, containing the top K viterbi decodings
+        Each decoding is a tuple  (tag_sequence, viterbi_score)
+
+        For backwards compatibility, if top_k is None, then instead returns a flat list of
+        tag sequences (the top tag sequence for each batch item).
         """
+        if top_k is None:
+            top_k = 1
+            flatten_output = True
+        else:
+            flatten_output = False
+
         _, max_seq_length, num_tags = logits.size()
 
         # Get the tensors out of the variables
@@ -387,11 +403,19 @@ class ConditionalRandomField(torch.nn.Module):
             tag_sequence[sequence_length + 1, end_tag] = 0.0
 
             # We pass the tags and the transitions to ``viterbi_decode``.
-            viterbi_path, viterbi_score = util.viterbi_decode(
-                tag_sequence[: (sequence_length + 2)], transitions
-            )
-            # Get rid of START and END sentinels and append.
-            viterbi_path = viterbi_path[1:-1]
-            best_paths.append((viterbi_path, viterbi_score.item()))
+            viterbi_paths, viterbi_scores = util.viterbi_decode(
+                tag_sequence=tag_sequence[:(sequence_length + 2)],
+                                                                transition_matrix=transitions
+            ,
+                                                                top_k=top_k)
+            top_k_paths = []
+            for viterbi_path, viterbi_score in zip(viterbi_paths, viterbi_scores):
+                # Get rid of START and END sentinels and append.
+                viterbi_path = viterbi_path[1:-1]
+                top_k_paths.append((viterbi_path, viterbi_score.item()))
+            best_paths.append(top_k_paths)
+
+        if flatten_output:
+            return [top_k_paths[0] for top_k_paths in best_paths]
 
         return best_paths

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -243,7 +243,7 @@ class ConditionalRandomField(torch.nn.Module):
             # Alpha is for the current_tag, so we broadcast along the next_tag axis.
             broadcast_alpha = alpha.view(batch_size, num_tags, 1)
 
-            # Add all the scores together and logexp over the current_tag axis
+            # Add all the scores together and logexp over the current_tag axis.
             inner = broadcast_alpha + emit_scores + transition_scores
 
             # In valid positions (mask == 1) we want to take the logsumexp over the current_tag dimension

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -331,9 +331,10 @@ class ConditionalRandomField(torch.nn.Module):
         return torch.sum(log_numerator - log_denominator)
 
     def viterbi_tags(
-        self, logits: torch.Tensor, mask: torch.Tensor
-    ,
-                     top_k: int = None) -> Union[List[VITERBI_DECODING], List[List[VITERBI_DECODING]]]:
+        self,
+        logits: torch.Tensor, mask: torch.Tensor,
+        top_k: int = None,
+    ) -> Union[List[VITERBI_DECODING], List[List[VITERBI_DECODING]]]:
         """
         Uses viterbi algorithm to find most likely tags for the given inputs.
         If constraints are applied, disallows all other transitions.
@@ -405,9 +406,8 @@ class ConditionalRandomField(torch.nn.Module):
             # We pass the tags and the transitions to ``viterbi_decode``.
             viterbi_paths, viterbi_scores = util.viterbi_decode(
                 tag_sequence=tag_sequence[:(sequence_length + 2)],
-                                                                transition_matrix=transitions
-            ,
-                                                                top_k=top_k)
+                transition_matrix=transitions,
+                top_k=top_k)
             top_k_paths = []
             for viterbi_path, viterbi_score in zip(viterbi_paths, viterbi_scores):
                 # Get rid of START and END sentinels and append.

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -557,9 +557,9 @@ def viterbi_decode(
         path_indices.append(paths.squeeze())
 
     # Construct the most likely sequence backwards.
-    path_scores = path_scores[-1].view(-1)
-    max_k = min(path_scores.size()[0], top_k)
-    viterbi_scores, best_paths = torch.topk(path_scores, k=max_k, dim=0)
+    path_scores_v = path_scores[-1].view(-1)
+    max_k = min(path_scores_v.size()[0], top_k)
+    viterbi_scores, best_paths = torch.topk(path_scores_v, k=max_k, dim=0)
     viterbi_paths = []
     for i in range(max_k):
         viterbi_path = [best_paths[i]]

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -408,6 +408,7 @@ def viterbi_decode(
     tag_observations: Optional[List[int]] = None,
     allowed_start_transitions: torch.Tensor = None,
     allowed_end_transitions: torch.Tensor = None,
+    top_k: int = None,
 ):
     """
     Perform Viterbi decoding in log space over a sequence given a transition matrix
@@ -439,6 +440,10 @@ def viterbi_decode(
         An optional tensor of shape (num_tags,) describing which tags may transition *to* the
         end tag. If provided, additional transition constraints will be used for determining
         the end element of the sequence.
+    top_k : int, optional, (default = None)
+        Optional integer specifying how many of the top paths to return. For top_k>=1, returns
+        a tuple of two lists: top_k_paths, top_k_scores, For top_k==None, returns a flattened
+        tuple with just the top path and its score (not in lists, for backwards compatibility).
 
     Returns
     -------
@@ -447,6 +452,14 @@ def viterbi_decode(
     viterbi_score : torch.Tensor
         The score of the viterbi path.
     """
+    if top_k is None:
+        top_k = 1
+        flatten_output = True
+    elif top_k >= 1:
+        flatten_output = False
+    else:
+        raise ValueError(f"top_k must be either None or an integer >=1. Instead received {top_k}")
+
     sequence_length, num_tags = list(tag_sequence.size())
 
     has_start_end_restrictions = (
@@ -509,15 +522,19 @@ def viterbi_decode(
     if tag_observations[0] != -1:
         one_hot = torch.zeros(num_tags)
         one_hot[tag_observations[0]] = 100000.0
-        path_scores.append(one_hot)
+        path_scores.append(one_hot.unsqueeze(0))
     else:
-        path_scores.append(tag_sequence[0, :])
+        path_scores.append(tag_sequence[0, :].unsqueeze(0))
 
     # Evaluate the scores for all possible paths.
     for timestep in range(1, sequence_length):
         # Add pairwise potentials to current scores.
-        summed_potentials = path_scores[timestep - 1].unsqueeze(-1) + transition_matrix
-        scores, paths = torch.max(summed_potentials, 0)
+        summed_potentials = path_scores[timestep - 1].unsqueeze(2) + transition_matrix
+        summed_potentials = summed_potentials.view(-1, num_tags)
+
+        # Best pairwise potential path score from the previous timestep.
+        max_k = min(summed_potentials.size()[0], top_k)
+        scores, paths = torch.topk(summed_potentials, k=max_k, dim=0)
 
         # If we have an observation for this timestep, use it
         # instead of the distribution over tags.
@@ -534,22 +551,34 @@ def viterbi_decode(
         if observation != -1:
             one_hot = torch.zeros(num_tags)
             one_hot[observation] = 100000.0
-            path_scores.append(one_hot)
+            path_scores.append(one_hot.unsqueeze(0))
         else:
-            path_scores.append(tag_sequence[timestep, :] + scores.squeeze())
+            path_scores.append(tag_sequence[timestep, :] + scores)
         path_indices.append(paths.squeeze())
 
     # Construct the most likely sequence backwards.
-    viterbi_score, best_path = torch.max(path_scores[-1], 0)
-    viterbi_path = [int(best_path.numpy())]
-    for backward_timestep in reversed(path_indices):
-        viterbi_path.append(int(backward_timestep[viterbi_path[-1]]))
-    # Reverse the backward path.
-    viterbi_path.reverse()
+    path_scores = path_scores[-1].view(-1)
+    max_k = min(path_scores.size()[0], top_k)
+    viterbi_scores, best_paths = torch.topk(path_scores, k=max_k, dim=0)
+    viterbi_paths = []
+    for i in range(max_k):
+        viterbi_path = [best_paths[i]]
+        for backward_timestep in reversed(path_indices):
+            viterbi_path.append(int(backward_timestep.view(-1)[viterbi_path[-1]]))
+        # Reverse the backward path.
+        viterbi_path.reverse()
 
-    if has_start_end_restrictions:
-        viterbi_path = viterbi_path[1:-1]
-    return viterbi_path, viterbi_score
+        if has_start_end_restrictions:
+            viterbi_path = viterbi_path[1:-1]
+
+        # Viterbi paths uses (num_tags * n_permutations) nodes; therefore, we need to modulo.
+        viterbi_path = [j % num_tags for j in viterbi_path]
+        viterbi_paths.append(viterbi_path)
+
+    if flatten_output:
+        return viterbi_paths[0], viterbi_scores[0]
+
+    return viterbi_paths, viterbi_scores
 
 
 def get_text_field_mask(

--- a/allennlp/tests/models/crf_tagger_test.py
+++ b/allennlp/tests/models/crf_tagger_test.py
@@ -44,6 +44,18 @@ class CrfTaggerTest(ModelTestCase):
                 tag = self.model.vocab.get_token_from_index(tag_id, namespace="labels")
                 assert tag in {"O", "I-ORG", "I-PER", "I-LOC"}
 
+    def test_forward_pass_top_k(self):
+        training_tensors = self.dataset.as_tensor_dict()
+        self.model.top_k = 5
+        output_dict = self.model.decode(self.model(**training_tensors))
+        top_k_tags = [[x["tags"] for x in item_topk] for item_topk in output_dict['top_k_tags']]
+        first_choices = [x[0] for x in top_k_tags]
+        assert first_choices == output_dict['tags']
+        lengths = [len(x) for x in top_k_tags]
+        assert set(lengths) == {5}
+        tags_used = set(tag for item_top_k in top_k_tags for tag_seq in item_top_k for tag in tag_seq)
+        assert all(tag in {'O', 'I-ORG', 'I-PER', 'I-LOC'} for tag in tags_used)
+
     def test_mismatching_dimensions_throws_configuration_error(self):
         params = Params.from_file(self.param_file)
         # Make the encoder wrong - it should be 2 to match

--- a/allennlp/tests/models/crf_tagger_test.py
+++ b/allennlp/tests/models/crf_tagger_test.py
@@ -48,13 +48,15 @@ class CrfTaggerTest(ModelTestCase):
         training_tensors = self.dataset.as_tensor_dict()
         self.model.top_k = 5
         output_dict = self.model.decode(self.model(**training_tensors))
-        top_k_tags = [[x["tags"] for x in item_topk] for item_topk in output_dict['top_k_tags']]
+        top_k_tags = [[x["tags"] for x in item_topk] for item_topk in output_dict["top_k_tags"]]
         first_choices = [x[0] for x in top_k_tags]
-        assert first_choices == output_dict['tags']
+        assert first_choices == output_dict["tags"]
         lengths = [len(x) for x in top_k_tags]
         assert set(lengths) == {5}
-        tags_used = set(tag for item_top_k in top_k_tags for tag_seq in item_top_k for tag in tag_seq)
-        assert all(tag in {'O', 'I-ORG', 'I-PER', 'I-LOC'} for tag in tags_used)
+        tags_used = set(
+            tag for item_top_k in top_k_tags for tag_seq in item_top_k for tag in tag_seq
+        )
+        assert all(tag in {"O", "I-ORG", "I-PER", "I-LOC"} for tag in tags_used)
 
     def test_mismatching_dimensions_throws_configuration_error(self):
         params = Params.from_file(self.param_file)

--- a/allennlp/tests/modules/conditional_random_field_test.py
+++ b/allennlp/tests/modules/conditional_random_field_test.py
@@ -142,10 +142,7 @@ class TestConditionalRandomField(AllenNlpTestCase):
         assert viterbi_scores == best_scores
 
     def test_viterbi_tags_top_k(self):
-        mask = torch.LongTensor([
-                [1, 1, 1],
-                [1, 1, 0]
-        ])
+        mask = torch.LongTensor([[1, 1, 1], [1, 1, 0]])
 
         best_paths = self.crf.viterbi_tags(self.logits, mask, top_k=2)
 
@@ -157,10 +154,7 @@ class TestConditionalRandomField(AllenNlpTestCase):
         next_viterbi_tags = [x for x, _ in next_path_and_score]
 
         # Check that the next best viterbi tags are what I think they should be.
-        assert next_viterbi_tags == [
-                [4, 2, 3],
-                [3, 2]
-        ]
+        assert next_viterbi_tags == [[4, 2, 3], [3, 2]]
 
     def test_constrained_viterbi_tags(self):
         constraints = {

--- a/allennlp/tests/modules/conditional_random_field_test.py
+++ b/allennlp/tests/modules/conditional_random_field_test.py
@@ -141,6 +141,27 @@ class TestConditionalRandomField(AllenNlpTestCase):
         assert viterbi_tags == most_likely_tags
         assert viterbi_scores == best_scores
 
+    def test_viterbi_tags_top_k(self):
+        mask = torch.LongTensor([
+                [1, 1, 1],
+                [1, 1, 0]
+        ])
+
+        best_paths = self.crf.viterbi_tags(self.logits, mask, top_k=2)
+
+        # Ensure the top path matches not passing top_k
+        top_path_and_score = [top_k_paths[0] for top_k_paths in best_paths]
+        assert top_path_and_score == self.crf.viterbi_tags(self.logits, mask)
+
+        next_path_and_score = [top_k_paths[1] for top_k_paths in best_paths]
+        next_viterbi_tags = [x for x, _ in next_path_and_score]
+
+        # Check that the next best viterbi tags are what I think they should be.
+        assert next_viterbi_tags == [
+                [4, 2, 3],
+                [3, 2]
+        ]
+
     def test_constrained_viterbi_tags(self):
         constraints = {
             (0, 0),

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -684,8 +684,16 @@ class TestNnUtil(AllenNlpTestCase):
 
         # Test that pairwise potentials effect the sequence correctly and that
         # viterbi_decode can handle -inf values.
-        sequence_logits = torch.FloatTensor([[0, 0, 0, 3, 4], [0, 0, 0, 3, 4], [0, 0, 0, 3, 4],
-                                             [0, 0, 0, 3, 4], [0, 0, 0, 3, 4], [0, 0, 0, 3, 4]])
+        sequence_logits = torch.FloatTensor(
+            [
+                [0, 0, 0, 3, 4],
+                [0, 0, 0, 3, 4],
+                [0, 0, 0, 3, 4],
+                [0, 0, 0, 3, 4],
+                [0, 0, 0, 3, 4],
+                [0, 0, 0, 3, 4]
+            ]
+        )
         # The same tags shouldn't appear sequentially.
         transition_matrix = torch.zeros([5, 5])
         for i in range(5):
@@ -695,8 +703,16 @@ class TestNnUtil(AllenNlpTestCase):
 
         # Test that unbalanced pairwise potentials break ties
         # between paths with equal unary potentials.
-        sequence_logits = torch.FloatTensor([[0, 0, 0, 4, 4], [0, 0, 0, 4, 4], [0, 0, 0, 4, 4],
-                                             [0, 0, 0, 4, 4], [0, 0, 0, 4, 4], [0, 0, 0, 4, 0]])
+        sequence_logits = torch.FloatTensor(
+            [
+                [0, 0, 0, 4, 4],
+                [0, 0, 0, 4, 4],
+                [0, 0, 0, 4, 4],
+                [0, 0, 0, 4, 4],
+                [0, 0, 0, 4, 4],
+                [0, 0, 0, 4, 0]
+            ]
+        )
         # The 5th tag has a penalty for appearing sequentially
         # or for transitioning to the 4th tag, making the best
         # path uniquely to take the 4th tag only.
@@ -706,7 +722,13 @@ class TestNnUtil(AllenNlpTestCase):
         indices, _ = util.viterbi_decode(sequence_logits, transition_matrix, top_k=5)
         assert indices[0] == [3, 3, 3, 3, 3, 3]
 
-        sequence_logits = torch.FloatTensor([[1, 0, 0, 4], [1, 0, 6, 2], [0, 3, 0, 4]])
+        sequence_logits = torch.FloatTensor(
+            [
+                [1, 0, 0, 4],
+                [1, 0, 6, 2],
+                [0, 3, 0, 4]
+            ]
+        )
         # Best path would normally be [3, 2, 3] but we add a
         # potential from 2 -> 1, making [3, 2, 1] the best path.
         transition_matrix = torch.zeros([4, 4])
@@ -716,7 +738,11 @@ class TestNnUtil(AllenNlpTestCase):
         assert indices[0] == [3, 2, 1]
         assert value[0] == 18
 
-        def _brute_decode(tag_sequence: torch.Tensor, transition_matrix: torch.Tensor, top_k: int = 5) -> Any:
+        def _brute_decode(
+                tag_sequence: torch.Tensor,
+                transition_matrix: torch.Tensor,
+                top_k: int = 5,
+        ) -> Any:
             """
             Top-k decoder that uses brute search instead of the Viterbi Decode dynamic programing algorithm
             """

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -1,11 +1,11 @@
 import json
+import random
 from typing import NamedTuple
 
 import numpy
 from numpy.testing import assert_array_almost_equal, assert_almost_equal
 import torch
 import pytest
-import random
 from flaky import flaky
 
 from allennlp.common.checks import ConfigurationError
@@ -676,6 +676,7 @@ class TestNnUtil(AllenNlpTestCase):
         # Test Viterbi decoding is equal to greedy decoding with no pairwise potentials.
         sequence_logits = torch.autograd.Variable(torch.rand([5, 9]))
         transition_matrix = torch.zeros([9, 9])
+        # pylint: disable=no-member
         indices, _ = util.viterbi_decode(sequence_logits.data, transition_matrix, top_k=5)
         _, argmax_indices = torch.max(sequence_logits, 1)
         assert indices[0] == argmax_indices.data.squeeze().tolist()

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -5,6 +5,7 @@ import numpy
 from numpy.testing import assert_array_almost_equal, assert_almost_equal
 import torch
 import pytest
+import random
 from flaky import flaky
 
 from allennlp.common.checks import ConfigurationError
@@ -667,6 +668,93 @@ class TestNnUtil(AllenNlpTestCase):
         observations = [2, -1, -1, 0, 4, -1]
         indices, _ = util.viterbi_decode(sequence_logits, transition_matrix, observations)
         assert indices == [2, 3, 3, 0, 4, 3]
+
+    def test_viterbi_decode_top_k(self):
+        # Test cases taken from: https://gist.github.com/PetrochukM/afaa3613a99a8e7213d2efdd02ae4762
+
+        # Test Viterbi decoding is equal to greedy decoding with no pairwise potentials.
+        sequence_logits = torch.autograd.Variable(torch.rand([5, 9]))
+        transition_matrix = torch.zeros([9, 9])
+        indices, _ = util.viterbi_decode(sequence_logits.data, transition_matrix)
+        _, argmax_indices = torch.max(sequence_logits, 1)
+        assert indices[0] == argmax_indices.data.squeeze().tolist()
+
+        # Test that pairwise potentials effect the sequence correctly and that
+        # viterbi_decode can handle -inf values.
+        sequence_logits = torch.FloatTensor([[0, 0, 0, 3, 4], [0, 0, 0, 3, 4], [0, 0, 0, 3, 4],
+                                             [0, 0, 0, 3, 4], [0, 0, 0, 3, 4], [0, 0, 0, 3, 4]])
+        # The same tags shouldn't appear sequentially.
+        transition_matrix = torch.zeros([5, 5])
+        for i in range(5):
+            transition_matrix[i, i] = float("-inf")
+        indices, _ = util.viterbi_decode(sequence_logits, transition_matrix)
+        assert indices[0] == [3, 4, 3, 4, 3, 4]
+
+        # Test that unbalanced pairwise potentials break ties
+        # between paths with equal unary potentials.
+        sequence_logits = torch.FloatTensor([[0, 0, 0, 4, 4], [0, 0, 0, 4, 4], [0, 0, 0, 4, 4],
+                                             [0, 0, 0, 4, 4], [0, 0, 0, 4, 4], [0, 0, 0, 4, 0]])
+        # The 5th tag has a penalty for appearing sequentially
+        # or for transitioning to the 4th tag, making the best
+        # path uniquely to take the 4th tag only.
+        transition_matrix = torch.zeros([5, 5])
+        transition_matrix[4, 4] = -10
+        transition_matrix[4, 3] = -10
+        indices, _ = util.viterbi_decode(sequence_logits, transition_matrix)
+        assert indices[0] == [3, 3, 3, 3, 3, 3]
+
+        sequence_logits = torch.FloatTensor([[1, 0, 0, 4], [1, 0, 6, 2], [0, 3, 0, 4]])
+        # Best path would normally be [3, 2, 3] but we add a
+        # potential from 2 -> 1, making [3, 2, 1] the best path.
+        transition_matrix = torch.zeros([4, 4])
+        transition_matrix[0, 0] = 1
+        transition_matrix[2, 1] = 5
+        indices, value = util.viterbi_decode(sequence_logits, transition_matrix)
+        assert indices[0] == [3, 2, 1]
+        assert value[0] == 18
+
+        def brute_decode(tag_sequence: torch.Tensor, transition_matrix: torch.Tensor, top_k: int = 5):
+            """
+            Top-k decoder that uses brute search instead of the Viterbi Decode dynamic programing algorithm
+            """
+            # Create all possible sequences
+            sequence_length, num_tags = list(tag_sequence.size())
+            sequences = [[]]
+            for i in range(len(tag_sequence)):
+                new_sequences = []
+                for j in range(len(tag_sequence[i])):
+                    for sequence in sequences:
+                        new_sequences.append(sequence[:] + [j])
+                sequences = new_sequences
+
+            # Score
+            scored_sequences = []
+            for sequence in sequences:
+                emission_score = sum([tag_sequence[i, j] for i, j in enumerate(sequence)])
+                transition_score = sum(
+                    [transition_matrix[sequence[i - 1], sequence[i]] for i in range(1, len(sequence))])
+                score = emission_score + transition_score
+                scored_sequences.append((score, sequence))
+
+            # Get the top k scores / paths
+            top_k_sequences = sorted(scored_sequences, key=lambda r: r[0], reverse=True)[:top_k]
+            scores, paths = zip(*top_k_sequences)
+
+            return paths, scores
+
+        # Run 100 randomly generated parameters and compare the outputs.
+        for i in range(100):
+            num_tags = random.randint(1, 5)
+            seq_len = random.randint(1, 5)
+            k = random.randint(1, 5)
+            sequence_logits = torch.rand([seq_len, num_tags])
+            transition_matrix = torch.rand([num_tags, num_tags])
+            viterbi_paths_v1, viterbi_scores_v1 = util.viterbi_decode(
+                sequence_logits, transition_matrix, top_k=k)
+            viterbi_path_brute, viterbi_score_brute = brute_decode(
+                sequence_logits, transition_matrix, top_k=k)
+            numpy.testing.assert_almost_equal(
+                list(viterbi_score_brute), viterbi_scores_v1.tolist(), decimal=3)
 
     def test_sequence_cross_entropy_with_logits_masks_loss_correctly(self):
 

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -1,6 +1,6 @@
 import json
 import random
-from typing import NamedTuple
+from typing import NamedTuple, Any
 
 import numpy
 from numpy.testing import assert_array_almost_equal, assert_almost_equal
@@ -678,6 +678,7 @@ class TestNnUtil(AllenNlpTestCase):
         transition_matrix = torch.zeros([9, 9])
         # pylint: disable=no-member
         indices, _ = util.viterbi_decode(sequence_logits.data, transition_matrix, top_k=5)
+        # pylint: enable=no-member
         _, argmax_indices = torch.max(sequence_logits, 1)
         assert indices[0] == argmax_indices.data.squeeze().tolist()
 
@@ -715,18 +716,20 @@ class TestNnUtil(AllenNlpTestCase):
         assert indices[0] == [3, 2, 1]
         assert value[0] == 18
 
-        def brute_decode(tag_sequence: torch.Tensor, transition_matrix: torch.Tensor, top_k: int = 5):
+        def brute_decode(tag_sequence: torch.Tensor, transition_matrix: torch.Tensor, top_k: int = 5) -> Any:
             """
             Top-k decoder that uses brute search instead of the Viterbi Decode dynamic programing algorithm
             """
             # Create all possible sequences
             sequences = [[]]
+            # pylint: disable=consider-using-enumerate
             for i in range(len(tag_sequence)):
                 new_sequences = []
                 for j in range(len(tag_sequence[i])):
                     for sequence in sequences:
                         new_sequences.append(sequence[:] + [j])
                 sequences = new_sequences
+            # pylint: enable=consider-using-enumerate
 
             # Score
             scored_sequences = []
@@ -741,7 +744,7 @@ class TestNnUtil(AllenNlpTestCase):
             top_k_sequences = sorted(scored_sequences, key=lambda r: r[0], reverse=True)[:top_k]
             scores, paths = zip(*top_k_sequences)
 
-            return paths, scores
+            return paths, scores  # type: ignore
 
         # Run 100 randomly generated parameters and compare the outputs.
         for i in range(100):

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -675,7 +675,7 @@ class TestNnUtil(AllenNlpTestCase):
         # Test Viterbi decoding is equal to greedy decoding with no pairwise potentials.
         sequence_logits = torch.autograd.Variable(torch.rand([5, 9]))
         transition_matrix = torch.zeros([9, 9])
-        indices, _ = util.viterbi_decode(sequence_logits.data, transition_matrix)
+        indices, _ = util.viterbi_decode(sequence_logits.data, transition_matrix, top_k=5)
         _, argmax_indices = torch.max(sequence_logits, 1)
         assert indices[0] == argmax_indices.data.squeeze().tolist()
 
@@ -687,7 +687,7 @@ class TestNnUtil(AllenNlpTestCase):
         transition_matrix = torch.zeros([5, 5])
         for i in range(5):
             transition_matrix[i, i] = float("-inf")
-        indices, _ = util.viterbi_decode(sequence_logits, transition_matrix)
+        indices, _ = util.viterbi_decode(sequence_logits, transition_matrix, top_k=5)
         assert indices[0] == [3, 4, 3, 4, 3, 4]
 
         # Test that unbalanced pairwise potentials break ties
@@ -700,7 +700,7 @@ class TestNnUtil(AllenNlpTestCase):
         transition_matrix = torch.zeros([5, 5])
         transition_matrix[4, 4] = -10
         transition_matrix[4, 3] = -10
-        indices, _ = util.viterbi_decode(sequence_logits, transition_matrix)
+        indices, _ = util.viterbi_decode(sequence_logits, transition_matrix, top_k=5)
         assert indices[0] == [3, 3, 3, 3, 3, 3]
 
         sequence_logits = torch.FloatTensor([[1, 0, 0, 4], [1, 0, 6, 2], [0, 3, 0, 4]])
@@ -709,7 +709,7 @@ class TestNnUtil(AllenNlpTestCase):
         transition_matrix = torch.zeros([4, 4])
         transition_matrix[0, 0] = 1
         transition_matrix[2, 1] = 5
-        indices, value = util.viterbi_decode(sequence_logits, transition_matrix)
+        indices, value = util.viterbi_decode(sequence_logits, transition_matrix, top_k=5)
         assert indices[0] == [3, 2, 1]
         assert value[0] == 18
 

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -1,6 +1,6 @@
 import json
 import random
-from typing import NamedTuple, Any
+from typing import NamedTuple, List, Any
 
 import numpy
 from numpy.testing import assert_array_almost_equal, assert_almost_equal
@@ -716,15 +716,15 @@ class TestNnUtil(AllenNlpTestCase):
         assert indices[0] == [3, 2, 1]
         assert value[0] == 18
 
-        def brute_decode(tag_sequence: torch.Tensor, transition_matrix: torch.Tensor, top_k: int = 5) -> Any:
+        def _brute_decode(tag_sequence: torch.Tensor, transition_matrix: torch.Tensor, top_k: int = 5) -> Any:
             """
             Top-k decoder that uses brute search instead of the Viterbi Decode dynamic programing algorithm
             """
             # Create all possible sequences
-            sequences = [[]]
+            sequences = [[]]  # type: ignore
             # pylint: disable=consider-using-enumerate
             for i in range(len(tag_sequence)):
-                new_sequences = []
+                new_sequences = []  # type: ignore
                 for j in range(len(tag_sequence[i])):
                     for sequence in sequences:
                         new_sequences.append(sequence[:] + [j])
@@ -732,7 +732,7 @@ class TestNnUtil(AllenNlpTestCase):
             # pylint: enable=consider-using-enumerate
 
             # Score
-            scored_sequences = []
+            scored_sequences = []  # type: ignore
             for sequence in sequences:
                 emission_score = sum([tag_sequence[i, j] for i, j in enumerate(sequence)])
                 transition_score = sum([transition_matrix[sequence[i - 1], sequence[i]]
@@ -754,7 +754,7 @@ class TestNnUtil(AllenNlpTestCase):
             sequence_logits = torch.rand([seq_len, num_tags])
             transition_matrix = torch.rand([num_tags, num_tags])
             viterbi_paths_v1, viterbi_scores_v1 = util.viterbi_decode(sequence_logits, transition_matrix, top_k=k)
-            viterbi_path_brute, viterbi_score_brute = brute_decode(sequence_logits, transition_matrix, top_k=k)
+            viterbi_path_brute, viterbi_score_brute = _brute_decode(sequence_logits, transition_matrix, top_k=k)
             numpy.testing.assert_almost_equal(list(viterbi_score_brute), viterbi_scores_v1.tolist(), decimal=3)
             numpy.testing.assert_equal(sanitize(viterbi_paths_v1), viterbi_path_brute)
 

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -1,6 +1,6 @@
 import json
 import random
-from typing import NamedTuple, List, Any
+from typing import NamedTuple, Any
 
 import numpy
 from numpy.testing import assert_array_almost_equal, assert_almost_equal


### PR DESCRIPTION
Adds a top_k option to `viterbi_decode`, `ConditionalRandomField` and `CrfTagger` 

To maintain backwards compatibility the returned value types are different depending on whether `top_k` is supplied. Another option would be to implement `viterbi_decode` as a thin wrapper around a separate `top_k_viterbi_decode` function. I wasn't sure which was the preferred method.

This can be used for prediction on models serialized before this feature, e.g. by calling `allennlp predict --overrides {"model": "top_k": 10}` I wasn't sure where to document this use case.

The code is based on the implementation at https://gist.github.com/PetrochukM/afaa3613a99a8e7213d2efdd02ae4762 (which is in turn based on AllenNLPs implementation)