### PR TITLE
Update code fences in getting started tutorial

### DIFF
--- a/tutorials/tagger/README.md
+++ b/tutorials/tagger/README.md
@@ -455,7 +455,7 @@ lstm = PytorchSeq2SeqWrapper(torch.nn.LSTM(EMBEDDING_DIM, HIDDEN_DIM, batch_firs
 
 You could write
 
-```
+```python
 lstm_params = Params({
     "type": "lstm",
     "input_size": EMBEDDING_DIM,
@@ -589,7 +589,7 @@ The first big change is that we need to add a second `TokenIndexer` to our datas
 that captures the character-level indices. As the token indexers can be provided as a
 constructor input, we can accomplish this with just a small change to our configuration file:
 
-```json
+```jsonnet
     "dataset_reader": {
         "type": "pos-tutorial",
         "token_indexers": {
@@ -613,7 +613,7 @@ when we specify token embedders inside our model.
 
 The section of the configuration corresponding to our model was previously
 
-```json
+```jsonnet
     "model": {
         "type": "lstm-tagger",
         "word_embeddings": {
@@ -636,7 +636,7 @@ The `BasicTokenEmbedder` already knows that if it has multiple token embedders i
 should concatenate their outputs. So all we need to do is add a second token embedder
 with the right key:
 
-```json
+```jsonnet
             "token_embedders": {
                 "tokens": {
                     "type": "embedding",


### PR DESCRIPTION
Just a tiny aesthetic change to the markdown of the Getting Started tutorial.

I noticed the code fences for the jsonnet configs specified `json` as the language, which leads to these unsightly red highlights

![image](https://user-images.githubusercontent.com/8917831/70066604-f82cb000-15ba-11ea-84eb-d211f409238d.png)

This is easily solved by specifying the language as `jsonnet`, which is a valid keyword in [linguist](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L2540), the [library used by GitHub for syntax highlighting](https://help.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks).

I also added the `python` keyword to a code fence that appeard to be missing it.

