### PR TITLE
Add missing type hint

### DIFF
--- a/allennlp/data/dataset_readers/seq2seq.py
+++ b/allennlp/data/dataset_readers/seq2seq.py
@@ -79,7 +79,7 @@ class Seq2SeqDatasetReader(DatasetReader):
         self._target_max_exceeded = 0
 
     @overrides
-    def _read(self, file_path):
+    def _read(self, file_path: str):
         # Reset exceeded counts
         self._source_max_exceeded = 0
         self._target_max_exceeded = 0


### PR DESCRIPTION
The input argument `file_path` to the `_read` method of `Seq2SeqDatasetReader` was missing a type hint (`str`).