### PR TITLE
Reduce hotflip vocab size, batch input reduction beam search

### DIFF
--- a/allennlp/data/token_indexers/elmo_indexer.py
+++ b/allennlp/data/token_indexers/elmo_indexer.py
@@ -85,6 +85,11 @@ class ELMoCharacterMapper:
         # +1 one for masking
         return [c + 1 for c in char_ids]
 
+    def __eq__(self, other) -> bool:
+        if isinstance(self, other.__class__):
+            return self.__dict__ == other.__dict__
+        return NotImplemented
+
 
 @TokenIndexer.register("elmo_characters")
 class ELMoTokenCharactersIndexer(TokenIndexer[List[int]]):

--- a/allennlp/interpret/attackers/hotflip.py
+++ b/allennlp/interpret/attackers/hotflip.py
@@ -42,7 +42,6 @@ class Hotflip(Attacker):
             if not self.vocab._index_to_token[self.namespace][i].isalnum():
                 self.invalid_replacement_indices.append(i)
         self.embedding_matrix: torch.Tensor = None
-        self.initialize()
 
     def initialize(self):
         """

--- a/allennlp/interpret/attackers/hotflip.py
+++ b/allennlp/interpret/attackers/hotflip.py
@@ -31,7 +31,7 @@ class Hotflip(Attacker):
     def __init__(self,
                  predictor: Predictor,
                  vocab_namespace: str = 'tokens',
-                 max_tokens: int = 5) -> None:
+                 max_tokens: int = 5000) -> None:
         super().__init__(predictor)
         self.vocab = self.predictor._model.vocab
         self.namespace = vocab_namespace
@@ -208,7 +208,7 @@ class Hotflip(Attacker):
 
             while True:
                 # Compute L2 norm of all grads.
-                grad = grads[grad_input_field]
+                grad = grads[grad_input_field][0]
                 grads_magnitude = [g.dot(g) for g in grad]
 
                 # only flip a token once

--- a/allennlp/interpret/attackers/hotflip.py
+++ b/allennlp/interpret/attackers/hotflip.py
@@ -221,9 +221,9 @@ class Hotflip(Attacker):
                     break
                 flipped.append(index_of_token_to_flip)
 
-                # TODO(mattg): This is quite a bit of a hack, both for gpt2 and for getting the
-                # vocab id in general...  I don't have better ideas at the moment, though.
-                indexer_name = 'tokens' if self.namespace == 'gpt2' else self.namespace
+                # TODO(mattg): This is quite a bit of a hack for getting the vocab id...  I don't
+                # have better ideas at the moment, though.
+                indexer_name = self.namespace
                 input_tokens = text_field._indexed_tokens[indexer_name]
                 original_id_of_token_to_flip = input_tokens[index_of_token_to_flip]
 

--- a/allennlp/interpret/attackers/input_reduction.py
+++ b/allennlp/interpret/attackers/input_reduction.py
@@ -80,12 +80,28 @@ class InputReduction(Attacker):
                 return len(input_text_field.tokens)
             candidates = heapq.nsmallest(self.beam_size, candidates, key=lambda x: get_length(x[0]))
 
+            # predictor.get_gradients is where the most expensive computation happens, so we're
+            # going to do it in a batch, up front, before iterating over the results.
             beam_candidates = deepcopy(candidates)
+            all_grads, all_outputs = self.predictor.get_gradients([x[0] for x in beam_candidates])
+            split_grads = []
+            for i in range(len(beam_candidates)):
+                split_grads.append({key: value[i] for key, value in all_grads.items()})
+            split_outputs = []
+            for i in range(len(beam_candidates)):
+                instance_outputs = {}
+                for key, value in all_outputs.items():
+                    if key == 'loss':
+                        continue
+                    instance_outputs[key] = value[i]
+                split_outputs.append(instance_outputs)
+            beam_candidates = [(x[0], x[1], x[2], split_grads[i], split_outputs[i])
+                               for i, x in enumerate(beam_candidates)]
+
             candidates = []
-            for beam_instance, smallest_idx, tag_mask in beam_candidates:
+            for beam_instance, smallest_idx, tag_mask, grads, outputs in beam_candidates:
                 # get gradients and predictions
                 beam_tag_mask = deepcopy(tag_mask)
-                grads, outputs = self.predictor.get_gradients([beam_instance])
 
                 for output in outputs:
                     if isinstance(outputs[output], torch.Tensor):

--- a/allennlp/interpret/attackers/input_reduction.py
+++ b/allennlp/interpret/attackers/input_reduction.py
@@ -100,8 +100,6 @@ class InputReduction(Attacker):
 
             candidates = []
             for beam_instance, smallest_idx, tag_mask, grads, outputs in beam_candidates:
-                # get gradients and predictions
-                beam_tag_mask = deepcopy(tag_mask)
 
                 for output in outputs:
                     if isinstance(outputs[output], torch.Tensor):
@@ -118,6 +116,7 @@ class InputReduction(Attacker):
 
                 # special case for sentence tagging (we have tested NER)
                 else:
+                    beam_tag_mask = deepcopy(tag_mask)
                     # remove the mask where you remove the input token from.
                     if smallest_idx != -1: # Don't delete on the very first iteration
                         del beam_tag_mask[smallest_idx]

--- a/allennlp/interpret/attackers/input_reduction.py
+++ b/allennlp/interpret/attackers/input_reduction.py
@@ -82,13 +82,13 @@ class InputReduction(Attacker):
 
             # predictor.get_gradients is where the most expensive computation happens, so we're
             # going to do it in a batch, up front, before iterating over the results.
-            beam_candidates = deepcopy(candidates)
-            all_grads, all_outputs = self.predictor.get_gradients([x[0] for x in beam_candidates])
+            copied_candidates = deepcopy(candidates)
+            all_grads, all_outputs = self.predictor.get_gradients([x[0] for x in copied_candidates])
             split_grads = []
-            for i in range(len(beam_candidates)):
+            for i in range(len(copied_candidates)):
                 split_grads.append({key: value[i] for key, value in all_grads.items()})
             split_outputs = []
-            for i in range(len(beam_candidates)):
+            for i in range(len(copied_candidates)):
                 instance_outputs = {}
                 for key, value in all_outputs.items():
                     if key == 'loss':
@@ -96,7 +96,7 @@ class InputReduction(Attacker):
                     instance_outputs[key] = value[i]
                 split_outputs.append(instance_outputs)
             beam_candidates = [(x[0], x[1], x[2], split_grads[i], split_outputs[i])
-                               for i, x in enumerate(beam_candidates)]
+                               for i, x in enumerate(copied_candidates)]
 
             candidates = []
             for beam_instance, smallest_idx, tag_mask, grads, outputs in beam_candidates:

--- a/allennlp/interpret/attackers/input_reduction.py
+++ b/allennlp/interpret/attackers/input_reduction.py
@@ -100,6 +100,7 @@ class InputReduction(Attacker):
 
             candidates = []
             for beam_instance, smallest_idx, tag_mask, grads, outputs in beam_candidates:
+                beam_tag_mask = deepcopy(tag_mask)
 
                 for output in outputs:
                     if isinstance(outputs[output], torch.Tensor):
@@ -116,7 +117,6 @@ class InputReduction(Attacker):
 
                 # special case for sentence tagging (we have tested NER)
                 else:
-                    beam_tag_mask = deepcopy(tag_mask)
                     # remove the mask where you remove the input token from.
                     if smallest_idx != -1: # Don't delete on the very first iteration
                         del beam_tag_mask[smallest_idx]

--- a/allennlp/interpret/attackers/input_reduction.py
+++ b/allennlp/interpret/attackers/input_reduction.py
@@ -84,6 +84,10 @@ class InputReduction(Attacker):
             # going to do it in a batch, up front, before iterating over the results.
             copied_candidates = deepcopy(candidates)
             all_grads, all_outputs = self.predictor.get_gradients([x[0] for x in copied_candidates])
+
+            # The output in `all_grads` and `all_outputs` is batched in a dictionary (e.g.,
+            # {'grad_output_1': batched_tensor}).  We need to split this into a list of non-batched
+            # dictionaries that we can iterate over.
             split_grads = []
             for i in range(len(copied_candidates)):
                 split_grads.append({key: value[i] for key, value in all_grads.items()})

--- a/allennlp/interpret/saliency_interpreters/integrated_gradient.py
+++ b/allennlp/interpret/saliency_interpreters/integrated_gradient.py
@@ -25,7 +25,8 @@ class IntegratedGradient(SaliencyInterpreter):
 
             # Normalize results
             for key, grad in grads.items():
-                embedding_grad = numpy.sum(grad, axis=1)
+                # The [0] here is undo-ing the batching that happens in get_gradients.
+                embedding_grad = numpy.sum(grad[0], axis=1)
                 norm = numpy.linalg.norm(embedding_grad, ord=1)
                 normalized_grad = [math.fabs(e) / norm for e in embedding_grad]
                 grads[key] = normalized_grad

--- a/allennlp/interpret/saliency_interpreters/simple_gradient.py
+++ b/allennlp/interpret/saliency_interpreters/simple_gradient.py
@@ -36,7 +36,8 @@ class SimpleGradient(SaliencyInterpreter):
                 # This is then used as an index into the reversed input array to match up the
                 # gradient and its respective embedding.
                 input_idx = int(key[-1]) - 1
-                emb_grad = numpy.sum(grad * embeddings_list[input_idx], axis=1)
+                # The [0] here is undo-ing the batching that happens in get_gradients.
+                emb_grad = numpy.sum(grad[0] * embeddings_list[input_idx], axis=1)
                 norm = numpy.linalg.norm(emb_grad, ord=1)
                 normalized_grad = [math.fabs(e) / norm for e in emb_grad]
                 grads[key] = normalized_grad

--- a/allennlp/interpret/saliency_interpreters/smooth_gradient.py
+++ b/allennlp/interpret/saliency_interpreters/smooth_gradient.py
@@ -35,7 +35,9 @@ class SmoothGradient(SaliencyInterpreter):
             for key, grad in grads.items():
                 # TODO (@Eric-Wallace), SmoothGrad is not using times input normalization.
                 # Fine for now, but should fix for consistency.
-                embedding_grad = numpy.sum(grad, axis=1)
+
+                # The [0] here is undo-ing the batching that happens in get_gradients.
+                embedding_grad = numpy.sum(grad[0], axis=1)
                 norm = numpy.linalg.norm(embedding_grad, ord=1)
                 normalized_grad = [math.fabs(e) / norm for e in embedding_grad]
                 grads[key] = normalized_grad

--- a/allennlp/models/next_token_lm.py
+++ b/allennlp/models/next_token_lm.py
@@ -68,10 +68,10 @@ class NextTokenLM(Model):
                 tokens: Dict[str, torch.LongTensor],
                 target_ids: Dict[str, torch.LongTensor] = None) -> Dict[str, torch.Tensor]:
         # pylint: disable=arguments-differ
-        batch_size = tokens['tokens'].size()[0]
 
          # Shape: (batch_size, num_tokens, embedding_dim)
         embeddings = self._text_field_embedder(tokens)
+        batch_size = embeddings.size(0)
 
          # Shape: (batch_size, num_tokens, encoding_dim)
         if self._contextualizer:

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -1488,8 +1488,8 @@ def find_embedding_layer(model: torch.nn.Module) -> torch.nn.Module:
     from pytorch_transformers.modeling_gpt2 import GPT2Model
     from pytorch_transformers.modeling_bert import BertEmbeddings as BertEmbeddingsNew
     from allennlp.modules.text_field_embedders.text_field_embedder import TextFieldEmbedder
-    from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
-    from allennlp.modules.token_embedders import Embedding
+    from allennlp.modules.text_field_embedders.basic_text_field_embedder import BasicTextFieldEmbedder
+    from allennlp.modules.token_embedders.embedding import Embedding
     for module in model.modules():
         if isinstance(module, BertEmbeddingsOld):
             return module.word_embeddings
@@ -1499,6 +1499,7 @@ def find_embedding_layer(model: torch.nn.Module) -> torch.nn.Module:
             return module.wte
     for module in model.modules():
         if isinstance(module, TextFieldEmbedder):
+            # pylint: disable=protected-access
             if isinstance(module, BasicTextFieldEmbedder):
                 # We'll have a check for single Embedding cases, because we can be more efficient
                 # in cases like this.  If this check fails, then for something like hotflip we need

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -1506,6 +1506,10 @@ def find_embedding_layer(model: torch.nn.Module) -> torch.nn.Module:
                 if len(module._token_embedders) == 1:
                     embedder = list(module._token_embedders.values())[0]
                     if isinstance(embedder, Embedding):
-                        return embedder
+                        if embedder._projection is None:  # pylint: disable=protected-access
+                            # If there's a projection inside the Embedding, then we need to return
+                            # the whole TextFieldEmbedder, because there's more computation that
+                            # needs to be done than just multiply by an embedding matrix.
+                            return embedder
             return module
     raise RuntimeError("No embedding module found!")

--- a/allennlp/predictors/predictor.py
+++ b/allennlp/predictors/predictor.py
@@ -120,7 +120,7 @@ class Predictor(Registrable):
         grad_dict = dict()
         for idx, grad in enumerate(embedding_gradients):
             key = 'grad_input_' + str(idx + 1)
-            grad_dict[key] = grad.squeeze_(0).detach().cpu().numpy()
+            grad_dict[key] = grad.detach().cpu().numpy()
 
         return grad_dict, outputs
 

--- a/allennlp/tests/predictors/predictor_test.py
+++ b/allennlp/tests/predictors/predictor_test.py
@@ -45,5 +45,5 @@ class TestPredictor(AllenNlpTestCase):
             assert 'grad_input_2' in grads
             assert grads['grad_input_1'] is not None
             assert grads['grad_input_2'] is not None
-            assert len(grads['grad_input_1']) == 9  # 9 words in hypothesis
-            assert len(grads['grad_input_2']) == 5  # 5 words in premise
+            assert len(grads['grad_input_1'][0]) == 9  # 9 words in hypothesis
+            assert len(grads['grad_input_2'][0]) == 5  # 5 words in premise


### PR DESCRIPTION
This PR has two fixes for the interpret code:
1. When we have to compute a fake embedding matrix for hotflip (e.g., when using ELMo), the vocab size can be so large that the embedding matrix is way too big.  This PR adds a parameter to limit the vocab size, with a default of 5000 (meaning we'll do our hotflip search over only the most frequent 5000 tokens).  For reference, the full BiDAF-ELMo vocab is close to 100,000, so this dramatically cuts down memory usage, such that I can easily fit it in RAM on my laptop.  The cost is a less rich vocab for hotflipping, but I think it still gets the point across, so it's probably ok.
2. It batches the beam search inside of the input reduction code.  This required a few small changes to everything else, because `get_gradients` used to assume that it only was ever given non-batched input (even though it took a list of instances as input...  that list was always of length 1).