### PR TITLE
Automatically handle special symbols for pretrained transformers

### DIFF
--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -9,6 +9,7 @@ and report any metrics calculated by the model.
     usage: allennlp evaluate [-h] [--output-file OUTPUT_FILE]
                              [--weights-file WEIGHTS_FILE]
                              [--cuda-device CUDA_DEVICE] [-o OVERRIDES]
+                             [--batch-size BATCH_SIZE]
                              [--batch-weight-key BATCH_WEIGHT_KEY]
                              [--extend-vocab]
                              [--embedding-sources-mapping EMBEDDING_SOURCES_MAPPING]
@@ -32,6 +33,8 @@ and report any metrics calculated by the model.
       -o OVERRIDES, --overrides OVERRIDES
                             a JSON structure used to override the experiment
                             configuration
+      --batch-size BATCH_SIZE
+                            If non-empty, the batch size to use during evaluation.
       --batch-weight-key BATCH_WEIGHT_KEY
                             If non-empty, name of metric used to weight the loss
                             on a per-batch basis.
@@ -103,6 +106,10 @@ class Evaluate(Subcommand):
         )
 
         subparser.add_argument(
+            "--batch-size", type=int, help="If non-empty, the batch size to use during evaluation."
+        )
+
+        subparser.add_argument(
             "--batch-weight-key",
             type=str,
             default="",
@@ -170,6 +177,8 @@ def evaluate_from_args(args: argparse.Namespace) -> Dict[str, Any]:
     iterator_params = config.pop("validation_iterator", None)
     if iterator_params is None:
         iterator_params = config.pop("iterator")
+    if args.batch_size:
+        iterator_params["batch_size"] = args.batch_size
     iterator = DataIterator.from_params(iterator_params)
     iterator.index_with(model.vocab)
 

--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -9,7 +9,6 @@ and report any metrics calculated by the model.
     usage: allennlp evaluate [-h] [--output-file OUTPUT_FILE]
                              [--weights-file WEIGHTS_FILE]
                              [--cuda-device CUDA_DEVICE] [-o OVERRIDES]
-                             [--batch-size BATCH_SIZE]
                              [--batch-weight-key BATCH_WEIGHT_KEY]
                              [--extend-vocab]
                              [--embedding-sources-mapping EMBEDDING_SOURCES_MAPPING]
@@ -33,8 +32,6 @@ and report any metrics calculated by the model.
       -o OVERRIDES, --overrides OVERRIDES
                             a JSON structure used to override the experiment
                             configuration
-      --batch-size BATCH_SIZE
-                            If non-empty, the batch size to use during evaluation.
       --batch-weight-key BATCH_WEIGHT_KEY
                             If non-empty, name of metric used to weight the loss
                             on a per-batch basis.
@@ -106,10 +103,6 @@ class Evaluate(Subcommand):
         )
 
         subparser.add_argument(
-            "--batch-size", type=int, help="If non-empty, the batch size to use during evaluation."
-        )
-
-        subparser.add_argument(
             "--batch-weight-key",
             type=str,
             default="",
@@ -177,8 +170,6 @@ def evaluate_from_args(args: argparse.Namespace) -> Dict[str, Any]:
     iterator_params = config.pop("validation_iterator", None)
     if iterator_params is None:
         iterator_params = config.pop("iterator")
-    if args.batch_size:
-        iterator_params["batch_size"] = args.batch_size
     iterator = DataIterator.from_params(iterator_params)
     iterator.index_with(model.vocab)
 

--- a/allennlp/data/dataset_readers/ccgbank.py
+++ b/allennlp/data/dataset_readers/ccgbank.py
@@ -94,9 +94,13 @@ class CcgBankDatasetReader(DatasetReader):
                     tuples = zip(*[leaf.split() for leaf in leaves])
 
                     # Convert to lists and assign to variables.
-                    ccg_categories, modified_pos_tags, original_pos_tags, tokens, predicate_arg_categories = [
-                        list(result) for result in tuples
-                    ]
+                    (
+                        ccg_categories,
+                        modified_pos_tags,
+                        original_pos_tags,
+                        tokens,
+                        predicate_arg_categories,
+                    ) = [list(result) for result in tuples]
 
                     yield self.text_to_instance(
                         tokens,

--- a/allennlp/data/dataset_readers/semantic_dependency_parsing.py
+++ b/allennlp/data/dataset_readers/semantic_dependency_parsing.py
@@ -16,7 +16,7 @@ FIELDS = ["id", "form", "lemma", "pos", "head", "deprel", "top", "pred", "frame"
 
 
 def parse_sentence(
-    sentence_blob: str
+    sentence_blob: str,
 ) -> Tuple[List[Dict[str, str]], List[Tuple[int, int]], List[str]]:
     """
     Parses a chunk of text in the SemEval SDP format.

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -31,10 +31,13 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
         We use a somewhat confusing default value of ``tags`` so that we do not add padding or UNK
         tokens to this namespace, which would break on loading because we wouldn't find our default
         OOV token.
+    add_special_tokens: ``bool``, optional (default=``True``)
+        We will add special tokens to your sentence or sentence pair depending on the pretrained model
+        you are using.
 
     See huggingface's ``encode`` function from tokenization_utils.py
     https://github.com/huggingface/transformers/blob/155c782a2ccd103cf63ad48a2becd7c76a7d2115/transformers/tokenization_utils.py#L691
-    for other arguments descriptions.
+    for descriptions of other arguments.
     """
 
     def __init__(

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -9,7 +9,7 @@ from allennlp.common.util import pad_sequence_to_length
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.data.tokenizers.token import Token
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
-
+from allennlp.data.vocabulary import DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN
 
 logger = logging.getLogger(__name__)
 
@@ -31,10 +31,15 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
         We use a somewhat confusing default value of ``tags`` so that we do not add padding or UNK
         tokens to this namespace, which would break on loading because we wouldn't find our default
         OOV token.
+
+    See huggingface's ``encode`` function from tokenization_utils.py
+    https://github.com/huggingface/transformers/blob/155c782a2ccd103cf63ad48a2becd7c76a7d2115/transformers/tokenization_utils.py#L691
+    for other arguments descriptions.
     """
 
     def __init__(
-        self, model_name: str, namespace: str = "tags", token_min_padding_length: int = 0
+        self, model_name: str, namespace: str = "tags", token_min_padding_length: int = 0,
+        add_special_tokens: bool = True, max_length=None, stride=0, truncation_strategy='longest_first'
     ) -> None:
         super().__init__(token_min_padding_length)
         self._model_name = model_name
@@ -43,6 +48,10 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
         self._added_to_vocabulary = False
         self._padding_value = self.tokenizer.convert_tokens_to_ids([self.tokenizer.pad_token])[0]
         logger.info(f"Using token indexer padding value of {self._padding_value}")
+        self._add_special_tokens = add_special_tokens
+        self._max_length = max_length
+        self._stride = stride
+        self._truncation_strategy = truncation_strategy
 
     @overrides
     def count_vocab_items(self, token: Token, counter: Dict[str, Dict[str, int]]):
@@ -50,7 +59,7 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
         pass
 
     def _add_encoding_to_vocabulary(self, vocabulary: Vocabulary) -> None:
-
+        # TODO: figure out if the special tokens are already added to the vocabulary of pretrained model
         for word, idx in self.tokenizer.vocab.items():
             vocabulary._token_to_index[self._namespace][word] = idx
             vocabulary._index_to_token[self._namespace][idx] = word
@@ -63,7 +72,22 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
             self._add_encoding_to_vocabulary(vocabulary)
             self._added_to_vocabulary = True
         token_text = [token.text for token in tokens]
-        indices = self.tokenizer.convert_tokens_to_ids(token_text)
+        if DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN in token_text:
+            sep_pos = token_text.index(DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN)
+            first_sentence = token_text[:sep_pos]
+            second_sentence = token_text[sep_pos + 1:]
+        else:
+            first_sentence = token_text
+            second_sentence = None
+
+        # Our input can be a single sentences, or a pair of sentences.
+        # In both cases, the output is always single list of indexes.
+        print("1", first_sentence)
+        print("2", second_sentence)
+        indices = self.tokenizer.encode(text=first_sentence, text_pair=second_sentence,
+                                        add_special_tokens=self._add_special_tokens, max_length=self._max_length,
+                                        stride=self._stride, truncation_strategy=self._truncation_strategy,
+                                        return_tensors=False)
 
         return {index_name: indices}
 

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -38,8 +38,14 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
     """
 
     def __init__(
-        self, model_name: str, namespace: str = "tags", token_min_padding_length: int = 0,
-        add_special_tokens: bool = True, max_length=None, stride=0, truncation_strategy='longest_first'
+        self,
+        model_name: str,
+        namespace: str = "tags",
+        token_min_padding_length: int = 0,
+        add_special_tokens: bool = True,
+        max_length=None,
+        stride=0,
+        truncation_strategy="longest_first",
     ) -> None:
         super().__init__(token_min_padding_length)
         self._model_name = model_name
@@ -75,7 +81,7 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
         if DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN in token_text:
             sep_pos = token_text.index(DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN)
             first_sentence = token_text[:sep_pos]
-            second_sentence = token_text[sep_pos + 1:]
+            second_sentence = token_text[sep_pos + 1 :]
         else:
             first_sentence = token_text
             second_sentence = None
@@ -84,10 +90,15 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
         # In both cases, the output is always single list of indexes.
         print("1", first_sentence)
         print("2", second_sentence)
-        indices = self.tokenizer.encode(text=first_sentence, text_pair=second_sentence,
-                                        add_special_tokens=self._add_special_tokens, max_length=self._max_length,
-                                        stride=self._stride, truncation_strategy=self._truncation_strategy,
-                                        return_tensors=False)
+        indices = self.tokenizer.encode(
+            text=first_sentence,
+            text_pair=second_sentence,
+            add_special_tokens=self._add_special_tokens,
+            max_length=self._max_length,
+            stride=self._stride,
+            truncation_strategy=self._truncation_strategy,
+            return_tensors=False,
+        )
 
         return {index_name: indices}
 

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -86,10 +86,8 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
             first_sentence = token_text
             second_sentence = None
 
-        # Our input can be a single sentences, or a pair of sentences.
-        # In both cases, the output is always single list of indexes.
-        print("1", first_sentence)
-        print("2", second_sentence)
+        # Our input can be a single sentences or a pair of sentences.
+        # In both cases, the output is always a single list of indexes.
         indices = self.tokenizer.encode(
             text=first_sentence,
             text_pair=second_sentence,

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -86,7 +86,7 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
             first_sentence = token_text
             second_sentence = None
 
-        # Our input can be a single sentences or a pair of sentences.
+        # Our input can be a single sentence or a pair of sentences.
         # In both cases, the output is always a single list of indexes.
         indices = self.tokenizer.encode(
             text=first_sentence,

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -22,10 +22,10 @@ class PretrainedTransformerTokenizer(Tokenizer):
     We take a model name as an input parameter, which we will pass to
     ``AutoTokenizer.from_pretrained``.
 
-    By default we add correct start and end tokens in the token indexer depending on transformer model type you
-    have chosen. In order to add correct tokens for sentence pair, you should tell separate first and
-    second sentence with a special DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN in your dataset reader.
-    Note that this token has to be added after splitting sentence(s) into wordpieces (tokenization).
+    By default we add correct start and end tokens in the token indexer (depending on transformer model you
+    have chosen). All you have to do is to use DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN to separate
+    1st and 2nd sentence in your dataset reader.
+    Note that the token has to be added after applying this tokenizer.
 
     Parameters
     ----------

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_NON_PADDED_NAMESPACES = ("*tags", "*labels")
 DEFAULT_PADDING_TOKEN = "@@PADDING@@"
 DEFAULT_OOV_TOKEN = "@@UNKNOWN@@"
+DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN = "@@PAIR_SEP@@"
 NAMESPACE_PADDING_FILE = "non_padded_namespaces.txt"
 
 

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -234,7 +234,11 @@ class CoreferenceResolver(Model):
         # (num_spans_to_keep, max_antecedents),
         # (1, max_antecedents),
         # (1, num_spans_to_keep, max_antecedents)
-        valid_antecedent_indices, valid_antecedent_offsets, valid_antecedent_log_mask = self._generate_valid_antecedents(  # noqa
+        (
+            valid_antecedent_indices,
+            valid_antecedent_offsets,
+            valid_antecedent_log_mask,
+        ) = self._generate_valid_antecedents(  # noqa
             num_spans_to_keep, max_antecedents, util.get_device_of(text_mask)
         )
         # Select tensors relating to the antecedent spans.

--- a/allennlp/modules/bimpm_matching.py
+++ b/allennlp/modules/bimpm_matching.py
@@ -171,8 +171,8 @@ class BiMpmMatching(nn.Module, FromParams):
             return weights_to_share if share_weights_between_directions else create_parameter()
 
         output_dim = (
-            2
-        )  # used to calculate total output dimension, 2 is for cosine max and cosine min
+            2  # used to calculate total output dimension, 2 is for cosine max and cosine min
+        )
         if with_full_match:
             if is_forward is None:
                 raise ConfigurationError("Must specify is_forward to enable full matching")

--- a/allennlp/modules/encoder_base.py
+++ b/allennlp/modules/encoder_base.py
@@ -97,9 +97,12 @@ class _EncoderBase(torch.nn.Module):
         num_valid = torch.sum(mask[:, 0]).int().item()
 
         sequence_lengths = get_lengths_from_binary_sequence_mask(mask)
-        sorted_inputs, sorted_sequence_lengths, restoration_indices, sorting_indices = sort_batch_by_length(
-            inputs, sequence_lengths
-        )
+        (
+            sorted_inputs,
+            sorted_sequence_lengths,
+            restoration_indices,
+            sorting_indices,
+        ) = sort_batch_by_length(inputs, sequence_lengths)
 
         # Now create a PackedSequence with only the non-empty, sorted sequences.
         packed_sequence_input = pack_padded_sequence(

--- a/allennlp/modules/sampled_softmax_loss.py
+++ b/allennlp/modules/sampled_softmax_loss.py
@@ -169,9 +169,11 @@ class SampledSoftmaxLoss(torch.nn.Module):
 
         # NOTE: targets input has padding removed (so 0 == the first id, NOT the padding id)
 
-        sampled_ids, target_expected_count, sampled_expected_count = self.log_uniform_candidate_sampler(
-            targets, choice_func=self.choice_func
-        )
+        (
+            sampled_ids,
+            target_expected_count,
+            sampled_expected_count,
+        ) = self.log_uniform_candidate_sampler(targets, choice_func=self.choice_func)
 
         long_targets = targets.long()
         long_targets.requires_grad_(False)

--- a/allennlp/tests/common/test_util.py
+++ b/allennlp/tests/common/test_util.py
@@ -82,8 +82,9 @@ class TestCommonUtils(AllenNlpTestCase):
         named_parameters = dict(model.named_parameters())
         named_parameters["linear.weight"].requires_grad_(False)
         named_parameters["linear.bias"].requires_grad_(False)
-        frozen_parameter_names, tunable_parameter_names = util.get_frozen_and_tunable_parameter_names(
-            model
-        )
+        (
+            frozen_parameter_names,
+            tunable_parameter_names,
+        ) = util.get_frozen_and_tunable_parameter_names(model)
         assert set(frozen_parameter_names) == {"linear.weight", "linear.bias"}
         assert set(tunable_parameter_names) == {"conv.weight", "conv.bias"}

--- a/allennlp/tests/data/dataset_readers/masked_language_modeling_test.py
+++ b/allennlp/tests/data/dataset_readers/masked_language_modeling_test.py
@@ -32,7 +32,6 @@ class TestMaskedLanguageModelingDatasetReader(AllenNlpTestCase):
             sentence="This is AllenNLP [MASK] token .", targets=["This"]
         )
         assert [t.text for t in instance["tokens"]] == [
-            "[CLS]",
             "This",
             "is",
             "Allen",
@@ -41,9 +40,8 @@ class TestMaskedLanguageModelingDatasetReader(AllenNlpTestCase):
             "[MASK]",
             "token",
             ".",
-            "[SEP]",
         ]
-        assert [i.sequence_index for i in instance["mask_positions"]] == [6]
+        assert [i.sequence_index for i in instance["mask_positions"]] == [5]
         assert [t.text for t in instance["target_ids"]] == ["This"]
 
         vocab = Vocabulary()
@@ -54,4 +52,4 @@ class TestMaskedLanguageModelingDatasetReader(AllenNlpTestCase):
         target_ids = tensor_dict["target_ids"]["bert"].numpy().tolist()
         # I don't know what wordpiece id BERT is going to assign to 'This', but it at least should
         # be the same between the input and the target.
-        assert target_ids[0] == bert_token_ids[1]
+        assert target_ids[0] == bert_token_ids[0]

--- a/allennlp/tests/data/dataset_readers/next_token_lm_test.py
+++ b/allennlp/tests/data/dataset_readers/next_token_lm_test.py
@@ -27,13 +27,7 @@ class TestNextTokenLmReader(AllenNlpTestCase):
         token_indexer = PretrainedTransformerIndexer("bert-base-cased")
         reader = NextTokenLmReader(tokenizer, {"bert": token_indexer})
         instance = reader.text_to_instance(sentence="AllenNLP is very", target="very")
-        assert [t.text for t in instance["tokens"]] == [
-            "Allen",
-            "##NL",
-            "##P",
-            "is",
-            "very",
-        ]
+        assert [t.text for t in instance["tokens"]] == ["Allen", "##NL", "##P", "is", "very"]
         assert [t.text for t in instance["target_ids"]] == ["very"]
 
         vocab = Vocabulary()

--- a/allennlp/tests/data/dataset_readers/next_token_lm_test.py
+++ b/allennlp/tests/data/dataset_readers/next_token_lm_test.py
@@ -28,13 +28,11 @@ class TestNextTokenLmReader(AllenNlpTestCase):
         reader = NextTokenLmReader(tokenizer, {"bert": token_indexer})
         instance = reader.text_to_instance(sentence="AllenNLP is very", target="very")
         assert [t.text for t in instance["tokens"]] == [
-            "[CLS]",
             "Allen",
             "##NL",
             "##P",
             "is",
             "very",
-            "[SEP]",
         ]
         assert [t.text for t in instance["target_ids"]] == ["very"]
 
@@ -46,4 +44,6 @@ class TestNextTokenLmReader(AllenNlpTestCase):
         target_ids = tensor_dict["target_ids"]["bert"].numpy().tolist()
         # I don't know what wordpiece id BERT is going to assign to 'This', but it at least should
         # be the same between the input and the target.
-        assert target_ids[0] == bert_token_ids[5]
+        assert target_ids[0] == bert_token_ids[0]
+        assert target_ids[-1] == bert_token_ids[-1]
+        assert target_ids[-2] == bert_token_ids[-2]

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -13,10 +13,14 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
         indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased")
         tokens_no_specials = tokenizer.tokenize("AllenNLP is great")
         tokens_with_specials = ["[CLS]"] + tokens_no_specials + ["[SEP]"]
-        expected_ids = tokenizer.convert_tokens_to_ids(tokens_with_specials) # this one does not append any additional tokens
+        expected_ids = tokenizer.convert_tokens_to_ids(
+            tokens_with_specials
+        )  # this one does not append any additional tokens
         allennlp_tokens_no_specials = [Token(token) for token in tokens_no_specials]
         vocab = Vocabulary()
-        indexed = indexer.tokens_to_indices(allennlp_tokens_no_specials, vocab, "key") # adds special token ids
+        indexed = indexer.tokens_to_indices(
+            allennlp_tokens_no_specials, vocab, "key"
+        )  # adds special token ids
         assert indexed["key"] == expected_ids
 
         # sentence pair
@@ -24,16 +28,26 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
         indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased")
         tokens_1_no_specials = tokenizer.tokenize("AllenNLP is great.")
         tokens_2_no_specials = tokenizer.tokenize("I mean it really is!")
-        tokens_with_specials = tokenizer.tokenize("[CLS] AllenNLP is great. [SEP] I mean it really is! [SEP]")
+        tokens_with_specials = tokenizer.tokenize(
+            "[CLS] AllenNLP is great. [SEP] I mean it really is! [SEP]"
+        )
 
-        expected_ids = tokenizer.convert_tokens_to_ids(tokens_with_specials) # this one does not append any additional tokens
+        expected_ids = tokenizer.convert_tokens_to_ids(
+            tokens_with_specials
+        )  # this one does not append any additional tokens
 
         allennlp_tokens_1_no_specials = [Token(token) for token in tokens_1_no_specials]
         allennlp_tokens_2_no_specials = [Token(token) for token in tokens_2_no_specials]
-        allennlp_tokens_prepared_no_specials = allennlp_tokens_1_no_specials + [Token(DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN)] + allennlp_tokens_2_no_specials
+        allennlp_tokens_prepared_no_specials = (
+            allennlp_tokens_1_no_specials
+            + [Token(DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN)]
+            + allennlp_tokens_2_no_specials
+        )
 
         vocab = Vocabulary()
-        indexed = indexer.tokens_to_indices(allennlp_tokens_prepared_no_specials, vocab, "key") # adds special token ids
+        indexed = indexer.tokens_to_indices(
+            allennlp_tokens_prepared_no_specials, vocab, "key"
+        )  # adds special token ids
         assert indexed["key"] == expected_ids
 
     def test_as_array_produces_token_sequence_roberta(self):
@@ -42,10 +56,14 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
         indexer = PretrainedTransformerIndexer(model_name="roberta-base")
         tokens_no_specials = tokenizer.tokenize("AllenNLP is great")
         tokens_with_specials = ["<s>"] + tokens_no_specials + ["</s>"]
-        expected_ids = tokenizer.convert_tokens_to_ids(tokens_with_specials) # this one does not append any additional tokens
+        expected_ids = tokenizer.convert_tokens_to_ids(
+            tokens_with_specials
+        )  # this one does not append any additional tokens
         allennlp_tokens_no_specials = [Token(token) for token in tokens_no_specials]
         vocab = Vocabulary()
-        indexed = indexer.tokens_to_indices(allennlp_tokens_no_specials, vocab, "key") # adds special token ids
+        indexed = indexer.tokens_to_indices(
+            allennlp_tokens_no_specials, vocab, "key"
+        )  # adds special token ids
         assert indexed["key"] == expected_ids
 
         # sentence pair
@@ -53,14 +71,24 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
         indexer = PretrainedTransformerIndexer(model_name="roberta-base")
         tokens_1_no_specials = tokenizer.tokenize("AllenNLP is great.")
         tokens_2_no_specials = tokenizer.tokenize("I mean it really is!")
-        tokens_with_specials = tokenizer.tokenize("<s> AllenNLP is great. </s> </s> I mean it really is! </s>")
+        tokens_with_specials = tokenizer.tokenize(
+            "<s> AllenNLP is great. </s> </s> I mean it really is! </s>"
+        )
 
-        expected_ids = tokenizer.convert_tokens_to_ids(tokens_with_specials) # this one does not append any additional tokens
+        expected_ids = tokenizer.convert_tokens_to_ids(
+            tokens_with_specials
+        )  # this one does not append any additional tokens
 
         allennlp_tokens_1_no_specials = [Token(token) for token in tokens_1_no_specials]
         allennlp_tokens_2_no_specials = [Token(token) for token in tokens_2_no_specials]
-        allennlp_tokens_prepared_no_specials = allennlp_tokens_1_no_specials + [Token(DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN)] + allennlp_tokens_2_no_specials
+        allennlp_tokens_prepared_no_specials = (
+            allennlp_tokens_1_no_specials
+            + [Token(DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN)]
+            + allennlp_tokens_2_no_specials
+        )
 
         vocab = Vocabulary()
-        indexed = indexer.tokens_to_indices(allennlp_tokens_prepared_no_specials, vocab, "key") # adds special token ids
+        indexed = indexer.tokens_to_indices(
+            allennlp_tokens_prepared_no_specials, vocab, "key"
+        )  # adds special token ids
         assert indexed["key"] == expected_ids

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -3,24 +3,64 @@ from transformers.tokenization_auto import AutoTokenizer
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Token, Vocabulary
 from allennlp.data.token_indexers import PretrainedTransformerIndexer
+from allennlp.data.vocabulary import DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN
 
 
 class TestPretrainedTransformerIndexer(AllenNlpTestCase):
-    def test_as_array_produces_token_sequence(self):
+    def test_as_array_produces_token_sequence_bert(self):
+        # single sentence
         tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
         indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased")
-        tokens = tokenizer.tokenize("AllenNLP is great")
-        expected_ids = tokenizer.convert_tokens_to_ids(tokens)
-        allennlp_tokens = [Token(token) for token in tokens]
+        tokens_no_specials = tokenizer.tokenize("AllenNLP is great")
+        tokens_with_specials = ["[CLS]"] + tokens_no_specials + ["[SEP]"]
+        expected_ids = tokenizer.convert_tokens_to_ids(tokens_with_specials) # this one does not append any additional tokens
+        allennlp_tokens_no_specials = [Token(token) for token in tokens_no_specials]
         vocab = Vocabulary()
-        indexed = indexer.tokens_to_indices(allennlp_tokens, vocab, "key")
+        indexed = indexer.tokens_to_indices(allennlp_tokens_no_specials, vocab, "key") # adds special token ids
         assert indexed["key"] == expected_ids
 
-        tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-        indexer = PretrainedTransformerIndexer(model_name="bert-base-cased")
-        tokens = tokenizer.tokenize("AllenNLP is great")
-        expected_ids = tokenizer.convert_tokens_to_ids(tokens)
-        allennlp_tokens = [Token(token) for token in tokens]
+        # sentence pair
+        tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+        indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased")
+        tokens_1_no_specials = tokenizer.tokenize("AllenNLP is great.")
+        tokens_2_no_specials = tokenizer.tokenize("I mean it really is!")
+        tokens_with_specials = tokenizer.tokenize("[CLS] AllenNLP is great. [SEP] I mean it really is! [SEP]")
+
+        expected_ids = tokenizer.convert_tokens_to_ids(tokens_with_specials) # this one does not append any additional tokens
+
+        allennlp_tokens_1_no_specials = [Token(token) for token in tokens_1_no_specials]
+        allennlp_tokens_2_no_specials = [Token(token) for token in tokens_2_no_specials]
+        allennlp_tokens_prepared_no_specials = allennlp_tokens_1_no_specials + [Token(DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN)] + allennlp_tokens_2_no_specials
+
         vocab = Vocabulary()
-        indexed = indexer.tokens_to_indices(allennlp_tokens, vocab, "key")
+        indexed = indexer.tokens_to_indices(allennlp_tokens_prepared_no_specials, vocab, "key") # adds special token ids
+        assert indexed["key"] == expected_ids
+
+    def test_as_array_produces_token_sequence_roberta(self):
+        # single sentence
+        tokenizer = AutoTokenizer.from_pretrained("roberta-base")
+        indexer = PretrainedTransformerIndexer(model_name="roberta-base")
+        tokens_no_specials = tokenizer.tokenize("AllenNLP is great")
+        tokens_with_specials = ["<s>"] + tokens_no_specials + ["</s>"]
+        expected_ids = tokenizer.convert_tokens_to_ids(tokens_with_specials) # this one does not append any additional tokens
+        allennlp_tokens_no_specials = [Token(token) for token in tokens_no_specials]
+        vocab = Vocabulary()
+        indexed = indexer.tokens_to_indices(allennlp_tokens_no_specials, vocab, "key") # adds special token ids
+        assert indexed["key"] == expected_ids
+
+        # sentence pair
+        tokenizer = AutoTokenizer.from_pretrained("roberta-base")
+        indexer = PretrainedTransformerIndexer(model_name="roberta-base")
+        tokens_1_no_specials = tokenizer.tokenize("AllenNLP is great.")
+        tokens_2_no_specials = tokenizer.tokenize("I mean it really is!")
+        tokens_with_specials = tokenizer.tokenize("<s> AllenNLP is great. </s> </s> I mean it really is! </s>")
+
+        expected_ids = tokenizer.convert_tokens_to_ids(tokens_with_specials) # this one does not append any additional tokens
+
+        allennlp_tokens_1_no_specials = [Token(token) for token in tokens_1_no_specials]
+        allennlp_tokens_2_no_specials = [Token(token) for token in tokens_2_no_specials]
+        allennlp_tokens_prepared_no_specials = allennlp_tokens_1_no_specials + [Token(DEFAULT_SENTENCE_PAIR_SEPARATION_TOKEN)] + allennlp_tokens_2_no_specials
+
+        vocab = Vocabulary()
+        indexed = indexer.tokens_to_indices(allennlp_tokens_prepared_no_specials, vocab, "key") # adds special token ids
         assert indexed["key"] == expected_ids

--- a/allennlp/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -6,7 +6,6 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
     def test_splits_cased(self):
         sentence = "A, [MASK] AllenNLP sentence."
         expected_tokens = [
-            "[CLS]",
             "A",
             ",",
             "[MASK]",
@@ -14,8 +13,7 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
             "##NL",
             "##P",
             "sentence",
-            ".",
-            "[SEP]",
+            "."
         ]
         tokenizer = PretrainedTransformerTokenizer("bert-base-cased")
         tokens = [t.text for t in tokenizer.tokenize(sentence)]
@@ -24,7 +22,6 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
     def test_splits_uncased(self):
         sentence = "A, [MASK] AllenNLP sentence."
         expected_tokens = [
-            "[CLS]",
             "a",
             ",",
             "[MASK]",
@@ -32,8 +29,7 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
             "##nl",
             "##p",
             "sentence",
-            ".",
-            "[SEP]",
+            "."
         ]
         tokenizer = PretrainedTransformerTokenizer("bert-base-uncased")
         tokens = [t.text for t in tokenizer.tokenize(sentence)]

--- a/allennlp/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -5,32 +5,14 @@ from allennlp.data.tokenizers import PretrainedTransformerTokenizer
 class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
     def test_splits_cased(self):
         sentence = "A, [MASK] AllenNLP sentence."
-        expected_tokens = [
-            "A",
-            ",",
-            "[MASK]",
-            "Allen",
-            "##NL",
-            "##P",
-            "sentence",
-            "."
-        ]
+        expected_tokens = ["A", ",", "[MASK]", "Allen", "##NL", "##P", "sentence", "."]
         tokenizer = PretrainedTransformerTokenizer("bert-base-cased")
         tokens = [t.text for t in tokenizer.tokenize(sentence)]
         assert tokens == expected_tokens
 
     def test_splits_uncased(self):
         sentence = "A, [MASK] AllenNLP sentence."
-        expected_tokens = [
-            "a",
-            ",",
-            "[MASK]",
-            "allen",
-            "##nl",
-            "##p",
-            "sentence",
-            "."
-        ]
+        expected_tokens = ["a", ",", "[MASK]", "allen", "##nl", "##p", "sentence", "."]
         tokenizer = PretrainedTransformerTokenizer("bert-base-uncased")
         tokens = [t.text for t in tokenizer.tokenize(sentence)]
         assert tokens == expected_tokens

--- a/allennlp/tests/training/callback_trainer_test.py
+++ b/allennlp/tests/training/callback_trainer_test.py
@@ -449,7 +449,7 @@ class TestCallbackTrainer(ModelTestCase):
             np.testing.assert_almost_equal(metrics1[key], metrics2[key])
 
     def test_metric_only_considered_best_so_far_when_strictly_better_than_those_before_it_increasing_metric(
-        self
+        self,
     ):
         new_trainer = CallbackTrainer(
             self.model,
@@ -483,7 +483,7 @@ class TestCallbackTrainer(ModelTestCase):
         assert not new_tracker.is_best_so_far()
 
     def test_metric_only_considered_best_so_far_when_strictly_better_than_those_before_it_decreasing_metric(
-        self
+        self,
     ):
         new_trainer = CallbackTrainer(
             self.model,
@@ -950,7 +950,7 @@ class TestCallbackTrainer(ModelTestCase):
         assert best_validation_metrics_epoch_2 == best_validation_metrics_epoch_1
 
     def test_restored_training_returns_best_epoch_metrics_even_if_no_better_epoch_is_found_after_restoring(
-        self
+        self,
     ):
         # Instead of -loss, use +loss to assure 2nd epoch is considered worse.
         # Run 1 epoch of original training.

--- a/allennlp/tests/training/gan_callback_trainer_test.py
+++ b/allennlp/tests/training/gan_callback_trainer_test.py
@@ -234,7 +234,7 @@ class GanCallbackTrainer(CallbackTrainer):
 
     def train_one_batch_group(self, batch_group):
         # Each batch_group should have only one batch
-        batch, = batch_group
+        (batch,) = batch_group
         array = batch["array"]
 
         # We should not have mixed batches:

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -220,7 +220,7 @@ class TestTrainer(AllenNlpTestCase):
         new_trainer.train()
 
     def test_metric_only_considered_best_so_far_when_strictly_better_than_those_before_it_increasing_metric(
-        self
+        self,
     ):
         new_trainer = Trainer(
             self.model,
@@ -256,7 +256,7 @@ class TestTrainer(AllenNlpTestCase):
         assert not new_tracker.is_best_so_far()
 
     def test_metric_only_considered_best_so_far_when_strictly_better_than_those_before_it_decreasing_metric(
-        self
+        self,
     ):
         new_trainer = Trainer(
             self.model,
@@ -764,7 +764,7 @@ class TestTrainer(AllenNlpTestCase):
         assert best_validation_metrics_epoch_2 == best_validation_metrics_epoch_1
 
     def test_restored_training_returns_best_epoch_metrics_even_if_no_better_epoch_is_found_after_restoring(
-        self
+        self,
     ):
         # Instead of -loss, use +loss to assure 2nd epoch is considered worse.
         # Run 1 epoch of original training.

--- a/scripts/examine_sql_coverage.py
+++ b/scripts/examine_sql_coverage.py
@@ -128,9 +128,14 @@ def main(
         for json_file in data_files:
             print(f"\tParsing split at {json_file}")
             file_path = os.path.join(directory, json_file)
-            num_parsed, num_queries, filtered_errors, non_basic_as_aliases, as_count, queries_with_weird_as = parse_dataset(
-                file_path, filter_by, verbose
-            )
+            (
+                num_parsed,
+                num_queries,
+                filtered_errors,
+                non_basic_as_aliases,
+                as_count,
+                queries_with_weird_as,
+            ) = parse_dataset(file_path, filter_by, verbose)
 
             parsed += num_parsed
             total += num_queries


### PR DESCRIPTION
This PR uses the function from huggingface that adds special tokens based on the pretrained models chosen. 

I also introduced a special separation symbol that PretrainedTransformerIndexer uses to know that sentence pair is passed (as opposed to a single sentence).

This PR can fix https://github.com/allenai/allennlp/issues/3356
