### PR TITLE
Fix verb_index condition in write_conll_formatted_tags_to_file

### DIFF
--- a/allennlp/models/srl_util.py
+++ b/allennlp/models/srl_util.py
@@ -84,7 +84,7 @@ def write_conll_formatted_tags_to_file(
         The gold CoNLL-formatted labels.
     """
     verb_only_sentence = ["-"] * len(sentence)
-    if verb_index:
+    if verb_index is not None:
         verb_only_sentence[verb_index] = sentence[verb_index]
 
     for word, predicted, gold in zip(

--- a/allennlp/tests/training/metrics/srl_eval_scorer_test.py
+++ b/allennlp/tests/training/metrics/srl_eval_scorer_test.py
@@ -7,7 +7,7 @@ from allennlp.training.metrics import SrlEvalScorer
 
 class SrlEvalScorerTest(AllenNlpTestCase):
     def test_srl_eval_correctly_scores_identical_tags(self):
-        batch_verb_indices = [3, 8, 2]
+        batch_verb_indices = [3, 8, 2, 0]
         batch_sentences = [
             [
                 "Mali",
@@ -50,6 +50,7 @@ class SrlEvalScorerTest(AllenNlpTestCase):
                 "hearings",
                 ".",
             ],
+            ["Come", "in", "and", "buy", "."],
         ]
         batch_bio_predicted_tags = [
             [
@@ -81,6 +82,7 @@ class SrlEvalScorerTest(AllenNlpTestCase):
                 "I-ARGM-TMP",
                 "O",
             ],
+            ["B-V", "B-AM-DIR", "O", "O", "O"],
         ]
         batch_conll_predicted_tags = [
             convert_bio_tags_to_conll_format(tags) for tags in batch_bio_predicted_tags
@@ -115,6 +117,7 @@ class SrlEvalScorerTest(AllenNlpTestCase):
                 "I-ARGM-TMP",
                 "O",
             ],
+            ["B-V", "B-AM-DIR", "O", "O", "O"],
         ]
         batch_conll_gold_tags = [
             convert_bio_tags_to_conll_format(tags) for tags in batch_bio_gold_tags
@@ -125,7 +128,7 @@ class SrlEvalScorerTest(AllenNlpTestCase):
             batch_verb_indices, batch_sentences, batch_conll_predicted_tags, batch_conll_gold_tags
         )
         metrics = srl_scorer.get_metric()
-        assert len(metrics) == 15
+        assert len(metrics) == 18
         assert_allclose(metrics["precision-ARG0"], 1.0)
         assert_allclose(metrics["recall-ARG0"], 1.0)
         assert_allclose(metrics["f1-measure-ARG0"], 1.0)
@@ -138,6 +141,9 @@ class SrlEvalScorerTest(AllenNlpTestCase):
         assert_allclose(metrics["precision-ARGM-TMP"], 1.0)
         assert_allclose(metrics["recall-ARGM-TMP"], 1.0)
         assert_allclose(metrics["f1-measure-ARGM-TMP"], 1.0)
+        assert_allclose(metrics["precision-AM-DIR"], 1.0)
+        assert_allclose(metrics["recall-AM-DIR"], 1.0)
+        assert_allclose(metrics["f1-measure-AM-DIR"], 1.0)
         assert_allclose(metrics["precision-overall"], 1.0)
         assert_allclose(metrics["recall-overall"], 1.0)
         assert_allclose(metrics["f1-measure-overall"], 1.0)


### PR DESCRIPTION
This PR fixes unexpected behavior in `write_conll_formatted_tags_to_file` when a verbal predicate is at the beginning of a sentence. Previous code checks whether a sentence has a predicate by `if verb_index:`, but this means that a sentence has no predicate when the predicate is at the beginning of the sentence.

Actually, this error affects the result of `srl-eval.pl`, though I don't know the detail of this script. The added test code did not pass before modifying `write_conll_formatted_tags_to_file`.

Because this fix affects `SrlEvalScorer`, it may be needed to make changes to some model's predictive score provided in https://github.com/allenai/allennlp/blob/master/MODELS.md.