### PR TITLE
Ignore errors when cleaning up temp files.

### DIFF
--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -249,4 +249,4 @@ def load_archive(
 def _cleanup_archive_dir(path: str):
     if os.path.exists(path):
         logger.info("removing temporary unarchived model dir at %s", path)
-        shutil.rmtree(path)
+        shutil.rmtree(path, ignore_errors=True)


### PR DESCRIPTION
Our builds are full of errors that are not very helpful.  My hope is that this flag will cause our build system to omit these exceptions, which are cluttering up our logs.

```
[11:36:38][Step 6/6] --- Logging error ---
[11:36:38][Step 6/6] Traceback (most recent call last):
[11:36:38][Step 6/6]   File "/usr/local/lib/python3.7/logging/__init__.py", line 1037, in emit
[11:36:38][Step 6/6]     stream.write(msg + self.terminator)
[11:36:38][Step 6/6]   File "/usr/local/lib/python3.7/site-packages/_pytest/capture.py", line 427, in write
[11:36:38][Step 6/6]     self.buffer.write(obj)
[11:36:38][Step 6/6] ValueError: I/O operation on closed file
[11:36:38][Step 6/6] Call stack:
[11:36:38][Step 6/6]   File "/usr/local/lib/python3.7/site-packages/allennlp/models/archival.py", line 251, in _cleanup_archive_dir
[11:36:38][Step 6/6]     logger.info("removing temporary unarchived model dir at %s", path)
```