### PR TITLE
Make Instance in charge of when to re-index

### DIFF
--- a/allennlp/data/fields/adjacency_field.py
+++ b/allennlp/data/fields/adjacency_field.py
@@ -90,8 +90,9 @@ class AdjacencyField(Field[torch.Tensor]):
 
     @overrides
     def index(self, vocab: Vocabulary):
-        self._indexed_labels = [vocab.get_token_index(label, self._label_namespace)
-                                for label in self.labels]
+        if self.labels is not None:
+            self._indexed_labels = [vocab.get_token_index(label, self._label_namespace)
+                                    for label in self.labels]
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:

--- a/allennlp/data/fields/adjacency_field.py
+++ b/allennlp/data/fields/adjacency_field.py
@@ -90,9 +90,8 @@ class AdjacencyField(Field[torch.Tensor]):
 
     @overrides
     def index(self, vocab: Vocabulary):
-        if self._indexed_labels is None and self.labels is not None:
-            self._indexed_labels = [vocab.get_token_index(label, self._label_namespace)
-                                    for label in self.labels]
+        self._indexed_labels = [vocab.get_token_index(label, self._label_namespace)
+                                for label in self.labels]
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -79,8 +79,7 @@ class LabelField(Field[torch.Tensor]):
 
     @overrides
     def index(self, vocab: Vocabulary):
-        if self._label_id is None:
-            self._label_id = vocab.get_token_index(self.label, self._label_namespace)  # type: ignore
+        self._label_id = vocab.get_token_index(self.label, self._label_namespace)  # type: ignore
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:  # pylint: disable=no-self-use

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -50,6 +50,7 @@ class LabelField(Field[torch.Tensor]):
         self._label_namespace = label_namespace
         self._label_id = None
         self._maybe_warn_for_namespace(label_namespace)
+        self._skip_indexing = skip_indexing
 
         if skip_indexing:
             if not isinstance(label, int):
@@ -79,7 +80,8 @@ class LabelField(Field[torch.Tensor]):
 
     @overrides
     def index(self, vocab: Vocabulary):
-        self._label_id = vocab.get_token_index(self.label, self._label_namespace)  # type: ignore
+        if not self._skip_indexing:
+            self._label_id = vocab.get_token_index(self.label, self._label_namespace)  # type: ignore
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:  # pylint: disable=no-self-use

--- a/allennlp/data/fields/metadata_field.py
+++ b/allennlp/data/fields/metadata_field.py
@@ -62,6 +62,5 @@ class MetadataField(Field[DataArray], Mapping[str, Any]):
     def batch_tensors(self, tensor_list: List[DataArray]) -> List[DataArray]:  # type: ignore
         return tensor_list
 
-
     def __str__(self) -> str:
         return f"MetadataField (print field.metadata to see specific information)."

--- a/allennlp/data/fields/sequence_label_field.py
+++ b/allennlp/data/fields/sequence_label_field.py
@@ -57,8 +57,10 @@ class SequenceLabelField(Field[torch.Tensor]):
             raise ConfigurationError("Label length and sequence length "
                                      "don't match: %d and %d" % (len(labels), sequence_field.sequence_length()))
 
+        self._skip_indexing = False
         if all([isinstance(x, int) for x in labels]):
             self._indexed_labels = labels
+            self._skip_indexing = True
 
         elif not all([isinstance(x, str) for x in labels]):
             raise ConfigurationError("SequenceLabelFields must be passed either all "
@@ -93,8 +95,9 @@ class SequenceLabelField(Field[torch.Tensor]):
 
     @overrides
     def index(self, vocab: Vocabulary):
-        self._indexed_labels = [vocab.get_token_index(label, self._label_namespace)  # type: ignore
-                                for label in self.labels]
+        if not self._skip_indexing:
+            self._indexed_labels = [vocab.get_token_index(label, self._label_namespace)  # type: ignore
+                                    for label in self.labels]
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:

--- a/allennlp/data/fields/sequence_label_field.py
+++ b/allennlp/data/fields/sequence_label_field.py
@@ -93,9 +93,8 @@ class SequenceLabelField(Field[torch.Tensor]):
 
     @overrides
     def index(self, vocab: Vocabulary):
-        if self._indexed_labels is None:
-            self._indexed_labels = [vocab.get_token_index(label, self._label_namespace)  # type: ignore
-                                    for label in self.labels]
+        self._indexed_labels = [vocab.get_token_index(label, self._label_namespace)  # type: ignore
+                                for label in self.labels]
 
     @overrides
     def get_padding_lengths(self) -> Dict[str, int]:


### PR DESCRIPTION
The `Instance` has a flag for whether or not its fields have been indexed, and our fields are mixed regarding whether or not they have their own check (e.g., `TextFields` always re-index when `index()` is called, while the ones in this PR don't).  I think it makes the most sense to have `Instance` own this, as it gives a user one place to reset the `Instance`, without having to check for all kinds of crazy places to know how to reset things (we need to do this in the interpret code).

This PR makes all `Fields` consistent: when `index()` is called, the field is re-indexed.  It's the `Instance`'s job to make sure this only happens when necessary.