### PR TITLE
Fix an f-formatted string

### DIFF
--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -86,9 +86,8 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
                 # # It computed in PretrainedTransformerTokenizer.
                 indices.append(token.text_id)
             else:
-                raise KeyError(
-                    f"Using PretrainedTransformerIndexer but field text_id is not set for the following token: {token.text}"
-                )
+                raise KeyError(("Using PretrainedTransformerIndexer but field text_id is not set"
+                                f" for the following token: {token.text}"))
 
         return {index_name: indices}
 

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -86,8 +86,10 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
                 # # It computed in PretrainedTransformerTokenizer.
                 indices.append(token.text_id)
             else:
-                raise KeyError(("Using PretrainedTransformerIndexer but field text_id is not set"
-                                f" for the following token: {token.text}"))
+                raise KeyError(
+                    "Using PretrainedTransformerIndexer but field text_id is not set"
+                    f" for the following token: {token.text}"
+                )
 
         return {index_name: indices}
 

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -87,8 +87,7 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
                 indices.append(token.text_id)
             else:
                 raise KeyError(
-                    """Using PretrainedTransformerIndexer but field text_id is
-                                not set for the following token: {token.text}"""
+                    f"Using PretrainedTransformerIndexer but field text_id is not set for the following token: {token.text}"
                 )
 
         return {index_name: indices}


### PR DESCRIPTION
There is a `KeyError` message in `pretrained_transformer_indexer.py` that appears to be an f-formatted string with broken syntax. This resulted in the literal string `token.text` being printed when the error is raised, instead of the value of the `text` attribute of `token`.

I simply fixed the syntax, so now this error message will print the value of `token.text` to screen when the error is raised.