### PR TITLE
Remove `sequence_mask` in self_attentive_span_extractor.py

### DIFF
--- a/allennlp/modules/span_extractors/self_attentive_span_extractor.py
+++ b/allennlp/modules/span_extractors/self_attentive_span_extractor.py
@@ -47,7 +47,6 @@ class SelfAttentiveSpanExtractor(SpanExtractor):
         self,
         sequence_tensor: torch.FloatTensor,
         span_indices: torch.LongTensor,
-        sequence_mask: torch.LongTensor = None,
         span_indices_mask: torch.LongTensor = None,
     ) -> torch.FloatTensor:
         # both of shape (batch_size, num_spans, 1)


### PR DESCRIPTION
Remove the unnecessary argument `sequence_mask` in self_attentive_span_extractor.py

Fixes https://github.com/allenai/allennlp/issues/3565