### PR TITLE
add double backquotes on doc strings 

### DIFF
--- a/allennlp/modules/attention/additive_attention.py
+++ b/allennlp/modules/attention/additive_attention.py
@@ -17,11 +17,11 @@ class AdditiveAttention(Attention):
 
     Parameters
     ----------
-    vector_dim : ``int``
+    vector_dim : ``int``, required
         The dimension of the vector, ``x``, described above.  This is ``x.size()[-1]`` - the length
         of the vector that will go into the similarity computation.  We need this so we can build
         the weight matrix correctly.
-    matrix_dim : ``int``
+    matrix_dim : ``int``, required
         The dimension of the matrix, ``y``, described above.  This is ``y.size()[-1]`` - the length
         of the vector that will go into the similarity computation.  We need this so we can build
         the weight matrix correctly.

--- a/allennlp/modules/attention/bilinear_attention.py
+++ b/allennlp/modules/attention/bilinear_attention.py
@@ -15,11 +15,11 @@ class BilinearAttention(Attention):
 
     Parameters
     ----------
-    vector_dim : ``int``
+    vector_dim : ``int``, required
         The dimension of the vector, ``x``, described above.  This is ``x.size()[-1]`` - the length
         of the vector that will go into the similarity computation.  We need this so we can build
         the weight matrix correctly.
-    matrix_dim : ``int``
+    matrix_dim : ``int``, required
         The dimension of the matrix, ``y``, described above.  This is ``y.size()[-1]`` - the length
         of the vector that will go into the similarity computation.  We need this so we can build
         the weight matrix correctly.

--- a/allennlp/modules/attention/linear_attention.py
+++ b/allennlp/modules/attention/linear_attention.py
@@ -28,19 +28,20 @@ class LinearAttention(Attention):
 
     Parameters
     ----------
-    tensor_1_dim : ``int``
+    tensor_1_dim: ``int``, required
         The dimension of the first tensor, ``x``, described above.  This is ``x.size()[-1]`` - the
         length of the vector that will go into the similarity computation.  We need this so we can
         build weight vectors correctly.
-    tensor_2_dim : ``int``
+    tensor_2_dim: ``int``, required
         The dimension of the second tensor, ``y``, described above.  This is ``y.size()[-1]`` - the
         length of the vector that will go into the similarity computation.  We need this so we can
         build weight vectors correctly.
-    combination : ``str``, optional (default="x,y")
+    combination: ``str``, optional (default="x,y")
         Described above.
-    activation : ``Activation``, optional (default=linear (i.e. no activation))
+    activation: ``Activation``, optional (default=linear (i.e. no activation))
         An activation function applied after the ``w^T * [x;y] + b`` calculation.  Default is no
         activation.
+    normalize: ``bool``, optional (default=True)
     """
 
     def __init__(

--- a/allennlp/modules/augmented_lstm.py
+++ b/allennlp/modules/augmented_lstm.py
@@ -24,21 +24,21 @@ class AugmentedLstm(torch.nn.Module):
 
     Parameters
     ----------
-    input_size : int, required.
+    input_size : ``int``, required.
         The dimension of the inputs to the LSTM.
-    hidden_size : int, required.
+    hidden_size : ``int``, required.
         The dimension of the outputs of the LSTM.
-    go_forward: bool, optional (default = True)
+    go_forward: ``bool``, optional (default = True)
         The direction in which the LSTM is applied to the sequence.
         Forwards by default, or backwards if False.
-    recurrent_dropout_probability: float, optional (default = 0.0)
+    recurrent_dropout_probability: ``float``, optional (default = 0.0)
         The dropout probability to be used in a dropout scheme as stated in
         `A Theoretically Grounded Application of Dropout in Recurrent Neural Networks
         <https://arxiv.org/abs/1512.05287>`_ . Implementation wise, this simply
         applies a fixed dropout mask per sequence to the recurrent connection of the
         LSTM. Dropout is not applied to the output sequence nor the last hidden
         state that is returned, it is only applied to all previous hidden states.
-    use_highway: bool, optional (default = True)
+    use_highway: ``bool``, optional (default = True)
         Whether or not to use highway connections between layers. This effectively involves
         reparameterising the normal output of an LSTM as::
 
@@ -109,11 +109,11 @@ class AugmentedLstm(torch.nn.Module):
         """
         Parameters
         ----------
-        inputs : PackedSequence, required.
+        inputs : ``PackedSequence``, required.
             A tensor of shape (batch_size, num_timesteps, input_size)
             to apply the LSTM over.
 
-        initial_state : Tuple[torch.Tensor, torch.Tensor], optional, (default = None)
+        initial_state : ``Tuple[torch.Tensor, torch.Tensor]``, optional, (default = None)
             A tuple (state, memory) representing the initial hidden state and memory
             of the LSTM. Each tensor has shape (1, batch_size, output_dimension).
 

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -165,14 +165,14 @@ class ConditionalRandomField(torch.nn.Module):
 
     Parameters
     ----------
-    num_tags : int, required
+    num_tags : ``int``, required
         The number of tags.
-    constraints : List[Tuple[int, int]], optional (default: None)
+    constraints : ``List[Tuple[int, int]]``, optional (default: None)
         An optional list of allowed transitions (from_tag_id, to_tag_id).
         These are applied to ``viterbi_tags()`` but do not affect ``forward()``.
         These should be derived from `allowed_transitions` so that the
         start and end transitions are handled correctly for your tag type.
-    include_start_end_transitions : bool, optional (default: True)
+    include_start_end_transitions : ``bool``, optional (default: True)
         Whether to include the start and end transition parameters.
     """
 

--- a/allennlp/modules/drop_connect.py
+++ b/allennlp/modules/drop_connect.py
@@ -39,9 +39,9 @@ class DropConnect(torch.nn.Module):
 
     Parameters
     ==========
-    module : ``torch.nn.Module``
+    module : ``torch.nn.Module``, required
         Module to apply weight dropout to.
-    parameter_regex : ``str``
+    parameter_regex : ``str``, required
         Regular expression identifying which parameters to apply weight dropout to.
     dropout : ``float``, optional (default = 0.0)
         Probability that a given weight is dropped.

--- a/allennlp/modules/feedforward.py
+++ b/allennlp/modules/feedforward.py
@@ -17,19 +17,19 @@ class FeedForward(torch.nn.Module, FromParams):
 
     Parameters
     ----------
-    input_dim : ``int``
+    input_dim : ``int``, required
         The dimensionality of the input.  We assume the input has shape ``(batch_size, input_dim)``.
-    num_layers : ``int``
+    num_layers : ``int``, required
         The number of ``Linear`` layers to apply to the input.
-    hidden_dims : ``Union[int, List[int]]``
+    hidden_dims : ``Union[int, List[int]]``, required
         The output dimension of each of the ``Linear`` layers.  If this is a single ``int``, we use
         it for all ``Linear`` layers.  If it is a ``List[int]``, ``len(hidden_dims)`` must be
         ``num_layers``.
-    activations : ``Union[Callable, List[Callable]]``
+    activations : ``Union[Callable, List[Callable]]``, required
         The activation function to use after each ``Linear`` layer.  If this is a single function,
         we use it after all ``Linear`` layers.  If it is a ``List[Callable]``,
         ``len(activations)`` must be ``num_layers``.
-    dropout : ``Union[float, List[float]]``, optional
+    dropout : ``Union[float, List[float]]``, optional (default = 0.0)
         If given, we will apply this amount of dropout after each layer.  Semantics of ``float``
         versus ``List[float]`` is the same as with other parameters.
     """

--- a/allennlp/modules/highway.py
+++ b/allennlp/modules/highway.py
@@ -21,7 +21,7 @@ class Highway(torch.nn.Module):
 
     Parameters
     ----------
-    input_dim : ``int``
+    input_dim : ``int``, required
         The dimensionality of :math:`x`.  We assume the input has shape ``(batch_size, ...,
         input_dim)``.
     num_layers : ``int``, optional (default=``1``)

--- a/allennlp/modules/matrix_attention/bilinear_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/bilinear_matrix_attention.py
@@ -15,11 +15,11 @@ class BilinearMatrixAttention(MatrixAttention):
 
     Parameters
     ----------
-    matrix_1_dim : ``int``
+    matrix_1_dim : ``int``, required
         The dimension of the matrix ``X``, described above.  This is ``X.size()[-1]`` - the length
         of the vector that will go into the similarity computation.  We need this so we can build
         the weight matrix correctly.
-    matrix_2_dim : ``int``
+    matrix_2_dim : ``int``, required
         The dimension of the matrix ``Y``, described above.  This is ``Y.size()[-1]`` - the length
         of the vector that will go into the similarity computation.  We need this so we can build
         the weight matrix correctly.

--- a/allennlp/modules/matrix_attention/linear_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/linear_matrix_attention.py
@@ -30,11 +30,11 @@ class LinearMatrixAttention(MatrixAttention):
 
     Parameters
     ----------
-    tensor_1_dim : ``int``
+    tensor_1_dim : ``int``, required
         The dimension of the first tensor, ``x``, described above.  This is ``x.size()[-1]`` - the
         length of the vector that will go into the similarity computation.  We need this so we can
         build weight vectors correctly.
-    tensor_2_dim : ``int``
+    tensor_2_dim : ``int``, required
         The dimension of the second tensor, ``y``, described above.  This is ``y.size()[-1]`` - the
         length of the vector that will go into the similarity computation.  We need this so we can
         build weight vectors correctly.

--- a/allennlp/modules/maxout.py
+++ b/allennlp/modules/maxout.py
@@ -15,19 +15,19 @@ class Maxout(torch.nn.Module, FromParams):
 
     Parameters
     ----------
-    input_dim : ``int``
+    input_dim : ``int``, required
         The dimensionality of the input.  We assume the input has shape ``(batch_size, input_dim)``.
-    num_layers : ``int``
+    num_layers : ``int``, required
         The number of maxout layers to apply to the input.
-    output_dims : ``Union[int, Sequence[int]]``
+    output_dims : ``Union[int, Sequence[int]]``, required
         The output dimension of each of the maxout layers.  If this is a single ``int``, we use
         it for all maxout layers.  If it is a ``Sequence[int]``, ``len(output_dims)`` must be
         ``num_layers``.
-    pool_sizes : ``Union[int, Sequence[int]]``
+    pool_sizes : ``Union[int, Sequence[int]]``, required
         The size of max-pools.  If this is a single ``int``, we use
         it for all maxout layers.  If it is a ``Sequence[int]``, ``len(pool_sizes)`` must be
         ``num_layers``.
-    dropout : ``Union[float, Sequence[float]]``, optional
+    dropout : ``Union[float, Sequence[float]]``, optional (default = 0.0)
         If given, we will apply this amount of dropout after each layer.  Semantics of ``float``
         versus ``Sequence[float]`` is the same as with other parameters.
     """

--- a/allennlp/modules/sampled_softmax_loss.py
+++ b/allennlp/modules/sampled_softmax_loss.py
@@ -55,11 +55,11 @@ class SampledSoftmaxLoss(torch.nn.Module):
 
     Parameters
     ----------
-    num_words, ``int``
+    num_words, ``int``, required
         The number of words in the vocabulary
-    embedding_dim, ``int``
+    embedding_dim, ``int``, required
         The dimension to softmax over
-    num_samples, ``int``
+    num_samples, ``int``, required
         During training take this many samples. Must be less than num_words.
     sparse, ``bool``, optional (default = False)
         If this is true, we use a sparse embedding matrix.

--- a/allennlp/modules/seq2seq_decoders/auto_regressive_seq_decoder.py
+++ b/allennlp/modules/seq2seq_decoders/auto_regressive_seq_decoder.py
@@ -30,9 +30,9 @@ class AutoRegressiveSeqDecoder(SeqDecoder):
         be specified as `target_namespace`.
     decoder_net : ``DecoderNet``, required
         Module that contains implementation of neural network for decoding output elements
-    max_decoding_steps : ``int``
+    max_decoding_steps : ``int``, required
         Maximum length of decoded sequences.
-    target_embedder : ``Embedding``
+    target_embedder : ``Embedding``, required
         Embedder for target tokens.
     target_namespace : ``str``, optional (default = 'tokens')
         If the target side vocabulary is different from the source side's, you need to specify the

--- a/allennlp/modules/seq2seq_decoders/seq_decoder.py
+++ b/allennlp/modules/seq2seq_decoders/seq_decoder.py
@@ -23,7 +23,7 @@ class SeqDecoder(Module, Registrable):
 
     Parameters
     ----------
-    target_embedder : ``Embedding``
+    target_embedder : ``Embedding``, required
         Embedder for target tokens. Needed in the base class to enable weight tying.
     """
 

--- a/allennlp/modules/seq2seq_encoders/gated_cnn_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/gated_cnn_encoder.py
@@ -141,13 +141,13 @@ class GatedCnnEncoder(Seq2SeqEncoder):
 
     Parameters
     ----------
-    input_dim : int
+    input_dim: ``int``, required
         The dimension of the inputs.
-    layers : ``Sequence[Sequence[Sequence[int]]]```
+    layers: ``Sequence[Sequence[Sequence[int]]]``, required
         The layer dimensions for each ``ResidualBlock``.
-    dropout : float, optional (default = 0.0)
+    dropout: ``float``, optional (default = 0.0)
         The dropout for each ``ResidualBlock``.
-    return_all_layers : bool, optional (default: False)
+    return_all_layers: ``bool``, optional (default = False)
         Whether to return all layers or just the last layer.
     """
 

--- a/allennlp/modules/seq2seq_encoders/intra_sentence_attention.py
+++ b/allennlp/modules/seq2seq_encoders/intra_sentence_attention.py
@@ -25,7 +25,7 @@ class IntraSentenceAttentionEncoder(Seq2SeqEncoder):
 
     Parameters
     ----------
-    input_dim : ``int``
+    input_dim : ``int`` required
         The dimension of the vector for each element in the input sequence;
         ``input_tensor.size(-1)``.
     projection_dim : ``int``, optional

--- a/allennlp/modules/seq2vec_encoders/bert_pooler.py
+++ b/allennlp/modules/seq2vec_encoders/bert_pooler.py
@@ -25,7 +25,7 @@ class BertPooler(Seq2VecEncoder):
 
     Parameters
     ----------
-    pretrained_model : ``Union[str, BertModel]``
+    pretrained_model : ``Union[str, BertModel]``, required
         The pretrained BERT model to use. If this is a string,
         we will call ``BertModel.from_pretrained(pretrained_model)``
         and use that.

--- a/allennlp/modules/seq2vec_encoders/boe_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/boe_encoder.py
@@ -16,7 +16,7 @@ class BagOfEmbeddingsEncoder(Seq2VecEncoder):
 
     Parameters
     ----------
-    embedding_dim: ``int``
+    embedding_dim: ``int``, required
         This is the input dimension to the encoder.
     averaged: ``bool``, optional (default=``False``)
         If ``True``, this module will average the embeddings across time, rather than simply summing

--- a/allennlp/modules/seq2vec_encoders/cnn_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/cnn_encoder.py
@@ -30,10 +30,10 @@ class CnnEncoder(Seq2VecEncoder):
 
     Parameters
     ----------
-    embedding_dim : ``int``
+    embedding_dim : ``int``, required
         This is the input dimension to the encoder.  We need this because we can't do shape
         inference in pytorch, and we need to know what size filters to construct in the CNN.
-    num_filters: ``int``
+    num_filters: ``int``, required
         This is the output dim for each convolutional layer, which is the number of "filters"
         learned by that layer.
     ngram_filter_sizes: ``Tuple[int]``, optional (default=``(2, 3, 4, 5)``)

--- a/allennlp/modules/seq2vec_encoders/cnn_highway_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/cnn_highway_encoder.py
@@ -20,17 +20,17 @@ class CnnHighwayEncoder(Seq2VecEncoder):
 
     Parameters
     ----------
-    embedding_dim: int
+    embedding_dim: ``int``, required
         The dimension of the initial character embedding.
-    filters: ``Sequence[Sequence[int]]``
+    filters: ``Sequence[Sequence[int]]``, required
         A sequence of pairs (filter_width, num_filters).
-    num_highway: int
+    num_highway: ``int``, required
         The number of highway layers.
-    projection_dim: int
+    projection_dim: ``int``, required
         The output dimension of the projection layer.
-    activation: str, optional (default = 'relu')
+    activation: ``str``, optional (default = 'relu')
         The activation function for the convolutional layers.
-    projection_location: str, optional (default = 'after_highway')
+    projection_location: ``str``, optional (default = 'after_highway')
         Where to apply the projection layer. Valid values are
         'after_highway', 'after_cnn', and None.
     """

--- a/allennlp/modules/span_extractors/bidirectional_endpoint_span_extractor.py
+++ b/allennlp/modules/span_extractors/bidirectional_endpoint_span_extractor.py
@@ -38,13 +38,13 @@ class BidirectionalEndpointSpanExtractor(SpanExtractor):
 
     Parameters
     ----------
-    input_dim : ``int``, required.
+    input_dim : ``int``, required
         The final dimension of the ``sequence_tensor``.
-    forward_combination : str, optional (default = "y-x").
+    forward_combination : ``str``, optional (default = "y-x").
         The method used to combine the ``forward_start_embeddings`` and ``forward_end_embeddings``
         for the forward direction of the bidirectional representation.
         See above for a full description.
-    backward_combination : str, optional (default = "x-y").
+    backward_combination : ``str``, optional (default = "x-y").
         The method used to combine the ``backward_start_embeddings`` and ``backward_end_embeddings``
         for the backward direction of the bidirectional representation.
         See above for a full description.

--- a/allennlp/modules/span_extractors/endpoint_span_extractor.py
+++ b/allennlp/modules/span_extractors/endpoint_span_extractor.py
@@ -28,7 +28,7 @@ class EndpointSpanExtractor(SpanExtractor):
     ----------
     input_dim : ``int``, required.
         The final dimension of the ``sequence_tensor``.
-    combination : str, optional (default = "x,y").
+    combination : ``str``, optional (default = "x,y").
         The method used to combine the ``start_embedding`` and ``end_embedding``
         representations. See above for a full description.
     num_width_embeddings : ``int``, optional (default = None).

--- a/allennlp/modules/stacked_alternating_lstm.py
+++ b/allennlp/modules/stacked_alternating_lstm.py
@@ -21,17 +21,17 @@ class StackedAlternatingLstm(torch.nn.Module):
 
     Parameters
     ----------
-    input_size : int, required
+    input_size : ``int``, required
         The dimension of the inputs to the LSTM.
-    hidden_size : int, required
+    hidden_size : ``int``, required
         The dimension of the outputs of the LSTM.
-    num_layers : int, required
+    num_layers : ``int``, required
         The number of stacked LSTMs to use.
-    recurrent_dropout_probability: float, optional (default = 0.0)
+    recurrent_dropout_probability: ``float``, optional (default = 0.0)
         The dropout probability to be used in a dropout scheme as stated in
         `A Theoretically Grounded Application of Dropout in Recurrent Neural Networks
         <https://arxiv.org/abs/1512.05287>`_ .
-    use_input_projection_bias : bool, optional (default = True)
+    use_input_projection_bias : ``bool``, optional (default = True)
         Whether or not to use a bias on the input projection layer. This is mainly here
         for backwards compatibility reasons and will be removed (and set to False)
         in future releases.

--- a/allennlp/modules/stacked_bidirectional_lstm.py
+++ b/allennlp/modules/stacked_bidirectional_lstm.py
@@ -20,21 +20,21 @@ class StackedBidirectionalLstm(torch.nn.Module):
 
     Parameters
     ----------
-    input_size : int, required
+    input_size : ``int``, required
         The dimension of the inputs to the LSTM.
-    hidden_size : int, required
+    hidden_size : ``int``, required
         The dimension of the outputs of the LSTM.
-    num_layers : int, required
+    num_layers : ``int``, required
         The number of stacked Bidirectional LSTMs to use.
-    recurrent_dropout_probability: float, optional (default = 0.0)
+    recurrent_dropout_probability: ``float``, optional (default = 0.0)
         The recurrent dropout probability to be used in a dropout scheme as
         stated in `A Theoretically Grounded Application of Dropout in Recurrent
         Neural Networks <https://arxiv.org/abs/1512.05287>`_ .
-    layer_dropout_probability: float, optional (default = 0.0)
+    layer_dropout_probability: ``float``, optional (default = 0.0)
         The layer wise dropout probability to be used in a dropout scheme as
         stated in  `A Theoretically Grounded Application of Dropout in
         Recurrent Neural Networks <https://arxiv.org/abs/1512.05287>`_ .
-    use_highway: bool, optional (default = True)
+    use_highway: ``bool``, optional (default = True)
         Whether or not to use highway connections between layers. This effectively involves
         reparameterising the normal output of an LSTM as::
 

--- a/allennlp/modules/token_embedders/bert_token_embedder.py
+++ b/allennlp/modules/token_embedders/bert_token_embedder.py
@@ -57,15 +57,15 @@ class BertEmbedder(TokenEmbedder):
         The BERT model being wrapped.
     top_layer_only: ``bool``, optional (default = ``False``)
         If ``True``, then only return the top layer instead of apply the scalar mix.
-    max_pieces : int, optional (default: 512)
+    max_pieces: ``int``, optional (default: 512)
         The BERT embedder uses positional embeddings and so has a corresponding
         maximum length for its input ids. Assuming the inputs are windowed
         and padded appropriately by this length, the embedder will split them into a
         large batch, feed them into BERT, and recombine the output as if it was a
         longer sequence.
-    num_start_tokens : int, optional (default: 1)
+    num_start_tokens: ``int``, optional (default: 1)
         The number of starting special tokens input to BERT (usually 1, i.e., [CLS])
-    num_end_tokens : int, optional (default: 1)
+    num_end_tokens: ``int``, optional (default: 1)
         The number of ending tokens input to BERT (usually 1, i.e., [SEP])
     scalar_mix_parameters: ``List[float]``, optional, (default = None)
         If not ``None``, use these scalar mix parameters to weight the representations
@@ -111,9 +111,9 @@ class BertEmbedder(TokenEmbedder):
         """
         Parameters
         ----------
-        input_ids : ``torch.LongTensor``
+        input_ids: ``torch.LongTensor``
             The (batch_size, ..., max_sequence_length) tensor of wordpiece ids.
-        offsets : ``torch.LongTensor``, optional
+        offsets: ``torch.LongTensor``, optional
             The BERT embeddings are one per wordpiece. However it's possible/likely
             you might want one per original token. In that case, ``offsets``
             represents the indices of the desired wordpiece for each original token.
@@ -128,7 +128,7 @@ class BertEmbedder(TokenEmbedder):
             embeddings at those positions, and (in particular) will contain one embedding
             per token. If offsets are not provided, the entire tensor of wordpiece embeddings
             will be returned.
-        token_type_ids : ``torch.LongTensor``, optional
+        token_type_ids: ``torch.LongTensor``, optional
             If an input consists of two sentences (as in the BERT paper),
             tokens from the first sentence should have type 0 and tokens from
             the second sentence should have type 1.  If you don't provide this
@@ -272,7 +272,7 @@ class PretrainedBertEmbedder(BertEmbedder):
         If the name is a key in the list of pretrained models at
         https://github.com/huggingface/pytorch-pretrained-BERT/blob/master/pytorch_pretrained_bert/modeling.py#L41
         the corresponding path will be used; otherwise it will be interpreted as a path or URL.
-    requires_grad : ``bool``, optional (default = False)
+    requires_grad: ``bool``, optional (default = False)
         If True, compute gradient of BERT parameters for fine tuning.
     top_layer_only: ``bool``, optional (default = ``False``)
         If ``True``, then only return the top layer instead of apply the scalar mix.

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -45,35 +45,35 @@ class Embedding(TokenEmbedder):
 
     Parameters
     ----------
-    num_embeddings : int
+    num_embeddings: ``int``
         Size of the dictionary of embeddings (vocabulary size).
-    embedding_dim : int
+    embedding_dim: ``int``
         The size of each embedding vector.
-    projection_dim : int, (optional, default=None)
+    projection_dim: ``int``, (optional, default=None)
         If given, we add a projection layer after the embedding layer.  This really only makes
         sense if ``trainable`` is ``False``.
-    weight : torch.FloatTensor, (optional, default=None)
+    weight: ``torch.FloatTensor``, (optional, default=None)
         A pre-initialised weight matrix for the embedding lookup, allowing the use of
         pretrained vectors.
-    padding_index : int, (optional, default=None)
+    padding_index: ``int``, (optional, default=None)
         If given, pads the output with zeros whenever it encounters the index.
-    trainable : bool, (optional, default=True)
+    trainable: ``bool``, (optional, default=True)
         Whether or not to optimize the embedding parameters.
-    max_norm : float, (optional, default=None)
+    max_norm: ``float``, (optional, default=None)
         If given, will renormalize the embeddings to always have a norm lesser than this
-    norm_type : float, (optional, default=2)
+    norm_type: ``float``, (optional, default=2)
         The p of the p-norm to compute for the max_norm option
-    scale_grad_by_freq : boolean, (optional, default=False)
+    scale_grad_by_freq: ``bool``, (optional, default=False)
         If given, this will scale gradients by the frequency of the words in the mini-batch.
-    sparse : bool, (optional, default=False)
+    sparse: ``bool``, (optional, default=False)
         Whether or not the Pytorch backend should use a sparse representation of the embedding weight.
-    vocab_namespace : str, (optional, default=None)
+    vocab_namespace: ``str``, (optional, default=None)
         In case of fine-tuning/transfer learning, the model's embedding matrix needs to be
         extended according to the size of extended-vocabulary. To be able to know how much to
         extend the embedding-matrix, it's necessary to know which vocab_namspace was used to
         construct it in the original training. We store vocab_namespace used during the original
         training as an attribute, so that it can be retrieved during fine-tuning.
-    pretrained_file : str, (optional, default=None)
+    pretrained_file: ``str``, (optional, default=None)
         Used to keep track of what is the source of the weights and loading more embeddings at test time.
         **It does not load the weights from this pretrained_file.** For that purpose, use
         ``Embedding.from_params``.
@@ -177,19 +177,19 @@ class Embedding(TokenEmbedder):
 
         Parameters
         ----------
-        extended_vocab : Vocabulary:
+        extended_vocab: ``Vocabulary``
             Vocabulary extended from original vocabulary used to construct
             this ``Embedding``.
-        vocab_namespace : str, (optional, default=None)
+        vocab_namespace: ``str``, (optional, default=None)
             In case you know what vocab_namespace should be used for extension, you
             can pass it. If not passed, it will check if vocab_namespace used at the
             time of ``Embedding`` construction is available. If so, this namespace
             will be used or else extend_vocab will be a no-op.
-        extension_pretrained_file : str, (optional, default=None)
+        extension_pretrained_file: ``str``, (optional, default=None)
             A file containing pretrained embeddings can be specified here. It can be
             the path to a local file or an URL of a (cached) remote file. Check format
             details in ``from_params`` of ``Embedding`` class.
-        model_path : str, (optional, default=None)
+        model_path: ``str``, (optional, default=None)
             Path traversing the model attributes upto this embedding module.
             Eg. "_text_field_embedder.token_embedder_tokens". This is only useful
             to give helpful error message when extend_vocab is implicitly called
@@ -363,7 +363,7 @@ def _read_pretrained_embeddings_file(
 
     Parameters
     ----------
-    file_uri : str, required.
+    file_uri: ``str``, required.
         It can be:
 
         * a file system path or a URL of an eventually compressed text file or a zip/tar archive
@@ -372,11 +372,11 @@ def _read_pretrained_embeddings_file(
         * URI of the type ``(archive_path_or_url)#file_path_inside_archive`` if the text file
           is contained in a multi-file archive.
 
-    vocab : Vocabulary, required.
+    vocab: ``Vocabulary``, required.
         A Vocabulary object.
-    namespace : str, (optional, default=tokens)
+    namespace: ``str``, (optional, default=tokens)
         The namespace of the vocabulary to find pretrained embeddings for.
-    trainable : bool, (optional, default=True)
+    trainable: ``bool``, (optional, default=True)
         Whether or not the embedding parameters should be optimized.
 
     Returns
@@ -522,7 +522,7 @@ class EmbeddingsTextFile(Iterator[str]):
 
     Parameters
     ----------
-    file_uri: str
+    file_uri: ``str``
         It can be:
 
         * a file system path or a URL of an eventually compressed text file or a zip/tar archive
@@ -530,8 +530,8 @@ class EmbeddingsTextFile(Iterator[str]):
         * URI of the type ``(archive_path_or_url)#file_path_inside_archive`` if the text file
           is contained in a multi-file archive.
 
-    encoding: str
-    cache_dir: str
+    encoding: ``str``
+    cache_dir: ``str``
     """
 
     DEFAULT_ENCODING = "utf-8"

--- a/allennlp/modules/token_embedders/pass_through_token_embedder.py
+++ b/allennlp/modules/token_embedders/pass_through_token_embedder.py
@@ -10,7 +10,7 @@ class PassThroughTokenEmbedder(TokenEmbedder):
 
     Parameters
     ----------
-    hidden_dim : `int`, required.
+    hidden_dim: ``int``, required.
 
     """
 


### PR DESCRIPTION
I formated docstrings so that sphinx can recognize arguments and types separately. 

```python 

class ClassName: 
"""
arg1: ``int``, required 
    explanation of argument 1 
arg2: ``str``, optional (default = None)
    explanation of argument2
"""

     def __init__(self, arg1: int, arg2: str = None): 
         pass
```

On documentation, this modification will be reflected like [this](https://allenai.github.io/allennlp-docs/api/allennlp.modules.elmo.html#allennlp.modules.elmo.Elmo).

## Background
Previously, some classes had troubles on documentations like 

```
arg1int
arg2str
```

These were caused by below docstrings

```python
class ClassName
"""
Parameters
----------
arg1 : int 
arg2 : str
"""
    def __init__(self, arg1: int, arg2: str = None): 
        pass
```

## Solutions 

1. Don't add whitespace between argument name and type 
2. Wrap type name by double backquotes like ``type``

Looking at existing codes, codes using the second is more than the first, so I've modified by the second. Also, since some codes lacked information of whether this argument is required or optional, I added such information on docstring based on initializers. 

## Remains

Since I checked only allennlp.modules, the others might have the same trouble. 