### PR TITLE
Tokenize with offsets: Hugging Face's transformers

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -314,18 +314,10 @@ def get_spacy_model(
                 f"Spacy models '{spacy_model_name}' not found.  Downloading and installing."
             )
             spacy_download(spacy_model_name)
-            # NOTE(mattg): The following four lines are a workaround suggested by Ines for spacy
-            # 2.1.0, which removed the linking that was done in spacy 2.0.  importlib doesn't find
-            # packages that were installed in the same python session, so the way `spacy_download`
-            # works in 2.1.0 is broken for this use case.  These four lines can probably be removed
-            # at some point in the future, once spacy has figured out a better way to handle this.
-            # See https://github.com/explosion/spaCy/issues/3435.
-            from spacy.cli import link
-            from spacy.util import get_package_path
 
-            package_path = get_package_path(spacy_model_name)
-            link(spacy_model_name, spacy_model_name, model_path=package_path)
-            spacy_model = spacy.load(spacy_model_name, disable=disable)
+            # Import the downloaded model module directly and load from there
+            spacy_model_module = __import__(spacy_model_name)
+            spacy_model = spacy_model_module.load(disable=disable)  # type: ignore
 
         LOADED_SPACY_MODELS[options] = spacy_model
     return LOADED_SPACY_MODELS[options]

--- a/allennlp/data/fields/__init__.py
+++ b/allennlp/data/fields/__init__.py
@@ -13,6 +13,7 @@ from allennlp.data.fields.list_field import ListField
 from allennlp.data.fields.metadata_field import MetadataField
 from allennlp.data.fields.sequence_field import SequenceField
 from allennlp.data.fields.sequence_label_field import SequenceLabelField
+from allennlp.data.fields.labels_field import LabelsField
 from allennlp.data.fields.span_field import SpanField
 from allennlp.data.fields.text_field import TextField
 from allennlp.data.fields.namespace_swapping_field import NamespaceSwappingField

--- a/allennlp/data/fields/labels_field.py
+++ b/allennlp/data/fields/labels_field.py
@@ -1,0 +1,133 @@
+from typing import Dict, List, Union, Set, Iterator
+import logging
+import textwrap
+
+from overrides import overrides
+import torch
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.common.util import pad_sequence_to_length
+from allennlp.data.fields.sequence_field import SequenceField
+from allennlp.data.vocabulary import Vocabulary
+
+logger = logging.getLogger(__name__)
+
+
+class LabelsField(SequenceField):
+    """
+    A ``LabelsField`` is a sequence of labels.
+
+    This field will get converted into a list of integer class ids, representing the correct class
+    for each element in the sequence.
+
+    Parameters
+    ----------
+    labels : ``Union[List[str], List[int]]``
+        A sequence of categorical labels, encoded as strings or integers.  These could be POS tags like [NN,
+        JJ, ...], BIO tags like [B-PERS, I-PERS, O, O, ...], or any other categorical tag sequence. If the
+        labels are encoded as integers, they will not be indexed using a vocab.
+    label_namespace : ``str``, optional (default='labels')
+        The namespace to use for converting tag strings into integers.  We convert tag strings to
+        integers for you, and this parameter tells the ``Vocabulary`` object which mapping from
+        strings to integers to use (so that "O" as a tag doesn't get the same id as "O" as a word).
+    """
+
+    # It is possible that users want to use this field with a namespace which uses OOV/PAD tokens.
+    # This warning will be repeated for every instantiation of this class (i.e for every data
+    # instance), spewing a lot of warnings so this class variable is used to only log a single
+    # warning per namespace.
+    _already_warned_namespaces: Set[str] = set()
+
+    def __init__(
+        self,
+        labels: Union[List[str], List[int]],
+        label_namespace: str = "labels",
+        padding_value: int = 0
+    ) -> None:
+        self.labels = labels
+        self._label_namespace = label_namespace
+        self._padding_value = padding_value
+
+        self._indexed_labels = None
+        self._maybe_warn_for_namespace(label_namespace)
+
+        self._skip_indexing = False
+        if all([isinstance(x, int) for x in labels]):
+            self._indexed_labels = labels
+            self._skip_indexing = True
+
+        elif not all([isinstance(x, str) for x in labels]):
+            raise ConfigurationError(
+                "LabelsFields must be passed either all "
+                "strings or all ints. Found labels {} with "
+                "types: {}.".format(labels, [type(x) for x in labels])
+            )
+
+    def _maybe_warn_for_namespace(self, label_namespace: str) -> None:
+        if not (self._label_namespace.endswith("labels") or self._label_namespace.endswith("tags")):
+            if label_namespace not in self._already_warned_namespaces:
+                logger.warning(
+                    "Your label namespace was '%s'. We recommend you use a namespace "
+                    "ending with 'labels' or 'tags', so we don't add UNK and PAD tokens by "
+                    "default to your vocabulary.  See documentation for "
+                    "`non_padded_namespaces` parameter in Vocabulary.",
+                    self._label_namespace,
+                )
+                self._already_warned_namespaces.add(label_namespace)
+
+    # Sequence methods
+    def __iter__(self) -> Iterator[Union[str, int]]:
+        return iter(self.labels)
+
+    def __getitem__(self, idx: int) -> Union[str, int]:
+        return self.labels[idx]
+
+    def __len__(self) -> int:
+        return len(self.labels)
+
+    @overrides
+    def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
+        if self._indexed_labels is None:
+            for label in self.labels:
+                counter[self._label_namespace][label] += 1  # type: ignore
+
+    @overrides
+    def index(self, vocab: Vocabulary):
+        if not self._skip_indexing:
+            self._indexed_labels = [
+                vocab.get_token_index(label, self._label_namespace)  # type: ignore
+                for label in self.labels
+            ]
+
+    @overrides
+    def get_padding_lengths(self) -> Dict[str, int]:
+        return {"num_tokens": len(self.labels)}
+
+    @overrides
+    def as_tensor(self, padding_lengths: Dict[str, int]) -> torch.Tensor:
+        desired_num_tokens = padding_lengths["num_tokens"]
+        padded_tags = pad_sequence_to_length(self._indexed_labels, desired_num_tokens, default_value=lambda: self._padding_value)
+        tensor = torch.LongTensor(padded_tags)
+        return tensor
+
+    def sequence_length(self) -> int:
+        return len(self.labels)
+
+    @overrides
+    def empty_field(self) -> "LabelsField":
+
+        # The empty_list here is needed for mypy
+        empty_list: List[str] = []
+        labels_field = LabelsField(empty_list)
+        labels_field._indexed_labels = empty_list
+        return labels_field
+
+    def __str__(self) -> str:
+        length = len(self.labels)
+        formatted_labels = "".join(
+            ["\t\t" + labels + "\n" for labels in textwrap.wrap(repr(self.labels), 100)]
+        )
+        return (
+            f"LabelsField of length {length} with "
+            f"labels:\n {formatted_labels} \t\tin namespace: '{self._label_namespace}'."
+        )

--- a/allennlp/data/fields/labels_field.py
+++ b/allennlp/data/fields/labels_field.py
@@ -42,7 +42,7 @@ class LabelsField(SequenceField):
         self,
         labels: Union[List[str], List[int]],
         label_namespace: str = "labels",
-        padding_value: int = 0
+        padding_value: int = 0,
     ) -> None:
         self.labels = labels
         self._label_namespace = label_namespace
@@ -106,7 +106,9 @@ class LabelsField(SequenceField):
     @overrides
     def as_tensor(self, padding_lengths: Dict[str, int]) -> torch.Tensor:
         desired_num_tokens = padding_lengths["num_tokens"]
-        padded_tags = pad_sequence_to_length(self._indexed_labels, desired_num_tokens, default_value=lambda: self._padding_value)
+        padded_tags = pad_sequence_to_length(
+            self._indexed_labels, desired_num_tokens, default_value=lambda: self._padding_value
+        )
         tensor = torch.LongTensor(padded_tags)
         return tensor
 

--- a/allennlp/data/tokenizers/__init__.py
+++ b/allennlp/data/tokenizers/__init__.py
@@ -6,7 +6,9 @@ tokenization.
 from allennlp.data.tokenizers.tokenizer import Token, Tokenizer
 from allennlp.data.tokenizers.spacy_tokenizer import SpacyTokenizer
 from allennlp.data.tokenizers.letters_digits_tokenizer import LettersDigitsTokenizer
-from allennlp.data.tokenizers.huggingface_transformers_tokenizer import HuggingfaceTransformersTokenizer
+from allennlp.data.tokenizers.huggingface_transformers_tokenizer import (
+    HuggingfaceTransformersTokenizer,
+)
 from allennlp.data.tokenizers.pretrained_transformer_tokenizer import PretrainedTransformerTokenizer
 from allennlp.data.tokenizers.pretrained_transformer_pre_tokenizer import (
     OpenAIPreTokenizer,

--- a/allennlp/data/tokenizers/__init__.py
+++ b/allennlp/data/tokenizers/__init__.py
@@ -6,6 +6,7 @@ tokenization.
 from allennlp.data.tokenizers.tokenizer import Token, Tokenizer
 from allennlp.data.tokenizers.spacy_tokenizer import SpacyTokenizer
 from allennlp.data.tokenizers.letters_digits_tokenizer import LettersDigitsTokenizer
+from allennlp.data.tokenizers.huggingface_transformers_tokenizer import HuggingfaceTransformersTokenizer
 from allennlp.data.tokenizers.pretrained_transformer_tokenizer import PretrainedTransformerTokenizer
 from allennlp.data.tokenizers.pretrained_transformer_pre_tokenizer import (
     OpenAIPreTokenizer,

--- a/allennlp/data/tokenizers/huggingface_transformers_tokenizer.py
+++ b/allennlp/data/tokenizers/huggingface_transformers_tokenizer.py
@@ -12,8 +12,12 @@ from transformers.tokenization_auto import AutoTokenizer
 
 logger = logging.getLogger(__name__)
 
-CONTROL_CHARS = u''.join(chr(c) for c in range(sys.maxunicode + 1) if unicodedata.category(chr(c))[0] == 'C')
+CONTROL_CHARS = u"".join(
+    chr(c) for c in range(sys.maxunicode + 1) if unicodedata.category(chr(c))[0] == "C"
+)
 SPIECE_UNDERLINE = u"▁"
+
+
 @Tokenizer.register("huggingface_transformers")
 class HuggingfaceTransformersTokenizer(Tokenizer):
     """

--- a/allennlp/data/tokenizers/huggingface_transformers_tokenizer.py
+++ b/allennlp/data/tokenizers/huggingface_transformers_tokenizer.py
@@ -5,6 +5,7 @@ from allennlp.data.tokenizers import Token, Tokenizer
 
 from transformers.tokenization_auto import AutoTokenizer
 
+
 @Tokenizer.register("huggingface_transformers")
 class HuggingfaceTransformersTokenizer(Tokenizer):
     """
@@ -42,10 +43,10 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
     kwargs : ``Dict[str, Any]
         Arguments to pass to the ``tokenize`` method
     """
-    def __init__(self, 
-                 pretrained_model: str,
-                 init_kwargs: Dict[str, Any] = {},
-                 kwargs: Dict[str, Any] = {}):
+
+    def __init__(
+        self, pretrained_model: str, init_kwargs: Dict[str, Any] = {}, kwargs: Dict[str, Any] = {}
+    ):
         self._pretrained_model = pretrained_model
         self._kwargs = kwargs
         self._tokenizer = AutoTokenizer.from_pretrained(pretrained_model, **init_kwargs)
@@ -67,8 +68,10 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
                 original_token_text = text[offset:]
             original_token_text = original_token_text.strip()
             if not original_token_text:
-                original_token_text = ' '
-            tokens_with_offsets.append(Token(text=tokens[i], idx=offset, original_text=original_token_text))
+                original_token_text = " "
+            tokens_with_offsets.append(
+                Token(text=tokens[i], idx=offset, original_text=original_token_text)
+            )
 
         return tokens_with_offsets
 
@@ -76,7 +79,8 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
     def encode_plus(self):
         return self._tokenizer.encode_plus
 
-    SPIECE_UNDERLINE = u'▁'
+    SPIECE_UNDERLINE = u"▁"
+
     def _detokenize_for_offsets(self, tok):
         """
         Remove any tokenization artifacts for sub-word tokens.
@@ -85,34 +89,42 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
         :param tok: the token from the tokenizer
         :return: the token as it would have looked (best approximation) in the original text
         """
-        if 't5' in self._pretrained_model:
+        if "t5" in self._pretrained_model:
             return self._tokenizer.sp_model.decode_pieces([tok])
-        elif 'distilbert' in self._pretrained_model:
-            if tok.startswith('##'):
+        elif "distilbert" in self._pretrained_model:
+            if tok.startswith("##"):
                 return tok[2:]
             return tok.strip()
-        elif 'albert' in self._pretrained_model:
-            return tok.replace(SPIECE_UNDERLINE, ' ').strip()
-        elif 'roberta' in self._pretrained_model:
-            return bytearray([self.byte_decoder[c] for c in tok]).decode('utf-8', errors=self.errors).strip()
-        elif 'bert-base-japanese' in self._pretrained_model:
-            if tok.startswith('##'):
+        elif "albert" in self._pretrained_model:
+            return tok.replace(SPIECE_UNDERLINE, " ").strip()
+        elif "roberta" in self._pretrained_model:
+            return (
+                bytearray([self.byte_decoder[c] for c in tok])
+                .decode("utf-8", errors=self.errors)
+                .strip()
+            )
+        elif "bert-base-japanese" in self._pretrained_model:
+            if tok.startswith("##"):
                 return tok[2:]
             return tok.strip()
-        elif 'bert' in self._pretrained_model:
-            if tok.startswith('##'):
+        elif "bert" in self._pretrained_model:
+            if tok.startswith("##"):
                 return tok[2:]
             return tok.strip()
-        elif 'openai-gpt' in self._pretrained_model:
-            return tok.replace('</w>', ' ').strip()
-        elif 'gpt2' in self._pretrained_model:
-            return bytearray([self.byte_decoder[c] for c in tok]).decode('utf-8', errors=self.errors).strip()
-        elif 'xlnet' in self._pretrained_model:
-            return tok.replace(SPIECE_UNDERLINE, ' ').strip()
-        elif 'xlm' in self._pretrained_model:
-            return tok.replace('</w>', ' ').strip()
-        elif 'ctrl' in self._pretrained_model:
-            if tok.endswith('@@'):
+        elif "openai-gpt" in self._pretrained_model:
+            return tok.replace("</w>", " ").strip()
+        elif "gpt2" in self._pretrained_model:
+            return (
+                bytearray([self.byte_decoder[c] for c in tok])
+                .decode("utf-8", errors=self.errors)
+                .strip()
+            )
+        elif "xlnet" in self._pretrained_model:
+            return tok.replace(SPIECE_UNDERLINE, " ").strip()
+        elif "xlm" in self._pretrained_model:
+            return tok.replace("</w>", " ").strip()
+        elif "ctrl" in self._pretrained_model:
+            if tok.endswith("@@"):
                 return tok[:-2]
             return tok.strip()
         return tok.strip()
@@ -159,6 +171,7 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
                 ``offsets``: list of offsets in the text corresponsing to ``tokens``
 
         """
+
         def get_max_space_length(text):
             max_space_length = 0
             count = False
@@ -179,10 +192,17 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
             """
             if len(lst) > len(other_lst):
                 return False
-            return other_lst[:len(lst)] == lst
+            return other_lst[: len(lst)] == lst
 
-        def get_comparison_tokens(tokenize_func, text, boundary_token_offset, token_offset, 
-                                search_length, cache, **tokenize_func_kwargs):
+        def get_comparison_tokens(
+            tokenize_func,
+            text,
+            boundary_token_offset,
+            token_offset,
+            search_length,
+            cache,
+            **tokenize_func_kwargs
+        ):
             search_text = text[boundary_token_offset : token_offset + search_length]
             if search_text not in cache:
                 cache[search_text] = tokenize_func(search_text, **tokenize_func_kwargs)
@@ -190,7 +210,7 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
 
         def remove_control_chars(text):
             for control_char in CONTROL_CHARS:
-                text = text.replace(control_char, '')
+                text = text.replace(control_char, "")
             return text
 
         def unescape_html_and_remove_control_chars(text):
@@ -199,7 +219,9 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
 
         # Tokenize text
         tokens = self._tokenizer.tokenize(text, **kwargs)
-        is_lower_casing = True # TODO: Recommended way to handle this? Keeping it always True would also be okay
+        is_lower_casing = (
+            True  # TODO: Recommended way to handle this? Keeping it always True would also be okay
+        )
 
         # Get maximum search length
         max_word_length = max([len(word) for word in text.split()])
@@ -228,10 +250,16 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
             search_length = 1
             comparison_tokens = []
             while True:
-                prev_comparison_tokens = comparison_tokens # for debugging
-                comparison_tokens = get_comparison_tokens(self._tokenizer.tokenize, text, 
-                                                            offsets[boundary_token_index], offset, search_length, 
-                                                            self._tokenization_cache, **kwargs)
+                prev_comparison_tokens = comparison_tokens  # for debugging
+                comparison_tokens = get_comparison_tokens(
+                    self._tokenizer.tokenize,
+                    text,
+                    offsets[boundary_token_index],
+                    offset,
+                    search_length,
+                    self._tokenization_cache,
+                    **kwargs
+                )
 
                 target_tokens = tokens[boundary_token_index : i + 1]
                 if is_prefix(target_tokens, comparison_tokens):
@@ -245,8 +273,8 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
                             detokenized = detokenized.lower()
                         # TODO: Remove accents with tokenization_xlm.lowercase_and_remove_accent? Will improve accuracy for XLM
                         index = matching_text.find(detokenized)
-                        if (index != -1):
-                            # Words that have a wordpiece tokenization that 
+                        if index != -1:
+                            # Words that have a wordpiece tokenization that
                             # doesn't contain the tokenization of its prefixes.
                             # Example for XLNet:
                             # text = "1603"
@@ -254,10 +282,10 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
                             # tokenization for "160": ["▁160"]
                             search_length = index + len(detokenized)
                         else:
-                            # For cases in which the current token won't be produced 
+                            # For cases in which the current token won't be produced
                             # without an additional character that is only part of the
                             # text that corresponds to the next tokens.
-                            # Example for XLNet: 
+                            # Example for XLNet:
                             # text = "How many points did the buccaneers need to tie in the first?"
                             # tokens = [..., '▁the', '▁', 'bu', 'cca', 'ne', 'ers', ...]
                             # target_tokens = ['▁']
@@ -299,9 +327,15 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
                     if len(text) == offset + search_length:
                         break
 
-                    comparison_tokens = get_comparison_tokens(self._tokenizer.tokenize, text, 
-                                                                offsets[boundary_token_index], offset, search_length + 1, 
-                                                                self._tokenization_cache, **kwargs)
+                    comparison_tokens = get_comparison_tokens(
+                        self._tokenizer.tokenize,
+                        text,
+                        offsets[boundary_token_index],
+                        offset,
+                        search_length + 1,
+                        self._tokenization_cache,
+                        **kwargs
+                    )
                     if is_prefix(comparison_tokens, target_tokens):
                         search_length += 1
                     else:
@@ -317,7 +351,7 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
         assert not match_error, "Unknown failure reason"
         # Relaxed for XLM, instead: # assert len(tokens) == len(offsets), "Number of tokens doesn't match the number of offsets"
         while len(tokens) != len(offsets):
-            offsets.append(len(text) - 1) # bad, but better than having nothing
+            offsets.append(len(text) - 1)  # bad, but better than having nothing
 
         # TODO: Move to a test?
         # Construct the original text that corresponds (up to spaces) to each token
@@ -328,8 +362,8 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
                 original_token_text = text[offset:next_offset]
             else:
                 original_token_text = text[offset:]
-            original_token_texts.append(original_token_text) 
-        # We assume whitespaces are a tokenization boundary, 
+            original_token_texts.append(original_token_text)
+        # We assume whitespaces are a tokenization boundary,
         # so we use this assumption to verify the alignment was valid
         # (considering special cases)
         for i, original_token_text in enumerate(original_token_texts):
@@ -341,7 +375,7 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
                 splits = len(original_token_text.strip().split())
             if splits >= 2 and html is not None:
                 # Don't warn about cases in which the tokenizer unescapes html entities (OpenAIGPTTokenizer)
-                # and ignores control characters. 
+                # and ignores control characters.
                 # Example: "98&#160; yards" might be tokenized as ["98", "yards"] but matched to ["98", "&#160; yards"]
                 original_token_text = unescape_html_and_remove_control_chars(original_token_text)
                 splits = len(original_token_text.strip().split())
@@ -349,15 +383,23 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
             if splits == 2:
                 # In XLM, "\"." is tokenized to [".", "\""] and similarly "\",", so it's not possible to create contiguous offsets.
                 # Also in XLM, "30\xa0000" is tokenized to ['3', '0.', '000</w>'] which is problematic.
-                logger.warning("""Possible error: 
+                logger.warning(
+                    """Possible error: 
                                 A token is consuming text of another token as well, 
                                 probably due to a bad character in the input or out-of-order tokenization. 
-                                Token #%d, %s""" % (i, original_token_text))
+                                Token #%d, %s"""
+                    % (i, original_token_text)
+                )
 
             # Not expected to happen
-            assert splits <= 2, """Error: 
+            assert (
+                splits <= 2
+            ), """Error: 
                             A token is consuming text of multiple other tokens as well, 
                             probably due to a bad character in the input or out-of-order tokenization. 
-                            Token #%d, %s""" % (i, original_token_text)
+                            Token #%d, %s""" % (
+                i,
+                original_token_text,
+            )
 
         return tokens, offsets

--- a/allennlp/data/tokenizers/huggingface_transformers_tokenizer.py
+++ b/allennlp/data/tokenizers/huggingface_transformers_tokenizer.py
@@ -1,0 +1,363 @@
+from typing import Dict, List, Union, Tuple, Any
+from overrides import overrides
+
+from allennlp.data.tokenizers import Token, Tokenizer
+
+from transformers.tokenization_auto import AutoTokenizer
+
+@Tokenizer.register("huggingface_transformers")
+class HuggingfaceTransformersTokenizer(Tokenizer):
+    """
+    A ``HuggingfaceTransformersTokenizer`` uses a model from HuggingFace's
+    ``transformers`` library to tokenize some input text.  This often means wordpieces
+    (where ``'AllenNLP is awesome'`` might get split into ``['Allen', '##NL', '##P', 'is',
+    'awesome']``), but it could also use byte-pair encoding, or some other tokenization, depending
+    on the pretrained model that you're using.
+
+    We take a model name as an input parameter, which we will pass to
+    ``AutoTokenizer.from_pretrained``.
+
+    A suggestion for a usage *without* TokenIndexer, in order to fully utilize the Hugging Face's API:
+    1. Tokenize with ``tokenize`` or ``tokenize_with_offsets``
+    2. Encode the tokens with ``encode_plus``, in order to get the appropriate form the pretrained model expects
+    3. Create a LabelsField field with the encoded tokens
+    4. Optioanlly, add fields such as `token_type_ids` and `special_tokens_mask`
+
+    Example:
+        tokens = tokenizer.tokenize(text)
+        encoded_inputs = self._tokenizer.encode_plus([token.text for token in tokens], 
+                                    add_special_tokens=True, 
+                                    return_token_type_ids=True, 
+                                    return_special_tokens_mask=True)
+        fields: Dict[str, Field] = {}
+        fields['tokens'] = LabelsField(encoded_inputs['input_ids'])
+        fields['token_type_ids'] = LabelsField(encoded_inputs['token_type_ids'])
+        fields['special_tokens_mask'] = LabelsField(encoded_inputs['special_tokens_mask'])
+        fields['pad_mask'] = LabelsField([1] * len(question_passage_tokens)) # For right padding
+
+    pretrained_model : ``str``
+        The name of the tokenizer to use.
+    init_kwargs : ``Dict[str, Any]
+        Arguments to pass to the constructor of the tokenizer
+    kwargs : ``Dict[str, Any]
+        Arguments to pass to the ``tokenize`` method
+    """
+    def __init__(self, 
+                 pretrained_model: str,
+                 init_kwargs: Dict[str, Any] = {},
+                 kwargs: Dict[str, Any] = {}):
+        self._pretrained_model = pretrained_model
+        self._kwargs = kwargs
+        self._tokenizer = AutoTokenizer.from_pretrained(pretrained_model, **init_kwargs)
+        self._tokenization_cache = {}
+
+    @overrides
+    def tokenize(self, text: str) -> List[Token]:
+        return [Token(text=token) for token in self._tokenizer.tokenize(text, **self._kwargs)]
+
+    def tokenize_with_offsets(self, text: str) -> List[Token]:
+        tokens, offsets = self._tokenize_with_offsets(text, **self._kwargs)
+
+        tokens_with_offsets = []
+        for i, offset in enumerate(offsets):
+            if i < len(offsets) - 1:
+                next_offset = offsets[i + 1]
+                original_token_text = text[offset:next_offset]
+            else:
+                original_token_text = text[offset:]
+            original_token_text = original_token_text.strip()
+            if not original_token_text:
+                original_token_text = ' '
+            tokens_with_offsets.append(Token(text=tokens[i], idx=offset, original_text=original_token_text))
+
+        return tokens_with_offsets
+
+    @property
+    def encode_plus(self):
+        return self._tokenizer.encode_plus
+
+    SPIECE_UNDERLINE = u'▁'
+    def _detokenize_for_offsets(self, tok):
+        """
+        Remove any tokenization artifacts for sub-word tokens.
+        Used by tokenize_with_offsets to match tokens back in the original text.
+         (like ## prefix for BERT)
+        :param tok: the token from the tokenizer
+        :return: the token as it would have looked (best approximation) in the original text
+        """
+        if 't5' in self._pretrained_model:
+            return self._tokenizer.sp_model.decode_pieces([tok])
+        elif 'distilbert' in self._pretrained_model:
+            if tok.startswith('##'):
+                return tok[2:]
+            return tok.strip()
+        elif 'albert' in self._pretrained_model:
+            return tok.replace(SPIECE_UNDERLINE, ' ').strip()
+        elif 'roberta' in self._pretrained_model:
+            return bytearray([self.byte_decoder[c] for c in tok]).decode('utf-8', errors=self.errors).strip()
+        elif 'bert-base-japanese' in self._pretrained_model:
+            if tok.startswith('##'):
+                return tok[2:]
+            return tok.strip()
+        elif 'bert' in self._pretrained_model:
+            if tok.startswith('##'):
+                return tok[2:]
+            return tok.strip()
+        elif 'openai-gpt' in self._pretrained_model:
+            return tok.replace('</w>', ' ').strip()
+        elif 'gpt2' in self._pretrained_model:
+            return bytearray([self.byte_decoder[c] for c in tok]).decode('utf-8', errors=self.errors).strip()
+        elif 'xlnet' in self._pretrained_model:
+            return tok.replace(SPIECE_UNDERLINE, ' ').strip()
+        elif 'xlm' in self._pretrained_model:
+            return tok.replace('</w>', ' ').strip()
+        elif 'ctrl' in self._pretrained_model:
+            if tok.endswith('@@'):
+                return tok[:-2]
+            return tok.strip()
+        return tok.strip()
+
+    def _tokenize_with_offsets(self, text, **kwargs):
+        """ Converts a string in a sequence of tokens (string), using the tokenizer
+            and also keeps track of the token offsets relative to the original text.
+            Split in words for word-based vocabulary or sub-words for sub-word-based
+            vocabularies (BPE/SentencePieces/WordPieces).
+
+            Take care of added tokens.
+
+            Keep track of token offsets by trying to progressively tokenize the text character by character, 
+            and consume matching tokens along the way.
+            For efficiency, parts of the text that were already matched should be discarded.
+            However, since some tokenizations are dependent on neighboring past text,
+            in cases of mismatch we fall back to use previously matched parts of the text.
+            For some tokenizers, more than a single token can be generated for a single character.
+            In such cases, the nonfinal tokens will have the same offset as the final token.
+
+            Tested with the following:
+            - OpenAIGPTTokenizer
+            - TransfoXLTokenizer
+            - DistilBertTokenizer
+            - BertTokenizer
+            - BertJapaneseTokenizer
+            - RobertaTokenizer
+            - GPT2Tokenizer
+            - XLNetTokenizer
+            - AlbertTokenizer
+            - CTRLTokenizer
+            - XLMTokenizer - Problem in the tokenization, specifics are in the comments
+            - T5Tokenizer
+
+            Args:
+                text: The sequence to be encoded.
+                **kwargs: passed to the child `self.tokenize()` method
+
+            Return:
+                A tuple of shape::
+                    (tokens: list[str], offsets: list[int])
+            With the fields:
+                ``tokens``: list of tokens
+                ``offsets``: list of offsets in the text corresponsing to ``tokens``
+
+        """
+        def get_max_space_length(text):
+            max_space_length = 0
+            count = False
+            for i, c in enumerate(text):
+                if c == " ":
+                    if not count:
+                        count = True
+                        start_index = i
+                else:
+                    if count:
+                        count = False
+                        max_space_length = max(max_space_length, i - start_index)
+            return max_space_length
+
+        def is_prefix(lst, other_lst):
+            """
+            Checks if `lst` is a prefix of `other_lst` 
+            """
+            if len(lst) > len(other_lst):
+                return False
+            return other_lst[:len(lst)] == lst
+
+        def get_comparison_tokens(tokenize_func, text, boundary_token_offset, token_offset, 
+                                search_length, cache, **tokenize_func_kwargs):
+            search_text = text[boundary_token_offset : token_offset + search_length]
+            if search_text not in cache:
+                cache[search_text] = tokenize_func(search_text, **tokenize_func_kwargs)
+            return cache[search_text]
+
+        def remove_control_chars(text):
+            for control_char in CONTROL_CHARS:
+                text = text.replace(control_char, '')
+            return text
+
+        def unescape_html_and_remove_control_chars(text):
+            text = html.unescape(text)
+            return remove_control_chars(text)
+
+        # Tokenize text
+        tokens = self._tokenizer.tokenize(text, **kwargs)
+        is_lower_casing = True # TODO: Recommended way to handle this? Keeping it always True would also be okay
+
+        # Get maximum search length
+        max_word_length = max([len(word) for word in text.split()])
+        max_space_length = get_max_space_length(text)
+        max_search_length = max_word_length + max_space_length
+
+        # Initialize token iteration variables
+        boundary_token_index = 0
+        prev_boundary_token_indexes = [0]
+        offsets = [0]
+        i = 0
+        retry = 0
+        while True:
+            token = tokens[i]
+            match_error = False
+
+            if retry > 0:
+                # The tokenization from the boundary doesn't match the text, retrying with a previous boundary
+                boundary_token_index = prev_boundary_token_indexes[-retry]
+            else:
+                # Try boundary of the current token
+                boundary_token_index = i
+
+            # Initialize search variables
+            offset = offsets[i]
+            search_length = 1
+            comparison_tokens = []
+            while True:
+                prev_comparison_tokens = comparison_tokens # for debugging
+                comparison_tokens = get_comparison_tokens(self._tokenizer.tokenize, text, 
+                                                            offsets[boundary_token_index], offset, search_length, 
+                                                            self._tokenization_cache, **kwargs)
+
+                target_tokens = tokens[boundary_token_index : i + 1]
+                if is_prefix(target_tokens, comparison_tokens):
+                    # Found a tokenization match
+                    if len(comparison_tokens) > len(target_tokens):
+                        # Handle special cases
+                        matching_text = text[offset : offset + search_length]
+                        detokenized = self._detokenize_for_offsets(token)
+                        if is_lower_casing:
+                            matching_text = matching_text.lower()
+                            detokenized = detokenized.lower()
+                        # TODO: Remove accents with tokenization_xlm.lowercase_and_remove_accent? Will improve accuracy for XLM
+                        index = matching_text.find(detokenized)
+                        if (index != -1):
+                            # Words that have a wordpiece tokenization that 
+                            # doesn't contain the tokenization of its prefixes.
+                            # Example for XLNet:
+                            # text = "1603"
+                            # tokens = ["▁16", "03"]
+                            # tokenization for "160": ["▁160"]
+                            search_length = index + len(detokenized)
+                        else:
+                            # For cases in which the current token won't be produced 
+                            # without an additional character that is only part of the
+                            # text that corresponds to the next tokens.
+                            # Example for XLNet: 
+                            # text = "How many points did the buccaneers need to tie in the first?"
+                            # tokens = [..., '▁the', '▁', 'bu', 'cca', 'ne', 'ers', ...]
+                            # target_tokens = ['▁']
+                            # comparison_tokens = ['▁', 'b']
+                            # prev_comparison_tokens = ['']
+                            # OR
+                            # For characters that are tokenized to two or more tokens
+                            search_length = 0
+
+                    # Store successful boundary
+                    if prev_boundary_token_indexes[-1] != boundary_token_index:
+                        prev_boundary_token_indexes.append(boundary_token_index)
+                    retry = 0
+                    break
+
+                if search_length == max_search_length:
+                    # The tokenization from the boundary doesn't match the text, retry with a previous boundary,
+                    # keep retrying until all the previous successful boundaries are used
+                    match_error = True
+                    if retry < len(prev_boundary_token_indexes):
+                        retry += 1
+                    else:
+                        retry = 0
+                    break
+
+                # Search step
+                search_length += 1
+
+            if match_error:
+                if retry > 0:
+                    continue
+                # Failed to match offsets to the tokens
+                break
+
+            # Keep consuming characters until there's no tokenization match.
+            # Required due to special characters such as in "Moskva: Russkiĭ fond sodeĭstviii︠a︡ obrazovanii︠u︡ i nauke"
+            if comparison_tokens == target_tokens:
+                while True:
+                    if len(text) == offset + search_length:
+                        break
+
+                    comparison_tokens = get_comparison_tokens(self._tokenizer.tokenize, text, 
+                                                                offsets[boundary_token_index], offset, search_length + 1, 
+                                                                self._tokenization_cache, **kwargs)
+                    if is_prefix(comparison_tokens, target_tokens):
+                        search_length += 1
+                    else:
+                        break
+
+            if len(text) != offset + search_length:
+                # Add the next token offset only if the end of the text wasn't reached
+                offsets.append(offset + search_length)
+            else:
+                break
+            i += 1
+
+        assert not match_error, "Unknown failure reason"
+        # Relaxed for XLM, instead: # assert len(tokens) == len(offsets), "Number of tokens doesn't match the number of offsets"
+        while len(tokens) != len(offsets):
+            offsets.append(len(text) - 1) # bad, but better than having nothing
+
+        # TODO: Move to a test?
+        # Construct the original text that corresponds (up to spaces) to each token
+        original_token_texts = []
+        for i, offset in enumerate(offsets):
+            if i < len(offsets) - 1:
+                next_offset = offsets[i + 1]
+                original_token_text = text[offset:next_offset]
+            else:
+                original_token_text = text[offset:]
+            original_token_texts.append(original_token_text) 
+        # We assume whitespaces are a tokenization boundary, 
+        # so we use this assumption to verify the alignment was valid
+        # (considering special cases)
+        for i, original_token_text in enumerate(original_token_texts):
+            splits = len(original_token_text.strip().split())
+            if splits >= 2:
+                # Don't warn about cases in which the tokenizer ignores control characters.
+                # Example: "a \ufeff test" might be tokenized as ["a", "test"] but matched to ["a \ufeff", "test"]
+                original_token_text = remove_control_chars(original_token_text)
+                splits = len(original_token_text.strip().split())
+            if splits >= 2 and html is not None:
+                # Don't warn about cases in which the tokenizer unescapes html entities (OpenAIGPTTokenizer)
+                # and ignores control characters. 
+                # Example: "98&#160; yards" might be tokenized as ["98", "yards"] but matched to ["98", "&#160; yards"]
+                original_token_text = unescape_html_and_remove_control_chars(original_token_text)
+                splits = len(original_token_text.strip().split())
+
+            if splits == 2:
+                # In XLM, "\"." is tokenized to [".", "\""] and similarly "\",", so it's not possible to create contiguous offsets.
+                # Also in XLM, "30\xa0000" is tokenized to ['3', '0.', '000</w>'] which is problematic.
+                logger.warning("""Possible error: 
+                                A token is consuming text of another token as well, 
+                                probably due to a bad character in the input or out-of-order tokenization. 
+                                Token #%d, %s""" % (i, original_token_text))
+
+            # Not expected to happen
+            assert splits <= 2, """Error: 
+                            A token is consuming text of multiple other tokens as well, 
+                            probably due to a bad character in the input or out-of-order tokenization. 
+                            Token #%d, %s""" % (i, original_token_text)
+
+        return tokens, offsets

--- a/allennlp/data/tokenizers/huggingface_transformers_tokenizer.py
+++ b/allennlp/data/tokenizers/huggingface_transformers_tokenizer.py
@@ -58,7 +58,7 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
         self._pretrained_model = pretrained_model
         self._kwargs = kwargs
         self._tokenizer = AutoTokenizer.from_pretrained(pretrained_model, **init_kwargs)
-        self._tokenization_cache = {}
+        self._tokenization_cache: Dict[str, str] = {}
 
     @overrides
     def tokenize(self, text: str) -> List[Token]:

--- a/allennlp/data/tokenizers/huggingface_transformers_tokenizer.py
+++ b/allennlp/data/tokenizers/huggingface_transformers_tokenizer.py
@@ -183,6 +183,8 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
         """
 
         def get_max_space_length(text):
+            original_text = text
+            text = unescape_html_and_remove_control_chars(text)
             max_space_length = 0
             count = False
             for i, c in enumerate(text):
@@ -194,7 +196,8 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
                     if count:
                         count = False
                         max_space_length = max(max_space_length, i - start_index)
-            return max_space_length
+            # with a safety margin
+            return max_space_length + (len(original_text) - len(text))
 
         def is_prefix(lst, other_lst):
             """
@@ -385,7 +388,7 @@ class HuggingfaceTransformersTokenizer(Tokenizer):
                 # Example: "a \ufeff test" might be tokenized as ["a", "test"] but matched to ["a \ufeff", "test"]
                 original_token_text = remove_control_chars(original_token_text)
                 splits = len(original_token_text.strip().split())
-            if splits >= 2 and html is not None:
+            if splits >= 2:
                 # Don't warn about cases in which the tokenizer unescapes html entities (OpenAIGPTTokenizer)
                 # and ignores control characters.
                 # Example: "98&#160; yards" might be tokenized as ["98", "yards"]

--- a/allennlp/data/tokenizers/token.py
+++ b/allennlp/data/tokenizers/token.py
@@ -31,6 +31,8 @@ class Token(NamedTuple):
         still use a character-level representation in addition to a hash-based word embedding.
     type_id : ``int``, optional
         Token type id used by some pretrained language models like original BERT
+    original_text: ``str``, optional
+        The original text that was mapped to this token
 
         The other fields on ``Token`` follow the fields on spacy's ``Token`` object; this is one we
         added, similar to spacy's ``lex_id``.
@@ -45,6 +47,7 @@ class Token(NamedTuple):
     ent_type_: str = None
     text_id: int = None
     type_id: int = None
+    original_text: str = None
 
     def __str__(self):
         return self.text
@@ -64,4 +67,5 @@ def show_token(token: Token) -> str:
         f"(ent_type: {token.ent_type_}) "
         f"(text_id: {token.text_id}) "
         f"(type_id: {token.type_id}) "
+        f"(original_text: {token.original_text})"
     )

--- a/allennlp/tests/data/fields/labels_field_test.py
+++ b/allennlp/tests/data/fields/labels_field_test.py
@@ -1,0 +1,89 @@
+from collections import defaultdict
+
+import pytest
+import numpy
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data import Token, Vocabulary
+from allennlp.data.token_indexers import SingleIdTokenIndexer
+
+
+class TestLabelsField(AllenNlpTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_count_vocab_items_correctly_indexes_tags(self):
+        tags = ["B", "I", "O", "O", "O"]
+        labels_field = LabelsField(tags, self.text, label_namespace="labels")
+
+        counter = defaultdict(lambda: defaultdict(int))
+        labels_field.count_vocab_items(counter)
+
+        assert counter["labels"]["B"] == 1
+        assert counter["labels"]["I"] == 1
+        assert counter["labels"]["O"] == 3
+        assert set(counter.keys()) == {"labels"}
+
+    def test_index_converts_field_correctly(self):
+        vocab = Vocabulary()
+        b_index = vocab.add_token_to_namespace("B", namespace="*labels")
+        i_index = vocab.add_token_to_namespace("I", namespace="*labels")
+        o_index = vocab.add_token_to_namespace("O", namespace="*labels")
+
+        tags = ["B", "I", "O", "O", "O"]
+        labels_field = LabelsField(tags, label_namespace="*labels")
+        labels_field.index(vocab)
+
+        assert labels_field._indexed_labels == [b_index, i_index, o_index, o_index, o_index]
+
+    def test_as_tensor_produces_integer_targets(self):
+        vocab = Vocabulary()
+        vocab.add_token_to_namespace("B", namespace="*labels")
+        vocab.add_token_to_namespace("I", namespace="*labels")
+        vocab.add_token_to_namespace("O", namespace="*labels")
+
+        tags = ["B", "I", "O", "O", "O"]
+        labels_field = LabelsField(tags, label_namespace="*labels")
+        labels_field.index(vocab)
+        padding_lengths = labels_field.get_padding_lengths()
+        tensor = labels_field.as_tensor(padding_lengths).detach().cpu().numpy()
+        numpy.testing.assert_array_almost_equal(tensor, numpy.array([0, 1, 2, 2, 2]))
+
+    def test_labels_field_raises_on_incorrect_type(self):
+
+        with pytest.raises(ConfigurationError):
+            _ = LabelsField([[], [], [], [], []])
+
+    def test_class_variables_for_namespace_warnings_work_correctly(self):
+
+        tags = ["B", "I", "O", "O", "O"]
+        assert "text" not in LabelsField._already_warned_namespaces
+        with self.assertLogs(logger="allennlp.data.fields.labels_field", level="WARNING"):
+            _ = LabelsField(tags, label_namespace="text")
+
+        # We've warned once, so we should have set the class variable to False.
+        assert "text" in LabelsField._already_warned_namespaces
+        with pytest.raises(AssertionError):
+            with self.assertLogs(
+                logger="allennlp.data.fields.labels_field", level="WARNING"
+            ):
+                _ = LabelsField(tags, label_namespace="text")
+
+        # ... but a new namespace should still log a warning.
+        assert "text2" not in LabelsField._already_warned_namespaces
+        with self.assertLogs(logger="allennlp.data.fields.labels_field", level="WARNING"):
+            _ = LabelsField(tags, label_namespace="text2")
+
+    def test_printing_doesnt_crash(self):
+        tags = ["B", "I", "O", "O", "O"]
+        labels_field = LabelField(tags, label_namespace="labels")
+        print(labels_field)
+
+    def test_sequence_methods(self):
+        tags = ["B", "I", "O", "O", "O"]
+        labels_field = LabelField(tags, label_namespace="labels")
+
+        assert len(labels_field) == 5
+        assert labels_field[1] == "I"
+        assert [label for label in labels_field] == tags

--- a/allennlp/tests/data/fields/labels_field_test.py
+++ b/allennlp/tests/data/fields/labels_field_test.py
@@ -6,6 +6,7 @@ import numpy
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Token, Vocabulary
+from allennlp.data.fields import LabelsField
 from allennlp.data.token_indexers import SingleIdTokenIndexer
 
 
@@ -15,7 +16,7 @@ class TestLabelsField(AllenNlpTestCase):
 
     def test_count_vocab_items_correctly_indexes_tags(self):
         tags = ["B", "I", "O", "O", "O"]
-        labels_field = LabelsField(tags, self.text, label_namespace="labels")
+        labels_field = LabelsField(tags, label_namespace="labels")
 
         counter = defaultdict(lambda: defaultdict(int))
         labels_field.count_vocab_items(counter)
@@ -65,9 +66,7 @@ class TestLabelsField(AllenNlpTestCase):
         # We've warned once, so we should have set the class variable to False.
         assert "text" in LabelsField._already_warned_namespaces
         with pytest.raises(AssertionError):
-            with self.assertLogs(
-                logger="allennlp.data.fields.labels_field", level="WARNING"
-            ):
+            with self.assertLogs(logger="allennlp.data.fields.labels_field", level="WARNING"):
                 _ = LabelsField(tags, label_namespace="text")
 
         # ... but a new namespace should still log a warning.
@@ -77,12 +76,12 @@ class TestLabelsField(AllenNlpTestCase):
 
     def test_printing_doesnt_crash(self):
         tags = ["B", "I", "O", "O", "O"]
-        labels_field = LabelField(tags, label_namespace="labels")
+        labels_field = LabelsField(tags, label_namespace="labels")
         print(labels_field)
 
     def test_sequence_methods(self):
         tags = ["B", "I", "O", "O", "O"]
-        labels_field = LabelField(tags, label_namespace="labels")
+        labels_field = LabelsField(tags, label_namespace="labels")
 
         assert len(labels_field) == 5
         assert labels_field[1] == "I"

--- a/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
@@ -12,7 +12,9 @@ class TestHuggingTransformersTokenizer(AllenNlpTestCase):
         assert tokens == expected_tokens
 
         # tokenize with offsets
-        tokens, offsets = list(map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)])))
+        tokens, offsets = list(
+            map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)]))
+        )
         assert tokens == expected_tokens
         assert offsets == [0, 1, 3, 10, 15, 16, 19, 27]
 
@@ -20,21 +22,14 @@ class TestHuggingTransformersTokenizer(AllenNlpTestCase):
         tokenizer = HuggingfaceTransformersTokenizer("bert-base-cased")
 
         sentence = "A, [MASK] AllenNLP sentence."
-        expected_tokens = [
-            "A",
-            ",",
-            "[MASK]",
-            "Allen",
-            "##NL",
-            "##P",
-            "sentence",
-            "."
-        ]
+        expected_tokens = ["A", ",", "[MASK]", "Allen", "##NL", "##P", "sentence", "."]
         tokens = [t.text for t in tokenizer.tokenize(sentence)]
         assert tokens == expected_tokens
 
         # tokenize with offsets
-        tokens, offsets = list(map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)])))
+        tokens, offsets = list(
+            map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)]))
+        )
         assert tokens == expected_tokens
         assert offsets == [0, 1, 3, 10, 15, 17, 19, 27]
 
@@ -55,6 +50,8 @@ class TestHuggingTransformersTokenizer(AllenNlpTestCase):
         assert tokens == expected_tokens
 
         # tokenize with offsets
-        tokens, offsets = list(map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)])))
+        tokens, offsets = list(
+            map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)]))
+        )
         assert tokens == expected_tokens
         assert offsets == [0, 1, 3, 10, 15, 17, 19, 27]

--- a/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
@@ -55,3 +55,62 @@ class TestHuggingTransformersTokenizer(AllenNlpTestCase):
         )
         assert tokens == expected_tokens
         assert offsets == [0, 1, 3, 10, 15, 17, 19, 27]
+
+    def test_tokenize_with_offsets_prefix_issue(self):
+        """ For words that have a wordpiece tokenization that
+            doesn't contain the tokenization of its prefixes.
+            Example for XLNet:
+            text = "1603"
+            tokens = ["▁16", "03"]
+            tokenization for "160": ["▁160"]
+        """
+        sentence = "1603"
+        expected_tokens = ["▁16", "03"]
+        tokenizer = HuggingfaceTransformersTokenizer("xlnet-base-cased")
+
+        # tokenize with offsets
+        tokens, offsets = list(
+            map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)]))
+        )
+        assert tokens == expected_tokens
+        assert offsets == [0, 2]
+
+    def test_tokenize_with_offsets_additional_char_issue(self):
+        """ For cases in which the current token won't be produced
+            without an additional character that is only part of the
+            text that corresponds to the next tokens.
+            Example for XLNet:
+            text = "How many points did the buccaneers need to tie in the first?"
+            tokens = [..., '▁the', '▁', 'bu', 'cca', 'ne', 'ers', ...]
+            target_tokens = ['▁']
+            comparison_tokens = ['▁', 'b']
+            prev_comparison_tokens = ['']
+        """
+        sentence = "How many points did the buccaneers need to tie in the first?"
+        expected_tokens = [
+            "▁How",
+            "▁many",
+            "▁points",
+            "▁did",
+            "▁the",
+            "▁",
+            "bu",
+            "cca",
+            "ne",
+            "ers",
+            "▁need",
+            "▁to",
+            "▁tie",
+            "▁in",
+            "▁the",
+            "▁first",
+            "?",
+        ]
+        tokenizer = HuggingfaceTransformersTokenizer("xlnet-base-cased")
+
+        # tokenize with offsets
+        tokens, offsets = list(
+            map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)]))
+        )
+        assert tokens == expected_tokens
+        assert offsets == [0, 4, 9, 16, 20, 24, 24, 26, 29, 31, 35, 40, 43, 47, 50, 54, 59]

--- a/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
@@ -1,0 +1,60 @@
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.tokenizers import HuggingfaceTransformersTokenizer
+
+
+class TestHuggingTransformersTokenizer(AllenNlpTestCase):
+    def test_splits_roberta(self):
+        tokenizer = HuggingfaceTransformersTokenizer("roberta-base")
+
+        sentence = "A, <mask> AllenNLP sentence."
+        expected_tokens = ["A", ",", "<mask>", "Allen", "N", "LP", "Ġsentence", "."]
+        tokens = [t.text for t in tokenizer.tokenize(sentence)]
+        assert tokens == expected_tokens
+
+        # tokenize with offsets
+        tokens, offsets = list(map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)])))
+        assert tokens == expected_tokens
+        assert offsets == [0, 1, 3, 10, 15, 16, 19, 27]
+
+    def test_splits_cased_bert(self):
+        tokenizer = HuggingfaceTransformersTokenizer("bert-base-cased")
+
+        sentence = "A, [MASK] AllenNLP sentence."
+        expected_tokens = [
+            "A",
+            ",",
+            "[MASK]",
+            "Allen",
+            "##NL",
+            "##P",
+            "sentence",
+            "."
+        ]
+        tokens = [t.text for t in tokenizer.tokenize(sentence)]
+        assert tokens == expected_tokens
+
+        # tokenize with offsets
+        tokens, offsets = list(map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)])))
+        assert tokens == expected_tokens
+        assert offsets == [0, 1, 3, 10, 15, 17, 19, 27]
+
+    def test_splits_uncased_bert(self):
+        sentence = "A, [MASK] AllenNLP sentence."
+        expected_tokens = [
+            "a",
+            ",",
+            "[MASK]",
+            "allen",
+            "##nl",
+            "##p",
+            "sentence",
+            ".",
+        ]
+        tokenizer = HuggingfaceTransformersTokenizer("bert-base-uncased")
+        tokens = [t.text for t in tokenizer.tokenize(sentence)]
+        assert tokens == expected_tokens
+
+        # tokenize with offsets
+        tokens, offsets = list(map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)])))
+        assert tokens == expected_tokens
+        assert offsets == [0, 1, 3, 10, 15, 17, 19, 27]

--- a/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
@@ -126,3 +126,15 @@ class TestHuggingTransformersTokenizer(AllenNlpTestCase):
         )
         assert tokens == expected_tokens
         assert offsets == [0, 2]
+
+    def test_tokenize_with_offsets_partial_correspondence(self):
+        sentence = "30\xa0000"
+        expected_tokens = ['3', '0.', '000</w>']
+        tokenizer = HuggingfaceTransformersTokenizer("xlm-mlm-en-2048")
+
+        # tokenize with offsets
+        tokens, offsets = list(
+            map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)]))
+        )
+        assert tokens == expected_tokens
+        assert offsets == [0, 1, 1]

--- a/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
@@ -129,7 +129,7 @@ class TestHuggingTransformersTokenizer(AllenNlpTestCase):
 
     def test_tokenize_with_offsets_partial_correspondence(self):
         sentence = "30\xa0000"
-        expected_tokens = ['3', '0.', '000</w>']
+        expected_tokens = ["3", "0.", "000</w>"]
         tokenizer = HuggingfaceTransformersTokenizer("xlm-mlm-en-2048")
 
         # tokenize with offsets

--- a/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/huggingface_transformers_tokenizer_test.py
@@ -114,3 +114,15 @@ class TestHuggingTransformersTokenizer(AllenNlpTestCase):
         )
         assert tokens == expected_tokens
         assert offsets == [0, 4, 9, 16, 20, 24, 24, 26, 29, 31, 35, 40, 43, 47, 50, 54, 59]
+
+    def test_tokenize_with_offsets_html_entity(self):
+        sentence = "98&#160; yards"
+        expected_tokens = ["98</w>", "yards</w>"]
+        tokenizer = HuggingfaceTransformersTokenizer("openai-gpt")
+
+        # tokenize with offsets
+        tokens, offsets = list(
+            map(list, zip(*[(t.text, t.idx) for t in tokenizer.tokenize_with_offsets(sentence)]))
+        )
+        assert tokens == expected_tokens
+        assert offsets == [0, 2]


### PR DESCRIPTION
This pull request suggests a new tokenizer that uses the tokenizers from https://github.com/huggingface/transformers.
In constrat to `PretrainedTransformerTokenizer`, the suggestion for this tokenizer is to be used with Hugging Face's API of `encode_plus`, and without TokenIndexer.

The main appeal of this tokenizer it is the addition of `tokenize_with_offsets`, which uses the same code as in https://github.com/huggingface/transformers/pull/2178 and for which thorough testing was performed. If Hugging Face will merge it, then the duplicate parts can be removed.