### PR TITLE
fix an annotation error in linking_transition_function.py

### DIFF
--- a/allennlp/state_machines/transition_functions/linking_transition_function.py
+++ b/allennlp/state_machines/transition_functions/linking_transition_function.py
@@ -127,7 +127,8 @@ class LinkingTransitionFunction(BasicTransitionFunction):
             if "linked" in instance_actions:
                 linking_scores, type_embeddings, linked_actions = instance_actions["linked"]
                 action_ids = embedded_actions + linked_actions
-                # (num_question_tokens, 1)
+                # linking_scores: (num_entities, num_question_tokens)
+                # linked_action_logits: (num_entities, 1)
                 linked_action_logits = linking_scores.mm(
                     attention_weights[group_index].unsqueeze(-1)
                 ).squeeze(-1)


### PR DESCRIPTION
I think the annotation in line 130 of linking_transition_function.py is not correct. The shape of linked_action_logits should be (num_entities, 1) instead of (num_question_tokens, 1) since we are copying from the entities list (columns, rows, cells, numbers, e.t.c) rather than the question tokens.