### PR TITLE
WIP: `Trainer` changes for distributed training

### DIFF
--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -297,8 +297,6 @@ def train_model(
                 "Multiple cuda devices need to be configured to run distributed training."
             )
 
-        logging.info("Switching to distributed training mode since multiple GPUs are configured")
-
         master_addr = params.params.get("trainer").get("master_address", "127.0.0.1")
         master_port = params.params.get("trainer").get("master_port", 29500)
         num_procs = len(device_id)
@@ -308,6 +306,11 @@ def train_model(
         os.environ["MASTER_ADDR"] = master_addr
         os.environ["MASTER_PORT"] = str(master_port)
         os.environ["WORLD_SIZE"] = str(world_size)
+
+        logging.info(f"Switching to distributed training mode since multiple GPUs are configured"
+                     f"Master is at: {master_addr}:{master_port} | Rank of this node: {node_rank} | "
+                     f"Number of workers in this node: {num_procs} | Number of nodes: {num_nodes} | "
+                     f"World size: {world_size}")
 
         # Creating `Vocabulary` objects from workers could be problematic since the data iterators
         # in each worker will yield only `rank` specific instances. Hence it is safe to construct
@@ -329,7 +332,8 @@ def train_model(
                 cache_directory,
                 cache_prefix,
                 include_package,
-                world_size,
+                node_rank,
+                world_size
             ),
             nprocs=num_procs
         )

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -138,7 +138,7 @@ class Train(Subcommand):
         )
 
         subparser.add_argument(
-            "--node-rank", type=int, help="Rank of this node in the distributed setup"
+            "--node-rank", type=int, default=0, help="Rank of this node in the distributed setup"
         )
 
         subparser.set_defaults(func=train_model_from_args)
@@ -282,6 +282,7 @@ def train_model(
             cache_directory=cache_directory,
             cache_prefix=cache_prefix,
             include_package=include_package,
+            node_rank=node_rank,
             world_size=1,
         )
         archive_model(serialization_dir, files_to_archive=params.files_to_archive)
@@ -469,7 +470,7 @@ def _train_worker(
     params.assert_empty("base train command")
 
     try:
-        if master and distributed:  # let the setup get ready for all the workers
+        if distributed:  # let the setup get ready for all the workers
             dist.barrier()
 
         metrics = trainer.train()

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -38,7 +38,8 @@ which to write the results.
                             parameter settings a name in the cache, instead of
                             computing a hash
       --node-rank NODE_RANK
-                            Rank of this node in the distributed setup
+                            Rank of this node in the distributed setup (default =
+                            0)
       --include-package INCLUDE_PACKAGE
                             additional packages to include
 """

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -355,7 +355,9 @@ def _train_worker(
     best_model: ``Model``
         The model with the best epoch weights.
     """
-    prepare_global_logging(serialization_dir, file_friendly_logging, rank=rank, world_size=world_size)
+    prepare_global_logging(
+        serialization_dir, file_friendly_logging, rank=rank, world_size=world_size
+    )
     prepare_environment(params)
 
     distributed = world_size > 1

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -9,7 +9,7 @@ which to write the results.
     usage: allennlp train [-h] -s SERIALIZATION_DIR [-r] [-f] [-o OVERRIDES]
                           [--file-friendly-logging]
                           [--cache-directory CACHE_DIRECTORY]
-                          [--cache-prefix CACHE_PREFIX]
+                          [--cache-prefix CACHE_PREFIX] [--node-rank NODE_RANK]
                           [--include-package INCLUDE_PACKAGE]
                           param_path
 
@@ -37,10 +37,10 @@ which to write the results.
                             Prefix to use for data caching, giving current
                             parameter settings a name in the cache, instead of
                             computing a hash
+      --node-rank NODE_RANK
+                            Rank of this node in the distributed setup
       --include-package INCLUDE_PACKAGE
                             additional packages to include
-      --node-rank NODE_RANK
-                            rank of the current node in the distributed distributed
 """
 
 import argparse
@@ -138,7 +138,7 @@ class Train(Subcommand):
         )
 
         subparser.add_argument(
-            "--node-rank", type=int, default=0, help="Rank of this node in the distributed setup"
+            "--node-rank", type=int, help="Rank of this node in the distributed setup"
         )
 
         subparser.set_defaults(func=train_model_from_args)
@@ -201,7 +201,7 @@ def train_model_from_file(
         For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
     cache_prefix : ``str``, optional
         For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
-    node_rank : ``int``, optional ( default = 0 )
+    node_rank : ``int``, optional
         Rank of the current node in distributed training
     include_package: ``str``, optional
         In distributed mode, extra packages mentioned will be imported in trainer workers.
@@ -255,7 +255,7 @@ def train_model(
         For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
     cache_prefix : ``str``, optional
         For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
-    node_rank: ``int``, optional ( default = 0 )
+    node_rank: ``int``, optional
         Rank of the current node in distributed training
     include_package: ``str``, optional
         In distributed mode, extra packages mentioned will be imported in trainer workers.
@@ -380,7 +380,7 @@ def _train_worker(
         In distributed mode, since this function would have been spawned as a separate process,
         the extra imports need to be done again. NOTE: This does not have any effect in single
         GPU training.
-    node_rank: ``int``, optional ( default = 0 )
+    node_rank: ``int``, optional
         Rank of the node
     world_size: ``int``, optional
         The number of processes involved in distributed training.

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -277,7 +277,7 @@ def train_model(
     distributed = params.params.get("trainer").get("distributed", False)
     if not distributed:
         model = _train_worker(
-            rank=0,
+            process_rank=0,
             params=params,
             serialization_dir=serialization_dir,
             file_friendly_logging=file_friendly_logging,
@@ -299,15 +299,15 @@ def train_model(
 
         logging.info("Switching to distributed training mode since multiple GPUs are configured")
 
-        master_addr = params.params.get("trainer").get("master_address")
-        master_port = params.params.get("trainer").get("master_port")
-        num_procs = params.params.get("trainer").get("num_procs_per_node")
-        num_nodes = params.params.get("trainer").get("num_nodes")
+        master_addr = params.params.get("trainer").get("master_address", "127.0.0.1")
+        master_port = params.params.get("trainer").get("master_port", 29500)
+        num_procs = len(device_id)
+        num_nodes = params.params.get("trainer").get("num_nodes", 1)
         world_size = num_nodes * num_procs
 
         os.environ["MASTER_ADDR"] = master_addr
-        os.environ["MASTER_PORT"] = master_port
-        os.environ["WORLD_SIZE"] = world_size
+        os.environ["MASTER_PORT"] = str(master_port)
+        os.environ["WORLD_SIZE"] = str(world_size)
 
         # Creating `Vocabulary` objects from workers could be problematic since the data iterators
         # in each worker will yield only `rank` specific instances. Hence it is safe to construct

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -62,6 +62,7 @@ from allennlp.common.util import (
     prepare_global_logging,
     dump_metrics,
     import_submodules,
+    is_master
 )
 from allennlp.models.archival import archive_model, CONFIG_NAME
 from allennlp.models.model import Model, _DEFAULT_WEIGHTS
@@ -402,6 +403,8 @@ def _train_worker(
     prepare_environment(params)
 
     distributed = world_size > 1
+
+    # not using `allennlp.common.util.is_master` as the process group is yet to be initialized
     master = process_rank == 0
 
     evaluate_on_test = params.pop_bool("evaluate_on_test", False)

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -138,10 +138,7 @@ class Train(Subcommand):
         )
 
         subparser.add_argument(
-            "--node-rank",
-            type=int,
-            default=0,
-            help="Rank of this node in the distributed setup"
+            "--node-rank", type=int, default=0, help="Rank of this node in the distributed setup"
         )
 
         subparser.set_defaults(func=train_model_from_args)
@@ -307,10 +304,12 @@ def train_model(
         os.environ["MASTER_PORT"] = str(master_port)
         os.environ["WORLD_SIZE"] = str(world_size)
 
-        logging.info(f"Switching to distributed training mode since multiple GPUs are configured"
-                     f"Master is at: {master_addr}:{master_port} | Rank of this node: {node_rank} | "
-                     f"Number of workers in this node: {num_procs} | Number of nodes: {num_nodes} | "
-                     f"World size: {world_size}")
+        logging.info(
+            f"Switching to distributed training mode since multiple GPUs are configured"
+            f"Master is at: {master_addr}:{master_port} | Rank of this node: {node_rank} | "
+            f"Number of workers in this node: {num_procs} | Number of nodes: {num_nodes} | "
+            f"World size: {world_size}"
+        )
 
         # Creating `Vocabulary` objects from workers could be problematic since the data iterators
         # in each worker will yield only `rank` specific instances. Hence it is safe to construct
@@ -333,9 +332,9 @@ def train_model(
                 cache_prefix,
                 include_package,
                 node_rank,
-                world_size
+                world_size,
             ),
-            nprocs=num_procs
+            nprocs=num_procs,
         )
         model = Model.load(params, serialization_dir)
         return model
@@ -423,7 +422,8 @@ def _train_worker(
         torch.cuda.set_device(gpu_id)
         dist.init_process_group(backend="nccl", world_size=world_size, rank=global_rank)
         logging.info(
-            f"Process group of world size {world_size} initialized for distributed training in worker {global_rank}"
+            f"Process group of world size {world_size} initialized "
+            f"for distributed training in worker {global_rank}"
         )
 
         # Till now, "cuda_device" will be a list of ids as configured originally

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -284,7 +284,7 @@ def train_model(
         # in each worker will yield only `rank` specific instances. Hence it is safe to construct
         # the vocabulary and write it to disk before initializing the distributed context. The workers
         # will load the vocabulary from the path specified.
-        make_vocab_from_params(params, serialization_dir)
+        make_vocab_from_params(params.duplicate(), serialization_dir)
         params["vocabulary"] = {
             "directory_path": os.path.join(serialization_dir, "vocabulary"),
             "extend": False,  # vocab extension would have been done above
@@ -355,7 +355,7 @@ def _train_worker(
     best_model: ``Model``
         The model with the best epoch weights.
     """
-    prepare_global_logging(serialization_dir, file_friendly_logging)
+    prepare_global_logging(serialization_dir, file_friendly_logging, rank=rank, world_size=world_size)
     prepare_environment(params)
 
     distributed = world_size > 1

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -62,7 +62,6 @@ from allennlp.common.util import (
     prepare_global_logging,
     dump_metrics,
     import_submodules,
-    is_master
 )
 from allennlp.models.archival import archive_model, CONFIG_NAME
 from allennlp.models.model import Model, _DEFAULT_WEIGHTS

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -282,7 +282,7 @@ def train_model(
             recover=recover,
             cache_directory=cache_directory,
             cache_prefix=cache_prefix,
-            include_package=include_package
+            include_package=include_package,
         )
         archive_model(serialization_dir, files_to_archive=params.files_to_archive)
         return model
@@ -423,13 +423,15 @@ def _train_worker(
         # In distributed training, the configured device is always going to be a list.
         # The corresponding gpu id for the particular worker is obtained by picking the id
         # from the device list with the rank as index
-        gpu_id = device_list[process_rank]
+        gpu_id = device_list[process_rank]  # type: ignore
 
         torch.cuda.set_device(gpu_id)
-        dist.init_process_group(backend="nccl",
-                                init_method=f"tcp://{master_addr}:{master_port}",
-                                world_size=world_size,
-                                rank=global_rank)
+        dist.init_process_group(
+            backend="nccl",
+            init_method=f"tcp://{master_addr}:{master_port}",
+            world_size=world_size,
+            rank=global_rank,
+        )
         logging.info(
             f"Process group of world size {world_size} initialized "
             f"for distributed training in worker {global_rank}"

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -290,7 +290,9 @@ def prepare_global_logging(
     # Remove the already set stream handler in root logger.
     # Not doing this will result in duplicate log messages
     # printed in the console
-    root_logger.removeHandler(root_logger.handlers[0])
+    if len(root_logger.handlers) > 0:
+        for handler in root_logger.handlers:
+            root_logger.removeHandler(handler)
 
     # file handlers need to be handled for tqdm's \r char
     file_friendly_log_filter = FileFriendlyLogFilter()

--- a/allennlp/models/biattentive_classification_network.py
+++ b/allennlp/models/biattentive_classification_network.py
@@ -129,13 +129,10 @@ class BiattentiveClassificationNetwork(Model):
 
             if len(self._elmo._scalar_mixes) != self._num_elmo_layers:
                 raise ConfigurationError(
-                    "Elmo object has num_output_representations=%s, but this does not "
-                    "match the number of use_*_elmo flags set to true. use_input_elmo "
-                    "is %s, and use_integrator_output_elmo is %s".format(
-                        str(len(self._elmo._scalar_mixes)),
-                        str(self._use_input_elmo),
-                        str(self._use_integrator_output_elmo),
-                    )
+                    f"Elmo object has num_output_representations={len(self._elmo._scalar_mixes)}, but this "
+                    f"does not match the number of use_*_elmo flags set to true. use_input_elmo "
+                    f"is {self._use_input_elmo}, and use_integrator_output_elmo "
+                    f"is {self._use_integrator_output_elmo}"
                 )
 
         # Calculate combined integrator output dim, taking into account elmo

--- a/allennlp/run.py
+++ b/allennlp/run.py
@@ -3,6 +3,8 @@ import logging
 import os
 import sys
 
+import torch
+
 if os.environ.get("ALLENNLP_DEBUG"):
     LEVEL = logging.DEBUG
 else:
@@ -19,4 +21,8 @@ def run():
 
 
 if __name__ == "__main__":
+    # First, let Pytorch's multiprocessing module know how to create child processes.
+    # Refer https://docs.python.org/3.7/library/multiprocessing.html#multiprocessing.set_start_method
+    torch.multiprocessing.set_start_method("spawn")
+
     run()

--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -153,8 +153,8 @@ class CallbackTrainer(TrainerBase):
         # will break the usages such as `Model.get_regularization_penalty`, `Model.get_metrics`, etc.
         #
         # Hence a reference to Pytorch's object is maintained in the case of distributed training and in the
-        # normal case, reference to `Model` is retained. This reference is only used in these places: `model.__call__`,
-        # `model.train` and `model.eval`.
+        # normal case, reference to `Model` is retained. This reference is only used in
+        # these places: `model.__call__`, `model.train` and `model.eval`.
         if self._distributed:
             self._pytorch_model = DistributedDataParallel(self.model, device_ids=[self._rank])
         else:

--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -26,6 +26,8 @@ from allennlp.training.optimizers import Optimizer
 from allennlp.training.trainer_pieces import TrainerPieces
 from allennlp.training.trainer_base import TrainerBase
 
+from torch.nn.parallel import DistributedDataParallel
+
 logger = logging.getLogger(__name__)
 
 
@@ -146,6 +148,18 @@ class CallbackTrainer(TrainerBase):
         # For capturing errors that occur during the train loop.
         self.exception: Optional[Exception] = None
 
+        # Using `DistributedDataParallel`(ddp) brings in a quirk wrt AllenNLP's `Model` interface and its
+        # usage. A `Model` object is wrapped by `ddp`, but assigning the wrapped model to `self.model`
+        # will break the usages such as `Model.get_regularization_penalty`, `Model.get_metrics`, etc.
+        #
+        # Hence a reference to Pytorch's object is maintained in the case of distributed training and in the
+        # normal case, reference to `Model` is retained. This reference is only used in these places: `model.__call__`,
+        # `model.train` and `model.eval`.
+        if self._distributed:
+            self._pytorch_model = DistributedDataParallel(self.model, device_ids=[self._rank])
+        else:
+            self._pytorch_model = self.model
+
     def generate_training_batches(self):
         """
         Generates one epoch worth of training data. Stores it in trainer instance variables
@@ -173,7 +187,7 @@ class CallbackTrainer(TrainerBase):
             assert len(batch_group) == 1
             batch = batch_group[0]
             batch = nn_util.move_to_device(batch, self._cuda_devices[0])
-            output_dict = self.model(**batch)
+            output_dict = self._pytorch_model(**batch)
 
         try:
             loss = output_dict["loss"]
@@ -232,7 +246,7 @@ class CallbackTrainer(TrainerBase):
 
         self.train_loss = 0.0
         # Set the model to "train" mode.
-        self.model.train()
+        self._pytorch_model.train()
 
         self.last_log = time.time()
 

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -567,7 +567,7 @@ class Trainer(TrainerBase):
                         num_batches,
                         reset=True,
                         world_size=self._world_size,
-                        cuda_device=self._cuda_devices
+                        cuda_device=self._cuda_devices,
                     )
 
                     # Check validation metric for early stopping

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -272,8 +272,8 @@ class Trainer(TrainerBase):
         # will break the usages such as `Model.get_regularization_penalty`, `Model.get_metrics`, etc.
         #
         # Hence a reference to Pytorch's object is maintained in the case of distributed training and in the
-        # normal case, reference to `Model` is retained. This reference is only used in these places: `model.__call__`,
-        # `model.train` and `model.eval`.
+        # normal case, reference to `Model` is retained. This reference is only used in
+        # these places: `model.__call__`, `model.train` and `model.eval`.
         if self._distributed:
             self._pytorch_model = DistributedDataParallel(self.model, device_ids=[self._rank])
         else:
@@ -342,8 +342,8 @@ class Trainer(TrainerBase):
 
         logger.info("Training")
 
-        # Having multiple tqdm bars in case of distributed training will be a mess. Hence only the master's progress
-        # is shown
+        # Having multiple tqdm bars in case of distributed training will be a mess. Hence only the master's
+        # progress is shown
         if self._master:
             train_generator_tqdm = Tqdm.tqdm(train_generator, total=num_training_batches)
         else:
@@ -399,8 +399,13 @@ class Trainer(TrainerBase):
                 self._moving_average.apply(batch_num_total)
 
             # Update the description with the latest metrics
-            metrics = training_util.get_metrics(self.model, train_loss, batches_this_epoch,
-                                                world_size=self._world_size, rank=self._rank)
+            metrics = training_util.get_metrics(
+                self.model,
+                train_loss,
+                batches_this_epoch,
+                world_size=self._world_size,
+                rank=self._rank,
+            )
 
             # Updating tqdm only for the master as the trainers wouldn't have one
             if self._master:
@@ -428,15 +433,23 @@ class Trainer(TrainerBase):
                     self._tensorboard.add_train_scalar("mean_batch_size", average)
 
             # Save model if needed.
-            if self._model_save_interval is not None and (
-                time.time() - last_save_time > self._model_save_interval
-            ) and self._master:
+            if (
+                self._model_save_interval is not None
+                and (time.time() - last_save_time > self._model_save_interval)
+                and self._master
+            ):
                 last_save_time = time.time()
                 self._save_checkpoint(
                     "{0}.{1}".format(epoch, training_util.time_to_str(int(last_save_time)))
                 )
-        metrics = training_util.get_metrics(self.model, train_loss, batches_this_epoch, reset=True,
-                                            world_size=self._world_size, rank=self._rank)
+        metrics = training_util.get_metrics(
+            self.model,
+            train_loss,
+            batches_this_epoch,
+            reset=True,
+            world_size=self._world_size,
+            rank=self._rank,
+        )
         metrics["cpu_memory_MB"] = peak_cpu_usage
         for (gpu_num, memory) in gpu_usage:
             metrics["gpu_" + str(gpu_num) + "_memory_MB"] = memory
@@ -482,8 +495,13 @@ class Trainer(TrainerBase):
                 val_loss += loss.detach().cpu().numpy()
 
             # Update the description with the latest metrics
-            val_metrics = training_util.get_metrics(self.model, val_loss, batches_this_epoch,
-                                                    world_size=self._world_size, rank=self._rank)
+            val_metrics = training_util.get_metrics(
+                self.model,
+                val_loss,
+                batches_this_epoch,
+                world_size=self._world_size,
+                rank=self._rank,
+            )
             description = training_util.description_from_metrics(val_metrics)
             val_generator_tqdm.set_description(description, refresh=False)
 
@@ -544,7 +562,12 @@ class Trainer(TrainerBase):
                     # We have a validation set, so compute all the metrics on it.
                     val_loss, num_batches = self._validation_loss()
                     val_metrics = training_util.get_metrics(
-                        self.model, val_loss, num_batches, reset=True, world_size=self._world_size, rank=self._rank
+                        self.model,
+                        val_loss,
+                        num_batches,
+                        reset=True,
+                        world_size=self._world_size,
+                        rank=self._rank,
                     )
 
                     # Check validation metric for early stopping

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -275,7 +275,7 @@ class Trainer(TrainerBase):
         # normal case, reference to `Model` is retained. This reference is only used in
         # these places: `model.__call__`, `model.train` and `model.eval`.
         if self._distributed:
-            self._pytorch_model = DistributedDataParallel(self.model, device_ids=[self._cuda_devices])
+            self._pytorch_model = DistributedDataParallel(self.model, device_ids=self._cuda_devices)
         else:
             self._pytorch_model = self.model
 

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -561,6 +561,12 @@ class Trainer(TrainerBase):
                 with torch.no_grad():
                     # We have a validation set, so compute all the metrics on it.
                     val_loss, num_batches = self._validation_loss()
+
+                    # It is safe again to wait till the validation is done. This is
+                    # important to get the metrics right.
+                    if self._distributed:
+                        dist.barrier()
+
                     val_metrics = training_util.get_metrics(
                         self.model,
                         val_loss,

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -12,6 +12,7 @@ import logging
 from typing import Dict, List, Union, Any
 
 from allennlp.common import Params, Registrable
+from allennlp.common.util import is_master
 from allennlp.common.checks import ConfigurationError, check_for_gpu
 from allennlp.models.model import Model
 
@@ -66,7 +67,7 @@ class TrainerBase(Registrable):
 
         self._distributed = distributed
         self._rank = rank
-        self._master = self._rank == 0
+        self._master = is_master()
         self._world_size = world_size
 
     def _move_to_gpu(self, model: Model) -> Model:

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -52,9 +52,12 @@ class TrainerBase(Registrable):
             )
 
         if isinstance(cuda_device, list):
-            assert (
-                not distributed
-            )  # For distributed training, every trainer worker is only assigned with a single GPU
+            # For distributed training, every trainer worker is only assigned with a single GPU
+            if distributed:
+                raise ConfigurationError(
+                    "Distributed worker can only be assigned a single `cuda_device`."
+                )
+
             self._multiple_gpu = True
             self._cuda_devices = cuda_device
         else:

--- a/allennlp/training/trainer_pieces.py
+++ b/allennlp/training/trainer_pieces.py
@@ -7,7 +7,11 @@ import torch.distributed as dist
 
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
-from allennlp.common.util import get_frozen_and_tunable_parameter_names
+from allennlp.common.util import (
+    get_frozen_and_tunable_parameter_names,
+    is_distributed,
+    is_master
+)
 from allennlp.data.instance import Instance
 from allennlp.data.iterators.data_iterator import DataIterator
 from allennlp.data.vocabulary import Vocabulary
@@ -81,7 +85,7 @@ class TrainerPieces(NamedTuple):
 
         # Initializing the model can have side effect of expanding the vocabulary
         # Save the vocab only in the master
-        if not dist.is_initialized() or dist.get_rank() == 0:
+        if not is_distributed() or is_master():
             vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
 
         iterator = DataIterator.from_params(params.pop("iterator"))

--- a/allennlp/training/trainer_pieces.py
+++ b/allennlp/training/trainer_pieces.py
@@ -3,15 +3,9 @@ import os
 import re
 from typing import Iterable, NamedTuple
 
-import torch.distributed as dist
-
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
-from allennlp.common.util import (
-    get_frozen_and_tunable_parameter_names,
-    is_distributed,
-    is_master
-)
+from allennlp.common.util import get_frozen_and_tunable_parameter_names, is_distributed, is_master
 from allennlp.data.instance import Instance
 from allennlp.data.iterators.data_iterator import DataIterator
 from allennlp.data.vocabulary import Vocabulary

--- a/allennlp/training/trainer_pieces.py
+++ b/allennlp/training/trainer_pieces.py
@@ -3,6 +3,8 @@ import os
 import re
 from typing import Iterable, NamedTuple
 
+import torch.distributed as dist
+
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.util import get_frozen_and_tunable_parameter_names
@@ -78,7 +80,8 @@ class TrainerPieces(NamedTuple):
         model.extend_embedder_vocab()
 
         # Initializing the model can have side effect of expanding the vocabulary
-        vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
+        if dist.is_initialized() and dist.get_rank() == 0:
+            vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
 
         iterator = DataIterator.from_params(params.pop("iterator"))
         iterator.index_with(model.vocab)

--- a/allennlp/training/trainer_pieces.py
+++ b/allennlp/training/trainer_pieces.py
@@ -80,7 +80,8 @@ class TrainerPieces(NamedTuple):
         model.extend_embedder_vocab()
 
         # Initializing the model can have side effect of expanding the vocabulary
-        if dist.is_initialized() and dist.get_rank() == 0:
+        # Save the vocab only in the master
+        if not dist.is_initialized() or dist.get_rank() == 0:
             vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
 
         iterator = DataIterator.from_params(params.pop("iterator"))

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -399,7 +399,10 @@ def get_metrics(
         # In distributed mode, average out all metrics across GPUs
         aggregated_metrics = {}
         for metric_name, metric_val in metrics.items():
-            metric_tensor = torch.tensor(metric_val).to(torch.device(cuda_device[0]))
+            if isinstance(cuda_device, list):
+                metric_tensor = torch.tensor(metric_val).to(torch.device(cuda_device[0]))
+            else:
+                metric_tensor = torch.tensor(metric_val).to(torch.device(cuda_device))
             dist.all_reduce(metric_tensor, op=dist.ReduceOp.SUM)
             reduced_metric = metric_tensor.item() / world_size
             aggregated_metrics[metric_name] = reduced_metric

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -385,7 +385,7 @@ def get_metrics(
     num_batches: int,
     reset: bool = False,
     world_size: int = 1,
-    cuda_device: int = 0,
+    cuda_device: Union[int, List] = 0,
 ) -> Dict[str, float]:
     """
     Gets the metrics but sets ``"loss"`` to
@@ -399,7 +399,7 @@ def get_metrics(
         # In distributed mode, average out all metrics across GPUs
         aggregated_metrics = {}
         for metric_name, metric_val in metrics.items():
-            metric_tensor = torch.tensor(metric_val).to(torch.device(cuda_device))
+            metric_tensor = torch.tensor(metric_val).to(torch.device(cuda_device[0]))
             dist.all_reduce(metric_tensor, op=dist.ReduceOp.SUM)
             reduced_metric = metric_tensor.item() / world_size
             aggregated_metrics[metric_name] = reduced_metric

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -385,7 +385,7 @@ def get_metrics(
     num_batches: int,
     reset: bool = False,
     world_size: int = 1,
-    rank: int = 0,
+    cuda_device: int = 0,
 ) -> Dict[str, float]:
     """
     Gets the metrics but sets ``"loss"`` to
@@ -399,7 +399,7 @@ def get_metrics(
         # In distributed mode, average out all metrics across GPUs
         aggregated_metrics = {}
         for metric_name, metric_val in metrics.items():
-            metric_tensor = torch.tensor(metric_val).to(torch.device(rank))
+            metric_tensor = torch.tensor(metric_val).to(torch.device(cuda_device))
             dist.all_reduce(metric_tensor, op=dist.ReduceOp.SUM)
             reduced_metric = metric_tensor.item() / world_size
             aggregated_metrics[metric_name] = reduced_metric


### PR DESCRIPTION
Followup PR to #3390 and #3372 to bring in distributed training support. Following are the major changes done:

* Workers are spawned using `mp.spawn` and each worker creates its own `Trainer` instance
* `Trainer.__init__` wraps up `self.model` with `DistributedDataParallel`
*  Logging and metric aggregation are already done in the previous PRs
* `Vocabulary` creation in case of distributed training is done before spawning the workers and creating `Trainer` class

To run distributed training, the trainer needs to have the following flag to be enabled:

```jsonnet
{
    "trainer": {
        "distributed": true,
        // ...
    }
}
```

TODO:
* Try to reproduce comparable results and share extensive results for existing/selected models
* Check if other commands like `evaluate`, `predict`, `fine-tune` works well with the new changes
* Should all the callbacks need to be called from every worker in case callback based training?
* Should the current dataset readers be changed to support distributed training as well?(to selectively yield data based on their rank)
* Write tests - _would be happy to get some suggestions on how to write tests for this_

@DeNeutoy 