### PR TITLE
Update conllu to 2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ h5py
 pytz>=2017.3
 
 # Reads Universal Dependencies files.
-conllu==1.3.1
+conllu==2.2
 
 #### ESSENTIAL TESTING-RELATED PACKAGES ####
 


### PR DESCRIPTION
This update has no backwards compatible changes, and all tests run clean ([meaning the same four tests fail as without this change](3570)) after this change.