### PR TITLE
Remove CUDA8 note from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@
 
 #### ESSENTIAL LIBRARIES FOR MAIN FUNCTIONALITY ####
 
-# This installs Pytorch for CUDA 8 only. If you are using a newer version,
-# please visit https://pytorch.org/ and install the relevant version.
 # allennlp>0.8.5 requires PyTorch 1.2 or greater. If you need to use
 # an older version of PyTorch you'll also need to use an older version of allennlp.
 # Note: We're not precisely avoiding 1.3.0 here. Pytorch released new binaries as


### PR DESCRIPTION
I don't think this message is accurate anymore, so I'm deleting it.  I don't think new releases of PyTorch are even compatible with CUDA 8.