### PR TITLE
 Filter by int instead of None to remove elided tokens

### DIFF
--- a/allennlp/data/dataset_readers/universal_dependencies.py
+++ b/allennlp/data/dataset_readers/universal_dependencies.py
@@ -55,8 +55,8 @@ class UniversalDependenciesDatasetReader(DatasetReader):
                 # CoNLLU annotations sometimes add back in words that have been elided
                 # in the original sentence; we remove these, as we're just predicting
                 # dependencies for the original sentence.
-                # We filter by None here as elided words have a non-integer word id,
-                # and are replaced with None by the conllu python library.
+                # We filter by integers here as elided words have a non-integer word id,
+                # as parsed by the conllu python library.
                 annotation = [x for x in annotation if isinstance(x["id"], int)]
 
                 heads = [x["head"] for x in annotation]

--- a/allennlp/data/dataset_readers/universal_dependencies_multilang.py
+++ b/allennlp/data/dataset_readers/universal_dependencies_multilang.py
@@ -112,9 +112,9 @@ class UniversalDependenciesMultiLangDatasetReader(DatasetReader):
                 # CoNLLU annotations sometimes add back in words that have been elided
                 # in the original sentence; we remove these, as we're just predicting
                 # dependencies for the original sentence.
-                # We filter by None here as elided words have a non-integer word id,
-                # and are replaced with None by the conllu python library.
-                annotation = [x for x in annotation if x["id"] is not None]
+                # We filter by integers here as elided words have a non-integer word id,
+                # as parsed by the conllu python library.
+                annotation = [x for x in annotation if isinstance(x["id"], int)]
 
                 heads = [x["head"] for x in annotation]
                 tags = [x["deprel"] for x in annotation]


### PR DESCRIPTION
This changed in conllu==1.0 (https://github.com/EmilStenstrom/conllu/wiki/Migrating-from-0.1-to-1.0#parsing-of-ids-now-include-ranges-and-decimals) which is what allennlp uses since 9db0042. I must have missed this when doing the last update over 6 months ago.

(It might be a good idea to see if it's possible to unify universal_dependencies.py and universal_dependencies_multilang.py, since they have duplicate code in them)

