### PR TITLE
Unidirectional LM doesn't return backward loss.

### DIFF
--- a/allennlp/models/language_model.py
+++ b/allennlp/models/language_model.py
@@ -313,17 +313,18 @@ class LanguageModel(Model):
                 return_dict.update({
                         'loss': average_loss,
                         'forward_loss': forward_loss / num_targets.float(),
-                        'backward_loss': (backward_loss / num_targets.float()
-                                          if backward_loss is not None else None),
                         'batch_weight': num_targets.float()
                 })
+                if backward_loss is not None:
+                    return_dict['backward_loss'] = backward_loss / num_targets.float()
             else:
                 # average_loss zero tensor, return it for all
                 return_dict.update({
                         'loss': average_loss,
                         'forward_loss': average_loss,
-                        'backward_loss': average_loss if backward_loss is not None else None
                 })
+                if backward_loss is not None:
+                    return_dict['backward_loss'] = average_loss
 
         return_dict.update({
                 # Note: These embeddings do not have dropout applied.

--- a/allennlp/tests/models/language_model_test.py
+++ b/allennlp/tests/models/language_model_test.py
@@ -6,7 +6,6 @@ from allennlp.common.testing import ModelTestCase
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.params import Params
 from allennlp.models import Model
-from allennlp.predictors import Predictor
 
 
 class TestUnidirectionalLanguageModel(ModelTestCase):
@@ -56,10 +55,9 @@ class TestUnidirectionalLanguageModel(ModelTestCase):
         with pytest.raises(ConfigurationError):
             Model.from_params(vocab=self.vocab, params=params.get("model"))
 
-    def test_language_model_predictions_are_valid(self):
-        predictor = Predictor(self.model)
-        instance = next(iter(self.dataset))
-        predictions = predictor.predict_instances(instance)
+    def test_language_model_forward_on_instances(self):
+        instances = self.dataset.instances
+        predictions = self.model.forward_on_instances(instances)
         assert predictions is not None
 
 class TestUnidirectionalLanguageModelUnsampled(TestUnidirectionalLanguageModel):

--- a/allennlp/tests/models/language_model_test.py
+++ b/allennlp/tests/models/language_model_test.py
@@ -6,6 +6,7 @@ from allennlp.common.testing import ModelTestCase
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.params import Params
 from allennlp.models import Model
+from allennlp.predictors import Predictor
 
 
 class TestUnidirectionalLanguageModel(ModelTestCase):
@@ -55,6 +56,12 @@ class TestUnidirectionalLanguageModel(ModelTestCase):
         with pytest.raises(ConfigurationError):
             Model.from_params(vocab=self.vocab, params=params.get("model"))
 
+    def test_language_model_predictions_are_valid(self):
+        predictor = Predictor(self.model)
+        instance = next(iter(self.dataset))
+        predictions = predictor.predict_instances(instance)
+        assert predictions is not None
+
 class TestUnidirectionalLanguageModelUnsampled(TestUnidirectionalLanguageModel):
     def setUp(self):
         super().setUp()
@@ -87,8 +94,7 @@ class TestBidirectionalLanguageModel(TestUnidirectionalLanguageModel):
 
         self.expected_embedding_shape = (2, 8, 14)
         self.bidirectional = True
-        self.result_keys = {"loss", "forward_loss", "backward_loss", "lm_embeddings",
-                            "noncontextual_token_embeddings", "mask", "batch_weight"}
+        self.result_keys.add("backward_loss")
 
         self.set_up_model(self.FIXTURES_ROOT / 'language_model' / 'experiment.jsonnet',
                           self.FIXTURES_ROOT / 'language_model' / 'sentences.txt')

--- a/allennlp/tests/models/language_model_test.py
+++ b/allennlp/tests/models/language_model_test.py
@@ -29,8 +29,7 @@ class TestUnidirectionalLanguageModel(ModelTestCase):
         training_tensors = self.dataset.as_tensor_dict()
         result = self.model(**training_tensors)
 
-        assert set(result) == {"loss", "forward_loss", "backward_loss", "lm_embeddings",
-                               "noncontextual_token_embeddings", "mask", "batch_weight"}
+        assert set(result) == self.get_result_keys()
 
         # The model should preserve the BOS / EOS tokens.
         embeddings = result["lm_embeddings"]
@@ -44,7 +43,6 @@ class TestUnidirectionalLanguageModel(ModelTestCase):
                                            decimal=3)
         else:
             np.testing.assert_almost_equal(loss, forward_loss, decimal=3)
-            assert result["backward_loss"] is None
 
     def test_mismatching_contextualizer_unidirectionality_throws_configuration_error(self):
         params = Params.from_file(self.param_file)
@@ -53,6 +51,10 @@ class TestUnidirectionalLanguageModel(ModelTestCase):
         params["model"]["contextualizer"]["bidirectional"] = (not self.bidirectional)
         with pytest.raises(ConfigurationError):
             Model.from_params(vocab=self.vocab, params=params.get("model"))
+
+    def get_result_keys(self):
+        return {"loss", "forward_loss", "lm_embeddings",
+                "noncontextual_token_embeddings", "mask", "batch_weight"}
 
 class TestUnidirectionalLanguageModelUnsampled(TestUnidirectionalLanguageModel):
     def setUp(self):
@@ -89,6 +91,10 @@ class TestBidirectionalLanguageModel(TestUnidirectionalLanguageModel):
 
         self.set_up_model(self.FIXTURES_ROOT / 'language_model' / 'experiment.jsonnet',
                           self.FIXTURES_ROOT / 'language_model' / 'sentences.txt')
+
+    def get_result_keys(self):
+        return {"loss", "forward_loss", "backward_loss", "lm_embeddings",
+                "noncontextual_token_embeddings", "mask", "batch_weight"}
 
 class TestBidirectionalLanguageModelUnsampled(TestBidirectionalLanguageModel):
     def setUp(self):


### PR DESCRIPTION
Changed `LanguageModel` so that, if there is no backward loss, then no backward loss key is added to the state dict. This was causing an issue when using `Predictor` with trained language models.

Fixes https://github.com/allenai/allennlp/issues/3255.