### PR TITLE
adding version to overrides packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ torch>=1.2.0,!=1.3.0
 jsonnet>=0.10.0 ; sys.platform != 'win32'
 
 # Adds an @overrides decorator for better documentation and error checking when using subclasses.
-overrides
+overrides==2.0
 
 # Used by some old code.  We moved away from it because it's too slow, but some old code still
 # imports this.


### PR DESCRIPTION
Adding the version number for overrides package in requirements to avoid the error reported in issue #3401 