### PR TITLE
Top Layer Only for LanguageModelTokenEmbedder

### DIFF
--- a/allennlp/modules/token_embedders/bidirectional_language_model_token_embedder.py
+++ b/allennlp/modules/token_embedders/bidirectional_language_model_token_embedder.py
@@ -37,6 +37,8 @@ class BidirectionalLanguageModelTokenEmbedder(LanguageModelTokenEmbedder):
         Warning: This only removes a single start and single end token!
     requires_grad : ``bool``, optional (default: False)
         If True, compute gradient of bidirectional language model parameters for fine tuning.
+    top_layer_only: ``bool``, optional (default = ``False``)
+        If ``True``, then only return the top layer instead of apply the scalar mix.
     """
 
     def __init__(
@@ -46,6 +48,7 @@ class BidirectionalLanguageModelTokenEmbedder(LanguageModelTokenEmbedder):
         bos_eos_tokens: Tuple[str, str] = ("<S>", "</S>"),
         remove_bos_eos: bool = True,
         requires_grad: bool = False,
+        top_layer_only: bool = False,
     ) -> None:
         super().__init__(
             archive_file=archive_file,
@@ -53,4 +56,5 @@ class BidirectionalLanguageModelTokenEmbedder(LanguageModelTokenEmbedder):
             bos_eos_tokens=bos_eos_tokens,
             remove_bos_eos=remove_bos_eos,
             requires_grad=requires_grad,
+            top_layer_only=top_layer_only,
         )

--- a/allennlp/tests/modules/token_embedders/language_model_token_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/language_model_token_embedder_test.py
@@ -1,14 +1,18 @@
+import copy
+import tempfile
+
 from allennlp.common.testing import ModelTestCase
+from allennlp.common.params import Params
 from allennlp.data.dataset import Batch
+from allennlp.models import Model
+from allennlp.modules.scalar_mix import ScalarMix
 
 
 class TestLanguageModelTokenEmbedder(ModelTestCase):
     def setUp(self):
         super().setUp()
-        self.set_up_model(
-            self.FIXTURES_ROOT / "language_model" / "characters_token_embedder.json",
-            self.FIXTURES_ROOT / "data" / "conll2003.txt",
-        )
+        self._model_fp = self.FIXTURES_ROOT / "language_model" / "characters_token_embedder.json"
+        self.set_up_model(self._model_fp, self.FIXTURES_ROOT / "data" / "conll2003.txt")
 
     def test_tagger_with_language_model_token_embedder_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)
@@ -26,6 +30,29 @@ class TestLanguageModelTokenEmbedder(ModelTestCase):
             for tag_id in example_tags:
                 tag = self.model.vocab.get_token_from_index(tag_id, namespace="labels")
                 assert tag in {"O", "I-ORG", "I-PER", "I-LOC"}
+        # Ensure that the scalar mix model exists within the Language Model
+        # TokenEmbedder
+        scalar_mix = self.model.text_field_embedder._token_embedders["elmo"]._scalar_mix
+        assert isinstance(scalar_mix, ScalarMix)
+
+    def test_tagger_with_language_model_token_embedder_top_only_layer(self):
+        params = Params.from_file(self._model_fp).duplicate()
+        elmo_params = {
+            "type": "language_model_token_embedder",
+            "archive_file": "allennlp/tests/fixtures/language_model/model.tar.gz",
+            "dropout": 0.2,
+            "bos_eos_tokens": ["<S>", "</S>"],
+            "remove_bos_eos": True,
+            "requires_grad": True,
+            "top_layer_only": True,
+        }
+        params["model"]["text_field_embedder"]["token_embedders"]["elmo"] = elmo_params
+        params_copy = copy.deepcopy(params)
+        model = Model.from_params(vocab=self.vocab, params=params_copy.get("model"))
+        with tempfile.NamedTemporaryFile(mode="w+") as temp_file:
+            params.to_file(temp_file.name)
+            self.ensure_model_can_train_save_and_load(temp_file.name)
+        assert model.text_field_embedder._token_embedders["elmo"]._scalar_mix is None
 
 
 class TestLanguageModelTokenEmbedderWithoutBosEos(TestLanguageModelTokenEmbedder):


### PR DESCRIPTION
Fixes #3460 by adding a `top_layer_only` argument into the constructor of [LanguageModelTokenEmbedder](https://github.com/allenai/allennlp/blob/master/allennlp/modules/token_embedders/language_model_token_embedder.py) and ensuring when `top_layer_only` is True that the `_scalar_mix` is `None`.

I have also added `top_layer_only` argument to the [BidirectionalLanguageModelTokenEmbedder](https://github.com/allenai/allennlp/blob/master/allennlp/modules/token_embedders/bidirectional_language_model_token_embedder.py).