### PR TITLE
Corrected outdated links to models

### DIFF
--- a/tutorials/getting_started/using_pretrained_models.md
+++ b/tutorials/getting_started/using_pretrained_models.md
@@ -2,13 +2,13 @@
 
 In this tutorial, we show how to use run the pretrained models in AllenNLP to make predictions.
 This tutorial uses the Named Entity Recognition model, but the same procedure applies to any of
-the models [available on our website](https://allennlp.org/models).
+the models [available on our website](https://github.com/allenai/allennlp/blob/master/MODELS.md).
 
 ## Making Predictions on the Command Line
 
-[The models page on the website](https://allennlp.org/models) lists all the models in AllenNLP,
+[The models page on the website](https://github.com/allenai/allennlp/blob/master/MODELS.md) lists all the models in AllenNLP,
 as well as examples for how to run the model on the command line.  For example, under the
-[Named Entity Recognition model](https://allennlp.org/models#named-entity-recognition) there
+[Named Entity Recognition model](https://github.com/allenai/allennlp/blob/master/MODELS.md#named-entity-recognition) there
 is a "Prediction" button that reveals the following example.
 
 ```bash


### PR DESCRIPTION
There were a few dead links (404) in the text. I guess I found out where they are supposed to go.