### PR TITLE
Replace staticmethods with classmethods

### DIFF
--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -448,8 +448,8 @@ class Params(MutableMapping):
             value = [self._check_is_dict(f"{new_history}.{i}", v) for i, v in enumerate(value)]
         return value
 
-    @staticmethod
-    def from_file(params_file: str, params_overrides: str = "", ext_vars: dict = None) -> 'Params':
+    @classmethod
+    def from_file(cls, params_file: str, params_overrides: str = "", ext_vars: dict = None) -> 'Params':
         """
         Load a `Params` object from a configuration file.
 
@@ -479,7 +479,7 @@ class Params(MutableMapping):
         overrides_dict = parse_overrides(params_overrides)
         param_dict = with_fallback(preferred=overrides_dict, fallback=file_dict)
 
-        return Params(param_dict)
+        return cls(param_dict)
 
     def to_file(self, params_file: str, preference_orders: List[List[str]] = None) -> None:
         with open(params_file, "w") as handle:

--- a/allennlp/training/trainer_pieces.py
+++ b/allennlp/training/trainer_pieces.py
@@ -32,8 +32,9 @@ class TrainerPieces(NamedTuple):
     validation_iterator: DataIterator
     params: Params
 
-    @staticmethod
-    def from_params(params: Params,
+    @classmethod
+    def from_params(cls,
+                    params: Params,
                     serialization_dir: str,
                     recover: bool = False,
                     cache_directory: str = None,
@@ -98,6 +99,6 @@ class TrainerPieces(NamedTuple):
         for name in tunable_parameter_names:
             logger.info(name)
 
-        return TrainerPieces(model, iterator,
-                             train_data, validation_data, test_data,
-                             validation_iterator, trainer_params)
+        return cls(model, iterator,
+                   train_data, validation_data, test_data,
+                   validation_iterator, trainer_params)


### PR DESCRIPTION
This pull request is to address #3196.
The problem is there are some classes (Params, TrainerPieces, previously - Vocabulary #2418 ) having factory staticmethods like `from_params` those are hardcoded to return themselves instead of the class they were called on,
which makes us copy the body to the inherited class, the method body can't be reused.
The pull request switches from using `staticmethod`  to `classmethod` to be aware of the context.

While it is not obvious, but sometimes there we need to extend these classes, e.g. we may want custom behaviour of serializing the Params to save additional configs.