### PR TITLE
Tighten pin to avoid only broken binaries and allow 1.3.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,9 @@
 # please visit https://pytorch.org/ and install the relevant version.
 # allennlp>0.8.5 requires PyTorch 1.2 or greater. If you need to use
 # an older version of PyTorch you'll also need to use an older version of allennlp.
-torch>=1.2.0
+# Note: We're not precisely avoiding 1.3.0 here. Pytorch released new binaries as
+# 1.3.0.post2 for a bugfix. This requirement allows 1.3.0.post2.
+torch>=1.2.0,!=1.3.0
 
 # Parameter parsing (but not on Windows).
 jsonnet>=0.10.0 ; sys.platform != 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 # please visit https://pytorch.org/ and install the relevant version.
 # allennlp>0.8.5 requires PyTorch 1.2 or greater. If you need to use
 # an older version of PyTorch you'll also need to use an older version of allennlp.
-torch>=1.2.0,<1.3.0
+torch>=1.2.0
 
 # Parameter parsing (but not on Windows).
 jsonnet>=0.10.0 ; sys.platform != 'win32'

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
     license="Apache",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
-        "torch>=1.2.0",
+        "torch>=1.2.0,!=1.3.0",
         "jsonnet>=0.10.0 ; sys.platform != 'win32'",
         "overrides",
         "nltk",

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
     license="Apache",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
-        "torch>=1.2.0,<1.3.0",
+        "torch>=1.2.0",
         "jsonnet>=0.10.0 ; sys.platform != 'win32'",
         "overrides",
         "nltk",


### PR DESCRIPTION
Resolution of https://github.com/allenai/allennlp/issues/3367. Pytorch has fixed their binaries for 1.3.0. Now we'll use 1.3.0.post2.

I've tested this locally on macOS 10.13.6 and both `pip install -r requirements.txt` and `pip install --editable allennlp` fix broken installations.