### PR TITLE
strip out old DP stuff, ensure multiple cuda devices raises errors

### DIFF
--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -316,7 +316,7 @@ def search_learning_rate(
     else:
         lr_update_factor = (end_lr / start_lr) ** (1.0 / num_batches)
 
-    for i, batch_group in enumerate(train_generator_tqdm):
+    for i, batch in enumerate(train_generator_tqdm):
 
         if linear_steps:
             current_lr = start_lr + (lr_update_factor * i)
@@ -327,7 +327,7 @@ def search_learning_rate(
             param_group["lr"] = current_lr
 
         trainer.optimizer.zero_grad()
-        loss = trainer.batch_loss(batch_group, for_training=True)
+        loss = trainer.batch_loss(batch, for_training=True)
         loss.backward()
         loss = loss.detach().cpu().item()
 

--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -52,7 +52,7 @@ import logging
 import shutil
 
 from allennlp.commands.subcommand import Subcommand
-from allennlp.common.checks import ConfigurationError, check_for_gpu, parse_cuda_device
+from allennlp.common.checks import ConfigurationError, check_for_gpu
 from allennlp.common import Params, Tqdm
 from allennlp.common.util import prepare_environment
 from allennlp.data import Vocabulary, DataIterator
@@ -193,14 +193,6 @@ def find_learning_rate_model(
     prepare_environment(params)
 
     cuda_device = params.params.get("trainer").get("cuda_device", -1)
-    devices = parse_cuda_device(cuda_device)
-
-    # HACK: The trainer can not be constructed with multiple gpus.
-    # TODO(Mark): rework this so that cuda devices for distributed training are passed
-    # somewhere else, so configs are always valid.
-    if isinstance(devices, list):
-        cuda_device = devices[0]
-        params.params["trainer"]["cuda_device"] = cuda_device
     check_for_gpu(cuda_device)
 
     all_datasets = datasets_from_params(params)

--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -54,7 +54,7 @@ import shutil
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError, check_for_gpu, parse_cuda_device
 from allennlp.common import Params, Tqdm
-from allennlp.common.util import prepare_environment, lazy_groups_of
+from allennlp.common.util import prepare_environment
 from allennlp.data import Vocabulary, DataIterator
 from allennlp.models import Model
 from allennlp.training import Trainer

--- a/allennlp/commands/fine_tune.py
+++ b/allennlp/commands/fine_tune.py
@@ -382,7 +382,7 @@ def fine_tune_model(
             model,
             test_data,
             validation_iterator or iterator,
-            cuda_device=trainer._cuda_devices[0],
+            cuda_device=trainer.cuda_device,
             batch_weight_key=batch_weight_key,
         )
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -435,6 +435,7 @@ def _train_worker(
         # But a worker trainer needs to only know about its specific GPU id.
         params["trainer"]["cuda_device"] = gpu_id
         params["trainer"]["world_size"] = world_size
+        params["trainer"]["distributed"] = True
 
         torch.cuda.set_device(gpu_id)
         dist.init_process_group(

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -438,7 +438,6 @@ def _train_worker(
         params["trainer"]["cuda_device"] = gpu_id
         params["trainer"]["world_size"] = world_size
 
-
         torch.cuda.set_device(gpu_id)
         dist.init_process_group(
             backend="nccl",

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -269,16 +269,16 @@ def train_model(
     create_serialization_dir(params, serialization_dir, recover, force)
     params.to_file(os.path.join(serialization_dir, CONFIG_NAME))
 
-    cuda_device = params.params.get("trainer").get("cuda_device", -1)
-    device_id = parse_cuda_device(cuda_device)
+    cuda_device = params.params.pop("distributed_cuda_devices", -1)
+    device_ids = parse_cuda_device(cuda_device)
     check_for_gpu(cuda_device)
 
-    multi_device = isinstance(device_id, list)
-    distributed = params.params.get("trainer").get("distributed", False)
+    multi_device = isinstance(device_ids, list)
+    distributed = params.params.pop("distributed", False)
 
     # If distributed isn't in the config and the config contains strictly
     # one cuda device, we just run a single training process.
-    if not distributed or not multi_device:
+    if not distributed:
         model = _train_worker(
             process_rank=0,
             params=params,
@@ -301,10 +301,10 @@ def train_model(
 
     # Otherwise, we are running multiple processes for training.
     else:
-        master_addr = params.params.get("trainer").pop("master_address", "127.0.0.1")
-        master_port = params.params.get("trainer").pop("master_port", 29500)
-        num_procs = len(device_id)
-        num_nodes = params.params.get("trainer").pop("num_nodes", 1)
+        master_addr = params.params.pop("master_address", "127.0.0.1")
+        master_port = params.params.pop("master_port", 29500)
+        num_procs = len(device_ids)
+        num_nodes = params.params.pop("num_nodes", 1)
         world_size = num_nodes * num_procs
 
         os.environ["MASTER_ADDR"] = master_addr
@@ -339,10 +339,10 @@ def train_model(
                 cache_prefix,
                 include_package,
                 node_rank,
-                num_procs,
                 master_addr,
                 master_port,
                 world_size,
+                device_ids,
             ),
             nprocs=num_procs,
         )
@@ -360,10 +360,10 @@ def _train_worker(
     cache_prefix: str = None,
     include_package: List[str] = None,
     node_rank: int = 0,
-    num_procs_per_node: int = 0,
     master_addr: str = "127.0.0.1",
     master_port: int = 29500,
     world_size: int = 1,
+    distributed_device_ids: List[str] = None,
 ) -> Optional[Model]:
     """
     Helper to train the configured model/experiment. In distributed mode, this is spawned as a
@@ -422,18 +422,22 @@ def _train_worker(
             for package_name in include_package:
                 import_submodules(package_name)
 
+        num_procs_per_node = len(distributed_device_ids)
         # The Unique identifier of the worker process among all the processes in the
         # distributed training group is computed here. This is used while initializing
         # the process group using `init_process_group`
         global_rank = node_rank * num_procs_per_node + process_rank
 
-        cuda_device = params.params.get("trainer").get("cuda_device", -1)
-        device_list = parse_cuda_device(cuda_device)
-
         # In distributed training, the configured device is always going to be a list.
         # The corresponding gpu id for the particular worker is obtained by picking the id
         # from the device list with the rank as index
-        gpu_id = device_list[process_rank]  # type: ignore
+        gpu_id = distributed_device_ids[process_rank]  # type: ignore
+
+        # Till now, "cuda_device" might not be set in the trainer params.
+        # But a worker trainer needs to only know about its specific GPU id.
+        params["trainer"]["cuda_device"] = gpu_id
+        params["trainer"]["world_size"] = world_size
+
 
         torch.cuda.set_device(gpu_id)
         dist.init_process_group(
@@ -446,12 +450,6 @@ def _train_worker(
             f"Process group of world size {world_size} initialized "
             f"for distributed training in worker {global_rank}"
         )
-
-        # Till now, "cuda_device" will be a list of ids as configured originally
-        # in params. But a worker trainer needs to only know about its specific
-        # GPU id.
-        params["trainer"]["cuda_device"] = gpu_id
-        params["trainer"]["world_size"] = world_size
 
     trainer_type = params.get("trainer", {}).get("type", "default")
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -511,7 +511,7 @@ def _train_worker(
                 trainer.model,
                 evaluation_dataset,
                 evaluation_iterator,
-                cuda_device=trainer._cuda_devices[0],  # pylint: disable=protected-access,
+                cuda_device=trainer.cuda_device,
                 # TODO(brendanr): Pass in an arg following Joel's trainer refactor.
                 batch_weight_key="",
             )

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -269,15 +269,10 @@ def train_model(
     create_serialization_dir(params, serialization_dir, recover, force)
     params.to_file(os.path.join(serialization_dir, CONFIG_NAME))
 
-    device_ids = params.params.pop("distributed_cuda_devices", -1)
-    check_for_gpu(device_ids)
-
-    multi_device = isinstance(device_ids, list) and len(device_ids) > 1
-    distributed = params.params.pop("distributed", False)
-
+    distributed_params = params.params.pop("distributed", None)
     # If distributed isn't in the config and the config contains strictly
     # one cuda device, we just run a single training process.
-    if not distributed:
+    if distributed_params is None:
         model = _train_worker(
             process_rank=0,
             params=params,
@@ -291,19 +286,23 @@ def train_model(
         archive_model(serialization_dir, files_to_archive=params.files_to_archive)
         return model
 
-    # If the config contains the distributed flag, but only one GPU, we raise an error,
-    # because this combination is probably a mistake.
-    elif distributed and not multi_device:
-        raise ConfigurationError(
-            "Multiple cuda devices need to be configured to run distributed training."
-        )
-
     # Otherwise, we are running multiple processes for training.
     else:
-        master_addr = params.params.pop("master_address", "127.0.0.1")
-        master_port = params.params.pop("master_port", 29500)
+        # We are careful here so that we can raise a good error if someone
+        # passed the wrong thing - cuda_devices are required.
+        device_ids = distributed_params.pop("cuda_devices", None)
+        multi_device = isinstance(device_ids, list) and len(device_ids) > 1
+
+        if not multi_device:
+            raise ConfigurationError(
+                "Multiple cuda devices need to be configured to run distributed training."
+            )
+        check_for_gpu(device_ids)
+
+        master_addr = distributed_params.pop("master_address", "127.0.0.1")
+        master_port = distributed_params.pop("master_port", 29500)
         num_procs = len(device_ids)
-        num_nodes = params.params.pop("num_nodes", 1)
+        num_nodes = distributed_params.pop("num_nodes", 1)
         world_size = num_nodes * num_procs
 
         os.environ["MASTER_ADDR"] = master_addr

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -56,7 +56,7 @@ import torch.multiprocessing as mp
 from allennlp.commands.make_vocab import make_vocab_from_params
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError, check_for_gpu, parse_cuda_device
+from allennlp.common.checks import ConfigurationError, check_for_gpu
 from allennlp.common.util import (
     prepare_environment,
     prepare_global_logging,
@@ -269,11 +269,10 @@ def train_model(
     create_serialization_dir(params, serialization_dir, recover, force)
     params.to_file(os.path.join(serialization_dir, CONFIG_NAME))
 
-    cuda_device = params.params.pop("distributed_cuda_devices", -1)
-    device_ids = parse_cuda_device(cuda_device)
-    check_for_gpu(cuda_device)
+    device_ids = params.params.pop("distributed_cuda_devices", -1)
+    check_for_gpu(device_ids)
 
-    multi_device = isinstance(device_ids, list)
+    multi_device = isinstance(device_ids, list) and len(device_ids) > 1
     distributed = params.params.pop("distributed", False)
 
     # If distributed isn't in the config and the config contains strictly

--- a/allennlp/common/checks.py
+++ b/allennlp/common/checks.py
@@ -52,14 +52,36 @@ def check_dimensions_match(
         )
 
 
-def parse_cuda_device(cuda_device: Union[str, int, List[int]]) -> Union[int, List[int]]:
+def parse_cuda_device(cuda_device: Union[str, int, List[int]]) -> int:
     """
     Disambiguates single GPU and multiple GPU settings for cuda_device param.
     """
 
+    message = """
+    In allennlp 1.0, the Trainer cannot be passed multiple cuda devices.
+    Instead, use the faster Distributed Data Parallel. For instance, if you previously had config like:
+        {
+          "trainer": {
+            "cuda_device": [0, 1, 2, 3],
+            "num_epochs": 20,
+            ...
+          }
+        }
+        simply change it to:
+        {
+          "distributed": {
+            "cuda_devices": [0, 1, 2, 3],
+          },
+          "trainer": {
+            "num_epochs": 20,
+            ...
+          }
+        }
+        """
+
     def from_list(strings):
         if len(strings) > 1:
-            return [int(d) for d in strings]
+            raise ConfigurationError(message)
         elif len(strings) == 1:
             return int(strings[0])
         else:
@@ -76,8 +98,7 @@ def parse_cuda_device(cuda_device: Union[str, int, List[int]]) -> Union[int, Lis
         return int(cuda_device)  # type: ignore
 
 
-def check_for_gpu(device_id: Union[int, list]):
-    device_id = parse_cuda_device(device_id)
+def check_for_gpu(device_id: Union[int, List[int]]):
     if isinstance(device_id, list):
         for did in device_id:
             check_for_gpu(did)

--- a/allennlp/tests/commands/train_test.py
+++ b/allennlp/tests/commands/train_test.py
@@ -102,9 +102,9 @@ class TestTrain(AllenNlpTestCase):
                 "trainer": {
                     "num_epochs": 2,
                     "optimizer": "adam",
-                    "distributed": True,
-                    "cuda_device": [0, 1],
                 },
+                "distributed": True,
+                "distributed_cuda_devices": [0, 1],
             }
         )
 
@@ -136,7 +136,8 @@ class TestTrain(AllenNlpTestCase):
                 "train_data_path": SEQUENCE_TAGGING_DATA_PATH,
                 "validation_data_path": SEQUENCE_TAGGING_DATA_PATH,
                 "iterator": {"type": "basic", "batch_size": 2},
-                "trainer": {"num_epochs": 2, "optimizer": "adam", "distributed": True},
+                "trainer": {"num_epochs": 2, "optimizer": "adam"},
+                "distributed": True
             }
         )
         with pytest.raises(ConfigurationError):
@@ -183,8 +184,8 @@ class TestTrain(AllenNlpTestCase):
                     "encoder": {"type": "lstm", "input_size": 5, "hidden_size": 7, "num_layers": 2},
                 },
                 "dataset_reader": {"type": "sequence_tagging"},
-                "train_data_path": "tests/fixtures/data/sequence_tagging.tsv",
-                "validation_data_path": "tests/fixtures/data/sequence_tagging.tsv",
+                "train_data_path": "allennlp/tests/fixtures/data/sequence_tagging.tsv",
+                "validation_data_path": "allennlp/tests/fixtures/data/sequence_tagging.tsv",
                 "iterator": {"type": "basic", "batch_size": 2},
                 "trainer": {
                     "num_epochs": 2,

--- a/allennlp/tests/commands/train_test.py
+++ b/allennlp/tests/commands/train_test.py
@@ -99,10 +99,7 @@ class TestTrain(AllenNlpTestCase):
                 "train_data_path": SEQUENCE_TAGGING_DATA_PATH,
                 "validation_data_path": SEQUENCE_TAGGING_DATA_PATH,
                 "iterator": {"type": "basic", "batch_size": 2},
-                "trainer": {
-                    "num_epochs": 2,
-                    "optimizer": "adam",
-                },
+                "trainer": {"num_epochs": 2, "optimizer": "adam"},
                 "distributed": True,
                 "distributed_cuda_devices": [0, 1],
             }
@@ -137,7 +134,7 @@ class TestTrain(AllenNlpTestCase):
                 "validation_data_path": SEQUENCE_TAGGING_DATA_PATH,
                 "iterator": {"type": "basic", "batch_size": 2},
                 "trainer": {"num_epochs": 2, "optimizer": "adam"},
-                "distributed": True
+                "distributed": True,
             }
         )
         with pytest.raises(ConfigurationError):

--- a/allennlp/tests/commands/train_test.py
+++ b/allennlp/tests/commands/train_test.py
@@ -100,8 +100,7 @@ class TestTrain(AllenNlpTestCase):
                 "validation_data_path": SEQUENCE_TAGGING_DATA_PATH,
                 "iterator": {"type": "basic", "batch_size": 2},
                 "trainer": {"num_epochs": 2, "optimizer": "adam"},
-                "distributed": True,
-                "distributed_cuda_devices": [0, 1],
+                "distributed": {"cuda_devices": [0, 1]},
             }
         )
 
@@ -134,7 +133,7 @@ class TestTrain(AllenNlpTestCase):
                 "validation_data_path": SEQUENCE_TAGGING_DATA_PATH,
                 "iterator": {"type": "basic", "batch_size": 2},
                 "trainer": {"num_epochs": 2, "optimizer": "adam"},
-                "distributed": True,
+                "distributed": {},
             }
         )
         with pytest.raises(ConfigurationError):

--- a/allennlp/tests/models/simple_tagger_test.py
+++ b/allennlp/tests/models/simple_tagger_test.py
@@ -63,8 +63,8 @@ class SimpleTaggerTest(ModelTestCase):
         training_batch = next(iterator(self.instances, num_epochs=1))
         validation_batch = next(iterator(self.instances, num_epochs=1))
 
-        training_loss = trainer.batch_loss([training_batch], for_training=True).item()
-        validation_loss = trainer.batch_loss([validation_batch], for_training=False).item()
+        training_loss = trainer.batch_loss(training_batch, for_training=True).item()
+        validation_loss = trainer.batch_loss(validation_batch, for_training=False).item()
 
         # Training loss should have the regularization penalty, but validation loss should not.
         numpy.testing.assert_almost_equal(training_loss, validation_loss)
@@ -124,8 +124,8 @@ class SimpleTaggerRegularizationTest(ModelTestCase):
         training_batch = next(self.iterator(self.instances, num_epochs=1))
         validation_batch = next(self.iterator(self.instances, num_epochs=1))
 
-        training_loss = self.trainer.batch_loss([training_batch], for_training=True).data
-        validation_loss = self.trainer.batch_loss([validation_batch], for_training=False).data
+        training_loss = self.trainer.batch_loss(training_batch, for_training=True).data
+        validation_loss = self.trainer.batch_loss(validation_batch, for_training=False).data
 
         # Training loss should have the regularization penalty, but validation loss should not.
         assert (training_loss != validation_loss).all()

--- a/allennlp/tests/training/callback_trainer_test.py
+++ b/allennlp/tests/training/callback_trainer_test.py
@@ -269,7 +269,7 @@ class TestCallbackTrainer(ModelTestCase):
         assert "peak_gpu_0_memory_MB" in metrics
         assert isinstance(metrics["peak_gpu_0_memory_MB"], int)
 
-    @pytest.mark.skipif(torch.cuda.device_count() < 2 , reason="2 or more GPUs required.")
+    @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="2 or more GPUs required.")
     def test_passing_trainer_multiple_gpus_raises_error(self):
         self.model.cuda()
 

--- a/allennlp/tests/training/callback_trainer_test.py
+++ b/allennlp/tests/training/callback_trainer_test.py
@@ -262,52 +262,29 @@ class TestCallbackTrainer(ModelTestCase):
             callbacks=self.default_callbacks(),
             cuda_device=0,
         )
-        trainer.train()
-
-    @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Need multiple GPUs.")
-    def test_trainer_can_run_multiple_gpu(self):
-        self.model.cuda()
-
-        class MetaDataCheckWrapper(Model):
-            """
-            Checks that the metadata field has been correctly split across the batch dimension
-            when running on multiple gpus.
-            """
-
-            def __init__(self, model):
-                super().__init__(model.vocab)
-                self.model = model
-
-            def forward(self, **kwargs) -> Dict[str, torch.Tensor]:  # type: ignore
-                assert (
-                    "metadata" in kwargs and "tags" in kwargs
-                ), f"tokens and metadata must be provided. Got {kwargs.keys()} instead."
-                batch_size = kwargs["tokens"]["tokens"].size()[0]
-                assert len(kwargs["metadata"]) == batch_size, (
-                    f"metadata must be split appropriately. Expected {batch_size} elements, "
-                    f"got {len(kwargs['metadata'])} elements."
-                )
-                return self.model.forward(**kwargs)
-
-        multigpu_iterator = BasicIterator(batch_size=4)
-        multigpu_iterator.index_with(self.vocab)
-        trainer = CallbackTrainer(
-            MetaDataCheckWrapper(self.model),
-            training_data=self.instances,
-            iterator=multigpu_iterator,
-            optimizer=self.optimizer,
-            num_epochs=2,
-            callbacks=self.default_callbacks(),
-            cuda_device=[0, 1],
-        )
         metrics = trainer.train()
         assert "peak_cpu_memory_MB" in metrics
         assert isinstance(metrics["peak_cpu_memory_MB"], float)
         assert metrics["peak_cpu_memory_MB"] > 0
         assert "peak_gpu_0_memory_MB" in metrics
         assert isinstance(metrics["peak_gpu_0_memory_MB"], int)
-        assert "peak_gpu_1_memory_MB" in metrics
-        assert isinstance(metrics["peak_gpu_1_memory_MB"], int)
+
+
+    def test_passing_trainer_multiple_gpus_raises_error(self):
+        self.model.cuda()
+
+        multigpu_iterator = BasicIterator(batch_size=4)
+        multigpu_iterator.index_with(self.vocab)
+        with pytest.raises(ConfigurationError):
+            trainer = CallbackTrainer(
+                self.model,
+                training_data=self.instances,
+                iterator=multigpu_iterator,
+                optimizer=self.optimizer,
+                num_epochs=2,
+                callbacks=self.default_callbacks(),
+                cuda_device=[0, 1],
+            )
 
     def test_trainer_can_resume_training(self):
         trainer = CallbackTrainer(

--- a/allennlp/tests/training/callback_trainer_test.py
+++ b/allennlp/tests/training/callback_trainer_test.py
@@ -269,14 +269,13 @@ class TestCallbackTrainer(ModelTestCase):
         assert "peak_gpu_0_memory_MB" in metrics
         assert isinstance(metrics["peak_gpu_0_memory_MB"], int)
 
-
     def test_passing_trainer_multiple_gpus_raises_error(self):
         self.model.cuda()
 
         multigpu_iterator = BasicIterator(batch_size=4)
         multigpu_iterator.index_with(self.vocab)
         with pytest.raises(ConfigurationError):
-            trainer = CallbackTrainer(
+            CallbackTrainer(
                 self.model,
                 training_data=self.instances,
                 iterator=multigpu_iterator,

--- a/allennlp/tests/training/callback_trainer_test.py
+++ b/allennlp/tests/training/callback_trainer_test.py
@@ -269,6 +269,7 @@ class TestCallbackTrainer(ModelTestCase):
         assert "peak_gpu_0_memory_MB" in metrics
         assert isinstance(metrics["peak_gpu_0_memory_MB"], int)
 
+    @pytest.mark.skipif(torch.cuda.device_count() < 2 , reason="2 or more GPUs required.")
     def test_passing_trainer_multiple_gpus_raises_error(self):
         self.model.cuda()
 

--- a/allennlp/tests/training/gan_callback_trainer_test.py
+++ b/allennlp/tests/training/gan_callback_trainer_test.py
@@ -207,7 +207,7 @@ class GanCallbackTrainer(CallbackTrainer):
         num_epochs: int = 20,
         shuffle: bool = False,
         serialization_dir: Optional[str] = None,
-        cuda_device: Union[int, List] = -1,
+        cuda_device: int = -1,
         callbacks: List[Callback] = None,
         distributed: bool = False,
         rank: int = 0,
@@ -235,9 +235,9 @@ class GanCallbackTrainer(CallbackTrainer):
         self.fake_stdev = 0.0
         self.count = 0
 
-    def train_one_batch_group(self, batch_group):
+    def train_one_batch(self, batch_group):
         # Each batch_group should have only one batch
-        batch, = batch_group
+        batch = batch_group
         array = batch["array"]
 
         # We should not have mixed batches:

--- a/allennlp/tests/training/gan_callback_trainer_test.py
+++ b/allennlp/tests/training/gan_callback_trainer_test.py
@@ -235,11 +235,9 @@ class GanCallbackTrainer(CallbackTrainer):
         self.fake_stdev = 0.0
         self.count = 0
 
-    def train_one_batch(self, batch_group):
-        # Each batch_group should have only one batch
-        batch = batch_group
-        array = batch["array"]
+    def train_one_batch(self, batch):
 
+        array = batch["array"]
         # We should not have mixed batches:
         if len(set(batch["stage"])) != 1:
             raise ValueError("mixed batch")
@@ -290,7 +288,7 @@ class GanCallbackTrainer(CallbackTrainer):
         # Reset epoch counters
         self._reset_counters()
 
-        # Will call `self.train_one_batch_group`
+        # Will call `self.train_one_batch`
         super().train_one_epoch()
 
 

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -114,6 +114,7 @@ class TestTrainer(AllenNlpTestCase):
         assert "peak_gpu_0_memory_MB" in metrics
         assert isinstance(metrics["peak_gpu_0_memory_MB"], int)
 
+    @pytest.mark.skipif(torch.cuda.device_count() < 2 , reason="2 or more GPUs required.")
     def test_passing_trainer_multiple_gpus_raises_error(self):
         self.model.cuda()
 

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -114,15 +114,13 @@ class TestTrainer(AllenNlpTestCase):
         assert "peak_gpu_0_memory_MB" in metrics
         assert isinstance(metrics["peak_gpu_0_memory_MB"], int)
 
-
-    @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Need multiple GPUs.")
     def test_passing_trainer_multiple_gpus_raises_error(self):
         self.model.cuda()
 
         multigpu_iterator = BasicIterator(batch_size=4)
         multigpu_iterator.index_with(self.vocab)
         with pytest.raises(ConfigurationError):
-            trainer = Trainer(
+            Trainer(
                 self.model,
                 self.optimizer,
                 multigpu_iterator,

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -107,51 +107,29 @@ class TestTrainer(AllenNlpTestCase):
         trainer = Trainer(
             self.model, self.optimizer, self.iterator, self.instances, num_epochs=2, cuda_device=0
         )
-        trainer.train()
-
-    @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Need multiple GPUs.")
-    def test_trainer_can_run_multiple_gpu(self):
-        self.model.cuda()
-
-        class MetaDataCheckWrapper(Model):
-            """
-            Checks that the metadata field has been correctly split across the batch dimension
-            when running on multiple gpus.
-            """
-
-            def __init__(self, model):
-                super().__init__(model.vocab)
-                self.model = model
-
-            def forward(self, **kwargs) -> Dict[str, torch.Tensor]:  # type: ignore
-                assert (
-                    "metadata" in kwargs and "tags" in kwargs
-                ), f"tokens and metadata must be provided. Got {kwargs.keys()} instead."
-                batch_size = kwargs["tokens"]["tokens"].size()[0]
-                assert len(kwargs["metadata"]) == batch_size, (
-                    f"metadata must be split appropriately. Expected {batch_size} elements, "
-                    f"got {len(kwargs['metadata'])} elements."
-                )
-                return self.model.forward(**kwargs)
-
-        multigpu_iterator = BasicIterator(batch_size=4)
-        multigpu_iterator.index_with(self.vocab)
-        trainer = Trainer(
-            MetaDataCheckWrapper(self.model),
-            self.optimizer,
-            multigpu_iterator,
-            self.instances,
-            num_epochs=2,
-            cuda_device=[0, 1],
-        )
         metrics = trainer.train()
         assert "peak_cpu_memory_MB" in metrics
         assert isinstance(metrics["peak_cpu_memory_MB"], float)
         assert metrics["peak_cpu_memory_MB"] > 0
         assert "peak_gpu_0_memory_MB" in metrics
         assert isinstance(metrics["peak_gpu_0_memory_MB"], int)
-        assert "peak_gpu_1_memory_MB" in metrics
-        assert isinstance(metrics["peak_gpu_1_memory_MB"], int)
+
+
+    @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Need multiple GPUs.")
+    def test_passing_trainer_multiple_gpus_raises_error(self):
+        self.model.cuda()
+
+        multigpu_iterator = BasicIterator(batch_size=4)
+        multigpu_iterator.index_with(self.vocab)
+        with pytest.raises(ConfigurationError):
+            trainer = Trainer(
+                self.model,
+                self.optimizer,
+                multigpu_iterator,
+                self.instances,
+                num_epochs=2,
+                cuda_device=[0, 1],
+            )
 
     def test_trainer_can_resume_training(self):
         trainer = Trainer(

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -114,7 +114,7 @@ class TestTrainer(AllenNlpTestCase):
         assert "peak_gpu_0_memory_MB" in metrics
         assert isinstance(metrics["peak_gpu_0_memory_MB"], int)
 
-    @pytest.mark.skipif(torch.cuda.device_count() < 2 , reason="2 or more GPUs required.")
+    @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="2 or more GPUs required.")
     def test_passing_trainer_multiple_gpus_raises_error(self):
         self.model.cuda()
 

--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -6,15 +6,13 @@ import logging
 import time
 import datetime
 import functools
-import math
 from typing import Dict, Optional, List, Any, Iterable
 import torch
 
 from allennlp.common import Params
 from allennlp.common.checks import parse_cuda_device, check_for_gpu
 from allennlp.common.tqdm import Tqdm
-from allennlp.common.util import lazy_groups_of
-from allennlp.data.instance import Instance
+from allennlp.data import Instance
 from allennlp.data.iterators.data_iterator import DataIterator, TensorDict
 from allennlp.models.model import Model
 from allennlp.nn import util as nn_util
@@ -345,7 +343,7 @@ class CallbackTrainer(TrainerBase):
         world_size = params.pop_int("world_size", 1)
 
         if distributed:
-            rank = model_device
+            rank = cuda_device
         else:
             rank = 0
 

--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -7,7 +7,7 @@ import time
 import datetime
 import functools
 import math
-from typing import Dict, Optional, List, Union, Any, Iterable
+from typing import Dict, Optional, List, Any, Iterable
 import torch
 
 from allennlp.common import Params

--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -11,7 +11,7 @@ from typing import Dict, Optional, List, Any, Iterable
 import torch
 
 from allennlp.common import Params
-from allennlp.common.checks import parse_cuda_device
+from allennlp.common.checks import parse_cuda_device, check_for_gpu
 from allennlp.common.tqdm import Tqdm
 from allennlp.common.util import lazy_groups_of
 from allennlp.data.instance import Instance
@@ -316,14 +316,11 @@ class CallbackTrainer(TrainerBase):
         num_epochs = params.pop_int("num_epochs", 20)
         cuda_device = parse_cuda_device(params.pop("cuda_device", -1))
 
-        if isinstance(cuda_device, list):
-            model_device = cuda_device[0]
-        else:
-            model_device = cuda_device
-        if model_device >= 0:
+        check_for_gpu(cuda_device)
+        if cuda_device >= 0:
             # Moving model to GPU here so that the optimizer state gets constructed on
             # the right device.
-            model = model.cuda(model_device)
+            model = model.cuda(cuda_device)
 
         parameters = [[n, p] for n, p in model.named_parameters() if p.requires_grad]
         optimizer = Optimizer.from_params(parameters, params.pop("optimizer"))

--- a/allennlp/training/callback_trainer.py
+++ b/allennlp/training/callback_trainer.py
@@ -10,7 +10,7 @@ from typing import Dict, Optional, List, Any, Iterable
 import torch
 
 from allennlp.common import Params
-from allennlp.common.checks import parse_cuda_device, check_for_gpu, ConfigurationError
+from allennlp.common.checks import parse_cuda_device, check_for_gpu
 from allennlp.common.tqdm import Tqdm
 from allennlp.data import Instance
 from allennlp.data.iterators.data_iterator import DataIterator, TensorDict
@@ -315,10 +315,6 @@ class CallbackTrainer(TrainerBase):
         cuda_device = parse_cuda_device(params.pop("cuda_device", -1))
 
         check_for_gpu(cuda_device)
-        if isinstance(cuda_device, list):
-            raise ConfigurationError(
-                "In allennlp 1.0, the Trainer cannot be passed multiple cuda devices."
-            )
         if cuda_device >= 0:
             # Moving model to GPU here so that the optimizer state gets constructed on
             # the right device.

--- a/allennlp/training/callbacks/log_to_tensorboard.py
+++ b/allennlp/training/callbacks/log_to_tensorboard.py
@@ -82,7 +82,7 @@ class LogToTensorboard(Callback):
             )
 
         if self.log_batch_size_period:
-            cur_batch = sum([training_util.get_batch_size(batch) for batch in trainer.batch_group])
+            cur_batch = training_util.get_batch_size(trainer.batch)
             self.cumulative_batch_size += cur_batch
             if (trainer.batches_this_epoch - 1) % self.log_batch_size_period == 0:
                 average = self.cumulative_batch_size / trainer.batches_this_epoch

--- a/allennlp/training/callbacks/validate.py
+++ b/allennlp/training/callbacks/validate.py
@@ -1,11 +1,9 @@
 from typing import Iterable, List, TYPE_CHECKING
 import logging
-import math
 
 import torch
 
 from allennlp.common.tqdm import Tqdm
-from allennlp.common.util import lazy_groups_of
 from allennlp.data.instance import Instance
 from allennlp.data.iterators import DataIterator
 from allennlp.training import util as training_util

--- a/allennlp/training/callbacks/validate.py
+++ b/allennlp/training/callbacks/validate.py
@@ -71,9 +71,9 @@ class Validate(Callback):
 
             batches_this_epoch = 0
             val_loss = 0
-            for batch_group in val_generator_tqdm:
+            for batch in val_generator_tqdm:
 
-                loss = trainer.batch_loss(batch_group, for_training=False)
+                loss = trainer.batch_loss(batch, for_training=False)
                 if loss is not None:
                     # You shouldn't necessarily have to compute a loss for validation, so we allow for
                     # `loss` to be None.  We need to be careful, though - `batches_this_epoch` is

--- a/allennlp/training/callbacks/validate.py
+++ b/allennlp/training/callbacks/validate.py
@@ -67,13 +67,8 @@ class Validate(Callback):
 
             trainer.model.eval()
 
-            num_gpus = len(trainer._cuda_devices)
-
-            raw_val_generator = self.iterator(self.instances, num_epochs=1, shuffle=False)
-            val_generator = lazy_groups_of(raw_val_generator, num_gpus)
-            num_validation_batches = math.ceil(
-                self.iterator.get_num_batches(self.instances) / num_gpus
-            )
+            val_generator = self.iterator(self.instances, num_epochs=1, shuffle=False)
+            num_validation_batches = self.iterator.get_num_batches(self.instances)
             val_generator_tqdm = Tqdm.tqdm(val_generator, total=num_validation_batches)
 
             batches_this_epoch = 0

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -12,7 +12,7 @@ import torch.optim.lr_scheduler
 from torch.nn.parallel import DistributedDataParallel
 
 from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError, parse_cuda_device
+from allennlp.common.checks import ConfigurationError, parse_cuda_device, check_for_gpu
 from allennlp.common.tqdm import Tqdm
 from allennlp.common.util import dump_metrics, gpu_memory_mb, peak_memory_mb, lazy_groups_of
 from allennlp.data.instance import Instance
@@ -764,14 +764,11 @@ class Trainer(TrainerBase):
         lr_scheduler_params = params.pop("learning_rate_scheduler", None)
         momentum_scheduler_params = params.pop("momentum_scheduler", None)
 
-        if isinstance(cuda_device, list):
-            model_device = cuda_device[0]
-        else:
-            model_device = cuda_device
-        if model_device >= 0:
+        check_for_gpu(cuda_device)
+        if cuda_device >= 0:
             # Moving model to GPU here so that the optimizer state gets constructed on
             # the right device.
-            model = model.cuda(model_device)
+            model = model.cuda(cuda_device)
 
         parameters = [[n, p] for n, p in model.named_parameters() if p.requires_grad]
         optimizer = Optimizer.from_params(parameters, params.pop("optimizer"))

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -764,6 +764,10 @@ class Trainer(TrainerBase):
         momentum_scheduler_params = params.pop("momentum_scheduler", None)
 
         check_for_gpu(cuda_device)
+        if isinstance(cuda_device, list):
+            raise ConfigurationError(
+                "In allennlp 1.0, the Trainer cannot be passed multiple cuda devices."
+            )
         if cuda_device >= 0:
             # Moving model to GPU here so that the optimizer state gets constructed on
             # the right device.

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -343,14 +343,14 @@ class Trainer(TrainerBase):
             train_generator_tqdm = train_generator
 
         cumulative_batch_size = 0
-        for batch_group in train_generator_tqdm:
+        for batch in train_generator_tqdm:
             batches_this_epoch += 1
             self._batch_num_total += 1
             batch_num_total = self._batch_num_total
 
             self.optimizer.zero_grad()
 
-            loss = self.batch_loss(batch_group, for_training=True)
+            loss = self.batch_loss(batch, for_training=True)
 
             if torch.isnan(loss):
                 raise ValueError("nan loss encountered")
@@ -417,7 +417,7 @@ class Trainer(TrainerBase):
                 self._tensorboard.log_histograms(self.model, histogram_parameters)
 
             if self._log_batch_size_period:
-                cur_batch = sum([training_util.get_batch_size(batch) for batch in batch_group])
+                cur_batch = training_util.get_batch_size(batch)
                 cumulative_batch_size += cur_batch
                 if (batches_this_epoch - 1) % self._log_batch_size_period == 0:
                     average = cumulative_batch_size / batches_this_epoch
@@ -470,9 +470,9 @@ class Trainer(TrainerBase):
         val_generator_tqdm = Tqdm.tqdm(val_generator, total=num_validation_batches)
         batches_this_epoch = 0
         val_loss = 0
-        for batch_group in val_generator_tqdm:
+        for batch in val_generator_tqdm:
 
-            loss = self.batch_loss(batch_group, for_training=False)
+            loss = self.batch_loss(batch, for_training=False)
             if loss is not None:
                 # You shouldn't necessarily have to compute a loss for validation, so we allow for
                 # `loss` to be None.  We need to be careful, though - `batches_this_epoch` is

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -764,10 +764,6 @@ class Trainer(TrainerBase):
         momentum_scheduler_params = params.pop("momentum_scheduler", None)
 
         check_for_gpu(cuda_device)
-        if isinstance(cuda_device, list):
-            raise ConfigurationError(
-                "In allennlp 1.0, the Trainer cannot be passed multiple cuda devices."
-            )
         if cuda_device >= 0:
             # Moving model to GPU here so that the optimizer state gets constructed on
             # the right device.

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -1,10 +1,9 @@
 import datetime
 import logging
-import math
 import os
 import time
 import traceback
-from typing import Dict, Optional, List, Tuple, Union, Iterable, Any
+from typing import Dict, Optional, Tuple, Union, Iterable, Any
 
 import torch
 import torch.distributed as dist
@@ -14,7 +13,7 @@ from torch.nn.parallel import DistributedDataParallel
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError, parse_cuda_device, check_for_gpu
 from allennlp.common.tqdm import Tqdm
-from allennlp.common.util import dump_metrics, gpu_memory_mb, peak_memory_mb, lazy_groups_of
+from allennlp.common.util import dump_metrics, gpu_memory_mb, peak_memory_mb
 from allennlp.data.instance import Instance
 from allennlp.data.iterators.data_iterator import DataIterator, TensorDict
 from allennlp.models.model import Model

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -284,13 +284,11 @@ class Trainer(TrainerBase):
     def rescale_gradients(self) -> Optional[float]:
         return training_util.rescale_gradients(self.model, self._grad_norm)
 
-    def batch_loss(self, batch_group: List[TensorDict], for_training: bool) -> torch.Tensor:
+    def batch_loss(self, batch: TensorDict, for_training: bool) -> torch.Tensor:
         """
         Does a forward pass on the given batches and returns the ``loss`` value in the result.
         If ``for_training`` is `True` also applies regularization penalty.
         """
-        assert len(batch_group) == 1
-        batch = batch_group[0]
         batch = nn_util.move_to_device(batch, self.cuda_device)
         output_dict = self._pytorch_model(**batch)
 

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -36,8 +36,8 @@ class TrainerBase(Registrable):
         rank: int = 0,
         world_size: int = 1,
     ) -> None:
-        check_for_gpu(cuda_device)
 
+        check_for_gpu(cuda_device)
         self._serialization_dir = serialization_dir
 
         if isinstance(cuda_device, list):

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -58,7 +58,6 @@ class TrainerBase(Registrable):
                 "`cuda_device` key in the experiment configuration."
             )
 
-        self._multiple_gpu = False
         self._cuda_devices = [cuda_device]
 
         self._distributed = distributed

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -58,7 +58,7 @@ class TrainerBase(Registrable):
                 "`cuda_device` key in the experiment configuration."
             )
 
-        self._cuda_devices = [cuda_device]
+        self.cuda_device = cuda_device
 
         self._distributed = distributed
         self._rank = rank
@@ -66,8 +66,8 @@ class TrainerBase(Registrable):
         self._world_size = world_size
 
     def _move_to_gpu(self, model: Model) -> Model:
-        if self._cuda_devices[0] != -1:
-            return model.cuda(self._cuda_devices[0])
+        if self.cuda_device != -1:
+            return model.cuda(self.cuda_device)
         else:
             return model
 

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -31,7 +31,7 @@ class TrainerBase(Registrable):
     def __init__(
         self,
         serialization_dir: str,
-        cuda_device: Union[int, List] = -1,
+        cuda_device: int = -1,
         distributed: bool = False,
         rank: int = 0,
         world_size: int = 1,
@@ -49,7 +49,7 @@ class TrainerBase(Registrable):
 
         if not isinstance(cuda_device, int):
             raise ConfigurationError(
-                "Expected an int or list for cuda_device, got {}".format(cuda_device)
+                "Expected an int for cuda_device, got {}".format(cuda_device)
             )
 
         if distributed and world_size <= 1:

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -9,7 +9,7 @@ rather than instantiating a ``Trainer`` yourself.
 
 
 import logging
-from typing import Dict, List, Union, Any
+from typing import Dict, Any
 
 from allennlp.common import Params, Registrable
 from allennlp.common.util import is_master
@@ -48,9 +48,7 @@ class TrainerBase(Registrable):
             )
 
         if not isinstance(cuda_device, int):
-            raise ConfigurationError(
-                "Expected an int for cuda_device, got {}".format(cuda_device)
-            )
+            raise ConfigurationError("Expected an int for cuda_device, got {}".format(cuda_device))
 
         if distributed and world_size <= 1:
             raise ConfigurationError(

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -11,8 +11,6 @@ import os
 import shutil
 
 import torch
-from torch.nn.parallel import replicate, parallel_apply
-from torch.nn.parallel.scatter_gather import gather
 
 from allennlp.common.checks import ConfigurationError, check_for_gpu
 from allennlp.common.params import Params
@@ -20,7 +18,6 @@ from allennlp.common.tqdm import Tqdm
 from allennlp.data.dataset_readers import DatasetReader
 from allennlp.data import Instance
 from allennlp.data.iterators import DataIterator
-from allennlp.data.iterators.data_iterator import TensorDict
 from allennlp.models.model import Model
 from allennlp.models.archival import CONFIG_NAME
 from allennlp.nn import util as nn_util

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -328,36 +328,6 @@ def create_serialization_dir(
         os.makedirs(serialization_dir, exist_ok=True)
 
 
-def data_parallel(
-    batch_group: List[TensorDict], model: Model, cuda_devices: List
-) -> Dict[str, torch.Tensor]:
-    """
-    Performs a forward pass using multiple GPUs.  This is a simplification
-    of torch.nn.parallel.data_parallel to support the allennlp model
-    interface.
-    """
-    assert len(batch_group) <= len(cuda_devices)
-
-    moved = [
-        nn_util.move_to_device(batch, device) for batch, device in zip(batch_group, cuda_devices)
-    ]
-
-    used_device_ids = cuda_devices[: len(moved)]
-    # Counterintuitively, it appears replicate expects the source device id to be the first element
-    # in the device id list. See torch.cuda.comm.broadcast_coalesced, which is called indirectly.
-    replicas = replicate(model, used_device_ids)
-
-    # We pass all our arguments as kwargs. Create a list of empty tuples of the
-    # correct shape to serve as (non-existent) positional arguments.
-    inputs = [()] * len(batch_group)
-    outputs = parallel_apply(replicas, inputs, moved, used_device_ids)
-
-    # Only the 'loss' is needed.
-    # a (num_gpu, ) tensor with loss on each GPU
-    losses = gather([output["loss"].unsqueeze(0) for output in outputs], used_device_ids[0], 0)
-    return {"loss": losses.mean()}
-
-
 def enable_gradient_clipping(model: Model, grad_clipping: Optional[float]) -> None:
     if grad_clipping is not None:
         for parameter in model.parameters():


### PR DESCRIPTION
- `DataParallel` is removed
- `Trainer` and `CallbackTrainer` now take a single cuda device
- `batch_loss` now takes only a single batch, rather than a list (prev required for DataParallel training).
- `trainer._cuda_devices` removed and replaced with `trainer.cuda_device`
- `trainer._multi_gpu` is removed
- Config for distributed training is now read from the top level of the config, rather than the `Trainer`, because it is not explicitly used to construct the `Trainer` object. This means we have to do less config inspection in `allennlp train`, as well as ensuring that `Trainer` configs work with all other commands.
