### PR TITLE
Changes to `train_model` for distributed training support

### DIFF
--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -48,11 +48,10 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
-import torch.multiprocessing as mp
 
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common import Params
-from allennlp.common.checks import check_for_gpu, parse_cuda_device
+from allennlp.common.checks import check_for_gpu
 from allennlp.common.util import (
     prepare_environment,
     prepare_global_logging,

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -419,3 +419,5 @@ def _train_worker(
 
     if not distributed:
         return trainer.model
+
+    return None  # to make mypy happy

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -294,7 +294,7 @@ def _train_worker(
     Parameters
     ----------
     rank : ``int``
-        The process index.
+        The process index that is initialized using the GPU device id.
     params : ``Params``
         A parameter object specifying an AllenNLP Experiment.
     serialization_dir : ``str``

--- a/allennlp/tests/training/gan_callback_trainer_test.py
+++ b/allennlp/tests/training/gan_callback_trainer_test.py
@@ -209,6 +209,9 @@ class GanCallbackTrainer(CallbackTrainer):
         serialization_dir: Optional[str] = None,
         cuda_device: Union[int, List] = -1,
         callbacks: List[Callback] = None,
+        distributed: bool = False,
+        rank: int = 0,
+        world_size: int = 1,
     ) -> None:
         super().__init__(
             model,

--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -11,7 +11,7 @@ from typing import Dict, Optional, List, Union, Any, Iterable
 import torch
 
 from allennlp.common import Params
-from allennlp.common.checks import parse_cuda_device
+from allennlp.common.checks import ConfigurationError, parse_cuda_device
 from allennlp.common.tqdm import Tqdm
 from allennlp.common.util import lazy_groups_of
 from allennlp.data.instance import Instance
@@ -55,6 +55,9 @@ class CallbackTrainer(TrainerBase):
         serialization_dir: Optional[str] = None,
         cuda_device: Union[int, List] = -1,
         callbacks: List[Callback] = None,
+        distributed: bool = False,
+        rank: int = 0,
+        world_size: int = 1,
     ) -> None:
         """
         A trainer for doing supervised learning. It just takes a labeled dataset
@@ -96,7 +99,7 @@ class CallbackTrainer(TrainerBase):
         callbacks : ``List[Callback]``, optional (default=None)
             A list of callbacks that will be called based on training events.
         """
-        super().__init__(serialization_dir, cuda_device)
+        super().__init__(serialization_dir, cuda_device, distributed, rank, world_size)
 
         logger.warning(
             "The CallbackTrainer should be considered 'experimental' code, "
@@ -334,6 +337,18 @@ class CallbackTrainer(TrainerBase):
             for callback_params in callbacks_params
         ]
 
+        distributed = params.pop_bool("distributed", False)
+        world_size = params.pop_int("world_size", 1)
+        if distributed and world_size <= 1:
+            raise ConfigurationError(
+                "Distributed training can be performed only with more than 1 GPU device. Check "
+                "`cuda_device` key in the experiment configuration."
+            )
+        if distributed:
+            rank = model_device
+        else:
+            rank = 0
+
         params.assert_empty(cls.__name__)
         return cls(
             model,
@@ -345,4 +360,7 @@ class CallbackTrainer(TrainerBase):
             serialization_dir=serialization_dir,
             cuda_device=cuda_device,
             callbacks=callbacks,
+            distributed=distributed,
+            rank=rank,
+            world_size=world_size,
         )

--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -339,11 +339,7 @@ class CallbackTrainer(TrainerBase):
 
         distributed = params.pop_bool("distributed", False)
         world_size = params.pop_int("world_size", 1)
-        if distributed and world_size <= 1:
-            raise ConfigurationError(
-                "Distributed training can be performed only with more than 1 GPU device. Check "
-                "`cuda_device` key in the experiment configuration."
-            )
+
         if distributed:
             rank = model_device
         else:

--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -11,7 +11,7 @@ from typing import Dict, Optional, List, Union, Any, Iterable
 import torch
 
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError, parse_cuda_device
+from allennlp.common.checks import parse_cuda_device
 from allennlp.common.tqdm import Tqdm
 from allennlp.common.util import lazy_groups_of
 from allennlp.data.instance import Instance

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -178,8 +178,8 @@ class Trainer(TrainerBase):
             If set, PyTorch's `DistributedDataParallel` is used to train the model in multiple GPUs. This also
             requires `world_size` to be greater than 1.
         rank: ``int``, optional, (default = 0)
-            This is the unique identifier of the `Trainer` in a distributed process group. The GPU device id is used
-            as the rank.
+            This is the unique identifier of the `Trainer` in a distributed process group. The GPU device id is
+            used as the rank.
         world_size: ``int``, (default = 1)
             The number of `Trainer` workers participating in the distributed training.
         """

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -174,6 +174,14 @@ class Trainer(TrainerBase):
             parameters. Be careful that when saving the checkpoint, we will save the moving averages of
             parameters. This is necessary because we want the saved model to perform as well as the validated
             model if we load it later. But this may cause problems if you restart the training from checkpoint.
+        distributed: ``bool``, optional, (default = False)
+            If set, PyTorch's `DistributedDataParallel` is used to train the model in multiple GPUs. This also
+            requires `world_size` to be greater than 1.
+        rank: ``int``, optional, (default = 0)
+            This is the unique identifier of the `Trainer` in a distributed process group. The GPU device id is used
+            as the rank.
+        world_size: ``int``, (default = 1)
+            The number of `Trainer` workers participating in the distributed training.
         """
         super().__init__(serialization_dir, cuda_device, distributed, rank, world_size)
 
@@ -758,11 +766,7 @@ class Trainer(TrainerBase):
 
         distributed = params.pop_bool("distributed", False)
         world_size = params.pop_int("world_size", 1)
-        if distributed and world_size <= 1:
-            raise ConfigurationError(
-                "Distributed training can be performed only with more than 1 GPU device. Check "
-                "`cuda_device` key in the experiment configuration."
-            )
+
         if distributed:
             rank = model_device
         else:

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -27,7 +27,14 @@ class TrainerBase(Registrable):
 
     default_implementation = "default"
 
-    def __init__(self, serialization_dir: str, cuda_device: Union[int, List] = -1) -> None:
+    def __init__(
+        self,
+        serialization_dir: str,
+        cuda_device: Union[int, List] = -1,
+        distributed: bool = False,
+        rank: int = 0,
+        world_size: int = 1,
+    ) -> None:
         check_for_gpu(cuda_device)
 
         self._serialization_dir = serialization_dir
@@ -39,11 +46,19 @@ class TrainerBase(Registrable):
             )
 
         if isinstance(cuda_device, list):
+            assert (
+                not distributed
+            )  # For distributed training, every trainer worker is only assigned with a single GPU
             self._multiple_gpu = True
             self._cuda_devices = cuda_device
         else:
             self._multiple_gpu = False
             self._cuda_devices = [cuda_device]
+
+        self._distributed = distributed
+        self._rank = rank
+        self._master = self._rank == 0
+        self._world_size = world_size
 
     def _move_to_gpu(self, model: Model) -> Model:
         if self._cuda_devices[0] != -1:

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -45,6 +45,12 @@ class TrainerBase(Registrable):
                 "Expected an int or list for cuda_device, got {}".format(cuda_device)
             )
 
+        if distributed and world_size <= 1:
+            raise ConfigurationError(
+                "Distributed training can be performed only with more than 1 GPU device. Check "
+                "`cuda_device` key in the experiment configuration."
+            )
+
         if isinstance(cuda_device, list):
             assert (
                 not distributed


### PR DESCRIPTION
This is the second PR after #3372 to bring in distributed training support. Following are the high level changes done:

* Extra params to `TrainerBase`, `Trainer` and `CallbackTrainer` classes to include rank and world_size options
* In a distributed setup, the plan is to run training in sub processes by using `multiprocessing.spawn`. Hence parts of `train_model` function in `train.py` is isolated to a new `_train_worker` function which is invoked as a process
* In this PR, changes for distributed training are still not in. Only the isolation of the above mentioned function is done, to mostly test its correctness when run with existing tests/experiments

~~P.S: Since this is a dependent PR, the changes done for the previous PR is being shown until the older one is merged. I'd be happy to know if there is a better way to do this :)~~

@DeNeutoy Once this reviewed, the next PR candidate would be the actual distributed training related code.