### PR TITLE
Add ability to compose Seq2SeqEncoders.

### DIFF
--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -29,6 +29,7 @@ from allennlp.modules.augmented_lstm import AugmentedLstm
 from allennlp.modules.seq2seq_encoders.bidirectional_language_model_transformer import (
     BidirectionalLanguageModelTransformer,
 )
+from allennlp.modules.seq2seq_encoders.compose_encoder import ComposeEncoder
 from allennlp.modules.seq2seq_encoders.gated_cnn_encoder import GatedCnnEncoder
 from allennlp.modules.seq2seq_encoders.intra_sentence_attention import IntraSentenceAttentionEncoder
 from allennlp.modules.seq2seq_encoders.pytorch_seq2seq_wrapper import PytorchSeq2SeqWrapper

--- a/allennlp/modules/seq2seq_encoders/compose_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/compose_encoder.py
@@ -1,0 +1,75 @@
+from overrides import overrides
+import torch
+from typing import List
+
+from allennlp.modules.seq2seq_encoders.seq2seq_encoder import Seq2SeqEncoder
+
+
+@Seq2SeqEncoder.register("compose")
+class ComposeEncoder(Seq2SeqEncoder):
+
+    """This class can be used to compose several encoders in sequence.
+
+    Among other things, this can be used to add a "pre-contextualizer" before a Seq2SeqEncoder.
+
+    Parameters
+    ----------
+    encoders : ``List[Seq2SeqEncoder]``, required.
+        A non-empty list of encoders to compose. The encoders must match in bidirectionality.
+    """
+
+    def __init__(self, encoders: List[Seq2SeqEncoder]):
+        super().__init__()
+        self.encoders = encoders
+        for idx, encoder in enumerate(encoders):
+            self.add_module("encoder%d" % idx, encoder)
+
+        # Compute bidirectionality.
+        all_bidirectional = all(encoder.is_bidirectional() for encoder in encoders)
+        any_bidirectional = any(encoder.is_bidirectional() for encoder in encoders)
+        self.bidirectional = all_bidirectional
+
+        if all_bidirectional != any_bidirectional:
+            raise ValueError("All encoders need to match in bidirectionality.")
+
+        if len(self.encoders) < 1:
+            raise ValueError("Need at least one encoder.")
+
+        last_encoder = None
+        for encoder in encoders:
+            if (last_encoder is not None and
+                    last_encoder.get_output_dim() != encoder.get_input_dim()):
+                raise ValueError("Encoder input and output dimensions don't match.")
+            last_encoder = encoder
+
+    @overrides
+    def forward(self,  # pylint: disable=arguments-differ
+                inputs: torch.Tensor,
+                mask: torch.LongTensor = None) -> torch.Tensor:
+        """
+        Parameters
+        ----------
+        inputs : ``torch.Tensor``, required.
+            A tensor of shape (batch_size, timesteps, input_dim)
+        mask : ``torch.LongTensor``, optional (default = None).
+            A tensor of shape (batch_size, timesteps).
+
+        Returns
+        -------
+        A tensor computed by composing the sequence of encoders.
+        """
+        for encoder in self.encoders:
+          inputs = encoder(inputs, mask)
+        return inputs
+
+    @overrides
+    def get_input_dim(self) -> int:
+        return self.encoders[0].get_input_dim()
+
+    @overrides
+    def get_output_dim(self) -> int:
+        return self.encoders[-1].get_output_dim()
+
+    @overrides
+    def is_bidirectional(self) -> bool:
+        return self.bidirectional

--- a/allennlp/modules/seq2seq_encoders/compose_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/compose_encoder.py
@@ -35,12 +35,11 @@ class ComposeEncoder(Seq2SeqEncoder):
         if len(self.encoders) < 1:
             raise ValueError("Need at least one encoder.")
 
-        last_encoder = None
-        for encoder in encoders:
-            if (last_encoder is not None and
-                    last_encoder.get_output_dim() != encoder.get_input_dim()):
+        last_enc = None
+        for enc in encoders:
+            if last_enc is not None and last_enc.get_output_dim() != enc.get_input_dim():
                 raise ValueError("Encoder input and output dimensions don't match.")
-            last_encoder = encoder
+            last_enc = enc
 
     @overrides
     def forward(self,  # pylint: disable=arguments-differ
@@ -59,7 +58,7 @@ class ComposeEncoder(Seq2SeqEncoder):
         A tensor computed by composing the sequence of encoders.
         """
         for encoder in self.encoders:
-          inputs = encoder(inputs, mask)
+            inputs = encoder(inputs, mask)
         return inputs
 
     @overrides

--- a/allennlp/modules/seq2seq_encoders/compose_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/compose_encoder.py
@@ -42,9 +42,11 @@ class ComposeEncoder(Seq2SeqEncoder):
             last_enc = enc
 
     @overrides
-    def forward(self,  # pylint: disable=arguments-differ
-                inputs: torch.Tensor,
-                mask: torch.LongTensor = None) -> torch.Tensor:
+    def forward(
+        self,  # pylint: disable=arguments-differ
+        inputs: torch.Tensor,
+        mask: torch.LongTensor = None,
+    ) -> torch.Tensor:
         """
         Parameters
         ----------

--- a/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
+++ b/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
@@ -44,7 +44,8 @@ class TestPassThroughEncoder(AllenNlpTestCase):
     def setUp(self):
         super().setUp()
         self.encoder = ComposeEncoder(
-            [_make_feedforward(9, 5), _make_feedforward(5, 10), _make_feedforward(10, 3)])
+            [_make_feedforward(9, 5), _make_feedforward(5, 10), _make_feedforward(10, 3)]
+        )
 
     def test_get_dimension_is_correct(self):
         assert self.encoder.get_input_dim() == 9

--- a/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
+++ b/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
@@ -10,7 +10,6 @@ from allennlp.modules import FeedForward
 
 class MockSeq2SeqEncoder(Seq2SeqEncoder):
 
-
     def __init__(self, input_dim: int, output_dim: int, bidirectional: bool = False):
         super().__init__()
         self.input_dim = input_dim

--- a/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
+++ b/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
@@ -44,8 +44,7 @@ class TestPassThroughEncoder(AllenNlpTestCase):
     def setUp(self):
         super().setUp()
         self.encoder = ComposeEncoder(
-            [_make_feedforward(9, 5), _make_feedforward(5, 10), _make_feedforward(10, 3),]
-        )
+            [_make_feedforward(9, 5), _make_feedforward(5, 10), _make_feedforward(10, 3)])
 
     def test_get_dimension_is_correct(self):
         assert self.encoder.get_input_dim() == 9

--- a/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
+++ b/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
@@ -1,0 +1,99 @@
+# pylint: disable=no-self-use,invalid-name
+import torch
+import numpy
+from overrides import overrides
+
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.modules.seq2seq_encoders import ComposeEncoder, FeedForwardEncoder, Seq2SeqEncoder
+from allennlp.modules import FeedForward
+
+
+class MockSeq2SeqEncoder(Seq2SeqEncoder):
+
+
+    def __init__(self, input_dim: int, output_dim: int, bidirectional: bool = False):
+        super().__init__()
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+        self.bidirectional = bidirectional
+
+    @overrides
+    def forward(self, inputs, mask):
+        pass
+
+    @overrides
+    def get_input_dim(self) -> int:
+        return self.input_dim
+
+    @overrides
+    def get_output_dim(self) -> int:
+        return self.output_dim
+
+    @overrides
+    def is_bidirectional(self) -> bool:
+        return self.bidirectional
+
+
+def _make_feedforward(input_dim, output_dim):
+    return FeedForwardEncoder(FeedForward(input_dim=input_dim, num_layers=1,
+                                          activations=torch.relu, hidden_dims=output_dim))
+
+
+class TestPassThroughEncoder(AllenNlpTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.encoder = ComposeEncoder([
+            _make_feedforward(9, 5),
+            _make_feedforward(5, 10),
+            _make_feedforward(10, 3),
+        ])
+
+    def test_get_dimension_is_correct(self):
+        assert self.encoder.get_input_dim() == 9
+        assert self.encoder.get_output_dim() == 3
+
+    def test_composes(self):
+        tensor = torch.zeros(2, 10, 9)
+        output = self.encoder(tensor)
+
+        for encoder in self.encoder.encoders:
+            tensor = encoder(tensor)
+
+        numpy.testing.assert_array_almost_equal(output.detach().cpu().numpy(),
+                                                tensor.detach().cpu().numpy())
+
+    def test_pass_through_encoder_with_mask(self):
+        tensor = torch.randn([2, 3, 9])
+        mask = torch.LongTensor([[1, 1, 1], [1, 0, 0]])
+        output = self.encoder(tensor, mask)
+
+        for encoder in self.encoder.encoders:
+            tensor = encoder(tensor, mask)
+
+        numpy.testing.assert_array_almost_equal(output.detach().cpu().numpy(),
+                                                tensor.detach().cpu().numpy())
+
+    def test_empty(self):
+        with self.assertRaises(ValueError):
+            ComposeEncoder([])
+
+    def test_mismatched_size(self):
+        with self.assertRaises(ValueError):
+            ComposeEncoder([
+                MockSeq2SeqEncoder(input_dim=9, output_dim=5),
+                MockSeq2SeqEncoder(input_dim=1, output_dim=2),
+            ])
+
+    def test_mismatched_bidirectionality(self):
+        with self.assertRaises(ValueError):
+            ComposeEncoder([
+                MockSeq2SeqEncoder(input_dim=9, output_dim=5),
+                MockSeq2SeqEncoder(input_dim=5, output_dim=2, bidirectional=True),
+            ])
+
+    def test_all_bidirectional(self):
+        ComposeEncoder([
+            MockSeq2SeqEncoder(input_dim=9, output_dim=5, bidirectional=True),
+            MockSeq2SeqEncoder(input_dim=5, output_dim=2, bidirectional=True),
+        ])

--- a/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
+++ b/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
@@ -9,7 +9,6 @@ from allennlp.modules import FeedForward
 
 
 class MockSeq2SeqEncoder(Seq2SeqEncoder):
-
     def __init__(self, input_dim: int, output_dim: int, bidirectional: bool = False):
         super().__init__()
         self.input_dim = input_dim
@@ -34,19 +33,19 @@ class MockSeq2SeqEncoder(Seq2SeqEncoder):
 
 
 def _make_feedforward(input_dim, output_dim):
-    return FeedForwardEncoder(FeedForward(input_dim=input_dim, num_layers=1,
-                                          activations=torch.relu, hidden_dims=output_dim))
+    return FeedForwardEncoder(
+        FeedForward(
+            input_dim=input_dim, num_layers=1, activations=torch.relu, hidden_dims=output_dim
+        )
+    )
 
 
 class TestPassThroughEncoder(AllenNlpTestCase):
-
     def setUp(self):
         super().setUp()
-        self.encoder = ComposeEncoder([
-            _make_feedforward(9, 5),
-            _make_feedforward(5, 10),
-            _make_feedforward(10, 3),
-        ])
+        self.encoder = ComposeEncoder(
+            [_make_feedforward(9, 5), _make_feedforward(5, 10), _make_feedforward(10, 3),]
+        )
 
     def test_get_dimension_is_correct(self):
         assert self.encoder.get_input_dim() == 9
@@ -59,8 +58,9 @@ class TestPassThroughEncoder(AllenNlpTestCase):
         for encoder in self.encoder.encoders:
             tensor = encoder(tensor)
 
-        numpy.testing.assert_array_almost_equal(output.detach().cpu().numpy(),
-                                                tensor.detach().cpu().numpy())
+        numpy.testing.assert_array_almost_equal(
+            output.detach().cpu().numpy(), tensor.detach().cpu().numpy()
+        )
 
     def test_pass_through_encoder_with_mask(self):
         tensor = torch.randn([2, 3, 9])
@@ -70,8 +70,9 @@ class TestPassThroughEncoder(AllenNlpTestCase):
         for encoder in self.encoder.encoders:
             tensor = encoder(tensor, mask)
 
-        numpy.testing.assert_array_almost_equal(output.detach().cpu().numpy(),
-                                                tensor.detach().cpu().numpy())
+        numpy.testing.assert_array_almost_equal(
+            output.detach().cpu().numpy(), tensor.detach().cpu().numpy()
+        )
 
     def test_empty(self):
         with self.assertRaises(ValueError):
@@ -79,20 +80,26 @@ class TestPassThroughEncoder(AllenNlpTestCase):
 
     def test_mismatched_size(self):
         with self.assertRaises(ValueError):
-            ComposeEncoder([
-                MockSeq2SeqEncoder(input_dim=9, output_dim=5),
-                MockSeq2SeqEncoder(input_dim=1, output_dim=2),
-            ])
+            ComposeEncoder(
+                [
+                    MockSeq2SeqEncoder(input_dim=9, output_dim=5),
+                    MockSeq2SeqEncoder(input_dim=1, output_dim=2),
+                ]
+            )
 
     def test_mismatched_bidirectionality(self):
         with self.assertRaises(ValueError):
-            ComposeEncoder([
-                MockSeq2SeqEncoder(input_dim=9, output_dim=5),
-                MockSeq2SeqEncoder(input_dim=5, output_dim=2, bidirectional=True),
-            ])
+            ComposeEncoder(
+                [
+                    MockSeq2SeqEncoder(input_dim=9, output_dim=5),
+                    MockSeq2SeqEncoder(input_dim=5, output_dim=2, bidirectional=True),
+                ]
+            )
 
     def test_all_bidirectional(self):
-        ComposeEncoder([
-            MockSeq2SeqEncoder(input_dim=9, output_dim=5, bidirectional=True),
-            MockSeq2SeqEncoder(input_dim=5, output_dim=2, bidirectional=True),
-        ])
+        ComposeEncoder(
+            [
+                MockSeq2SeqEncoder(input_dim=9, output_dim=5, bidirectional=True),
+                MockSeq2SeqEncoder(input_dim=5, output_dim=2, bidirectional=True),
+            ]
+        )

--- a/doc/api/allennlp.modules.seq2seq_encoders.rst
+++ b/doc/api/allennlp.modules.seq2seq_encoders.rst
@@ -55,3 +55,8 @@ allennlp.modules.seq2seq_encoders
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. automodule:: allennlp.modules.seq2seq_encoders.compose_encoder
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
## Problem

I have often faced the problem of wanting to add a "pre-contextualizer" before another kind of `Seq2SeqEncoder`. Currently, it seems the best way to accomplish this is to change a `Model` to have two encoder slots, or to add a nested sub-encoder to the `Seq2SeqEncoder` you are using. Both of these are ad hoc solutions, requiring code modifications as opposed to a simple fix in the configuration file.

## Solution

In order to solve this problem easily, I created a `ComposeEncoder` that allows you to create a new `Seq2SeqEncoder` out of a sequence of sub-encoders. If you are creating a `LanguageModel` and want to add an LSTM as a pre-contextualizer before `ENCODER`, you can simply write:

```json
    "contextualizer": {
      "type": "compose",
      "encoders": [
        {
          "type": "lstm",
          "input_size": 100,
          "hidden_size": 64,
          "bidirectional": false,
          "num_layers": 1,
        },
        ENCODER,
      ],
```

## Details

The `ComposeEncoder` applies its list of sub-encoders in sequence. It enforces the following basic constraints:
1. There must be at least one sub-encoder.
2. All sub-encoders must match in bidirectionality.
3. The output dimension of each sub-encoder is equal to the input dimension of the following sub-encoder.