### PR TITLE
Add workarounds to avoid _flat_weights issues for DropConnect.

### DIFF
--- a/allennlp/modules/drop_connect.py
+++ b/allennlp/modules/drop_connect.py
@@ -103,7 +103,7 @@ class DropConnect(torch.nn.Module):
         # This means they need to be compacted at every call, possibly greatly increasing memory
         # usage. To compact weights again call `flatten_parameters()`.
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
+            warnings.simplefilter("ignore")
             # Call the top-level module on the inputs.
             output = self._module.forward(*args)
         # Lastly, remove the dropped out parameters from their parent module's _parameter

--- a/allennlp/modules/drop_connect.py
+++ b/allennlp/modules/drop_connect.py
@@ -111,15 +111,3 @@ class DropConnect(torch.nn.Module):
         # Because PyTorch's optimizer won't include non-leaf tensors as parameters.
 
         return output
-
-    def reset(self):
-        if hasattr(self._module, "reset"):
-            self._module.reset()
-
-        # Reuse `self._matches` otherwise it may falsely match raw parameters.
-        for match in self._matches:
-            self.register_parameter(match.raw_parameter_name, match.parameter)
-            delattr(match.module, match.parameter_name)
-
-        if issubclass(type(self._module), torch.nn.RNNBase):
-            self._module.flatten_parameters = self._no_op_flatten_parameters

--- a/allennlp/modules/drop_connect.py
+++ b/allennlp/modules/drop_connect.py
@@ -87,7 +87,8 @@ class DropConnect(torch.nn.Module):
         We need to replace flatten_parameters with a no-op function.
         It must be a function rather than a lambda as otherwise pickling explodes.
         """
-        self._called_no_op_flatten_parameters += 1
+        if self._called_no_op_flatten_parameters is not None:
+            self._called_no_op_flatten_parameters += 1
         return
 
     def forward(self, *args):

--- a/allennlp/tests/modules/drop_connect_test.py
+++ b/allennlp/tests/modules/drop_connect_test.py
@@ -47,7 +47,7 @@ class DropConnectTest(AllenNlpTestCase):
         output_b, _ = dropped_lstm(input_tensor)
         assert torch.allclose(output_a, output_b)
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device registered.")
+    @unittest.skipIf(not torch.cuda.is_available(), reason="No CUDA device registered.")
     @flaky(max_runs=10, min_passes=1)
     def test_lstm_on_gpu(self):
         input_tensor = torch.ones(1, 2, 10, dtype=torch.float32).cuda()

--- a/allennlp/tests/modules/drop_connect_test.py
+++ b/allennlp/tests/modules/drop_connect_test.py
@@ -49,7 +49,6 @@ class DropConnectTest(AllenNlpTestCase):
         assert torch.allclose(output_a, output_b)
 
     @unittest.skipIf(not torch.cuda.is_available(), reason="No CUDA device registered.")
-    @flaky(max_runs=10, min_passes=1)
     def test_lstm_on_gpu(self):
         input_tensor = torch.ones(1, 2, 10, dtype=torch.float32).cuda()
         lstm = torch.nn.LSTM(input_size=10, hidden_size=10, batch_first=True).cuda()

--- a/allennlp/tests/modules/drop_connect_test.py
+++ b/allennlp/tests/modules/drop_connect_test.py
@@ -121,8 +121,8 @@ class DropConnectTest(AllenNlpTestCase):
         assert all(parameter.is_leaf for parameter in weight_dropped_linear.parameters())
 
         # Case 3: After forward
-        input_tensor = torch.ones(10, dtype=torch.float32)
-        target_tensor = torch.zeros(10, dtype=torch.float32)
+        input_tensor = torch.ones(_in_dim, dtype=torch.float32)
+        target_tensor = torch.zeros(_out_dim, dtype=torch.float32)
         sgd = torch.optim.SGD(weight_dropped_linear.parameters(), lr=0.01)
         _assert_sgd_states(sgd, has_grad=False)
 

--- a/allennlp/tests/modules/drop_connect_test.py
+++ b/allennlp/tests/modules/drop_connect_test.py
@@ -47,6 +47,7 @@ class DropConnectTest(AllenNlpTestCase):
         output_b, _ = dropped_lstm(input_tensor)
         assert torch.allclose(output_a, output_b)
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device registered.")
     @flaky(max_runs=10, min_passes=1)
     def test_lstm_on_gpu(self):
         input_tensor = torch.ones(1, 2, 10, dtype=torch.float32).cuda()

--- a/allennlp/tests/modules/drop_connect_test.py
+++ b/allennlp/tests/modules/drop_connect_test.py
@@ -1,5 +1,6 @@
 from flaky import flaky
 import torch
+import unittest
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.modules.drop_connect import DropConnect

--- a/allennlp/tests/modules/drop_connect_test.py
+++ b/allennlp/tests/modules/drop_connect_test.py
@@ -127,6 +127,7 @@ class DropConnectTest(AllenNlpTestCase):
         weight_dropped_linear = DropConnect(
             torch.nn.Linear(_in_dim, _out_dim), parameter_regex="weight", dropout=0.9
         )
+        assert weight_dropped_linear._called_no_op_flatten_parameters is None
         assert all(parameter.is_leaf for parameter in weight_dropped_linear.parameters())
 
         # Case 2: When in training mode
@@ -143,6 +144,7 @@ class DropConnectTest(AllenNlpTestCase):
         for epoch in range(2):
             sgd.zero_grad()
             output_tensor = weight_dropped_linear(input_tensor)
+            assert weight_dropped_linear._called_no_op_flatten_parameters is None
 
             # Replaced
             # `assert all(parameter.is_leaf for parameter in weight_dropped_linear.parameters())`
@@ -156,6 +158,7 @@ class DropConnectTest(AllenNlpTestCase):
 
         # Case 4: After reset()
         weight_dropped_linear.reset()
+        assert weight_dropped_linear._called_no_op_flatten_parameters is None
         assert all(parameter.is_leaf for parameter in weight_dropped_linear.parameters())
 
         # Case 5: When in eval mode

--- a/allennlp/tests/modules/drop_connect_test.py
+++ b/allennlp/tests/modules/drop_connect_test.py
@@ -7,6 +7,13 @@ from allennlp.modules.drop_connect import DropConnect
 
 
 class DropConnectTest(AllenNlpTestCase):
+    def test_no_op_flatten_parameters(self):
+        # A dummy test to make codecov/patch happy
+        dropped_linear = DropConnect(torch.nn.Linear(10, 10), parameter_regex="weight", dropout=0.9)
+        assert dropped_linear._called_no_op_flatten_parameters is None
+        dropped_linear._no_op_flatten_parameters()
+        assert dropped_linear._called_no_op_flatten_parameters == 0
+        
     @flaky(max_runs=10, min_passes=1)
     def test_linear_outputs(self):
         # Check that weights are (probably) being dropped out properly. There's an extremely small


### PR DESCRIPTION
I hesitate to open a pull request for it because it involves workarounds. However, since #3092 has been merged, I figure it might be better to submit early and submit often as long as it doesn't break tests.

I'm working on using AWD-BiLSTM-CRFs for sequence labeling. Two issues require workarounds for my implementation:
1. PyTorch raises `AttributeError`: '`LSTM`' object has no attribute '`_flat_weights`'.
2. If duplicated parameters are deleted, `allennlp fine-tune` won't work because it will try to load parameters based on the default model config and the deleted parameters won't be in the `state_dict` anymore.

This PR is for the first issue. The second issue may need further discussions and I can submit another PR for review, with a simple model based on the tutorial of POS tagging.

One of the diffs in this PR was included in #3092 until e439c64. I'm not so sure why it happened. Also, I suspect the test is running on CPU such that it won't encounter `AttributeError` of `_flat_weights` because it will be a no-op (See [torch/nn/modules/rnn.py#L102](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/rnn.py#L102)), and [salesforce's test may be using cuda()](https://github.com/salesforce/awd-lstm-lm/blob/master/weight_drop.py#L85) so it can cover this situation. To my best knowledge, it seems only `ModelTestCase` supports testing on GPU for the time being. Therefore it may require a complementary PR of a demo model to ensure that `DropConnect` works properly. 

Another part of the diffs is a workaround for #2793.

Please advise. Thank you!

----
I gather related discussions about fastai implementation here: https://forums.fast.ai/t/multilingual-ulmfit/28117/142