### PR TITLE
Revert "Use a NVIDIA base image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,37 @@
-FROM nvidia/cuda:10.0-base-ubuntu18.04
+FROM python:3.6.8-stretch
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
+ENV PATH /usr/local/nvidia/bin/:$PATH
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+# Tell nvidia-docker the driver spec that we need as well as to
+# use all available devices, which are mounted at /usr/local/nvidia.
+# The LABEL supports an older version of nvidia-docker, the env
+# variables a newer one.
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+
 WORKDIR /stage/allennlp
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-         build-essential \
-         cmake \
-         git \
-         python3.6-dev \
-         python3-setuptools \
-         python3-pip && \
-     rm -rf /var/lib/apt/lists/*
-
-RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
+# Install base packages.
+RUN apt-get update --fix-missing && apt-get install -y \
+    bzip2 \
+    ca-certificates \
+    curl \
+    gcc \
+    git \
+    libc-dev \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
+    wget \
+    libevent-dev \
+    build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy select files needed for installing requirements.
 # We only copy what we need here so small changes to the repository does not trigger re-installation of the requirements.

--- a/Dockerfile.pip
+++ b/Dockerfile.pip
@@ -1,29 +1,26 @@
 # This Dockerfile creates an environment suitable for downstream usage of AllenNLP.
 # It creates an environment that includes a pip installation of allennlp.
 
-FROM nvidia/cuda:10.0-base-ubuntu18.04
+FROM python:3.6.8-stretch
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
+
+ENV PATH /usr/local/nvidia/bin/:$PATH
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+# Tell nvidia-docker the driver spec that we need as well as to
+# use all available devices, which are mounted at /usr/local/nvidia.
+# The LABEL supports an older version of nvidia-docker, the env
+# variables a newer one.
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+LABEL com.nvidia.volumes.needed="nvidia_driver"
 
 WORKDIR /stage/allennlp
 
 ARG VERSION
 ARG SOURCE_COMMIT
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-         build-essential \
-         cmake \
-         git \
-         python3.6-dev \
-         python3-setuptools \
-         python3-pip && \
-     rm -rf /var/lib/apt/lists/*
-
-RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
-
-RUN pip install wheel
 
 # Install the specified version of AllenNLP.
 RUN if [ ! -z "$VERSION" ]; \


### PR DESCRIPTION
Reverts allenai/allennlp#3236

Reverting--as this breaks a rather brittle test in our CI that tests against Python 3.7.