### PR TITLE
Pins the version of python-dateutil to one that works

### DIFF
--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -82,7 +82,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
             truncation_strategy=self._truncation_strategy,
             return_tensors=None,
         )
-        # token_ids containes a final list with ids for both regualr and special tokens
+        # token_ids contains a final list with ids for both regular and special tokens
         token_ids, token_type_ids = encoded_tokens["input_ids"], encoded_tokens["token_type_ids"]
 
         tokens = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -133,3 +133,6 @@ pypandoc
 
 # Pypi uploads
 twine>=1.11.0
+
+# Pin this version to one that works
+python-dateutil<2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,8 @@ word2number>=1.1
 
 # To use the BERT model
 pytorch-pretrained-bert>=0.6.0
-transformers>=2.1.1
+transformers>=2.1.1,!=2.2.1
+# Version 2.2.1 has a broken tokenizer.
 
 # For caching processed data
 jsonpickle

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup(
         "pytorch-pretrained-bert>=0.6.0",
         "transformers>=2.1.1",
         "jsonpickle",
+        "python-dateutil<2.8.1",
     ],
     entry_points={"console_scripts": ["allennlp=allennlp.run:run"]},
     setup_requires=setup_requirements,

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
         "sqlparse>=0.2.4",
         "word2number>=1.1",
         "pytorch-pretrained-bert>=0.6.0",
-        "transformers>=2.1.1",
+        "transformers>=2.1.1,!=2.2.1",
         "jsonpickle",
         "python-dateutil<2.8.1",
     ],


### PR DESCRIPTION
During `pip install`, we see this:
```
ERROR: botocore 1.13.36 has requirement python-dateutil<2.8.1,>=2.1; python_version >= "2.7", but you'll have python-dateutil 2.8.1 which is incompatible.
```

Then, at runtime, we see this:
```
dirkg@Dirks-MacBook-Air ~/D/allennlp> allennlp train training_config/bidaf.jsonnet -s output_path
Traceback (most recent call last):
  File "/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (python-dateutil 2.8.1 (/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages), Requirement.parse('python-dateutil<2.8.1,>=2.1; python_version >= "2.7"'), {'botocore'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/dirkg/miniconda3/envs/allennlp/bin/allennlp", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3251, in <module>
    @_call_aside
  File "/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3235, in _call_aside
    f(*args, **kwargs)
  File "/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3264, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages/pkg_resources/__init__.py", line 585, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages/pkg_resources/__init__.py", line 598, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (python-dateutil 2.8.1 (/Users/dirkg/miniconda3/envs/allennlp/lib/python3.7/site-packages), Requirement.parse('python-dateutil<2.8.1,>=2.1; python_version >= "2.7"'), {'botocore'})
```

`pip` should do this correctly, but it does not. There is no reason for pip to install `python-dateutil==2.8.1` when there are several packages that require `python-dateutil<2.8.1`. As far as I can tell, this is a bug in `pip`.