### PR TITLE
Use attention_mask in pretrained transformers

### DIFF
--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -95,7 +95,7 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
         # tokens are attended to.
         attention_mask = [1] * len(indices)
 
-        return {index_name: indices, "attention_mask": attention_mask}
+        return {index_name: indices, "mask": attention_mask}
 
     @overrides
     def get_padding_lengths(self, token: int) -> Dict[str, int]:

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -31,10 +31,18 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
         We use a somewhat confusing default value of ``tags`` so that we do not add padding or UNK
         tokens to this namespace, which would break on loading because we wouldn't find our default
         OOV token.
+    mask_padding_with_zero:  ``bool``, optional (default=True)
+        If set to ``True``, the attention mask will be filled by ``1`` for actual values
+        and by ``0`` for padded values. If set to ``False``, inverts it (``1`` for padded values, ``0`` for
+        actual values)
     """
 
     def __init__(
-        self, model_name: str, namespace: str = "tags", token_min_padding_length: int = 0
+        self,
+        model_name: str,
+        namespace: str = "tags",
+        token_min_padding_length: int = 0,
+        mask_padding_with_zero: bool = True,
     ) -> None:
         super().__init__(token_min_padding_length)
         self._namespace = namespace
@@ -42,6 +50,8 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
         self._padding_value = self._tokenizer.convert_tokens_to_ids([self._tokenizer.pad_token])[0]
         logger.info(f"Using token indexer padding value of {self._padding_value}")
         self._added_to_vocabulary = False
+        self._mask_padding_with_zero = mask_padding_with_zero
+        self._mask_padding_value = 0 if mask_padding_with_zero else 1
 
     def _add_encoding_to_vocabulary(self, vocab: Vocabulary) -> None:
         """
@@ -91,7 +101,11 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
                     f" for the following token: {token.text}"
                 )
 
-        return {index_name: indices}
+        # The mask has 1 for real tokens and 0 for padding tokens. Only real
+        # tokens are attended to.
+        attention_mask = [1 if self._mask_padding_with_zero else 0] * len(indices)
+
+        return {index_name: indices, "attention_mask": attention_mask}
 
     @overrides
     def get_padding_lengths(self, token: int) -> Dict[str, int]:
@@ -104,14 +118,21 @@ class PretrainedTransformerIndexer(TokenIndexer[int]):
         desired_num_tokens: Dict[str, int],
         padding_lengths: Dict[str, int],
     ) -> Dict[str, torch.Tensor]:
-        return {
-            key: torch.LongTensor(
-                pad_sequence_to_length(
-                    val, desired_num_tokens[key], default_value=lambda: self._padding_value
+        padded_tensor_dict = {}
+        for key, val in tokens.items():
+            if key == "attention_mask":
+                padded_tensor_dict[key] = torch.LongTensor(
+                    pad_sequence_to_length(
+                        val, desired_num_tokens[key], default_value=lambda: self._mask_padding_value
+                    )
                 )
-            )
-            for key, val in tokens.items()
-        }
+            else:
+                padded_tensor_dict[key] = torch.LongTensor(
+                    pad_sequence_to_length(
+                        val, desired_num_tokens[key], default_value=lambda: self._padding_value
+                    )
+                )
+        return padded_tensor_dict
 
     def __eq__(self, other):
         if isinstance(other, PretrainedTransformerIndexer):

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -22,6 +22,8 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
     def get_output_dim(self):
         return self.output_dim
 
-    def forward(self, token_ids: torch.LongTensor) -> torch.Tensor:  # type: ignore
+    def forward(
+        self, token_ids: torch.LongTensor, attention_mask: torch.LongTensor
+    ) -> torch.Tensor:  # type: ignore
 
-        return self.transformer_model(token_ids)[0]
+        return self.transformer_model(input_ids=token_ids, attention_mask=attention_mask)[0]

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -16,7 +16,6 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         self.transformer_model = AutoModel.from_pretrained(model_name)
         # I'm not sure if this works for all models; open an issue on github if you find a case
         # where it doesn't work.
-        self.model_type = model_name.split("-")[0]
         self.output_dim = self.transformer_model.config.hidden_size
 
     @overrides
@@ -26,7 +25,5 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
     def forward(
         self, token_ids: torch.LongTensor, attention_mask: torch.LongTensor
     ) -> torch.Tensor:  # type: ignore
-        if self.model_type == "xlnet":
-            return self.transformer_model(input_ids=token_ids, input_mask=attention_mask)[0]
 
         return self.transformer_model(input_ids=token_ids, attention_mask=attention_mask)[0]

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -16,6 +16,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         self.transformer_model = AutoModel.from_pretrained(model_name)
         # I'm not sure if this works for all models; open an issue on github if you find a case
         # where it doesn't work.
+        self.model_type = model_name.split("-")[0]
         self.output_dim = self.transformer_model.config.hidden_size
 
     @overrides
@@ -25,5 +26,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
     def forward(
         self, token_ids: torch.LongTensor, attention_mask: torch.LongTensor
     ) -> torch.Tensor:  # type: ignore
+        if self.model_type == "xlnet":
+            return self.transformer_model(input_ids=token_ids, input_mask=attention_mask)[0]
 
         return self.transformer_model(input_ids=token_ids, attention_mask=attention_mask)[0]

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -108,19 +108,19 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
         del indexed
         assert vocab.get_token_to_index_vocabulary(namespace=namespace) == tokenizer.encoder
 
-    def test_attention_mask(self):
+    def test_mask(self):
         allennlp_tokenizer = PretrainedTransformerTokenizer("bert-base-uncased")
         indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased")
         string_no_specials = "AllenNLP is great"
         allennlp_tokens = allennlp_tokenizer.tokenize(string_no_specials)
         vocab = Vocabulary()
         indexed = indexer.tokens_to_indices(allennlp_tokens, vocab, "key")
-        expected_attention_masks = [1] * len(indexed["key"])
-        assert indexed["attention_mask"] == expected_attention_masks
+        expected_masks = [1] * len(indexed["key"])
+        assert indexed["mask"] == expected_masks
         max_length = 10
-        desired_num_tokens = {"key": max_length, "attention_mask": max_length}
+        desired_num_tokens = {"key": max_length, "mask": max_length}
         padded_tokens = indexer.as_padded_tensor(indexed, desired_num_tokens, {})
-        padding_length = max_length - len(indexed["attention_mask"])
-        expected_attention_masks = expected_attention_masks + ([0] * padding_length)
-        assert len(padded_tokens["attention_mask"]) == max_length
-        assert padded_tokens["attention_mask"].tolist() == expected_attention_masks
+        padding_length = max_length - len(indexed["mask"])
+        expected_masks = expected_masks + ([0] * padding_length)
+        assert len(padded_tokens["mask"]) == max_length
+        assert padded_tokens["mask"].tolist() == expected_masks

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -110,9 +110,7 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
 
     def test_attention_mask(self):
         allennlp_tokenizer = PretrainedTransformerTokenizer("bert-base-uncased")
-        indexer = PretrainedTransformerIndexer(
-            model_name="bert-base-uncased", mask_padding_with_zero=True
-        )
+        indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased")
         string_no_specials = "AllenNLP is great"
         allennlp_tokens = allennlp_tokenizer.tokenize(string_no_specials)
         vocab = Vocabulary()

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -1,6 +1,13 @@
 import torch
 
 from allennlp.common import Params
+from allennlp.data import Vocabulary
+from allennlp.data.dataset import Batch
+from allennlp.data.fields import TextField
+from allennlp.data.instance import Instance
+from allennlp.data.token_indexers import PretrainedTransformerIndexer
+from allennlp.data.tokenizers import PretrainedTransformerTokenizer
+from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
 from allennlp.modules.token_embedders import PretrainedTransformerEmbedder
 from allennlp.common.testing import AllenNlpTestCase
 
@@ -15,3 +22,49 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
         mask = torch.randint(0, 2, (1, 4))
         output = embedder(token_ids=token_ids, attention_mask=mask)
         assert tuple(output.size()) == (1, 4, 768)
+
+    def test_end_to_end(self):
+        tokenizer = PretrainedTransformerTokenizer(model_name="bert-base-uncased")
+        token_indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased")
+
+        sentence1 = "A, AllenNLP sentence."
+        tokens1 = tokenizer.tokenize(sentence1)
+        expected_tokens1 = ["[CLS]", "a", ",", "allen", "##nl", "##p", "sentence", ".", "[SEP]"]
+        assert [t.text for t in tokens1] == expected_tokens1
+
+        sentence2 = "AllenNLP is great"
+        tokens2 = tokenizer.tokenize(sentence2)
+        expected_tokens2 = ["[CLS]", "allen", "##nl", "##p", "is", "great", "[SEP]"]
+        assert [t.text for t in tokens2] == expected_tokens2
+
+        vocab = Vocabulary()
+
+        params = Params(
+            {
+                "token_embedders": {
+                    "bert": {"type": "pretrained_transformer", "model_name": "bert-base-uncased"}
+                },
+                "embedder_to_indexer_map": {"bert": ["bert", "mask"]},
+                "allow_unmatched_keys": True,
+            }
+        )
+        token_embedder = BasicTextFieldEmbedder.from_params(vocab, params)
+
+        instance1 = Instance({"tokens": TextField(tokens1, {"bert": token_indexer})})
+        instance2 = Instance({"tokens": TextField(tokens2, {"bert": token_indexer})})
+
+        batch = Batch([instance1, instance2])
+        batch.index_instances(vocab)
+
+        padding_lengths = batch.get_padding_lengths()
+        tensor_dict = batch.as_tensor_dict(padding_lengths)
+        tokens = tensor_dict["tokens"]
+        max_length = max(len(tokens1), len(tokens2))
+
+        assert tokens["bert"].shape == (2, max_length)
+
+        assert tokens["mask"].tolist() == [[1, 1, 1, 1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1, 1, 0, 0]]
+
+        # Attention mask
+        bert_vectors = token_embedder(tokens)
+        assert bert_vectors.size() == (2, 9, 768)

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -11,6 +11,7 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
         # test.
         params = Params({"model_name": "bert-base-uncased"})
         embedder = PretrainedTransformerEmbedder.from_params(params)
-        tensor = torch.randint(0, 100, (1, 4))
-        output = embedder(tensor)
+        token_ids = torch.randint(0, 100, (1, 4))
+        mask = torch.randint(0, 2, (1, 4))
+        output = embedder(token_ids=token_ids, attention_mask=mask)
         assert tuple(output.size()) == (1, 4, 768)


### PR DESCRIPTION
Fix this issue https://github.com/allenai/allennlp/issues/3465

I also experimented with the MRPC dataset.
https://github.com/RyujiTamaki/mrpc-allennlp

Results is bellow.
```
2019-12-27 22:08:17,420 - INFO - allennlp.common.util - Metrics: {
  "best_epoch": 2,
  "peak_cpu_memory_MB": 3267.492,
  "peak_gpu_0_memory_MB": 10369,
  "peak_gpu_1_memory_MB": 19,
  "peak_gpu_2_memory_MB": 19,
  "training_duration": "0:01:17.479140",
  "training_start_epoch": 0,
  "training_epochs": 2,
  "epoch": 2,
  "training_accuracy": 0.9175637393767705,
  "training_loss": 0.20614140655274862,
  "training_cpu_memory_MB": 3267.492,
  "training_gpu_0_memory_MB": 10369,
  "training_gpu_1_memory_MB": 19,
  "training_gpu_2_memory_MB": 19,
  "validation_accuracy": 0.8505154639175257,
  "validation_loss": 0.4683948732339419,
  "best_validation_accuracy": 0.8505154639175257,
  "best_validation_loss": 0.4683948732339419
}
```