### PR TITLE
potential callback modifications

### DIFF
--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -116,8 +116,8 @@ class CallbackTrainer(TrainerBase):
         self.batch_num_total = 0
         self.batch_group: List[TensorDict] = []
         self.batches_this_epoch = 0
-        self.batch_output = None
-        self.batch_loss = None
+        self.batch_output: Dict[str, torch.Tensor] = None
+        self.batch_loss: torch.Tensor = None
 
         self.training_batches: Iterable[List[TensorDict]] = ()
         self.num_training_batches = 0

--- a/allennlp/training/callbacks/events.py
+++ b/allennlp/training/callbacks/events.py
@@ -7,6 +7,10 @@ class Events:
 
     FORWARD = "FORWARD"
 
+    FORWARD_COMPLETE = "FORWARD_COMPLETE"
+
+    LOSS = "LOSS"
+
     BACKWARD = "BACKWARD"
 
     BATCH_END = "BATCH_END"

--- a/allennlp/training/callbacks/validate.py
+++ b/allennlp/training/callbacks/validate.py
@@ -78,8 +78,7 @@ class Validate(Callback):
             batches_this_epoch = 0
             val_loss = 0
             for batch_group in val_generator_tqdm:
-
-                loss = trainer.batch_loss(batch_group, for_training=False)
+                loss = trainer.batch_group_forward(batch_group).get("loss", None)
                 if loss is not None:
                     # You shouldn't necessarily have to compute a loss for validation, so we allow for
                     # `loss` to be None.  We need to be careful, though - `batches_this_epoch` is


### PR DESCRIPTION
Some potential slight refactoring of CallbackTrainer to make it a bit more flexible for different kinds of callbacks (see issue #3218). The motivation for these changes are:

* simplifies callback's access to model’s output_dict (via `batch_group_forward()`), allowing (for example) serializing *validation* predictions during training from a callback

* most recent batch_output and batch_loss are now stored as trainer state, allowing (for example) serializing *training* predictions during training from a callback

* Simplifies the logic of `train_one_batch_group()` to just a sequence of setting trainer state variables without any `if training` special logic

* adds additional callback events before loss calculation and before backward pass (allowing advanced callbacks to modify loss or output_dict) — Not sure if this adds too many events, but the simplified logic of train_one_batch_group made it easy to add this.