### PR TITLE
Adding source_add_end_token to Seq2SeqDatasetReader

### DIFF
--- a/allennlp/data/dataset_readers/seq2seq.py
+++ b/allennlp/data/dataset_readers/seq2seq.py
@@ -46,6 +46,8 @@ class Seq2SeqDatasetReader(DatasetReader):
         ``source_token_indexers``.
     source_add_start_token : bool, (optional, default=True)
         Whether or not to add `START_SYMBOL` to the beginning of the source sequence.
+    source_add_end_token : bool, (optional, default=True)
+        Whether or not to add `END_SYMBOL` to the beginning of the source sequence.
     delimiter : str, (optional, default="\t")
         Set delimiter for tsv/csv file.
     """
@@ -57,6 +59,7 @@ class Seq2SeqDatasetReader(DatasetReader):
         source_token_indexers: Dict[str, TokenIndexer] = None,
         target_token_indexers: Dict[str, TokenIndexer] = None,
         source_add_start_token: bool = True,
+        source_add_end_token: bool = True,
         delimiter: str = "\t",
         source_max_tokens: Optional[int] = None,
         target_max_tokens: Optional[int] = None,
@@ -68,6 +71,7 @@ class Seq2SeqDatasetReader(DatasetReader):
         self._source_token_indexers = source_token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._target_token_indexers = target_token_indexers or self._source_token_indexers
         self._source_add_start_token = source_add_start_token
+        self._source_add_end_token = source_add_end_token
         self._delimiter = delimiter
         self._source_max_tokens = source_max_tokens
         self._target_max_tokens = target_max_tokens
@@ -112,7 +116,8 @@ class Seq2SeqDatasetReader(DatasetReader):
             tokenized_source = tokenized_source[: self._source_max_tokens]
         if self._source_add_start_token:
             tokenized_source.insert(0, Token(START_SYMBOL))
-        tokenized_source.append(Token(END_SYMBOL))
+        if self._source_add_end_token:
+            tokenized_source.append(Token(END_SYMBOL))
         source_field = TextField(tokenized_source, self._source_token_indexers)
         if target_string is not None:
             tokenized_target = self._target_tokenizer.tokenize(target_string)

--- a/allennlp/data/dataset_readers/seq2seq.py
+++ b/allennlp/data/dataset_readers/seq2seq.py
@@ -47,7 +47,7 @@ class Seq2SeqDatasetReader(DatasetReader):
     source_add_start_token : bool, (optional, default=True)
         Whether or not to add `START_SYMBOL` to the beginning of the source sequence.
     source_add_end_token : bool, (optional, default=True)
-        Whether or not to add `END_SYMBOL` to the beginning of the source sequence.
+        Whether or not to add `END_SYMBOL` to the end of the source sequence.
     delimiter : str, (optional, default="\t")
         Set delimiter for tsv/csv file.
     """

--- a/allennlp/tests/data/dataset_readers/seq2seq_test.py
+++ b/allennlp/tests/data/dataset_readers/seq2seq_test.py
@@ -92,6 +92,29 @@ class TestSeq2SeqDatasetReader:
             "@end@",
         ]
 
+    def test_source_add_end_token(self):
+        reader = Seq2SeqDatasetReader(source_add_end_token=False)
+        instances = reader.read(str(AllenNlpTestCase.FIXTURES_ROOT / "data" / "seq2seq_copy.tsv"))
+        instances = ensure_list(instances)
+
+        assert len(instances) == 3
+        fields = instances[0].fields
+        assert [t.text for t in fields["source_tokens"].tokens] == [
+            "@start@",
+            "this",
+            "is",
+            "a",
+            "sentence",
+        ]
+        assert [t.text for t in fields["target_tokens"].tokens] == [
+            "@start@",
+            "this",
+            "is",
+            "a",
+            "sentence",
+            "@end@",
+        ]
+
     def test_max_length_truncation(self):
         reader = Seq2SeqDatasetReader(source_max_tokens=3, target_max_tokens=5)
         instances = reader.read(str(AllenNlpTestCase.FIXTURES_ROOT / "data" / "seq2seq_copy.tsv"))


### PR DESCRIPTION
`Seq2SeqDatasetReader` has `source_add_start_token` parameter to control whether to add a start token to the source. I added `source_add_end_token` to control whether to add the end token to the source. The default is `True` so it is compatible with previous versions.