### PR TITLE
Update names of environment variables for consistency

### DIFF
--- a/training_config/ner.jsonnet
+++ b/training_config/ner.jsonnet
@@ -17,8 +17,8 @@
     }
   },
   "train_data_path": std.extVar("NER_TRAIN_DATA_PATH"),
-  "validation_data_path": std.extVar("NER_TEST_A_PATH"),
-  "test_data_path": std.extVar("NER_TEST_B_PATH"),
+  "validation_data_path": std.extVar("NER_TEST_A_DATA_PATH"),
+  "test_data_path": std.extVar("NER_TEST_B_DATA_PATH"),
   "model": {
     "type": "crf_tagger",
     "label_encoding": "BIOUL",

--- a/training_config/ner_elmo.jsonnet
+++ b/training_config/ner_elmo.jsonnet
@@ -28,7 +28,7 @@
     }
   },
   "train_data_path": std.extVar("NER_TRAIN_DATA_PATH"),
-  "validation_data_path": std.extVar("NER_TEST_A_PATH"),
+  "validation_data_path": std.extVar("NER_TEST_A_DATA_PATH"),
   "model": {
     "type": "crf_tagger",
     "label_encoding": "BIOUL",


### PR DESCRIPTION
**(This PR includes changes to break backward compatibility.)**

I update some environment variables for naming consistency.
I use `*_DATA_PATH` following [coref config](https://github.com/allenai/allennlp/blob/master/training_config/coref.jsonnet).