### PR TITLE
Remove [tool.poetry] and add [build-system]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.poetry]
-name = "allennlp"
-
 [tool.black]
 line-length = 100
 
@@ -20,3 +17,7 @@ exclude = '''
     | \bdoc\b
 )
 '''
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
`pyproject.toml` had a `[tool.poetry]` section that was incomplete. This removes that section and adds a `[build-system]` section that properly instructs any build system using `pyproject.toml` that it should use `setuptools` and `wheel` to build AllenNLP.

This should solve #3504 