### PR TITLE
Consistently format docstrings.

### DIFF
--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -165,18 +165,18 @@ def find_learning_rate_model(
         A parameter object specifying an AllenNLP Experiment.
     serialization_dir : ``str``
         The directory in which to save results.
-    start_lr: ``float``
+    start_lr : ``float``
         Learning rate to start the search.
-    end_lr: ``float``
+    end_lr : ``float``
         Learning rate upto which search is done.
-    num_batches: ``int``
+    num_batches : ``int``
         Number of mini-batches to run Learning rate finder.
-    linear_steps: ``bool``
+    linear_steps : ``bool``
         Increase learning rate linearly if False exponentially.
-    stopping_factor: ``float``
+    stopping_factor : ``float``
         Stop the search when the current loss exceeds the best loss recorded by
         multiple of stopping factor. If ``None`` search proceeds till the ``end_lr``
-    force: ``bool``
+    force : ``bool``
         If True and the serialization directory already exists, everything in it will
         be removed prior to finding the learning rate.
     """
@@ -273,20 +273,20 @@ def search_learning_rate(
     Parameters
     ----------
     trainer: :class:`~allennlp.training.trainer.Trainer`
-    start_lr: ``float``
+    start_lr : ``float``
         The learning rate to start the search.
-    end_lr: ``float``
+    end_lr : ``float``
         The learning rate upto which search is done.
-    num_batches: ``int``
+    num_batches : ``int``
         Number of batches to run the learning rate finder.
-    linear_steps: ``bool``
+    linear_steps : ``bool``
         Increase learning rate linearly if False exponentially.
-    stopping_factor: ``float``
+    stopping_factor : ``float``
         Stop the search when the current loss exceeds the best loss recorded by
         multiple of stopping factor. If ``None`` search proceeds till the ``end_lr``
     Returns
     -------
-    (learning_rates, losses): ``Tuple[List[float], List[float]]``
+    (learning_rates, losses) : ``Tuple[List[float], List[float]]``
         Returns list of learning rates and corresponding losses.
         Note: The losses are recorded before applying the corresponding learning rate
     """

--- a/allennlp/commands/fine_tune.py
+++ b/allennlp/commands/fine_tune.py
@@ -199,14 +199,14 @@ def fine_tune_model_from_file_paths(
         :func:`fine_tune_model`.
     overrides : ``str``
         A JSON string that we will use to override values in the input parameter file.
-    extend_vocab: ``bool``, optional (default=False)
+    extend_vocab : ``bool``, optional (default=False)
         If ``True``, we use the new instances to extend your vocabulary.
     file_friendly_logging : ``bool``, optional (default=False)
         If ``True``, we make our output more friendly to saved model files.  We just pass this
         along to :func:`fine_tune_model`.
     batch_weight_key : ``str``, optional (default="")
         If non-empty, name of metric used to weight the loss on a per-batch basis.
-    embedding_sources_mapping: ``str``, optional (default="")
+    embedding_sources_mapping : ``str``, optional (default="")
         JSON string to define dict mapping from embedding paths used during training to
         the corresponding embedding filepaths available during fine-tuning.
     """
@@ -255,14 +255,14 @@ def fine_tune_model(
         A parameter object specifying an AllenNLP Experiment
     serialization_dir : ``str``
         The directory in which to save results and logs.
-    extend_vocab: ``bool``, optional (default=False)
+    extend_vocab : ``bool``, optional (default=False)
         If ``True``, we use the new instances to extend your vocabulary.
     file_friendly_logging : ``bool``, optional (default=False)
         If ``True``, we add newlines to tqdm output, even on an interactive terminal, and we slow
         down tqdm's output to only once every 10 seconds.
     batch_weight_key : ``str``, optional (default="")
         If non-empty, name of metric used to weight the loss on a per-batch basis.
-    embedding_sources_mapping: ``Dict[str, str]``, optional (default=None)
+    embedding_sources_mapping : ``Dict[str, str]``, optional (default=None)
         mapping from model paths to the pretrained embedding filepaths
         used during fine-tuning.
     """

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -203,7 +203,7 @@ def train_model_from_file(
         For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
     node_rank : ``int``, optional
         Rank of the current node in distributed training
-    include_package: ``str``, optional
+    include_package : ``str``, optional
         In distributed mode, extra packages mentioned will be imported in trainer workers.
     """
     # Load the experiment config from a file and pass it to ``train_model``.
@@ -255,14 +255,14 @@ def train_model(
         For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
     cache_prefix : ``str``, optional
         For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
-    node_rank: ``int``, optional
+    node_rank : ``int``, optional
         Rank of the current node in distributed training
-    include_package: ``List[str]``, optional
+    include_package : ``List[str]``, optional
         In distributed mode, extra packages mentioned will be imported in trainer workers.
 
     Returns
     -------
-    best_model: ``Model``
+    best_model : ``Model``
         The model with the best epoch weights.
     """
     create_serialization_dir(params, serialization_dir, recover, force)
@@ -387,18 +387,18 @@ def _train_worker(
         For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
     cache_prefix : ``str``, optional
         For caching data pre-processing.  See :func:`allennlp.training.util.datasets_from_params`.
-    include_package: ``List[str]``, optional
+    include_package : ``List[str]``, optional
         In distributed mode, since this function would have been spawned as a separate process,
         the extra imports need to be done again. NOTE: This does not have any effect in single
         GPU training.
-    node_rank: ``int``, optional
+    node_rank : ``int``, optional
         Rank of the node
-    world_size: ``int``, optional
+    world_size : ``int``, optional
         The number of processes involved in distributed training.
 
     Returns
     -------
-    best_model: ``Model``
+    best_model : ``Model``
         The model with the best epoch weights.
     """
     prepare_global_logging(

--- a/allennlp/common/registrable.py
+++ b/allennlp/common/registrable.py
@@ -48,9 +48,9 @@ class Registrable(FromParams):
 
         Parameters
         ----------
-        name : ``str``
+        name: ``str``
             The name to register the class under.
-        exist_ok : ``bool`, optional (default=False)
+        exist_ok: ``bool`, optional (default=False)
             If True, overwrites any existing models registered under ``name``. Else,
             throws an error if a model is already registered under ``name``.
         """

--- a/allennlp/common/registrable.py
+++ b/allennlp/common/registrable.py
@@ -48,9 +48,9 @@ class Registrable(FromParams):
 
         Parameters
         ----------
-        name: ``str``
+        name : ``str``
             The name to register the class under.
-        exist_ok: ``bool`, optional (default=False)
+        exist_ok : ``bool`, optional (default=False)
             If True, overwrites any existing models registered under ``name``. Else,
             throws an error if a model is already registered under ``name``.
         """

--- a/allennlp/data/dataset_readers/babi.py
+++ b/allennlp/data/dataset_readers/babi.py
@@ -24,7 +24,7 @@ class BabiReader(DatasetReader):
 
     Parameters
     ----------
-    keep_sentences: ``bool``, optional, (default = ``False``)
+    keep_sentences : ``bool``, optional, (default = ``False``)
         Whether to keep each sentence in the context or to concatenate them.
         Default is ``False`` that corresponds to concatenation.
     token_indexers : ``Dict[str, TokenIndexer]``, optional (default=``{"tokens": SingleIdTokenIndexer()}``)

--- a/allennlp/data/dataset_readers/ccgbank.py
+++ b/allennlp/data/dataset_readers/ccgbank.py
@@ -42,17 +42,17 @@ class CcgBankDatasetReader(DatasetReader):
         are pre-tokenised in the data file.
     lazy : ``bool``, optional, (default = ``False``)
         Whether or not instances can be consumed lazily.
-    tag_label: ``str``, optional (default=``ccg``)
+    tag_label : ``str``, optional (default=``ccg``)
         Specify ``ccg``, ``modified_pos``, ``original_pos``, or ``predicate_arg`` to
         have that tag loaded into the instance field ``tag``.
-    feature_labels: ``Sequence[str]``, optional (default=``()``)
+    feature_labels : ``Sequence[str]``, optional (default=``()``)
         These labels will be loaded as features into the corresponding instance fields:
         ``ccg`` -> ``ccg_tags``, ``modified_pos`` -> ``modified_pos_tags``,
         ``original_pos`` -> ``original_pos_tags``, or ``predicate_arg`` -> ``predicate_arg_tags``
-        Each will have its own namespace: ``ccg_tags``, ``modified_pos_tags``,
+        Each will have its own namespace : ``ccg_tags``, ``modified_pos_tags``,
         ``original_pos_tags``, ``predicate_arg_tags``. If you want to use one of the tags
         as a feature in your model, it should be specified here.
-    label_namespace: ``str``, optional (default=``labels``)
+    label_namespace : ``str``, optional (default=``labels``)
         Specifies the namespace for the chosen ``tag_label``.
     """
 

--- a/allennlp/data/dataset_readers/conll2000.py
+++ b/allennlp/data/dataset_readers/conll2000.py
@@ -40,21 +40,21 @@ class Conll2000DatasetReader(DatasetReader):
     ----------
     token_indexers : ``Dict[str, TokenIndexer]``, optional (default=``{"tokens": SingleIdTokenIndexer()}``)
         We use this to define the input representation for the text.  See :class:`TokenIndexer`.
-    tag_label: ``str``, optional (default=``chunk``)
+    tag_label : ``str``, optional (default=``chunk``)
         Specify `pos`, or `chunk` to have that tag loaded into the instance field `tag`.
-    feature_labels: ``Sequence[str]``, optional (default=``()``)
+    feature_labels : ``Sequence[str]``, optional (default=``()``)
         These labels will be loaded as features into the corresponding instance fields:
         ``pos`` -> ``pos_tags`` or ``chunk`` -> ``chunk_tags``.
-        Each will have its own namespace: ``pos_tags`` or ``chunk_tags``.
+        Each will have its own namespace : ``pos_tags`` or ``chunk_tags``.
         If you want to use one of the tags as a `feature` in your model, it should be
         specified here.
-    coding_scheme: ``str``, optional (default=``BIO``)
+    coding_scheme : ``str``, optional (default=``BIO``)
         Specifies the coding scheme for ``chunk_labels``.
         Valid options are ``BIO`` and ``BIOUL``.  The ``BIO`` default maintains
         the original BIO scheme in the CoNLL 2000 chunking data.
         In the BIO scheme, B is a token starting a span, I is a token continuing a span, and
         O is a token outside of a span.
-    label_namespace: ``str``, optional (default=``labels``)
+    label_namespace : ``str``, optional (default=``labels``)
         Specifies the namespace for the chosen ``tag_label``.
     """
 

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -54,22 +54,22 @@ class Conll2003DatasetReader(DatasetReader):
     ----------
     token_indexers : ``Dict[str, TokenIndexer]``, optional (default=``{"tokens": SingleIdTokenIndexer()}``)
         We use this to define the input representation for the text.  See :class:`TokenIndexer`.
-    tag_label: ``str``, optional (default=``ner``)
+    tag_label : ``str``, optional (default=``ner``)
         Specify `ner`, `pos`, or `chunk` to have that tag loaded into the instance field `tag`.
-    feature_labels: ``Sequence[str]``, optional (default=``()``)
+    feature_labels : ``Sequence[str]``, optional (default=``()``)
         These labels will be loaded as features into the corresponding instance fields:
         ``pos`` -> ``pos_tags``, ``chunk`` -> ``chunk_tags``, ``ner`` -> ``ner_tags``
-        Each will have its own namespace: ``pos_tags``, ``chunk_tags``, ``ner_tags``.
+        Each will have its own namespace : ``pos_tags``, ``chunk_tags``, ``ner_tags``.
         If you want to use one of the tags as a `feature` in your model, it should be
         specified here.
-    coding_scheme: ``str``, optional (default=``IOB1``)
+    coding_scheme : ``str``, optional (default=``IOB1``)
         Specifies the coding scheme for ``ner_labels`` and ``chunk_labels``.
         Valid options are ``IOB1`` and ``BIOUL``.  The ``IOB1`` default maintains
         the original IOB1 scheme in the CoNLL 2003 NER data.
         In the IOB1 scheme, I is a token inside a span, O is a token outside
         a span and B is the beginning of span immediately following another
         span of the same type.
-    label_namespace: ``str``, optional (default=``labels``)
+    label_namespace : ``str``, optional (default=``labels``)
         Specifies the namespace for the chosen ``tag_label``.
     """
 

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -65,7 +65,7 @@ class ConllCorefReader(DatasetReader):
     scripts/compile_coref_data.sh for more details of how to pre-process the Ontonotes 5.0 data
     into the correct format.
 
-    Returns a ``Dataset`` where the ``Instances`` have four fields: ``text``, a ``TextField``
+    Returns a ``Dataset`` where the ``Instances`` have four fields : ``text``, a ``TextField``
     containing the full document text, ``spans``, a ``ListField[SpanField]`` of inclusive start and
     end indices for span candidates, and ``metadata``, a ``MetadataField`` that stores the instance's
     original text. For data with gold cluster labels, we also include the original ``clusters``
@@ -74,7 +74,7 @@ class ConllCorefReader(DatasetReader):
 
     Parameters
     ----------
-    max_span_width: ``int``, required.
+    max_span_width : ``int``, required.
         The maximum width of candidate spans to consider.
     token_indexers : ``Dict[str, TokenIndexer]``, optional
         This is used to index the words in the document.  See :class:`TokenIndexer`.

--- a/allennlp/data/dataset_readers/coreference_resolution/winobias.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/winobias.py
@@ -40,7 +40,7 @@ class WinobiasReader(DatasetReader):
     [The salesperson] sold (some books) to the librarian because [she] was trying to sell (them).
 
 
-    Returns a list of ``Instances`` which have four fields: ``text``, a ``TextField``
+    Returns a list of ``Instances`` which have four fields : ``text``, a ``TextField``
     containing the full sentence text, ``spans``, a ``ListField[SpanField]`` of inclusive start and
     end indices for span candidates, and ``metadata``, a ``MetadataField`` that stores the instance's
     original text. For data with gold cluster labels, we also include the original ``clusters``
@@ -49,7 +49,7 @@ class WinobiasReader(DatasetReader):
 
     Parameters
     ----------
-    max_span_width: ``int``, required.
+    max_span_width : ``int``, required.
         The maximum width of candidate spans to consider.
     token_indexers : ``Dict[str, TokenIndexer]``, optional
         This is used to index the words in the sentence.  See :class:`TokenIndexer`.

--- a/allennlp/data/dataset_readers/dataset_utils/ontonotes.py
+++ b/allennlp/data/dataset_readers/dataset_utils/ontonotes.py
@@ -151,29 +151,29 @@ class Ontonotes:
         This is the Penn Treebank style part of speech. When parse information is missing,
         all part of speeches except the one for which there is some sense or proposition
         annotation are marked with a XX tag. The verb is marked with just a VERB tag.
-    6 Parse bit: ``str``
+    6 Parse bit : ``str``
         This is the bracketed structure broken before the first open parenthesis in the parse,
         and the word/part-of-speech leaf replaced with a ``*``. When the parse information is
         missing, the first word of a sentence is tagged as ``(TOP*`` and the last word is tagged
         as ``*)`` and all intermediate words are tagged with a ``*``.
-    7 Predicate lemma: ``str``
+    7 Predicate lemma : ``str``
         The predicate lemma is mentioned for the rows for which we have semantic role
         information or word sense information. All other rows are marked with a "-".
-    8 Predicate Frameset ID: ``int``
+    8 Predicate Frameset ID : ``int``
         The PropBank frameset ID of the predicate in Column 7.
-    9 Word sense: ``float``
+    9 Word sense : ``float``
         This is the word sense of the word in Column 3.
-    10 Speaker/Author: ``str``
+    10 Speaker/Author : ``str``
         This is the speaker or author name where available. Mostly in Broadcast Conversation
         and Web Log data. When not available the rows are marked with an "-".
-    11 Named Entities: ``str``
+    11 Named Entities : ``str``
         These columns identifies the spans representing various named entities. For documents
         which do not have named entity annotation, each line is represented with an ``*``.
-    12+ Predicate Arguments: ``str``
+    12+ Predicate Arguments : ``str``
         There is one column each of predicate argument structure information for the predicate
         mentioned in Column 7. If there are no predicates tagged in a sentence this is a
         single column with all rows marked with an ``*``.
-    -1 Co-reference: ``str``
+    -1 Co-reference : ``str``
         Co-reference chain information encoded in a parenthesis structure. For documents that do
          not have co-reference annotations, each line is represented with a "-".
     """
@@ -386,7 +386,7 @@ class Ontonotes:
         clusters : ``DefaultDict[int, List[Tuple[int, int]]]``
             A dictionary mapping cluster ids to lists of inclusive spans into the
             sentence.
-        coref_stacks: ``DefaultDict[int, List[int]]``
+        coref_stacks : ``DefaultDict[int, List[int]]``
             Stacks for each cluster id to hold the start indices of active spans (spans
             which we are inside of when processing a given word). Spans with the same id
             can be nested, which is why we collect these opening spans on a stack, e.g:
@@ -428,7 +428,7 @@ class Ontonotes:
 
         Parameters
         ----------
-        annotations: ``List[str]``
+        annotations : ``List[str]``
             A list of labels to compute BIO tags for.
         span_labels : ``List[List[str]]``
             A list of lists, one for each annotation, to incrementally collect

--- a/allennlp/data/dataset_readers/dataset_utils/span_utils.py
+++ b/allennlp/data/dataset_readers/dataset_utils/span_utils.py
@@ -295,7 +295,7 @@ def to_bioul(tag_sequence: List[str], encoding: str = "IOB1") -> List[str]:
 
     Returns
     -------
-    bioul_sequence: ``List[str]``
+    bioul_sequence : ``List[str]``
         The tag sequence encoded in IOB1, e.g. ["B-PER", "L-PER", "O"].
     """
     if encoding not in {"IOB1", "BIO"}:

--- a/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
+++ b/allennlp/data/dataset_readers/multiprocess_dataset_reader.py
@@ -198,7 +198,7 @@ class MultiprocessDatasetReader(DatasetReader):
         multiple-process case, it's possible that you'd want finished workers to continue on to the
         next epoch even while others are still finishing the previous epoch. Passing in a value
         larger than 1 allows that to happen.
-    output_queue_size: ``int``, (optional, default=1000)
+    output_queue_size : ``int``, (optional, default=1000)
         The size of the queue on which read instances are placed to be yielded.
         You might need to increase this if you're generating instances too quickly.
     """

--- a/allennlp/data/dataset_readers/ontonotes_ner.py
+++ b/allennlp/data/dataset_readers/ontonotes_ner.py
@@ -44,7 +44,7 @@ class OntonotesNamedEntityRecognition(DatasetReader):
     token_indexers : ``Dict[str, TokenIndexer]``, optional
         We similarly use this for both the premise and the hypothesis.  See :class:`TokenIndexer`.
         Default is ``{"tokens": SingleIdTokenIndexer()}``.
-    domain_identifier: ``str``, (default = None)
+    domain_identifier : ``str``, (default = None)
         A string denoting a sub-domain of the Ontonotes 5.0 dataset to use. If present, only
         conll files under paths containing this domain identifier will be processed.
     coding_scheme : ``str``, (default = None).

--- a/allennlp/data/dataset_readers/reading_comprehension/drop.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/drop.py
@@ -85,13 +85,13 @@ class DropReader(DatasetReader):
         If specified, we will cut the passage if the length of passage exceeds this limit.
     question_length_limit : ``int``, optional (default=None)
         If specified, we will cut the question if the length of passage exceeds this limit.
-    skip_when_all_empty: ``List[str]``, optional (default=None)
+    skip_when_all_empty : ``List[str]``, optional (default=None)
         In some cases such as preparing for training examples, you may want to skip some examples
         when there are no gold labels. You can specify on what condition should the examples be
         skipped. Currently, you can put "passage_span", "question_span", "addition_subtraction",
         or "counting" in this list, to tell the reader skip when there are no such label found.
         If not specified, we will keep all the examples.
-    instance_format: ``str``, optional (default="drop")
+    instance_format : ``str``, optional (default="drop")
         We try to be generous in providing a few different formats for the instances in DROP,
         in terms of the ``Fields`` that we return for each ``Instance``, to allow for several
         different kinds of models.  "drop" format will do processing to detect numbers and

--- a/allennlp/data/dataset_readers/reading_comprehension/qangaroo.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/qangaroo.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class QangarooReader(DatasetReader):
     """
     Reads a JSON-formatted Qangaroo file and returns a ``Dataset`` where the ``Instances`` have six
-    fields: ``candidates``, a ``ListField[TextField]``, ``query``, a ``TextField``, ``supports``, a
+    fields : ``candidates``, a ``ListField[TextField]``, ``query``, a ``TextField``, ``supports``, a
     ``ListField[TextField]``, ``answer``, a ``TextField``, and ``answer_index``, a ``IndexField``.
     We also add a ``MetadataField`` that stores the instance's ID and annotations if they are present.
 

--- a/allennlp/data/dataset_readers/reading_comprehension/quac.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/quac.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class QuACReader(DatasetReader):
     """
     Reads a JSON-formatted Question Answering in Context (QuAC) data file
-    and returns a ``Dataset`` where the ``Instances`` have four fields: ``question``, a ``ListField``,
+    and returns a ``Dataset`` where the ``Instances`` have four fields : ``question``, a ``ListField``,
     ``passage``, another ``TextField``, and ``span_start`` and ``span_end``, both ``ListField`` composed of
     IndexFields`` into the ``passage`` ``TextField``.
     Two ``ListField``, composed of ``LabelField``, ``yesno_list`` and  ``followup_list`` is added.

--- a/allennlp/data/dataset_readers/reading_comprehension/squad.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/squad.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class SquadReader(DatasetReader):
     """
     Reads a JSON-formatted SQuAD file and returns a ``Dataset`` where the ``Instances`` have four
-    fields: ``question``, a ``TextField``, ``passage``, another ``TextField``, and ``span_start``
+    fields : ``question``, a ``TextField``, ``passage``, another ``TextField``, and ``span_start``
     and ``span_end``, both ``IndexFields`` into the ``passage`` ``TextField``.  We also add a
     ``MetadataField`` that stores the instance's ID, the original passage text, gold answer strings,
     and token offsets into the original passage, accessible as ``metadata['id']``,
@@ -49,7 +49,7 @@ class SquadReader(DatasetReader):
         if specified, we will cut the passage if the length of passage exceeds this limit.
     question_length_limit : ``int``, optional (default=None)
         if specified, we will cut the question if the length of passage exceeds this limit.
-    skip_invalid_examples: ``bool``, optional (default=False)
+    skip_invalid_examples : ``bool``, optional (default=False)
         if this is true, we will skip those invalid examples
     """
 

--- a/allennlp/data/dataset_readers/reading_comprehension/util.py
+++ b/allennlp/data/dataset_readers/reading_comprehension/util.py
@@ -165,7 +165,7 @@ def make_reading_comprehension_instance(
     Converts a question, a passage, and an optional answer (or answers) to an ``Instance`` for use
     in a reading comprehension model.
 
-    Creates an ``Instance`` with at least these fields: ``question`` and ``passage``, both
+    Creates an ``Instance`` with at least these fields : ``question`` and ``passage``, both
     ``TextFields``; and ``metadata``, a ``MetadataField``.  Additionally, if both ``answer_texts``
     and ``char_span_starts`` are given, the ``Instance`` has ``span_start`` and ``span_end``
     fields, which are both ``IndexFields``.
@@ -251,7 +251,7 @@ def make_reading_comprehension_instance_quac(
     Converts a question, a passage, and an optional answer (or answers) to an ``Instance`` for use
     in a reading comprehension model.
 
-    Creates an ``Instance`` with at least these fields: ``question`` and ``passage``, both
+    Creates an ``Instance`` with at least these fields : ``question`` and ``passage``, both
     ``TextFields``; and ``metadata``, a ``MetadataField``.  Additionally, if both ``answer_texts``
     and ``char_span_starts`` are given, the ``Instance`` has ``span_start`` and ``span_end``
     fields, which are both ``IndexFields``.

--- a/allennlp/data/dataset_readers/semantic_role_labeling.py
+++ b/allennlp/data/dataset_readers/semantic_role_labeling.py
@@ -111,7 +111,7 @@ class SrlReader(DatasetReader):
     token_indexers : ``Dict[str, TokenIndexer]``, optional
         We similarly use this for both the premise and the hypothesis.  See :class:`TokenIndexer`.
         Default is ``{"tokens": SingleIdTokenIndexer()}``.
-    domain_identifier: ``str``, (default = None)
+    domain_identifier : ``str``, (default = None)
         A string denoting a sub-domain of the Ontonotes 5.0 dataset to use. If present, only
         conll files under paths containing this domain identifier will be processed.
     bert_model_name : ``Optional[str]``, (default = None)

--- a/allennlp/data/dataset_readers/seq2seq.py
+++ b/allennlp/data/dataset_readers/seq2seq.py
@@ -25,8 +25,8 @@ class Seq2SeqDatasetReader(DatasetReader):
     Expected format for each input line: <source_sequence_string>\t<target_sequence_string>
 
     The output of ``read`` is a list of ``Instance`` s with the fields:
-        source_tokens: ``TextField`` and
-        target_tokens: ``TextField``
+        source_tokens : ``TextField`` and
+        target_tokens : ``TextField``
 
     `START_SYMBOL` and `END_SYMBOL` tokens are added to the source and target sequences.
 

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -27,9 +27,9 @@ class SequenceTaggingDatasetReader(DatasetReader):
 
     Parameters
     ----------
-    word_tag_delimiter : ``str``, optional (default=``"###"``)
+    word_tag_delimiter: ``str``, optional (default=``"###"``)
         The text that separates each WORD from its TAG.
-    token_delimiter : ``str``, optional (default=``None``)
+    token_delimiter: ``str``, optional (default=``None``)
         The text that separates each WORD-TAG pair from the next pair. If ``None``
         then the line will just be split on whitespace.
     token_indexers : ``Dict[str, TokenIndexer]``, optional (default=``{"tokens": SingleIdTokenIndexer()}``)

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -27,9 +27,9 @@ class SequenceTaggingDatasetReader(DatasetReader):
 
     Parameters
     ----------
-    word_tag_delimiter: ``str``, optional (default=``"###"``)
+    word_tag_delimiter : ``str``, optional (default=``"###"``)
         The text that separates each WORD from its TAG.
-    token_delimiter: ``str``, optional (default=``None``)
+    token_delimiter : ``str``, optional (default=``None``)
         The text that separates each WORD-TAG pair from the next pair. If ``None``
         then the line will just be split on whitespace.
     token_indexers : ``Dict[str, TokenIndexer]``, optional (default=``{"tokens": SingleIdTokenIndexer()}``)

--- a/allennlp/data/dataset_readers/simple_language_modeling.py
+++ b/allennlp/data/dataset_readers/simple_language_modeling.py
@@ -30,7 +30,7 @@ class SimpleLanguageModelingDatasetReader(DatasetReader):
     token_indexers : ``Dict[str, TokenIndexer]``, optional
         Indexers used to define input token representations. Defaults to
         ``{"tokens": SingleIdTokenIndexer()}``.
-    max_sequence_length: ``int``, optional
+    max_sequence_length : ``int``, optional
         If specified, sentences with more than this number of tokens will be dropped.
     start_tokens : ``List[str]``, optional (default=``None``)
         These are prepended to the tokens provided to the ``TextField``.

--- a/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
@@ -34,8 +34,8 @@ class StanfordSentimentTreeBankDatasetReader(DatasetReader):
     by their sentiment.
 
     The output of ``read`` is a list of ``Instance`` s with the fields:
-        tokens: ``TextField`` and
-        label: ``LabelField``
+        tokens : ``TextField`` and
+        label : ``LabelField``
 
     Parameters
     ----------

--- a/allennlp/data/dataset_readers/text_classification_json.py
+++ b/allennlp/data/dataset_readers/text_classification_json.py
@@ -20,8 +20,8 @@ class TextClassificationJsonReader(DatasetReader):
     Expects a "text" field and a "label" field in JSON format.
 
     The output of ``read`` is a list of ``Instance`` s with the fields:
-        tokens: ``TextField`` and
-        label: ``LabelField``
+        tokens : ``TextField`` and
+        label : ``LabelField``
 
     Parameters
     ----------
@@ -31,13 +31,13 @@ class TextClassificationJsonReader(DatasetReader):
         See :class:`TokenIndexer`.
     tokenizer : ``Tokenizer``, optional (default = ``{"tokens": SpacyTokenizer()}``)
         Tokenizer to use to split the input text into words or other kinds of tokens.
-    segment_sentences: ``bool``, optional (default = ``False``)
+    segment_sentences : ``bool``, optional (default = ``False``)
         If True, we will first segment the text into sentences using SpaCy and then tokenize words.
         Necessary for some models that require pre-segmentation of sentences, like the Hierarchical
         Attention Network (https://www.cs.cmu.edu/~hovy/papers/16HLT-hierarchical-attention-networks.pdf).
-    max_sequence_length: ``int``, optional (default = ``None``)
+    max_sequence_length : ``int``, optional (default = ``None``)
         If specified, will truncate tokens to specified maximum length.
-    skip_label_indexing: ``bool``, optional (default = ``False``)
+    skip_label_indexing : ``bool``, optional (default = ``False``)
         Whether or not to skip label indexing. You might want to skip label indexing if your
         labels are numbers, so the dataset reader doesn't re-number them starting from 0.
     lazy : ``bool``, optional, (default = ``False``)

--- a/allennlp/data/iterators/multiprocess_iterator.py
+++ b/allennlp/data/iterators/multiprocess_iterator.py
@@ -107,7 +107,7 @@ class MultiprocessIterator(DataIterator):
         processes, so it should not be stateful in any way.
     num_workers : ``int``, optional (default = 1)
         The number of processes used for generating tensor dicts.
-    output_queue_size: ``int``, optional (default = 1000)
+    output_queue_size : ``int``, optional (default = 1000)
         The size of the output queue on which tensor dicts are placed to be consumed.
         You might need to increase this if you're generating tensor dicts too quickly.
     """

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -32,7 +32,7 @@ class TokenCharactersIndexer(TokenIndexer[List[int]]):
         These are prepended to the tokens provided to ``tokens_to_indices``.
     end_tokens : ``List[str]``, optional (default=``None``)
         These are appended to the tokens provided to ``tokens_to_indices``.
-    min_padding_length: ``int``, optional (default=``0``)
+    min_padding_length : ``int``, optional (default=``0``)
         We use this value as the minimum length of padding. Usually used with :class:``CnnEncoder``, its
         value should be set to the maximum value of ``ngram_filter_sizes`` correspondingly.
     token_min_padding_length : ``int``, optional (default=``0``)

--- a/allennlp/data/token_indexers/wordpiece_indexer.py
+++ b/allennlp/data/token_indexers/wordpiece_indexer.py
@@ -47,7 +47,7 @@ class WordpieceIndexer(TokenIndexer[int]):
         You would need to do this if you are using an -uncased BERT model
         but your DatasetReader is not lowercasing tokens (which might be the
         case if you're also using other embeddings based on cased tokens).
-    never_lowercase: ``List[str]``, optional
+    never_lowercase : ``List[str]``, optional
         Tokens that should never be lowercased. Default is
         ['[UNK]', '[SEP]', '[PAD]', '[CLS]', '[MASK]'].
     start_tokens : ``List[str]``, optional (default=``None``)
@@ -329,7 +329,7 @@ class PretrainedBertIndexer(WordpieceIndexer):
 
     Parameters
     ----------
-    pretrained_model: ``str``
+    pretrained_model : ``str``
         Either the name of the pretrained model to use (e.g. 'bert-base-uncased'),
         or the path to the .txt file with its vocabulary.
 
@@ -340,9 +340,9 @@ class PretrainedBertIndexer(WordpieceIndexer):
         By default, the "offsets" created by the token indexer correspond to the
         last wordpiece in each word. If ``use_starting_offsets`` is specified,
         they will instead correspond to the first wordpiece in each word.
-    do_lowercase: ``bool``, optional (default = True)
+    do_lowercase : ``bool``, optional (default = True)
         Whether to lowercase the tokens before converting to wordpiece ids.
-    never_lowercase: ``List[str]``, optional
+    never_lowercase : ``List[str]``, optional
         Tokens that should never be lowercased. Default is
         ['[UNK]', '[SEP]', '[PAD]', '[CLS]', '[MASK]'].
     max_pieces: int, optional (default: 512)

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -31,23 +31,23 @@ class PretrainedTransformerTokenizer(Tokenizer):
     ----------
     model_name : ``str``
         The name of the pretrained wordpiece tokenizer to use.
-    add_special_tokens: ``bool``, optional, (default=True)
+    add_special_tokens : ``bool``, optional, (default=True)
         If set to ``True``, the sequences will be encoded with the special tokens relative
         to their model.
-    max_length: ``int``, optional (default=None)
+    max_length : ``int``, optional (default=None)
         If set to a number, will limit the total sequence returned so that it has a maximum length.
         If there are overflowing tokens, those will be added to the returned dictionary
-    stride: ``int``, optional (default=0)
+    stride : ``int``, optional (default=0)
         If set to a number along with max_length, the overflowing tokens returned will contain some tokens
         from the main sequence returned. The value of this argument defines the number of additional tokens.
-    truncation_strategy: ``str``, optional (default='longest_first')
+    truncation_strategy : ``str``, optional (default='longest_first')
         String selected in the following options:
         - 'longest_first' (default) Iteratively reduce the inputs sequence until the input is under max_length
         starting from the longest one at each token (when there is a pair of input sequences)
         - 'only_first': Only truncate the first sequence
         - 'only_second': Only truncate the second sequence
         - 'do_not_truncate': Do not truncate (raise an error if the input sequence is longer than max_length)
-    calculate_character_offsets: ``bool``, optional (default=False)
+    calculate_character_offsets : ``bool``, optional (default=False)
         Attempts to reconstruct character offsets for the instances of Token that this tokenizer produces.
 
     Argument descriptions are from

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -107,11 +107,11 @@ def archive_model(
 
     Parameters
     ----------
-    serialization_dir: ``str``
+    serialization_dir : ``str``
         The directory where the weights and vocabulary are written out.
-    weights: ``str``, optional (default=_DEFAULT_WEIGHTS)
+    weights : ``str``, optional (default=_DEFAULT_WEIGHTS)
         Which weights file to include in the archive. The default is ``best.th``.
-    files_to_archive: ``Dict[str, str]``, optional (default=None)
+    files_to_archive : ``Dict[str, str]``, optional (default=None)
         A mapping {flattened_key -> filename} of supplementary files to include
         in the archive. That is, if you wanted to include ``params['model']['weights']``
         then you would specify the key as `"model.weights"`.
@@ -165,14 +165,14 @@ def load_archive(
 
     Parameters
     ----------
-    archive_file: ``str``
+    archive_file : ``str``
         The archive file to load the model from.
-    weights_file: ``str``, optional (default = None)
+    weights_file : ``str``, optional (default = None)
         The weights file to use.  If unspecified, weights.th in the archive_file will be used.
-    cuda_device: ``int``, optional (default = -1)
+    cuda_device : ``int``, optional (default = -1)
         If `cuda_device` is >= 0, the model will be loaded onto the
         corresponding GPU. Otherwise it will be loaded onto the CPU.
-    overrides: ``str``, optional (default = "")
+    overrides : ``str``, optional (default = "")
         JSON overrides to apply to the unarchived ``Params`` object.
     """
     # redirect to the cache, if necessary

--- a/allennlp/models/basic_classifier.py
+++ b/allennlp/models/basic_classifier.py
@@ -36,10 +36,10 @@ class BasicClassifier(Model):
         An optional feedforward layer to apply after the seq2vec_encoder.
     dropout : ``float``, optional (default = ``None``)
         Dropout percentage to use.
-    num_labels: ``int``, optional (default = ``None``)
+    num_labels : ``int``, optional (default = ``None``)
         Number of labels to project to in classification layer. By default, the classification layer will
         project to the size of the vocabulary namespace corresponding to labels.
-    label_namespace: ``str``, optional (default = "labels")
+    label_namespace : ``str``, optional (default = "labels")
         Vocabulary namespace corresponding to labels. By default, we use the "labels" namespace.
     initializer : ``InitializerApplicator``, optional (default=``InitializerApplicator()``)
         If provided, will be used to initialize the model parameters.

--- a/allennlp/models/biaffine_dependency_parser.py
+++ b/allennlp/models/biaffine_dependency_parser.py
@@ -182,7 +182,7 @@ class BiaffineDependencyParser(Model):
         words : Dict[str, torch.LongTensor], required
             The output of ``TextField.as_array()``, which should typically be passed directly to a
             ``TextFieldEmbedder``. This output is a dictionary mapping keys to ``TokenIndexer``
-            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is: ``{"tokens":
+            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is : ``{"tokens":
             Tensor(batch_size, sequence_length)}``. This dictionary will have the same keys as were used
             for the ``TokenIndexers`` when you created the ``TextField`` representing your
             sequence.  The dictionary is designed to be passed directly to a ``TextFieldEmbedder``,

--- a/allennlp/models/bidirectional_lm.py
+++ b/allennlp/models/bidirectional_lm.py
@@ -24,20 +24,20 @@ class BidirectionalLanguageModel(LanguageModel):
 
     Parameters
     ----------
-    vocab: ``Vocabulary``
-    text_field_embedder: ``TextFieldEmbedder``
+    vocab : ``Vocabulary``
+    text_field_embedder : ``TextFieldEmbedder``
         Used to embed the indexed tokens we get in ``forward``.
-    contextualizer: ``Seq2SeqEncoder``
+    contextualizer : ``Seq2SeqEncoder``
         Used to "contextualize" the embeddings. As described above,
         this encoder must not cheat by peeking ahead.
-    dropout: ``float``, optional (default: None)
+    dropout : ``float``, optional (default: None)
         If specified, dropout is applied to the contextualized embeddings before computation of
         the softmax. The contextualized embeddings themselves are returned without dropout.
-    num_samples: ``int``, optional (default: None)
+    num_samples : ``int``, optional (default: None)
         If provided, the model will use ``SampledSoftmaxLoss``
         with the specified number of samples. Otherwise, it will use
         the full ``_SoftmaxLoss`` defined above.
-    sparse_embeddings: ``bool``, optional (default: False)
+    sparse_embeddings : ``bool``, optional (default: False)
         Passed on to ``SampledSoftmaxLoss`` if True.
     regularizer : ``RegularizerApplicator``, optional (default=``None``)
         If provided, will be used to calculate the regularization penalty during training.

--- a/allennlp/models/constituency_parser.py
+++ b/allennlp/models/constituency_parser.py
@@ -152,7 +152,7 @@ class SpanConstituencyParser(Model):
         tokens : Dict[str, torch.LongTensor], required
             The output of ``TextField.as_array()``, which should typically be passed directly to a
             ``TextFieldEmbedder``. This output is a dictionary mapping keys to ``TokenIndexer``
-            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is: ``{"tokens":
+            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is : ``{"tokens":
             Tensor(batch_size, num_tokens)}``. This dictionary will have the same keys as were used
             for the ``TokenIndexers`` when you created the ``TextField`` representing your
             sequence.  The dictionary is designed to be passed directly to a ``TextFieldEmbedder``,
@@ -376,7 +376,7 @@ class SpanConstituencyParser(Model):
 
         Parameters
         ----------
-        spans: ``List[SpanInformation]``, required.
+        spans : ``List[SpanInformation]``, required.
             A list of spans, where each span is a ``namedtuple`` containing the
             following attributes:
 

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -41,19 +41,19 @@ class CoreferenceResolver(Model):
     mention_feedforward : ``FeedForward``
         This feedforward network is applied to the span representations which is then scored
         by a linear layer.
-    antecedent_feedforward: ``FeedForward``
+    antecedent_feedforward : ``FeedForward``
         This feedforward network is applied to pairs of span representation, along with any
         pairwise features, which is then scored by a linear layer.
-    feature_size: ``int``
+    feature_size : ``int``
         The embedding size for all the embedded features, such as distances or span widths.
-    max_span_width: ``int``
+    max_span_width : ``int``
         The maximum width of candidate spans.
     spans_per_word: float, required.
         A multiplier between zero and one which controls what percentage of candidate mention
         spans we retain with respect to the number of words in the document.
     max_antecedents: int, required.
         For each mention which survives the pruning stage, we consider this many antecedents.
-    lexical_dropout: ``int``
+    lexical_dropout : ``int``
         The probability of dropping out dimensions of the embedded text.
     initializer : ``InitializerApplicator``, optional (default=``InitializerApplicator()``)
         Used to initialize the model parameters.
@@ -429,7 +429,7 @@ class CoreferenceResolver(Model):
             The number of spans that were kept while pruning.
         max_antecedents : ``int``, required.
             The maximum number of antecedent spans to consider for every span.
-        device: ``int``, required.
+        device : ``int``, required.
             The CUDA device to use.
 
         Returns
@@ -593,21 +593,21 @@ class CoreferenceResolver(Model):
 
         Parameters
         ----------
-        pairwise_embeddings: ``torch.FloatTensor``, required.
+        pairwise_embeddings : ``torch.FloatTensor``, required.
             Embedding representations of pairs of spans. Has shape
             (batch_size, num_spans_to_keep, max_antecedents, encoding_dim)
-        top_span_mention_scores: ``torch.FloatTensor``, required.
+        top_span_mention_scores : ``torch.FloatTensor``, required.
             Mention scores for every span. Has shape
             (batch_size, num_spans_to_keep, max_antecedents).
-        antecedent_mention_scores: ``torch.FloatTensor``, required.
+        antecedent_mention_scores : ``torch.FloatTensor``, required.
             Mention scores for every antecedent. Has shape
             (batch_size, num_spans_to_keep, max_antecedents).
-        antecedent_log_mask: ``torch.FloatTensor``, required.
+        antecedent_log_mask : ``torch.FloatTensor``, required.
             The log of the mask for valid antecedents.
 
         Returns
         -------
-        coreference_scores: ``torch.FloatTensor``
+        coreference_scores : ``torch.FloatTensor``
             A tensor of shape (batch_size, num_spans_to_keep, max_antecedents + 1),
             representing the unormalised score for each (span, antecedent) pair
             we considered.

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -174,7 +174,7 @@ class CrfTagger(Model):
         tokens : ``Dict[str, torch.LongTensor]``, required
             The output of ``TextField.as_array()``, which should typically be passed directly to a
             ``TextFieldEmbedder``. This output is a dictionary mapping keys to ``TokenIndexer``
-            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is: ``{"tokens":
+            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is : ``{"tokens":
             Tensor(batch_size, num_tokens)}``. This dictionary will have the same keys as were used
             for the ``TokenIndexers`` when you created the ``TextField`` representing your
             sequence.  The dictionary is designed to be passed directly to a ``TextFieldEmbedder``,

--- a/allennlp/models/encoder_decoders/simple_seq2seq.py
+++ b/allennlp/models/encoder_decoders/simple_seq2seq.py
@@ -52,7 +52,7 @@ class SimpleSeq2Seq(Model):
         If you want to use attention to get a dynamic summary of the encoder outputs at each step
         of decoding, this is the function used to compute similarity between the decoder hidden
         state and encoder outputs.
-    attention_function: ``SimilarityFunction``, optional (default = None)
+    attention_function : ``SimilarityFunction``, optional (default = None)
         This is if you want to use the legacy implementation of attention. This will be deprecated
         since it consumes more memory than the specialized attention modules.
     beam_size : ``int``, optional (default = None)

--- a/allennlp/models/event2mind.py
+++ b/allennlp/models/event2mind.py
@@ -47,7 +47,7 @@ class Event2Mind(Model):
         Length of decoded sequences.
     beam_size : int, optional (default = 10)
         The width of the beam search.
-    target_names: ``List[str]``, optional, (default = ['xintent', 'xreact', 'oreact'])
+    target_names : ``List[str]``, optional, (default = ['xintent', 'xreact', 'oreact'])
         Names of the target fields matching those in the ``Instance`` objects.
     target_namespace : str, optional (default = 'tokens')
         If the target side vocabulary is different from the source side's, you need to specify the
@@ -229,9 +229,9 @@ class Event2Mind(Model):
             The output of ``TextField.as_array()`` applied on some target ``TextField``.
         target_embedder : ``Embedding``, required
             Used to embed the target tokens.
-        decoder_cell: ``GRUCell``, required
+        decoder_cell : ``GRUCell``, required
             The recurrent cell used at each time step.
-        output_projection_layer: ``Linear``, required
+        output_projection_layer : ``Linear``, required
             Linear layer mapping to the desired number of classes.
         """
         num_decoding_steps = self._get_num_decoding_steps(target_tokens)
@@ -269,9 +269,9 @@ class Event2Mind(Model):
             Vector produced by ``self._encoder``.
         target_embedder : ``Embedding``, required
             Used to embed the target tokens.
-        decoder_cell: ``GRUCell``, required
+        decoder_cell : ``GRUCell``, required
             The recurrent cell used at each time step.
-        output_projection_layer: ``Linear``, required
+        output_projection_layer : ``Linear``, required
             Linear layer mapping to the desired number of classes.
         """
         num_decoding_steps = self._max_decoding_steps

--- a/allennlp/models/language_model.py
+++ b/allennlp/models/language_model.py
@@ -67,22 +67,22 @@ class LanguageModel(Model):
 
     Parameters
     ----------
-    vocab: ``Vocabulary``
-    text_field_embedder: ``TextFieldEmbedder``
+    vocab : ``Vocabulary``
+    text_field_embedder : ``TextFieldEmbedder``
         Used to embed the indexed tokens we get in ``forward``.
-    contextualizer: ``Seq2SeqEncoder``
+    contextualizer : ``Seq2SeqEncoder``
         Used to "contextualize" the embeddings. As described above,
         this encoder must not cheat by peeking ahead.
-    dropout: ``float``, optional (default: None)
+    dropout : ``float``, optional (default: None)
         If specified, dropout is applied to the contextualized embeddings before computation of
         the softmax. The contextualized embeddings themselves are returned without dropout.
-    num_samples: ``int``, optional (default: None)
+    num_samples : ``int``, optional (default: None)
         If provided, the model will use ``SampledSoftmaxLoss``
         with the specified number of samples. Otherwise, it will use
         the full ``_SoftmaxLoss`` defined above.
-    sparse_embeddings: ``bool``, optional (default: False)
+    sparse_embeddings : ``bool``, optional (default: False)
         Passed on to ``SampledSoftmaxLoss`` if True.
-    bidirectional: ``bool``, optional (default: False)
+    bidirectional : ``bool``, optional (default: False)
         Train a bidirectional language model, where the contextualizer
         is used to predict the next and previous token for each input token.
         This must match the bidirectionality of the contextualizer.
@@ -254,7 +254,7 @@ class LanguageModel(Model):
 
         Parameters
         ----------
-        source: ``Dict[str, torch.LongTensor]``, required.
+        source : ``Dict[str, torch.LongTensor]``, required.
             The output of ``Batch.as_tensor_dict()`` for a batch of sentences. By convention,
             it's required to have at least a ``"tokens"`` entry that's the output of a
             ``SingleIdTokenIndexer``, which is used to compute the language model targets.
@@ -263,21 +263,21 @@ class LanguageModel(Model):
         -------
         Dict with keys:
 
-        ``'loss'``: ``torch.Tensor``
+        ``'loss'`` : ``torch.Tensor``
             forward negative log likelihood, or the average of forward/backward
             if language model is bidirectional
-        ``'forward_loss'``: ``torch.Tensor``
+        ``'forward_loss'`` : ``torch.Tensor``
             forward direction negative log likelihood
-        ``'backward_loss'``: ``torch.Tensor`` or ``None``
+        ``'backward_loss'`` : ``torch.Tensor`` or ``None``
             backward direction negative log likelihood. If language model is not
             bidirectional, this is ``None``.
-        ``'lm_embeddings'``: ``Union[torch.Tensor, List[torch.Tensor]]``
+        ``'lm_embeddings'`` : ``Union[torch.Tensor, List[torch.Tensor]]``
             (batch_size, timesteps, embed_dim) tensor of top layer contextual representations or
             list of all layers. No dropout applied.
-        ``'noncontextual_token_embeddings'``: ``torch.Tensor``
+        ``'noncontextual_token_embeddings'`` : ``torch.Tensor``
             (batch_size, timesteps, token_embed_dim) tensor of bottom layer noncontextual
             representations
-        ``'mask'``: ``torch.Tensor``
+        ``'mask'`` : ``torch.Tensor``
             (batch_size, timesteps) mask for the embeddings
         """
 

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -104,7 +104,7 @@ class Model(torch.nn.Module, Registrable):
 
         Returns
         -------
-        output_dict: ``Dict[str, torch.Tensor]``
+        output_dict : ``Dict[str, torch.Tensor]``
             The outputs from the model. In order to train a model using the
             :class:`~allennlp.training.Trainer` api, you must provide a "loss" key pointing to a
             scalar ``torch.Tensor`` representing the loss to be optimized.

--- a/allennlp/models/reading_comprehension/dialog_qa.py
+++ b/allennlp/models/reading_comprehension/dialog_qa.py
@@ -46,9 +46,9 @@ class DialogQA(Model):
         LSTMs do not apply dropout to their last layer).
     num_context_answers : ``int``, optional (default=0)
         If greater than 0, the model will consider previous question answering context.
-    max_span_length: ``int``, optional (default=0)
+    max_span_length : ``int``, optional (default=0)
         Maximum token length of the output span.
-    max_turn_length: ``int``, optional (default=12)
+    max_turn_length : ``int``, optional (default=12)
         Maximum length of an interaction.
     """
 

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -54,9 +54,9 @@ class SemanticRoleLabeler(Model):
         If provided, will be used to calculate the regularization penalty during training.
     label_smoothing : ``float``, optional (default = 0.0)
         Whether or not to use label smoothing on the labels when computing cross entropy loss.
-    ignore_span_metric: ``bool``, optional (default = False)
+    ignore_span_metric : ``bool``, optional (default = False)
         Whether to calculate span loss, which is irrelevant when predicting BIO for Open Information Extraction.
-    srl_eval_path: ``str``, optional (default=``DEFAULT_SRL_EVAL_PATH``)
+    srl_eval_path : ``str``, optional (default=``DEFAULT_SRL_EVAL_PATH``)
         The path to the srl-eval.pl script. By default, will use the srl-eval.pl included with allennlp,
         which is located at allennlp/tools/srl-eval.pl . If ``None``, srl-eval.pl is not used.
     """
@@ -118,7 +118,7 @@ class SemanticRoleLabeler(Model):
         tokens : Dict[str, torch.LongTensor], required
             The output of ``TextField.as_array()``, which should typically be passed directly to a
             ``TextFieldEmbedder``. This output is a dictionary mapping keys to ``TokenIndexer``
-            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is: ``{"tokens":
+            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is : ``{"tokens":
             Tensor(batch_size, num_tokens)}``. This dictionary will have the same keys as were used
             for the ``TokenIndexers`` when you created the ``TextField`` representing your
             sequence.  The dictionary is designed to be passed directly to a ``TextFieldEmbedder``,

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -117,7 +117,7 @@ class SimpleTagger(Model):
         tokens : Dict[str, torch.LongTensor], required
             The output of ``TextField.as_array()``, which should typically be passed directly to a
             ``TextFieldEmbedder``. This output is a dictionary mapping keys to ``TokenIndexer``
-            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is: ``{"tokens":
+            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is : ``{"tokens":
             Tensor(batch_size, num_tokens)}``. This dictionary will have the same keys as were used
             for the ``TokenIndexers`` when you created the ``TextField`` representing your
             sequence.  The dictionary is designed to be passed directly to a ``TextFieldEmbedder``,

--- a/allennlp/models/srl_bert.py
+++ b/allennlp/models/srl_bert.py
@@ -31,9 +31,9 @@ class SrlBert(Model):
         If provided, will be used to calculate the regularization penalty during training.
     label_smoothing : ``float``, optional (default = 0.0)
         Whether or not to use label smoothing on the labels when computing cross entropy loss.
-    ignore_span_metric: ``bool``, optional (default = False)
+    ignore_span_metric : ``bool``, optional (default = False)
         Whether to calculate span loss, which is irrelevant when predicting BIO for Open Information Extraction.
-    srl_eval_path: ``str``, optional (default=``DEFAULT_SRL_EVAL_PATH``)
+    srl_eval_path : ``str``, optional (default=``DEFAULT_SRL_EVAL_PATH``)
         The path to the srl-eval.pl script. By default, will use the srl-eval.pl included with allennlp,
         which is located at allennlp/tools/srl-eval.pl . If ``None``, srl-eval.pl is not used.
     """

--- a/allennlp/modules/attention/additive_attention.py
+++ b/allennlp/modules/attention/additive_attention.py
@@ -25,7 +25,7 @@ class AdditiveAttention(Attention):
         The dimension of the matrix, ``y``, described above.  This is ``y.size()[-1]`` - the length
         of the vector that will go into the similarity computation.  We need this so we can build
         the weight matrix correctly.
-    normalize : ``bool``, optional (default: ``True``)
+    normalize : ``bool``, optional (default : ``True``)
         If true, we normalize the computed similarities with a softmax, to return a probability
         distribution for your attention.  If false, this is just computing a similarity score.
     """

--- a/allennlp/modules/attention/attention.py
+++ b/allennlp/modules/attention/attention.py
@@ -29,7 +29,7 @@ class Attention(torch.nn.Module, Registrable):
 
     Parameters
     ----------
-    normalize : ``bool``, optional (default: ``True``)
+    normalize : ``bool``, optional (default : ``True``)
         If true, we normalize the computed similarities with a softmax, to return a probability
         distribution for your attention.  If false, this is just computing a similarity score.
     """

--- a/allennlp/modules/attention/bilinear_attention.py
+++ b/allennlp/modules/attention/bilinear_attention.py
@@ -26,7 +26,7 @@ class BilinearAttention(Attention):
     activation : ``Activation``, optional (default=linear (i.e. no activation))
         An activation function applied after the ``x^T W y + b`` calculation.  Default is no
         activation.
-    normalize : ``bool``, optional (default: ``True``)
+    normalize : ``bool``, optional (default : ``True``)
         If true, we normalize the computed similarities with a softmax, to return a probability
         distribution for your attention.  If false, this is just computing a similarity score.
     """

--- a/allennlp/modules/attention/linear_attention.py
+++ b/allennlp/modules/attention/linear_attention.py
@@ -15,7 +15,7 @@ class LinearAttention(Attention):
     combination of the two input vectors, followed by an (optional) activation function.  The
     combination used is configurable.
 
-    If the two vectors are ``x`` and ``y``, we allow the following kinds of combinations: ``x``,
+    If the two vectors are ``x`` and ``y``, we allow the following kinds of combinations : ``x``,
     ``y``, ``x*y``, ``x+y``, ``x-y``, ``x/y``, where each of those binary operations is performed
     elementwise.  You can list as many combinations as you want, comma separated.  For example, you
     might give ``x,y,x*y`` as the ``combination`` parameter to this class.  The computed similarity
@@ -28,20 +28,20 @@ class LinearAttention(Attention):
 
     Parameters
     ----------
-    tensor_1_dim: ``int``, required
+    tensor_1_dim : ``int``, required
         The dimension of the first tensor, ``x``, described above.  This is ``x.size()[-1]`` - the
         length of the vector that will go into the similarity computation.  We need this so we can
         build weight vectors correctly.
-    tensor_2_dim: ``int``, required
+    tensor_2_dim : ``int``, required
         The dimension of the second tensor, ``y``, described above.  This is ``y.size()[-1]`` - the
         length of the vector that will go into the similarity computation.  We need this so we can
         build weight vectors correctly.
-    combination: ``str``, optional (default="x,y")
+    combination : ``str``, optional (default="x,y")
         Described above.
-    activation: ``Activation``, optional (default=linear (i.e. no activation))
+    activation : ``Activation``, optional (default=linear (i.e. no activation))
         An activation function applied after the ``w^T * [x;y] + b`` calculation.  Default is no
         activation.
-    normalize: ``bool``, optional (default=True)
+    normalize : ``bool``, optional (default=True)
     """
 
     def __init__(

--- a/allennlp/modules/augmented_lstm.py
+++ b/allennlp/modules/augmented_lstm.py
@@ -28,17 +28,17 @@ class AugmentedLstm(torch.nn.Module):
         The dimension of the inputs to the LSTM.
     hidden_size : ``int``, required.
         The dimension of the outputs of the LSTM.
-    go_forward: ``bool``, optional (default = True)
+    go_forward : ``bool``, optional (default = True)
         The direction in which the LSTM is applied to the sequence.
         Forwards by default, or backwards if False.
-    recurrent_dropout_probability: ``float``, optional (default = 0.0)
+    recurrent_dropout_probability : ``float``, optional (default = 0.0)
         The dropout probability to be used in a dropout scheme as stated in
         `A Theoretically Grounded Application of Dropout in Recurrent Neural Networks
         <https://arxiv.org/abs/1512.05287>`_ . Implementation wise, this simply
         applies a fixed dropout mask per sequence to the recurrent connection of the
         LSTM. Dropout is not applied to the output sequence nor the last hidden
         state that is returned, it is only applied to all previous hidden states.
-    use_highway: ``bool``, optional (default = True)
+    use_highway : ``bool``, optional (default = True)
         Whether or not to use highway connections between layers. This effectively involves
         reparameterising the normal output of an LSTM as::
 

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -72,13 +72,13 @@ def is_transition_allowed(
     from_tag : ``str``, required
         The tag that the transition originates from. For example, if the
         label is ``I-PER``, the ``from_tag`` is ``I``.
-    from_entity: ``str``, required
+    from_entity : ``str``, required
         The entity corresponding to the ``from_tag``. For example, if the
         label is ``I-PER``, the ``from_entity`` is ``PER``.
     to_tag : ``str``, required
         The tag that the transition leads to. For example, if the
         label is ``I-PER``, the ``to_tag`` is ``I``.
-    to_entity: ``str``, required
+    to_entity : ``str``, required
         The entity corresponding to the ``to_tag``. For example, if the
         label is ``I-PER``, the ``to_entity`` is ``PER``.
 

--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -58,11 +58,11 @@ class Elmo(torch.nn.Module):
         ELMo JSON options file
     weight_file : ``str``, required.
         ELMo hdf5 weight file
-    num_output_representations: ``int``, required.
+    num_output_representations : ``int``, required.
         The number of ELMo representation to output with
         different linear weighted combination of the 3 layers (i.e.,
         character-convnet output, 1st lstm output, 2nd lstm output).
-    requires_grad: ``bool``, optional
+    requires_grad : ``bool``, optional
         If True, compute gradient of ELMo parameters for fine tuning.
     do_layer_norm : ``bool``, optional, (default = False).
         Should we apply layer normalization (passed to ``ScalarMix``)?
@@ -143,7 +143,7 @@ class Elmo(torch.nn.Module):
         """
         Parameters
         ----------
-        inputs: ``torch.Tensor``, required.
+        inputs : ``torch.Tensor``, required.
         Shape ``(batch_size, timesteps, 50)`` of character ids representing the current batch.
         word_inputs : ``torch.Tensor``, required.
             If you passed a cached vocab, you can in addition pass a tensor of shape
@@ -152,7 +152,7 @@ class Elmo(torch.nn.Module):
         Returns
         -------
         Dict with keys:
-        ``'elmo_representations'``: ``List[torch.Tensor]``
+        ``'elmo_representations'`` : ``List[torch.Tensor]``
             A ``num_output_representations`` list of ELMo representations for the input sequence.
             Each representation is shape ``(batch_size, timesteps, embedding_dim)``
         ``'mask'``:  ``torch.Tensor``
@@ -297,7 +297,7 @@ class _ElmoCharacterEncoder(torch.nn.Module):
         ELMo JSON options file
     weight_file : ``str``
         ELMo hdf5 weight file
-    requires_grad: ``bool``, optional, (default = False).
+    requires_grad : ``bool``, optional, (default = False).
         If True, compute gradient of ELMo parameters for fine tuning.
 
     The relevant section of the options file is something like:
@@ -346,14 +346,14 @@ class _ElmoCharacterEncoder(torch.nn.Module):
 
         Parameters
         ----------
-        inputs: ``torch.Tensor``
+        inputs : ``torch.Tensor``
             Shape ``(batch_size, sequence_length, 50)`` of character ids representing the
             current batch.
 
         Returns
         -------
         Dict with keys:
-        ``'token_embedding'``: ``torch.Tensor``
+        ``'token_embedding'`` : ``torch.Tensor``
             Shape ``(batch_size, sequence_length + 2, embedding_dim)`` tensor with context
             insensitive token representations.
         ``'mask'``:  ``torch.Tensor``
@@ -516,7 +516,7 @@ class _ElmoBiLm(torch.nn.Module):
         ELMo JSON options file
     weight_file : ``str``
         ELMo hdf5 weight file
-    requires_grad: ``bool``, optional, (default = False).
+    requires_grad : ``bool``, optional, (default = False).
         If True, compute gradient of ELMo parameters for fine tuning.
     vocab_to_cache : ``List[str]``, optional, (default = None).
         A list of words to pre-compute and cache character convolutions
@@ -584,7 +584,7 @@ class _ElmoBiLm(torch.nn.Module):
         """
         Parameters
         ----------
-        inputs: ``torch.Tensor``, required.
+        inputs : ``torch.Tensor``, required.
             Shape ``(batch_size, timesteps, 50)`` of character ids representing the current batch.
         word_inputs : ``torch.Tensor``, required.
             If you passed a cached vocab, you can in addition pass a tensor of shape ``(batch_size, timesteps)``,
@@ -594,7 +594,7 @@ class _ElmoBiLm(torch.nn.Module):
         -------
         Dict with keys:
 
-        ``'activations'``: ``List[torch.Tensor]``
+        ``'activations'`` : ``List[torch.Tensor]``
             A list of activations at each layer of the network, each of shape
             ``(batch_size, timesteps + 2, embedding_dim)``
         ``'mask'``:  ``torch.Tensor``

--- a/allennlp/modules/elmo_lstm.py
+++ b/allennlp/modules/elmo_lstm.py
@@ -44,15 +44,15 @@ class ElmoLstm(_EncoderBase):
         :class:`~allennlp.modules.lstm_cell_with_projection.LstmCellWithProjection`.
     num_layers : ``int``, required
         The number of bidirectional LSTMs to use.
-    requires_grad: ``bool``, optional
+    requires_grad : ``bool``, optional
         If True, compute gradient of ELMo parameters for fine tuning.
-    recurrent_dropout_probability: ``float``, optional (default = 0.0)
+    recurrent_dropout_probability : ``float``, optional (default = 0.0)
         The dropout probability to be used in a dropout scheme as stated in
         `A Theoretically Grounded Application of Dropout in Recurrent Neural Networks
         <https://arxiv.org/abs/1512.05287>`_ .
-    state_projection_clip_value: ``float``, optional, (default = None)
+    state_projection_clip_value : ``float``, optional, (default = None)
         The magnitude with which to clip the hidden_state after projecting it.
-    memory_cell_clip_value: ``float``, optional, (default = None)
+    memory_cell_clip_value : ``float``, optional, (default = None)
         The magnitude with which to clip the memory cell.
     """
 
@@ -184,7 +184,7 @@ class ElmoLstm(_EncoderBase):
         -------
         output_sequence : ``torch.FloatTensor``
             The encoded sequence of shape (num_layers, batch_size, sequence_length, hidden_size)
-        final_states: ``Tuple[torch.FloatTensor, torch.FloatTensor]``
+        final_states : ``Tuple[torch.FloatTensor, torch.FloatTensor]``
             The per-layer final (state, memory) states of the LSTM, with shape
             (num_layers, batch_size, 2 * hidden_size) and  (num_layers, batch_size, 2 * cell_size)
             respectively. The last dimension is duplicated because it contains the state/memory

--- a/allennlp/modules/input_variational_dropout.py
+++ b/allennlp/modules/input_variational_dropout.py
@@ -19,12 +19,12 @@ class InputVariationalDropout(torch.nn.Dropout):
 
         Parameters
         ----------
-        input_tensor: ``torch.FloatTensor``
+        input_tensor : ``torch.FloatTensor``
             A tensor of shape ``(batch_size, num_timesteps, embedding_dim)``
 
         Returns
         -------
-        output: ``torch.FloatTensor``
+        output : ``torch.FloatTensor``
             A tensor of shape ``(batch_size, num_timesteps, embedding_dim)`` with dropout applied.
         """
         ones = input_tensor.data.new_ones(input_tensor.shape[0], input_tensor.shape[-1])

--- a/allennlp/modules/lstm_cell_with_projection.py
+++ b/allennlp/modules/lstm_cell_with_projection.py
@@ -26,18 +26,18 @@ class LstmCellWithProjection(torch.nn.Module):
         The dimension of the outputs of the LSTM.
     cell_size : ``int``, required.
         The dimension of the memory cell used for the LSTM.
-    go_forward: ``bool``, optional (default = True)
+    go_forward : ``bool``, optional (default = True)
         The direction in which the LSTM is applied to the sequence.
         Forwards by default, or backwards if False.
-    recurrent_dropout_probability: ``float``, optional (default = 0.0)
+    recurrent_dropout_probability : ``float``, optional (default = 0.0)
         The dropout probability to be used in a dropout scheme as stated in
         `A Theoretically Grounded Application of Dropout in Recurrent Neural Networks
         <https://arxiv.org/abs/1512.05287>`_ . Implementation wise, this simply
         applies a fixed dropout mask per sequence to the recurrent connection of the
         LSTM.
-    state_projection_clip_value: ``float``, optional, (default = None)
+    state_projection_clip_value : ``float``, optional, (default = None)
         The magnitude with which to clip the hidden_state after projecting it.
-    memory_cell_clip_value: ``float``, optional, (default = None)
+    memory_cell_clip_value : ``float``, optional, (default = None)
         The magnitude with which to clip the memory cell.
 
     Returns
@@ -47,7 +47,7 @@ class LstmCellWithProjection(torch.nn.Module):
         (batch_size, max_timesteps, hidden_size) where for a given batch
         element, all outputs past the sequence length for that batch are
         zero tensors.
-    final_state: ``Tuple[torch.FloatTensor, torch.FloatTensor]``
+    final_state : ``Tuple[torch.FloatTensor, torch.FloatTensor]``
         The final (state, memory) states of the LSTM, with shape
         (1, batch_size, hidden_size) and  (1, batch_size, cell_size)
         respectively. The first dimension is 1 in order to match the Pytorch

--- a/allennlp/modules/matrix_attention/legacy_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/legacy_matrix_attention.py
@@ -16,7 +16,7 @@ class LegacyMatrixAttention(MatrixAttention):
 
     Parameters
     ----------
-    similarity_function: ``SimilarityFunction``, optional (default=``DotProductSimilarity``)
+    similarity_function : ``SimilarityFunction``, optional (default=``DotProductSimilarity``)
         The similarity function to use when computing the attention.
     """
 

--- a/allennlp/modules/matrix_attention/linear_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/linear_matrix_attention.py
@@ -17,7 +17,7 @@ class LinearMatrixAttention(MatrixAttention):
     combination of the two input matrices, followed by an (optional) activation function.  The
     combination used is configurable.
 
-    If the two vectors are ``x`` and ``y``, we allow the following kinds of combinations: ``x``,
+    If the two vectors are ``x`` and ``y``, we allow the following kinds of combinations : ``x``,
     ``y``, ``x*y``, ``x+y``, ``x-y``, ``x/y``, where each of those binary operations is performed
     elementwise.  You can list as many combinations as you want, comma separated.  For example, you
     might give ``x,y,x*y`` as the ``combination`` parameter to this class.  The computed similarity

--- a/allennlp/modules/matrix_attention/matrix_attention.py
+++ b/allennlp/modules/matrix_attention/matrix_attention.py
@@ -12,8 +12,8 @@ class MatrixAttention(torch.nn.Module, Registrable):
     caller to deal with masking properly when this output is used.
 
     Input:
-        - matrix_1: ``(batch_size, num_rows_1, embedding_dim_1)``
-        - matrix_2: ``(batch_size, num_rows_2, embedding_dim_2)``
+        - matrix_1 : ``(batch_size, num_rows_1, embedding_dim_1)``
+        - matrix_2 : ``(batch_size, num_rows_2, embedding_dim_2)``
 
     Output:
         - ``(batch_size, num_rows_1, num_rows_2)``

--- a/allennlp/modules/openai_transformer.py
+++ b/allennlp/modules/openai_transformer.py
@@ -338,31 +338,31 @@ class OpenaiTransformer(torch.nn.Module, FromParams):
 
     Parameters
     ----------
-    vocab_size: ``int`` (optional, default: 40478)
+    vocab_size : ``int`` (optional, default: 40478)
         The size of the vocabulary (number of byte pair embeddings)
         excluding the n_special embeddings (if any), and the positional embeddings.
-    n_ctx: ``int`` (optional, default: 512)
+    n_ctx : ``int`` (optional, default: 512)
         The number of positional encodings to use for evaluation.
-    embedding_dim: ``int`` (optional, default: 768)
+    embedding_dim : ``int`` (optional, default: 768)
         The dimension of the output embeddings.
-    num_heads: ``int`` (optional, default: 12)
+    num_heads : ``int`` (optional, default: 12)
         How many "heads" the attention has.
-    num_layers: ``int`` (optional, default: 12)
+    num_layers : ``int`` (optional, default: 12)
         How many layers of "blocks" the transformer has.
-    embedding_dropout_probability: ``float`` (optional, default: 0.1)
+    embedding_dropout_probability : ``float`` (optional, default: 0.1)
         Dropout for the embedding.
-    attention_dropout_probability: ``float`` (optional, default: 0.1)
+    attention_dropout_probability : ``float`` (optional, default: 0.1)
         Dropout for attention.
-    residual_dropout_probability: ``float`` (optional, default: 0.1)
+    residual_dropout_probability : ``float`` (optional, default: 0.1)
         Dropout for residual
-    activation_function: ``str`` (optional, default: ``'gelu'``)
+    activation_function : ``str`` (optional, default : ``'gelu'``)
         Activation function for the multi-layer perceptron.
-    model_path: ``str`` (optional, default: ``None``)
+    model_path : ``str`` (optional, default : ``None``)
         A tar.gz file containing serialized model weights. If supplied,
         the weights will be loaded from that file.
-    requires_grad: ``bool`` (optional, default: ``False``)
+    requires_grad : ``bool`` (optional, default : ``False``)
         If true, the transformer will be fine-tuneable.
-    n_special: ``int`` (optional, default: ``-1``)
+    n_special : ``int`` (optional, default : ``-1``)
         The number of special tokens added to the byte pair vocabulary
         (via ``OpenaiTransformerBytePairIndexer``).
     """

--- a/allennlp/modules/residual_with_layer_dropout.py
+++ b/allennlp/modules/residual_with_layer_dropout.py
@@ -48,7 +48,7 @@ class ResidualWithLayerDropout(torch.nn.Module):
 
         Returns
         -------
-        output: ``torch.FloatTensor``
+        output : ``torch.FloatTensor``
             A tensor with the same shape as `layer_input` and `layer_output`.
         """
         if layer_index is not None and total_layers is not None:

--- a/allennlp/modules/seq2seq_decoders/stacked_self_attention_decoder_net.py
+++ b/allennlp/modules/seq2seq_decoders/stacked_self_attention_decoder_net.py
@@ -39,7 +39,7 @@ class StackedSelfAttentionDecoderNet(DecoderNet):
         The number of stacked self attention -> feedfoward -> layer normalisation blocks.
     num_attention_heads : ``int``, required.
         The number of attention heads to use per layer.
-    use_positional_encoding: ``bool``, optional, (default = True)
+    use_positional_encoding : ``bool``, optional, (default = True)
         Whether to add sinusoidal frequencies to the input tensor. This is strongly recommended,
         as without this feature, the self attention layers have no idea of absolute or relative
         position (as they are just computing pairwise similarity between vectors of elements),

--- a/allennlp/modules/seq2seq_encoders/gated_cnn_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/gated_cnn_encoder.py
@@ -141,13 +141,13 @@ class GatedCnnEncoder(Seq2SeqEncoder):
 
     Parameters
     ----------
-    input_dim: ``int``, required
+    input_dim : ``int``, required
         The dimension of the inputs.
-    layers: ``Sequence[Sequence[Sequence[int]]]``, required
+    layers : ``Sequence[Sequence[Sequence[int]]]``, required
         The layer dimensions for each ``ResidualBlock``.
-    dropout: ``float``, optional (default = 0.0)
+    dropout : ``float``, optional (default = 0.0)
         The dropout for each ``ResidualBlock``.
-    return_all_layers: ``bool``, optional (default = False)
+    return_all_layers : ``bool``, optional (default = False)
         Whether to return all layers or just the last layer.
     """
 

--- a/allennlp/modules/seq2seq_encoders/intra_sentence_attention.py
+++ b/allennlp/modules/seq2seq_encoders/intra_sentence_attention.py
@@ -33,7 +33,7 @@ class IntraSentenceAttentionEncoder(Seq2SeqEncoder):
         performing the attention-weighted sum.
     similarity_function : ``SimilarityFunction``, optional
         The similarity function to use when computing attentions.  Default is to use a dot product.
-    num_attention_heads: ``int``, optional
+    num_attention_heads : ``int``, optional
         If this is greater than one (default is 1), we will split the input into several "heads" to
         compute multi-headed weighted sums.  Must be used with a multi-headed similarity function,
         and you almost certainly want to do a projection in conjunction with the multiple heads.

--- a/allennlp/modules/seq2seq_encoders/qanet_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/qanet_encoder.py
@@ -31,13 +31,13 @@ class QaNetEncoder(Seq2SeqEncoder):
         dimensions are fixed to ensure sizes match up for the self attention layers.
     num_blocks : ``int``, required.
         The number of stacked encoder blocks.
-    num_convs_per_block: ``int``, required.
+    num_convs_per_block : ``int``, required.
         The number of convolutions in each block.
-    conv_kernel_size: ``int``, required.
+    conv_kernel_size : ``int``, required.
         The kernel size for convolution.
     num_attention_heads : ``int``, required.
         The number of attention heads to use per layer.
-    use_positional_encoding: ``bool``, optional, (default = True)
+    use_positional_encoding : ``bool``, optional, (default = True)
         Whether to add sinusoidal frequencies to the input tensor. This is strongly recommended,
         as without this feature, the self attention layers have no idea of absolute or relative
         position (as they are just computing pairwise similarity between vectors of elements),
@@ -144,13 +144,13 @@ class QaNetEncoderBlock(Seq2SeqEncoder):
     feedforward_hidden_dim : ``int``, required.
         The middle dimension of the FeedForward network. The input and output
         dimensions are fixed to ensure sizes match up for the self attention layers.
-    num_convs: ``int``, required.
+    num_convs : ``int``, required.
         The number of convolutions in each block.
-    conv_kernel_size: ``int``, required.
+    conv_kernel_size : ``int``, required.
         The kernel size for convolution.
     num_attention_heads : ``int``, required.
         The number of attention heads to use per layer.
-    use_positional_encoding: ``bool``, optional, (default = True)
+    use_positional_encoding : ``bool``, optional, (default = True)
         Whether to add sinusoidal frequencies to the input tensor. This is strongly recommended,
         as without this feature, the self attention layers have no idea of absolute or relative
         position (as they are just computing pairwise similarity between vectors of elements),

--- a/allennlp/modules/seq2seq_encoders/seq2seq_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/seq2seq_encoder.py
@@ -5,8 +5,8 @@ from allennlp.common import Registrable
 class Seq2SeqEncoder(_EncoderBase, Registrable):
     """
     A ``Seq2SeqEncoder`` is a ``Module`` that takes as input a sequence of vectors and returns a
-    modified sequence of vectors.  Input shape: ``(batch_size, sequence_length, input_dim)``; output
-    shape: ``(batch_size, sequence_length, output_dim)``.
+    modified sequence of vectors.  Input shape : ``(batch_size, sequence_length, input_dim)``; output
+    shape : ``(batch_size, sequence_length, output_dim)``.
 
     We add two methods to the basic ``Module`` API: :func:`get_input_dim()` and :func:`get_output_dim()`.
     You might need this if you want to construct a ``Linear`` layer using the output of this encoder,

--- a/allennlp/modules/seq2seq_encoders/stacked_self_attention.py
+++ b/allennlp/modules/seq2seq_encoders/stacked_self_attention.py
@@ -46,7 +46,7 @@ class StackedSelfAttentionEncoder(Seq2SeqEncoder):
         The number of stacked self attention -> feedfoward -> layer normalisation blocks.
     num_attention_heads : ``int``, required.
         The number of attention heads to use per layer.
-    use_positional_encoding: ``bool``, optional, (default = True)
+    use_positional_encoding : ``bool``, optional, (default = True)
         Whether to add sinusoidal frequencies to the input tensor. This is strongly recommended,
         as without this feature, the self attention layers have no idea of absolute or relative
         position (as they are just computing pairwise similarity between vectors of elements),

--- a/allennlp/modules/seq2vec_encoders/boe_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/boe_encoder.py
@@ -16,9 +16,9 @@ class BagOfEmbeddingsEncoder(Seq2VecEncoder):
 
     Parameters
     ----------
-    embedding_dim: ``int``, required
+    embedding_dim : ``int``, required
         This is the input dimension to the encoder.
-    averaged: ``bool``, optional (default=``False``)
+    averaged : ``bool``, optional (default=``False``)
         If ``True``, this module will average the embeddings across time, rather than simply summing
         (ie. we will divide the summed embeddings by the length of the sentence).
     """

--- a/allennlp/modules/seq2vec_encoders/cnn_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/cnn_encoder.py
@@ -33,14 +33,14 @@ class CnnEncoder(Seq2VecEncoder):
     embedding_dim : ``int``, required
         This is the input dimension to the encoder.  We need this because we can't do shape
         inference in pytorch, and we need to know what size filters to construct in the CNN.
-    num_filters: ``int``, required
+    num_filters : ``int``, required
         This is the output dim for each convolutional layer, which is the number of "filters"
         learned by that layer.
-    ngram_filter_sizes: ``Tuple[int]``, optional (default=``(2, 3, 4, 5)``)
+    ngram_filter_sizes : ``Tuple[int]``, optional (default=``(2, 3, 4, 5)``)
         This specifies both the number of convolutional layers we will create and their sizes.  The
         default of ``(2, 3, 4, 5)`` will have four convolutional layers, corresponding to encoding
         ngrams of size 2 to 5 with some number of filters.
-    conv_layer_activation: ``Activation``, optional (default=``torch.nn.ReLU``)
+    conv_layer_activation : ``Activation``, optional (default=``torch.nn.ReLU``)
         Activation to use after the convolution layers.
     output_dim : ``Optional[int]``, optional (default=``None``)
         After doing convolutions and pooling, we'll project the collected features into a vector of

--- a/allennlp/modules/seq2vec_encoders/cnn_highway_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/cnn_highway_encoder.py
@@ -20,17 +20,17 @@ class CnnHighwayEncoder(Seq2VecEncoder):
 
     Parameters
     ----------
-    embedding_dim: ``int``, required
+    embedding_dim : ``int``, required
         The dimension of the initial character embedding.
-    filters: ``Sequence[Sequence[int]]``, required
+    filters : ``Sequence[Sequence[int]]``, required
         A sequence of pairs (filter_width, num_filters).
-    num_highway: ``int``, required
+    num_highway : ``int``, required
         The number of highway layers.
-    projection_dim: ``int``, required
+    projection_dim : ``int``, required
         The output dimension of the projection layer.
-    activation: ``str``, optional (default = 'relu')
+    activation : ``str``, optional (default = 'relu')
         The activation function for the convolutional layers.
-    projection_location: ``str``, optional (default = 'after_highway')
+    projection_location : ``str``, optional (default = 'after_highway')
         Where to apply the projection layer. Valid values are
         'after_highway', 'after_cnn', and None.
     """

--- a/allennlp/modules/seq2vec_encoders/seq2vec_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/seq2vec_encoder.py
@@ -5,7 +5,7 @@ from allennlp.common import Registrable
 class Seq2VecEncoder(_EncoderBase, Registrable):
     """
     A ``Seq2VecEncoder`` is a ``Module`` that takes as input a sequence of vectors and returns a
-    single vector.  Input shape: ``(batch_size, sequence_length, input_dim)``; output shape:
+    single vector.  Input shape : ``(batch_size, sequence_length, input_dim)``; output shape:
     ``(batch_size, output_dim)``.
 
     We add two methods to the basic ``Module`` API: :func:`get_input_dim()` and :func:`get_output_dim()`.

--- a/allennlp/modules/similarity_functions/linear.py
+++ b/allennlp/modules/similarity_functions/linear.py
@@ -15,7 +15,7 @@ class LinearSimilarity(SimilarityFunction):
     combination of the two input vectors, followed by an (optional) activation function.  The
     combination used is configurable.
 
-    If the two vectors are ``x`` and ``y``, we allow the following kinds of combinations: ``x``,
+    If the two vectors are ``x`` and ``y``, we allow the following kinds of combinations : ``x``,
     ``y``, ``x*y``, ``x+y``, ``x-y``, ``x/y``, where each of those binary operations is performed
     elementwise.  You can list as many combinations as you want, comma separated.  For example, you
     might give ``x,y,x*y`` as the ``combination`` parameter to this class.  The computed similarity

--- a/allennlp/modules/stacked_alternating_lstm.py
+++ b/allennlp/modules/stacked_alternating_lstm.py
@@ -27,7 +27,7 @@ class StackedAlternatingLstm(torch.nn.Module):
         The dimension of the outputs of the LSTM.
     num_layers : ``int``, required
         The number of stacked LSTMs to use.
-    recurrent_dropout_probability: ``float``, optional (default = 0.0)
+    recurrent_dropout_probability : ``float``, optional (default = 0.0)
         The dropout probability to be used in a dropout scheme as stated in
         `A Theoretically Grounded Application of Dropout in Recurrent Neural Networks
         <https://arxiv.org/abs/1512.05287>`_ .

--- a/allennlp/modules/stacked_bidirectional_lstm.py
+++ b/allennlp/modules/stacked_bidirectional_lstm.py
@@ -26,15 +26,15 @@ class StackedBidirectionalLstm(torch.nn.Module):
         The dimension of the outputs of the LSTM.
     num_layers : ``int``, required
         The number of stacked Bidirectional LSTMs to use.
-    recurrent_dropout_probability: ``float``, optional (default = 0.0)
+    recurrent_dropout_probability : ``float``, optional (default = 0.0)
         The recurrent dropout probability to be used in a dropout scheme as
         stated in `A Theoretically Grounded Application of Dropout in Recurrent
         Neural Networks <https://arxiv.org/abs/1512.05287>`_ .
-    layer_dropout_probability: ``float``, optional (default = 0.0)
+    layer_dropout_probability : ``float``, optional (default = 0.0)
         The layer wise dropout probability to be used in a dropout scheme as
         stated in  `A Theoretically Grounded Application of Dropout in
         Recurrent Neural Networks <https://arxiv.org/abs/1512.05287>`_ .
-    use_highway: ``bool``, optional (default = True)
+    use_highway : ``bool``, optional (default = True)
         Whether or not to use highway connections between layers. This effectively involves
         reparameterising the normal output of an LSTM as::
 

--- a/allennlp/modules/token_embedders/bag_of_word_counts_token_embedder.py
+++ b/allennlp/modules/token_embedders/bag_of_word_counts_token_embedder.py
@@ -19,8 +19,8 @@ class BagOfWordCountsTokenEmbedder(TokenEmbedder):
 
     Parameters
     ----------
-    vocab: ``Vocabulary``
-    vocab_namespace: ``str``
+    vocab : ``Vocabulary``
+    vocab_namespace : ``str``
         namespace of vocabulary to embed
     projection_dim : ``int``, optional (default = ``None``)
         if specified, will project the resulting bag of words representation
@@ -59,7 +59,7 @@ class BagOfWordCountsTokenEmbedder(TokenEmbedder):
         """
         Parameters
         ----------
-        inputs: ``torch.Tensor``
+        inputs : ``torch.Tensor``
             Shape ``(batch_size, timesteps, sequence_length)`` of word ids
             representing the current batch.
 

--- a/allennlp/modules/token_embedders/bert_token_embedder.py
+++ b/allennlp/modules/token_embedders/bert_token_embedder.py
@@ -53,21 +53,21 @@ class BertEmbedder(TokenEmbedder):
 
     Parameters
     ----------
-    bert_model: ``BertModel``
+    bert_model : ``BertModel``
         The BERT model being wrapped.
-    top_layer_only: ``bool``, optional (default = ``False``)
+    top_layer_only : ``bool``, optional (default = ``False``)
         If ``True``, then only return the top layer instead of apply the scalar mix.
-    max_pieces: ``int``, optional (default: 512)
+    max_pieces : ``int``, optional (default: 512)
         The BERT embedder uses positional embeddings and so has a corresponding
         maximum length for its input ids. Assuming the inputs are windowed
         and padded appropriately by this length, the embedder will split them into a
         large batch, feed them into BERT, and recombine the output as if it was a
         longer sequence.
-    num_start_tokens: ``int``, optional (default: 1)
+    num_start_tokens : ``int``, optional (default: 1)
         The number of starting special tokens input to BERT (usually 1, i.e., [CLS])
-    num_end_tokens: ``int``, optional (default: 1)
+    num_end_tokens : ``int``, optional (default: 1)
         The number of ending tokens input to BERT (usually 1, i.e., [SEP])
-    scalar_mix_parameters: ``List[float]``, optional, (default = None)
+    scalar_mix_parameters : ``List[float]``, optional, (default = None)
         If not ``None``, use these scalar mix parameters to weight the representations
         produced by different layers. These mixing weights are not updated during
         training.
@@ -111,9 +111,9 @@ class BertEmbedder(TokenEmbedder):
         """
         Parameters
         ----------
-        input_ids: ``torch.LongTensor``
+        input_ids : ``torch.LongTensor``
             The (batch_size, ..., max_sequence_length) tensor of wordpiece ids.
-        offsets: ``torch.LongTensor``, optional
+        offsets : ``torch.LongTensor``, optional
             The BERT embeddings are one per wordpiece. However it's possible/likely
             you might want one per original token. In that case, ``offsets``
             represents the indices of the desired wordpiece for each original token.
@@ -128,7 +128,7 @@ class BertEmbedder(TokenEmbedder):
             embeddings at those positions, and (in particular) will contain one embedding
             per token. If offsets are not provided, the entire tensor of wordpiece embeddings
             will be returned.
-        token_type_ids: ``torch.LongTensor``, optional
+        token_type_ids : ``torch.LongTensor``, optional
             If an input consists of two sentences (as in the BERT paper),
             tokens from the first sentence should have type 0 and tokens from
             the second sentence should have type 1.  If you don't provide this
@@ -265,18 +265,18 @@ class PretrainedBertEmbedder(BertEmbedder):
     """
     Parameters
     ----------
-    pretrained_model: ``str``
+    pretrained_model : ``str``
         Either the name of the pretrained model to use (e.g. 'bert-base-uncased'),
         or the path to the .tar.gz file with the model weights.
 
         If the name is a key in the list of pretrained models at
         https://github.com/huggingface/pytorch-pretrained-BERT/blob/master/pytorch_pretrained_bert/modeling.py#L41
         the corresponding path will be used; otherwise it will be interpreted as a path or URL.
-    requires_grad: ``bool``, optional (default = False)
+    requires_grad : ``bool``, optional (default = False)
         If True, compute gradient of BERT parameters for fine tuning.
-    top_layer_only: ``bool``, optional (default = ``False``)
+    top_layer_only : ``bool``, optional (default = ``False``)
         If ``True``, then only return the top layer instead of apply the scalar mix.
-    scalar_mix_parameters: ``List[float]``, optional, (default = None)
+    scalar_mix_parameters : ``List[float]``, optional, (default = None)
         If not ``None``, use these scalar mix parameters to weight the representations
         produced by different layers. These mixing weights are not updated during
         training.

--- a/allennlp/modules/token_embedders/bidirectional_language_model_token_embedder.py
+++ b/allennlp/modules/token_embedders/bidirectional_language_model_token_embedder.py
@@ -29,7 +29,7 @@ class BidirectionalLanguageModelTokenEmbedder(LanguageModelTokenEmbedder):
     bos_eos_tokens : ``Tuple[str, str]``, optional (default=``("<S>", "</S>")``)
         These will be indexed and placed around the indexed tokens. Necessary if the language model
         was trained with them, but they were injected external to an indexer.
-    remove_bos_eos: ``bool``, optional (default: True)
+    remove_bos_eos : ``bool``, optional (default: True)
         Typically the provided token indexes will be augmented with begin-sentence and end-sentence
         tokens. (Alternatively, you can pass bos_eos_tokens.) If this flag is True the
         corresponding embeddings will be removed from the return values.

--- a/allennlp/modules/token_embedders/elmo_token_embedder.py
+++ b/allennlp/modules/token_embedders/elmo_token_embedder.py
@@ -84,7 +84,7 @@ class ElmoTokenEmbedder(TokenEmbedder):
         """
         Parameters
         ----------
-        inputs: ``torch.Tensor``
+        inputs : ``torch.Tensor``
             Shape ``(batch_size, timesteps, 50)`` of character ids representing the current batch.
         word_inputs : ``torch.Tensor``, optional.
             If you passed a cached vocab, you can in addition pass a tensor of shape

--- a/allennlp/modules/token_embedders/elmo_token_embedder_multilang.py
+++ b/allennlp/modules/token_embedders/elmo_token_embedder_multilang.py
@@ -116,7 +116,7 @@ class ElmoTokenEmbedderMultiLang(TokenEmbedder):
         """
         Parameters
         ----------
-        inputs: ``torch.Tensor``
+        inputs : ``torch.Tensor``
             Shape ``(batch_size, timesteps, 50)`` of character ids representing the current batch.
         lang : ``str``, , required.
             The language of the ELMo embedder to use.

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -45,35 +45,35 @@ class Embedding(TokenEmbedder):
 
     Parameters
     ----------
-    num_embeddings: ``int``
+    num_embeddings : ``int``
         Size of the dictionary of embeddings (vocabulary size).
-    embedding_dim: ``int``
+    embedding_dim : ``int``
         The size of each embedding vector.
-    projection_dim: ``int``, (optional, default=None)
+    projection_dim : ``int``, (optional, default=None)
         If given, we add a projection layer after the embedding layer.  This really only makes
         sense if ``trainable`` is ``False``.
-    weight: ``torch.FloatTensor``, (optional, default=None)
+    weight : ``torch.FloatTensor``, (optional, default=None)
         A pre-initialised weight matrix for the embedding lookup, allowing the use of
         pretrained vectors.
-    padding_index: ``int``, (optional, default=None)
+    padding_index : ``int``, (optional, default=None)
         If given, pads the output with zeros whenever it encounters the index.
-    trainable: ``bool``, (optional, default=True)
+    trainable : ``bool``, (optional, default=True)
         Whether or not to optimize the embedding parameters.
-    max_norm: ``float``, (optional, default=None)
+    max_norm : ``float``, (optional, default=None)
         If given, will renormalize the embeddings to always have a norm lesser than this
-    norm_type: ``float``, (optional, default=2)
+    norm_type : ``float``, (optional, default=2)
         The p of the p-norm to compute for the max_norm option
-    scale_grad_by_freq: ``bool``, (optional, default=False)
+    scale_grad_by_freq : ``bool``, (optional, default=False)
         If given, this will scale gradients by the frequency of the words in the mini-batch.
-    sparse: ``bool``, (optional, default=False)
+    sparse : ``bool``, (optional, default=False)
         Whether or not the Pytorch backend should use a sparse representation of the embedding weight.
-    vocab_namespace: ``str``, (optional, default=None)
+    vocab_namespace : ``str``, (optional, default=None)
         In case of fine-tuning/transfer learning, the model's embedding matrix needs to be
         extended according to the size of extended-vocabulary. To be able to know how much to
         extend the embedding-matrix, it's necessary to know which vocab_namspace was used to
         construct it in the original training. We store vocab_namespace used during the original
         training as an attribute, so that it can be retrieved during fine-tuning.
-    pretrained_file: ``str``, (optional, default=None)
+    pretrained_file : ``str``, (optional, default=None)
         Used to keep track of what is the source of the weights and loading more embeddings at test time.
         **It does not load the weights from this pretrained_file.** For that purpose, use
         ``Embedding.from_params``.
@@ -177,19 +177,19 @@ class Embedding(TokenEmbedder):
 
         Parameters
         ----------
-        extended_vocab: ``Vocabulary``
+        extended_vocab : ``Vocabulary``
             Vocabulary extended from original vocabulary used to construct
             this ``Embedding``.
-        vocab_namespace: ``str``, (optional, default=None)
+        vocab_namespace : ``str``, (optional, default=None)
             In case you know what vocab_namespace should be used for extension, you
             can pass it. If not passed, it will check if vocab_namespace used at the
             time of ``Embedding`` construction is available. If so, this namespace
             will be used or else extend_vocab will be a no-op.
-        extension_pretrained_file: ``str``, (optional, default=None)
+        extension_pretrained_file : ``str``, (optional, default=None)
             A file containing pretrained embeddings can be specified here. It can be
             the path to a local file or an URL of a (cached) remote file. Check format
             details in ``from_params`` of ``Embedding`` class.
-        model_path: ``str``, (optional, default=None)
+        model_path : ``str``, (optional, default=None)
             Path traversing the model attributes upto this embedding module.
             Eg. "_text_field_embedder.token_embedder_tokens". This is only useful
             to give helpful error message when extend_vocab is implicitly called
@@ -363,7 +363,7 @@ def _read_pretrained_embeddings_file(
 
     Parameters
     ----------
-    file_uri: ``str``, required.
+    file_uri : ``str``, required.
         It can be:
 
         * a file system path or a URL of an eventually compressed text file or a zip/tar archive
@@ -372,11 +372,11 @@ def _read_pretrained_embeddings_file(
         * URI of the type ``(archive_path_or_url)#file_path_inside_archive`` if the text file
           is contained in a multi-file archive.
 
-    vocab: ``Vocabulary``, required.
+    vocab : ``Vocabulary``, required.
         A Vocabulary object.
-    namespace: ``str``, (optional, default=tokens)
+    namespace : ``str``, (optional, default=tokens)
         The namespace of the vocabulary to find pretrained embeddings for.
-    trainable: ``bool``, (optional, default=True)
+    trainable : ``bool``, (optional, default=True)
         Whether or not the embedding parameters should be optimized.
 
     Returns
@@ -522,7 +522,7 @@ class EmbeddingsTextFile(Iterator[str]):
 
     Parameters
     ----------
-    file_uri: ``str``
+    file_uri : ``str``
         It can be:
 
         * a file system path or a URL of an eventually compressed text file or a zip/tar archive
@@ -530,8 +530,8 @@ class EmbeddingsTextFile(Iterator[str]):
         * URI of the type ``(archive_path_or_url)#file_path_inside_archive`` if the text file
           is contained in a multi-file archive.
 
-    encoding: ``str``
-    cache_dir: ``str``
+    encoding : ``str``
+    cache_dir : ``str``
     """
 
     DEFAULT_ENCODING = "utf-8"

--- a/allennlp/modules/token_embedders/language_model_token_embedder.py
+++ b/allennlp/modules/token_embedders/language_model_token_embedder.py
@@ -42,7 +42,7 @@ class LanguageModelTokenEmbedder(TokenEmbedder):
     bos_eos_tokens : ``Tuple[str, str]``, optional (default=``("<S>", "</S>")``)
         These will be indexed and placed around the indexed tokens. Necessary if the language model
         was trained with them, but they were injected external to an indexer.
-    remove_bos_eos: ``bool``, optional (default: True)
+    remove_bos_eos : ``bool``, optional (default: True)
         Typically the provided token indexes will be augmented with begin-sentence and end-sentence
         tokens. (Alternatively, you can pass bos_eos_tokens.) If this flag is True the
         corresponding embeddings will be removed from the return values.
@@ -156,7 +156,7 @@ class LanguageModelTokenEmbedder(TokenEmbedder):
         """
         Parameters
         ----------
-        inputs: ``torch.Tensor``
+        inputs : ``torch.Tensor``
             Shape ``(batch_size, timesteps, ...)`` of token ids representing the current batch.
             These must have been produced using the same indexer the LM was trained on.
 

--- a/allennlp/modules/token_embedders/openai_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/openai_transformer_embedder.py
@@ -17,9 +17,9 @@ class OpenaiTransformerEmbedder(TokenEmbedder):
 
     Parameters
     ----------
-    transformer: ``OpenaiTransformer``, required.
+    transformer : ``OpenaiTransformer``, required.
         The ``OpenaiTransformer`` module used for the embeddings.
-    top_layer_only: ``bool``, optional (default = ``False``)
+    top_layer_only : ``bool``, optional (default = ``False``)
         If ``True``, then only return the top layer instead of apply the scalar mix.
     """
 
@@ -41,10 +41,10 @@ class OpenaiTransformerEmbedder(TokenEmbedder):
         """
         Parameters
         ----------
-        inputs: ``torch.Tensor``, required
+        inputs : ``torch.Tensor``, required
             A ``(batch_size, num_timesteps)`` tensor representing the byte-pair encodings
             for the current batch.
-        offsets: ``torch.Tensor``, required
+        offsets : ``torch.Tensor``, required
             A ``(batch_size, max_sequence_length)`` tensor representing the word offsets
             for the current batch.
 

--- a/allennlp/modules/token_embedders/pass_through_token_embedder.py
+++ b/allennlp/modules/token_embedders/pass_through_token_embedder.py
@@ -10,7 +10,7 @@ class PassThroughTokenEmbedder(TokenEmbedder):
 
     Parameters
     ----------
-    hidden_dim: ``int``, required.
+    hidden_dim : ``int``, required.
 
     """
 

--- a/allennlp/nn/chu_liu_edmonds.py
+++ b/allennlp/nn/chu_liu_edmonds.py
@@ -114,11 +114,11 @@ def chu_liu_edmonds(
         A representative at it's most basic represents a node,
         but as the algorithm progresses, individual nodes will
         represent collapsed cycles in the graph.
-    final_edges: ``Dict[int, int]``, required.
+    final_edges : ``Dict[int, int]``, required.
         An empty dictionary which will be populated with the
         nodes which are connected in the maximum spanning tree.
-    old_input: ``numpy.ndarray``, required.
-    old_output: ``numpy.ndarray``, required.
+    old_input : ``numpy.ndarray``, required.
+    old_output : ``numpy.ndarray``, required.
     representatives : ``List[Set[int]]``, required.
         A list containing the nodes that a particular node
         is representing at this iteration in the graph.

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -895,7 +895,7 @@ def combine_tensors(combination: str, tensors: List[torch.Tensor]) -> torch.Tens
     ``combination`` string.  The string refers to (1-indexed) positions in the input tensor list,
     and looks like ``"1,2,1+2,3-1"``.
 
-    We allow the following kinds of combinations: ``x``, ``x*y``, ``x+y``, ``x-y``, and ``x/y``,
+    We allow the following kinds of combinations : ``x``, ``x*y``, ``x+y``, ``x-y``, and ``x/y``,
     where ``x`` and ``y`` are positive integers less than or equal to ``len(tensors)``.  Each of
     the binary operations is performed elementwise.  You can give as many combinations as you want
     in the ``combination`` string.  For example, for the input string ``"1,2,1*2"``, the result

--- a/allennlp/predictors/dialog_qa.py
+++ b/allennlp/predictors/dialog_qa.py
@@ -25,7 +25,7 @@ class DialogQAPredictor(Predictor):
 
         Parameters
         ----------
-        jsonline: ``str``
+        jsonline : ``str``
             A json line that has the same format as the quac data file.
 
         Returns

--- a/allennlp/predictors/predictor.py
+++ b/allennlp/predictors/predictor.py
@@ -252,15 +252,15 @@ class Predictor(Registrable):
 
         Parameters
         ----------
-        archive_path: ``str``
+        archive_path : ``str``
             The path to the archive.
-        predictor_name: ``str``, optional (default=None)
+        predictor_name : ``str``, optional (default=None)
             Name that the predictor is registered as, or None to use the
             predictor associated with the model.
-        cuda_device: ``int``, optional (default=-1)
+        cuda_device : ``int``, optional (default=-1)
             If `cuda_device` is >= 0, the model will be loaded onto the
             corresponding GPU. Otherwise it will be loaded onto the CPU.
-        dataset_reader_to_load: ``str``, optional (default="validation")
+        dataset_reader_to_load : ``str``, optional (default="validation")
             Which dataset reader to load from the archive, either "train" or
             "validation".
 

--- a/allennlp/training/learning_rate_schedulers/noam.py
+++ b/allennlp/training/learning_rate_schedulers/noam.py
@@ -16,7 +16,7 @@ class NoamLR(LearningRateScheduler):
     ----------
     model_size : ``int``, required.
         The hidden size parameter which dominates the number of parameters in your model.
-    warmup_steps: ``int``, required.
+    warmup_steps : ``int``, required.
         The number of steps to linearly increase the learning rate.
     factor : ``float``, optional (default = 1.0).
         The overall scale factor for the learning rate decay.

--- a/allennlp/training/learning_rate_schedulers/slanted_triangular.py
+++ b/allennlp/training/learning_rate_schedulers/slanted_triangular.py
@@ -29,18 +29,18 @@ class SlantedTriangular(LearningRateScheduler):
     ----------
     num_epochs : ``int``, required.
         The total number of epochs for which the model should be trained.
-    num_steps_per_epoch: ``int``, required.
+    num_steps_per_epoch : ``int``, required.
         The number of steps (updates, batches) per training epoch.
-    cut_frac: ``float``, optional (default = 0.1).
+    cut_frac : ``float``, optional (default = 0.1).
         The fraction of the steps to increase the learning rate.
-    ratio: ``float``, optional (default = 32).
+    ratio : ``float``, optional (default = 32).
         The ratio of the smallest to the (largest) base learning rate.
-    gradual_unfreezing: ``bool``, optional (default = False).
+    gradual_unfreezing : ``bool``, optional (default = False).
         Whether gradual unfreezing should be used.
-    discriminative_fine_tuning: ``bool``, optional (default = False).
+    discriminative_fine_tuning : ``bool``, optional (default = False).
         Whether discriminative fine-tuning (different learning rates per layer)
         are used.
-    decay_factor: ``float``, optional (default = 0.38).
+    decay_factor : ``float``, optional (default = 0.38).
         The decay factor by which the learning rate is reduced with
         discriminative fine-tuning when going a layer deeper.
     """

--- a/allennlp/training/metrics/attachment_scores.py
+++ b/allennlp/training/metrics/attachment_scores.py
@@ -50,7 +50,7 @@ class AttachmentScores(Metric):
             A tensor of the same shape as ``predicted_indices``.
         gold_labels : ``torch.Tensor``, required.
             A tensor of the same shape as ``predicted_labels``.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A tensor of the same shape as ``predicted_indices``.
         """
         unwrapped = self.unwrap_to_tensors(

--- a/allennlp/training/metrics/auc.py
+++ b/allennlp/training/metrics/auc.py
@@ -36,7 +36,7 @@ class Auc(Metric):
             A one-dimensional label tensor of shape (batch_size), with {1, 0}
             entries for positive and negative class. If it's not binary,
             `positive_label` should be passed in the initialization.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A one-dimensional label tensor of shape (batch_size).
         """
 

--- a/allennlp/training/metrics/boolean_accuracy.py
+++ b/allennlp/training/metrics/boolean_accuracy.py
@@ -40,7 +40,7 @@ class BooleanAccuracy(Metric):
             A tensor of predictions of shape (batch_size, ...).
         gold_labels : ``torch.Tensor``, required.
             A tensor of the same shape as ``predictions``.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A tensor of the same shape as ``predictions``.
         """
         predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)

--- a/allennlp/training/metrics/categorical_accuracy.py
+++ b/allennlp/training/metrics/categorical_accuracy.py
@@ -42,7 +42,7 @@ class CategoricalAccuracy(Metric):
         gold_labels : ``torch.Tensor``, required.
             A tensor of integer class label of shape (batch_size, ...). It must be the same
             shape as the ``predictions`` tensor without the ``num_classes`` dimension.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A masking tensor the same size as ``gold_labels``.
         """
         predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)

--- a/allennlp/training/metrics/conll_coref_scores.py
+++ b/allennlp/training/metrics/conll_coref_scores.py
@@ -32,7 +32,7 @@ class ConllCorefScores(Metric):
             For each span, the indices of all allowed antecedents for that span.  This is
             independent of the batch dimension, as it's just based on order in the document.
             Expected shape: (num_spans, num_antecedents)
-        predicted_antecedents: ``torch.Tensor``
+        predicted_antecedents : ``torch.Tensor``
             For each span, this contains the index (into antecedent_indices) of the most likely
             antecedent for that span.
             Expected shape: (batch_size, num_spans)

--- a/allennlp/training/metrics/covariance.py
+++ b/allennlp/training/metrics/covariance.py
@@ -45,7 +45,7 @@ class Covariance(Metric):
             A tensor of predictions of shape (batch_size, ...).
         gold_labels : ``torch.Tensor``, required.
             A tensor of the same shape as ``predictions``.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A tensor of the same shape as ``predictions``.
         """
         predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)

--- a/allennlp/training/metrics/drop_em_and_f1.py
+++ b/allennlp/training/metrics/drop_em_and_f1.py
@@ -26,10 +26,10 @@ class DropEmAndF1(Metric):
         """
         Parameters
         ----------
-        prediction: ``Union[str, List]``
+        prediction : ``Union[str, List]``
             The predicted answer from the model evaluated. This could be a string, or a list of string
             when multiple spans are predicted as answer.
-        ground_truths: ``List``
+        ground_truths : ``List``
             All the ground truth answer annotations.
         """
         # If you wanted to split this out by answer type, you could look at [1] here and group by

--- a/allennlp/training/metrics/entropy.py
+++ b/allennlp/training/metrics/entropy.py
@@ -23,7 +23,7 @@ class Entropy(Metric):
         ----------
         logits : ``torch.Tensor``, required.
             A tensor of unnormalized log probabilities of shape (batch_size, ..., num_classes).
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A masking tensor of shape (batch_size, ...).
         """
         logits, mask = self.unwrap_to_tensors(logits, mask)

--- a/allennlp/training/metrics/evalb_bracketing_scorer.py
+++ b/allennlp/training/metrics/evalb_bracketing_scorer.py
@@ -43,11 +43,11 @@ class EvalbBracketingScorer(Metric):
     ----------
     evalb_directory_path : ``str``, required.
         The directory containing the EVALB executable.
-    evalb_param_filename: ``str``, optional (default = "COLLINS.prm")
+    evalb_param_filename : ``str``, optional (default = "COLLINS.prm")
         The relative name of the EVALB configuration file used when scoring the trees.
         By default, this uses the COLLINS.prm configuration file which comes with EVALB.
         This configuration ignores POS tags and some punctuation labels.
-    evalb_num_errors_to_kill: ``int``, optional (default = "10")
+    evalb_num_errors_to_kill : ``int``, optional (default = "10")
         The number of errors to tolerate from EVALB before terminating evaluation.
     """
 

--- a/allennlp/training/metrics/fbeta_measure.py
+++ b/allennlp/training/metrics/fbeta_measure.py
@@ -99,7 +99,7 @@ class FBetaMeasure(Metric):
         gold_labels : ``torch.Tensor``, required.
             A tensor of integer class label of shape (batch_size, ...). It must be the same
             shape as the ``predictions`` tensor without the ``num_classes`` dimension.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A masking tensor the same size as ``gold_labels``.
         """
         predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)

--- a/allennlp/training/metrics/mean_absolute_error.py
+++ b/allennlp/training/metrics/mean_absolute_error.py
@@ -29,7 +29,7 @@ class MeanAbsoluteError(Metric):
             A tensor of predictions of shape (batch_size, ...).
         gold_labels : ``torch.Tensor``, required.
             A tensor of the same shape as ``predictions``.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A tensor of the same shape as ``predictions``.
         """
         predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)

--- a/allennlp/training/metrics/metric.py
+++ b/allennlp/training/metrics/metric.py
@@ -20,7 +20,7 @@ class Metric(Registrable):
             A tensor of predictions.
         gold_labels : ``torch.Tensor``, required.
             A tensor corresponding to some gold label to evaluate against.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A mask can be passed, in order to deal with metrics which are
             computed over potentially padded elements, such as sequence labels.
         """

--- a/allennlp/training/metrics/pearson_correlation.py
+++ b/allennlp/training/metrics/pearson_correlation.py
@@ -52,7 +52,7 @@ class PearsonCorrelation(Metric):
             A tensor of predictions of shape (batch_size, ...).
         gold_labels : ``torch.Tensor``, required.
             A tensor of the same shape as ``predictions``.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A tensor of the same shape as ``predictions``.
         """
         predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)

--- a/allennlp/training/metrics/sequence_accuracy.py
+++ b/allennlp/training/metrics/sequence_accuracy.py
@@ -31,7 +31,7 @@ class SequenceAccuracy(Metric):
             A tensor of predictions of shape (batch_size, k, sequence_length).
         gold_labels : ``torch.Tensor``, required.
             A tensor of integer class label of shape (batch_size, sequence_length).
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A masking tensor the same size as ``gold_labels``.
         """
         predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)

--- a/allennlp/training/metrics/span_based_f1_measure.py
+++ b/allennlp/training/metrics/span_based_f1_measure.py
@@ -67,7 +67,7 @@ class SpanBasedF1Measure(Metric):
         label_encoding : ``str``, optional (default = "BIO")
             The encoding used to specify label span endpoints in the sequence.
             Valid options are "BIO", "IOB1", "BIOUL" or "BMES".
-        tags_to_spans_function: ``Callable``, optional (default = ``None``)
+        tags_to_spans_function : ``Callable``, optional (default = ``None``)
             If ``label_encoding`` is ``None``, ``tags_to_spans_function`` will be
             used to generate spans.
         """
@@ -111,9 +111,9 @@ class SpanBasedF1Measure(Metric):
         gold_labels : ``torch.Tensor``, required.
             A tensor of integer class label of shape (batch_size, sequence_length). It must be the same
             shape as the ``predictions`` tensor without the ``num_classes`` dimension.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A masking tensor the same size as ``gold_labels``.
-        prediction_map: ``torch.Tensor``, optional (default = None).
+        prediction_map : ``torch.Tensor``, optional (default = None).
             A tensor of size (batch_size, num_classes) which provides a mapping from the index of predictions
             to the indices of the label vocabulary. If provided, the output label at each timestep will be
             ``vocabulary.get_index_to_token_vocabulary(prediction_map[batch, argmax(predictions[batch, t]))``,

--- a/allennlp/training/metrics/spearman_correlation.py
+++ b/allennlp/training/metrics/spearman_correlation.py
@@ -37,7 +37,7 @@ class SpearmanCorrelation(Metric):
             A tensor of predictions of shape (batch_size, ...).
         gold_labels : ``torch.Tensor``, required.
             A tensor of the same shape as ``predictions``.
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A tensor of the same shape as ``predictions``.
         """
         predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)

--- a/allennlp/training/metrics/unigram_recall.py
+++ b/allennlp/training/metrics/unigram_recall.py
@@ -35,7 +35,7 @@ class UnigramRecall(Metric):
             A tensor of predictions of shape (batch_size, k, sequence_length).
         gold_labels : ``torch.Tensor``, required.
             A tensor of integer class label of shape (batch_size, sequence_length).
-        mask: ``torch.Tensor``, optional (default = None).
+        mask : ``torch.Tensor``, optional (default = None).
             A masking tensor the same size as ``gold_labels``.
         """
         predictions, gold_labels, mask = self.unwrap_to_tensors(predictions, gold_labels, mask)

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -104,7 +104,7 @@ class Trainer(TrainerBase):
         validation_iterator : ``DataIterator``, optional (default=None)
             An iterator to use for the validation set.  If ``None``, then
             use the training `iterator`.
-        shuffle: ``bool``, optional (default=True)
+        shuffle : ``bool``, optional (default=True)
             Whether to shuffle the instances in the iterator or not.
         num_epochs : int, optional (default = 20)
             Number of training epochs.
@@ -149,7 +149,7 @@ class Trainer(TrainerBase):
         momentum_scheduler : ``MomentumScheduler``, optional (default = None)
             If specified, the momentum will be updated at the end of each batch or epoch
             according to the schedule.
-        summary_interval: ``int``, optional, (default = 100)
+        summary_interval : ``int``, optional, (default = 100)
             Number of batches between logging scalars to tensorboard
         histogram_interval : ``int``, optional, (default = ``None``)
             If not None, then log histograms to tensorboard every ``histogram_interval`` batches.
@@ -172,22 +172,22 @@ class Trainer(TrainerBase):
             Whether to send parameter specific learning rate to tensorboard.
         log_batch_size_period : ``int``, optional, (default = ``None``)
             If defined, how often to log the average batch size.
-        moving_average: ``MovingAverage``, optional, (default = None)
+        moving_average : ``MovingAverage``, optional, (default = None)
             If provided, we will maintain moving averages for all parameters. During training, we
             employ a shadow variable for each parameter, which maintains the moving average. During
             evaluation, we backup the original parameters and assign the moving averages to corresponding
             parameters. Be careful that when saving the checkpoint, we will save the moving averages of
             parameters. This is necessary because we want the saved model to perform as well as the validated
             model if we load it later. But this may cause problems if you restart the training from checkpoint.
-        distributed: ``bool``, optional, (default = False)
+        distributed : ``bool``, optional, (default = False)
             If set, PyTorch's `DistributedDataParallel` is used to train the model in multiple GPUs. This also
             requires `world_size` to be greater than 1.
-        rank: ``int``, optional, (default = 0)
+        rank : ``int``, optional, (default = 0)
             This is the unique identifier of the `Trainer` in a distributed process group. The GPU device id is
             used as the rank.
-        world_size: ``int``, (default = 1)
+        world_size : ``int``, (default = 1)
             The number of `Trainer` workers participating in the distributed training.
-        num_gradient_accumulation_steps: ``int``, optional, (default = 1)
+        num_gradient_accumulation_steps : ``int``, optional, (default = 1)
             Gradients are accumulated for the given number of steps before doing an optimizer step. This can
             be useful to accommodate batches that are larger than the RAM size. Refer Thomas Wolf's
             [post](https://tinyurl.com/y5mv44fw) for details on Gradient Accumulation.

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -254,14 +254,14 @@ def create_serialization_dir(
 
     Parameters
     ----------
-    params: ``Params``
+    params : ``Params``
         A parameter object specifying an AllenNLP Experiment.
-    serialization_dir: ``str``
+    serialization_dir : ``str``
         The directory in which to save results and logs.
-    recover: ``bool``
+    recover : ``bool``
         If ``True``, we will try to recover from an existing serialization directory, and crash if
         the directory doesn't exist, or doesn't match the configuration we're given.
-    force: ``bool``
+    force : ``bool``
         If ``True``, we will overwrite the serialization directory if it already exists.
     """
     if recover and force:


### PR DESCRIPTION
Without the space (`foo: bar`):

![image](https://user-images.githubusercontent.com/954798/71843901-ca370180-3079-11ea-9ac0-faf3365a812b.png)

With the space (`foo : bar`):

![image](https://user-images.githubusercontent.com/954798/71843913-d4590000-3079-11ea-9400-53cad1370551.png)

`find . -name '*py' -exec gsed -i 's/ *: ``/ : ``/g' \{\} \;`