### PR TITLE
Allow passing a Path in ElmoEmbedder

### DIFF
--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -68,7 +68,8 @@ import argparse
 import json
 import logging
 import os
-from typing import IO, List, Iterable, Tuple
+from pathlib import Path
+from typing import IO, List, Iterable, Tuple, Union
 import warnings
 
 with warnings.catch_warnings():
@@ -181,8 +182,8 @@ def empty_embedding() -> numpy.ndarray:
 class ElmoEmbedder:
     def __init__(
         self,
-        options_file: str = DEFAULT_OPTIONS_FILE,
-        weight_file: str = DEFAULT_WEIGHT_FILE,
+        options_file: Union[str, Path] = DEFAULT_OPTIONS_FILE,
+        weight_file: Union[str, Path] = DEFAULT_WEIGHT_FILE,
         cuda_device: int = -1,
     ) -> None:
         """

--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from pathlib import Path
 from typing import Union, List, Dict, Any
 import warnings
 
@@ -316,7 +317,12 @@ class _ElmoCharacterEncoder(torch.nn.Module):
             }
     """
 
-    def __init__(self, options_file: str, weight_file: str, requires_grad: bool = False) -> None:
+    def __init__(
+        self,
+        options_file: Union[str, Path],
+        weight_file: Union[str, Path],
+        requires_grad: bool = False,
+    ) -> None:
         super().__init__()
 
         with open(cached_path(options_file), "r") as fin:
@@ -528,8 +534,8 @@ class _ElmoBiLm(torch.nn.Module):
 
     def __init__(
         self,
-        options_file: str,
-        weight_file: str,
+        options_file: Union[str, Path],
+        weight_file: Union[str, Path],
         requires_grad: bool = False,
         vocab_to_cache: List[str] = None,
     ) -> None:

--- a/allennlp/modules/elmo_lstm.py
+++ b/allennlp/modules/elmo_lstm.py
@@ -1,7 +1,8 @@
 """
 A stacked bidirectional LSTM with skip connections between layers.
 """
-from typing import Optional, Tuple, List
+from pathlib import Path
+from typing import Optional, Tuple, List, Union
 import warnings
 
 import torch
@@ -258,7 +259,7 @@ class ElmoLstm(_EncoderBase):
         )
         return stacked_sequence_outputs, final_state_tuple
 
-    def load_weights(self, weight_file: str) -> None:
+    def load_weights(self, weight_file: Union[str, Path]) -> None:
         """
         Load the pre-trained weights from the file.
         """


### PR DESCRIPTION
`ElmoEmbedder` did accept `Path`s instead of strings, but the typings didn't acknowledge that.