### PR TITLE
Add support for the trainer param to be a str

### DIFF
--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -223,6 +223,9 @@ def find_learning_rate_model(
     train_data = all_datasets["train"]
 
     trainer_params = params.pop("trainer")
+    if isinstance(trainer_params, str):
+        trainer_params = Params({"type": trainer_params})
+
     no_grad_regexes = trainer_params.pop("no_grad", ())
     for name, parameter in model.named_parameters():
         if any(re.search(regex, name) for regex in no_grad_regexes):

--- a/allennlp/commands/fine_tune.py
+++ b/allennlp/commands/fine_tune.py
@@ -333,6 +333,9 @@ def fine_tune_model(
     test_data = all_datasets.get("test")
 
     trainer_params = params.pop("trainer")
+    if isinstance(trainer_params, str):
+        trainer_params = Params({"type": trainer_params})
+
     no_grad_regexes = trainer_params.pop("no_grad", ())
     for name, parameter in model.named_parameters():
         if any(re.search(regex, name) for regex in no_grad_regexes):

--- a/allennlp/tests/training/no_op_trainer_test.py
+++ b/allennlp/tests/training/no_op_trainer_test.py
@@ -3,11 +3,12 @@ from typing import Dict
 
 import torch
 
+from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Vocabulary
 from allennlp.data.dataset_readers import SequenceTaggingDatasetReader
 from allennlp.models.model import Model
-from allennlp.training import NoOpTrainer
+from allennlp.training import NoOpTrainer, TrainerBase
 
 
 class ConstantModel(Model):
@@ -32,3 +33,10 @@ class TestNoOpTrainer(AllenNlpTestCase):
         assert metrics == {}
         assert os.path.exists(serialization_dir / "best.th")
         assert os.path.exists(serialization_dir / "vocabulary")
+
+    def test_trainer_from_base_class_params_trainer_str(self):
+        params = Params.from_file(self.FIXTURES_ROOT / "simple_tagger" / "experiment.json")
+        params["trainer"] = "no_op"
+
+        # Can instantiate from base class params
+        TrainerBase.from_params(params, self.TEST_DIR)

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -66,8 +66,11 @@ class TrainerBase(Registrable):
         cache_directory: str = None,
         cache_prefix: str = None,
     ):
+        trainer_params = params.get("trainer", {})
+        if isinstance(trainer_params, str):
+            trainer_params = Params({"type": trainer_params})
 
-        typ3 = params.get("trainer", {}).pop("type", "default")
+        typ3 = trainer_params.pop("type", "default")
 
         if typ3 == "default":
             # Special logic to keep old from_params behavior.

--- a/allennlp/training/trainer_pieces.py
+++ b/allennlp/training/trainer_pieces.py
@@ -94,6 +94,9 @@ class TrainerPieces(NamedTuple):
         test_data = all_datasets.get("test")
 
         trainer_params = params.pop("trainer")
+        if isinstance(trainer_params, str):
+            trainer_params = Params({"type": trainer_params})
+
         no_grad_regexes = trainer_params.pop("no_grad", ())
         for name, parameter in model.named_parameters():
             if any(re.search(regex, name) for regex in no_grad_regexes):


### PR DESCRIPTION
As well as many (all?) params that support both `{"type": "param_type"}` and `"param_type"`, this adds support for the trainer param to be a `str`.