### PR TITLE
Reduce number of samples in smoothgrad

### DIFF
--- a/allennlp/interpret/saliency_interpreters/smooth_gradient.py
+++ b/allennlp/interpret/saliency_interpreters/smooth_gradient.py
@@ -20,7 +20,7 @@ class SmoothGradient(SaliencyInterpreter):
         super().__init__(predictor)
         # Hyperparameters
         self.stdev = 0.01
-        self.num_samples = 25
+        self.num_samples = 10
 
     def saliency_interpret_from_json(self, inputs: JsonDict) -> JsonDict:
         # Convert inputs to labeled instances


### PR DESCRIPTION
Smoothgrad is really slow with 25 samples, speed it up with only 10.