### PR TITLE
Adding padding_token and oov_token as parameters of Vocabulary

### DIFF
--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -226,11 +226,11 @@ class Vocabulary(Registrable):
         only_include_pretrained_words: bool = False,
         tokens_to_add: Dict[str, List[str]] = None,
         min_pretrained_embeddings: Dict[str, int] = None,
-        padding_token: str = DEFAULT_PADDING_TOKEN,
-        oov_token: str = DEFAULT_OOV_TOKEN,
+        padding_token: Optional[str] = DEFAULT_PADDING_TOKEN,
+        oov_token: Optional[str] = DEFAULT_OOV_TOKEN,
     ) -> None:
-        self._padding_token = padding_token
-        self._oov_token = oov_token
+        self._padding_token = padding_token if padding_token is not None else DEFAULT_PADDING_TOKEN
+        self._oov_token = oov_token if oov_token is not None else DEFAULT_OOV_TOKEN
         self._non_padded_namespaces = set(non_padded_namespaces)
         self._token_to_index = _TokenToIndexDefaultDict(
             self._non_padded_namespaces, self._padding_token, self._oov_token
@@ -317,8 +317,8 @@ class Vocabulary(Registrable):
     def from_files(
         cls,
         directory: str,
-        padding_token: str = DEFAULT_PADDING_TOKEN,
-        oov_token: str = DEFAULT_OOV_TOKEN,
+        padding_token: Optional[str] = DEFAULT_PADDING_TOKEN,
+        oov_token: Optional[str] = DEFAULT_OOV_TOKEN,
     ) -> "Vocabulary":
         """
         Loads a ``Vocabulary`` that was serialized using ``save_to_files``.
@@ -329,6 +329,8 @@ class Vocabulary(Registrable):
             The directory containing the serialized vocabulary.
         """
         logger.info("Loading token dictionary from %s.", directory)
+        padding_token = padding_token if padding_token is not None else DEFAULT_PADDING_TOKEN
+        oov_token = oov_token if oov_token is not None else DEFAULT_OOV_TOKEN
         with codecs.open(
             os.path.join(directory, NAMESPACE_PADDING_FILE), "r", "utf-8"
         ) as namespace_file:
@@ -421,8 +423,8 @@ class Vocabulary(Registrable):
         only_include_pretrained_words: bool = False,
         tokens_to_add: Dict[str, List[str]] = None,
         min_pretrained_embeddings: Dict[str, int] = None,
-        padding_token: str = DEFAULT_PADDING_TOKEN,
-        oov_token: str = DEFAULT_OOV_TOKEN,
+        padding_token: Optional[str] = DEFAULT_PADDING_TOKEN,
+        oov_token: Optional[str] = DEFAULT_OOV_TOKEN,
     ) -> "Vocabulary":
         """
         Constructs a vocabulary given a collection of `Instances` and some parameters.
@@ -431,6 +433,8 @@ class Vocabulary(Registrable):
         of what the other parameters do.
         """
         logger.info("Fitting token dictionary from dataset.")
+        padding_token = padding_token if padding_token is not None else DEFAULT_PADDING_TOKEN
+        oov_token = oov_token if oov_token is not None else DEFAULT_OOV_TOKEN
         namespace_token_counts: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
         for instance in Tqdm.tqdm(instances):
             instance.count_vocab_items(namespace_token_counts)

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -209,9 +209,9 @@ class Vocabulary(Registrable):
         the tokens to.  This is a way to be sure that certain items appear in your vocabulary,
         regardless of any other vocabulary computation.
     padding_token : ``str``,  optional (default=DEFAULT_PADDING_TOKEN)
-        TODO
+        If given, this the string used for padding.
     oov_token : ``str``,  optional (default=DEFAULT_OOV_TOKEN)
-        TODO
+        If given, this the string used for the out of vocabulary (OOVs) tokens.
     """
 
     default_implementation = "default"

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -208,6 +208,10 @@ class Vocabulary(Registrable):
         If given, this is a list of tokens to add to the vocabulary, keyed by the namespace to add
         the tokens to.  This is a way to be sure that certain items appear in your vocabulary,
         regardless of any other vocabulary computation.
+    padding_token : ``str``,  optional (default=DEFAULT_PADDING_TOKEN)
+        TODO
+    oov_token : ``str``,  optional (default=DEFAULT_OOV_TOKEN)
+        TODO
     """
 
     default_implementation = "default"
@@ -222,9 +226,11 @@ class Vocabulary(Registrable):
         only_include_pretrained_words: bool = False,
         tokens_to_add: Dict[str, List[str]] = None,
         min_pretrained_embeddings: Dict[str, int] = None,
+        padding_token: str = DEFAULT_PADDING_TOKEN,
+        oov_token: str = DEFAULT_OOV_TOKEN,
     ) -> None:
-        self._padding_token = DEFAULT_PADDING_TOKEN
-        self._oov_token = DEFAULT_OOV_TOKEN
+        self._padding_token = padding_token
+        self._oov_token = oov_token
         self._non_padded_namespaces = set(non_padded_namespaces)
         self._token_to_index = _TokenToIndexDefaultDict(
             self._non_padded_namespaces, self._padding_token, self._oov_token
@@ -308,7 +314,12 @@ class Vocabulary(Registrable):
                     print(mapping[i].replace("\n", "@@NEWLINE@@"), file=token_file)
 
     @classmethod
-    def from_files(cls, directory: str) -> "Vocabulary":
+    def from_files(
+        cls,
+        directory: str,
+        padding_token: str = DEFAULT_PADDING_TOKEN,
+        oov_token: str = DEFAULT_OOV_TOKEN,
+    ) -> "Vocabulary":
         """
         Loads a ``Vocabulary`` that was serialized using ``save_to_files``.
 
@@ -323,7 +334,11 @@ class Vocabulary(Registrable):
         ) as namespace_file:
             non_padded_namespaces = [namespace_str.strip() for namespace_str in namespace_file]
 
-        vocab = cls(non_padded_namespaces=non_padded_namespaces)
+        vocab = cls(
+            non_padded_namespaces=non_padded_namespaces,
+            padding_token=padding_token,
+            oov_token=oov_token,
+        )
 
         # Check every file in the directory.
         for namespace_filename in os.listdir(directory):
@@ -337,7 +352,7 @@ class Vocabulary(Registrable):
             else:
                 is_padded = True
             filename = os.path.join(directory, namespace_filename)
-            vocab.set_from_file(filename, is_padded, namespace=namespace)
+            vocab.set_from_file(filename, is_padded, namespace=namespace, oov_token=oov_token)
 
         return vocab
 
@@ -406,6 +421,8 @@ class Vocabulary(Registrable):
         only_include_pretrained_words: bool = False,
         tokens_to_add: Dict[str, List[str]] = None,
         min_pretrained_embeddings: Dict[str, int] = None,
+        padding_token: str = DEFAULT_PADDING_TOKEN,
+        oov_token: str = DEFAULT_OOV_TOKEN,
     ) -> "Vocabulary":
         """
         Constructs a vocabulary given a collection of `Instances` and some parameters.
@@ -427,6 +444,8 @@ class Vocabulary(Registrable):
             only_include_pretrained_words=only_include_pretrained_words,
             tokens_to_add=tokens_to_add,
             min_pretrained_embeddings=min_pretrained_embeddings,
+            padding_token=padding_token,
+            oov_token=oov_token,
         )
 
     # There's enough logic here to require a custom from_params.
@@ -491,8 +510,11 @@ class Vocabulary(Registrable):
             else:
                 logger.info("Loading Vocab from files instead of dataset.")
 
+        padding_token = params.pop("padding_token", DEFAULT_PADDING_TOKEN)
+        oov_token = params.pop("oov_token", DEFAULT_OOV_TOKEN)
+
         if vocabulary_directory:
-            vocab = cls.from_files(vocabulary_directory)
+            vocab = cls.from_files(vocabulary_directory, padding_token, oov_token)
             if not extend:
                 params.assert_empty("Vocabulary - from files")
                 return vocab
@@ -516,6 +538,8 @@ class Vocabulary(Registrable):
             only_include_pretrained_words=only_include_pretrained_words,
             tokens_to_add=tokens_to_add,
             min_pretrained_embeddings=min_pretrained_embeddings,
+            padding_token=padding_token,
+            oov_token=oov_token,
         )
 
     def _extend(

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -252,7 +252,9 @@ class Model(torch.nn.Module, Registrable):
         # If the config specifies a vocabulary subclass, we need to use it.
         vocab_params = config.get("vocabulary", Params({}))
         vocab_choice = vocab_params.pop_choice("type", Vocabulary.list_available(), True)
-        vocab = Vocabulary.by_name(vocab_choice).from_files(vocab_dir)
+        vocab = Vocabulary.by_name(vocab_choice).from_files(
+            vocab_dir, vocab_params.get("padding_token", None), vocab_params.get("oov_token", None)
+        )
 
         model_params = config.get("model")
 

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -790,3 +790,15 @@ class TestVocabulary(AllenNlpTestCase):
         vocab = Vocabulary(padding_token="[PAD]")
         assert vocab._oov_token == "@@UNKNOWN@@"
         assert vocab._padding_token == "[PAD]"
+
+        vocab_dir = self.TEST_DIR / "vocab_save"
+        vocab = Vocabulary(oov_token="<UNK>")
+        vocab.add_tokens_to_namespace(["a0", "a1", "a2"], namespace="a")
+        vocab.save_to_files(vocab_dir)
+
+        vocab = Vocabulary.from_params(Params({"directory_path": vocab_dir, "oov_token": "<UNK>"}))
+
+        with pytest.raises(AssertionError) as excinfo:
+            vocab = Vocabulary.from_params(Params({"directory_path": vocab_dir}))
+
+        assert "OOV token not found!" in str(excinfo.value)

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -781,3 +781,12 @@ class TestVocabulary(AllenNlpTestCase):
         vocab = Vocabulary.from_params(params=params, instances=self.dataset)
         assert vocab.get_vocab_size() >= 50
         assert vocab.get_token_index("his") > 1  # not @@UNKNOWN@@
+
+    def test_custom_padding_oov_tokens(self):
+        vocab = Vocabulary(oov_token="[UNK]")
+        assert vocab._oov_token == "[UNK]"
+        assert vocab._padding_token == "@@PADDING@@"
+
+        vocab = Vocabulary(padding_token="[PAD]")
+        assert vocab._oov_token == "@@UNKNOWN@@"
+        assert vocab._padding_token == "[PAD]"

--- a/allennlp/training/trainer_pieces.py
+++ b/allennlp/training/trainer_pieces.py
@@ -55,8 +55,12 @@ class TrainerPieces(NamedTuple):
         )
 
         if recover and os.path.exists(os.path.join(serialization_dir, "vocabulary")):
-            vocab = Vocabulary.from_files(os.path.join(serialization_dir, "vocabulary"))
-            params.pop("vocabulary", {})
+            vocab_params = params.pop("vocabulary", {})
+            vocab = Vocabulary.from_files(
+                os.path.join(serialization_dir, "vocabulary"),
+                vocab_params.get("padding_token", None),
+                vocab_params.get("oov_token", None),
+            )
         else:
             vocab = Vocabulary.from_params(
                 params.pop("vocabulary", {}),


### PR DESCRIPTION
I added `padding_token` and `oov_token` as parameters of the `Vocabulary` class initialiser.

When using any pre-trained token embedder where OOV and unknown tokens are defined differently (e.g., OOV is `[UNK]` instead of `@@UNKNOWN@@`) this is useful.

Fixes #3434.  Partial fix for #3097.