### PR TITLE
Use correct method in auto_regressive_seq_decoder when computing token based metric

### DIFF
--- a/allennlp/modules/seq2seq_decoders/auto_regressive_seq_decoder.py
+++ b/allennlp/modules/seq2seq_decoders/auto_regressive_seq_decoder.py
@@ -426,7 +426,7 @@ class AutoRegressiveSeqDecoder(SeqDecoder):
                     )
 
                 if self._token_based_metric is not None:
-                    output_dict = self.decode(output_dict)
+                    output_dict = self.post_process(output_dict)
                     predicted_tokens = output_dict["predicted_tokens"]
 
                     self._token_based_metric(  # type: ignore


### PR DESCRIPTION
Fix for #3407.

There are currently no existing tests for the whole `auto_regressive_seq_decoder` module, and I was not sure of what fixtures to create to test the module.

To test just this PR, I needed to use a `token_based_metric`. From a cursory glance of the available metrics, `BLEU` seemed to be a good choice. However, `BLEU` works on tensors, whereas this class is passing `List[List[str]]`.

As noted in #2919, even `tensor_based_metric` is not being called correctly, as `SequenceAccuracy` expects a different format. Maybe the metrics can be removed from this class?