### PR TITLE
Be robust to not having torch.distributed.

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -518,7 +518,7 @@ def is_master(rank: int = None, world_size: int = None) -> bool:
         Number of processes in the distributed group. If not
         given, this is obtained using `torch.distributed.get_world_size()`
     """
-    distributed = dist.is_initialized()
+    distributed = is_distributed()
 
     # In non-distributed case, a "master" process doesn't make any
     # sense. So instead of raising an error, returning True would
@@ -540,6 +540,6 @@ def is_master(rank: int = None, world_size: int = None) -> bool:
 
 def is_distributed() -> bool:
     """
-    Checks if the distributed process group has been initialized
+    Checks if the distributed process group is available and has been initialized
     """
-    return dist.is_initialized()
+    return dist.is_available() and dist.is_initialized()

--- a/allennlp/training/trainer_pieces.py
+++ b/allennlp/training/trainer_pieces.py
@@ -5,7 +5,7 @@ from typing import Iterable, NamedTuple
 
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
-from allennlp.common.util import get_frozen_and_tunable_parameter_names, is_distributed, is_master
+from allennlp.common.util import get_frozen_and_tunable_parameter_names, is_master
 from allennlp.data.instance import Instance
 from allennlp.data.iterators.data_iterator import DataIterator
 from allennlp.data.vocabulary import Vocabulary
@@ -82,8 +82,9 @@ class TrainerPieces(NamedTuple):
         model.extend_embedder_vocab()
 
         # Initializing the model can have side effect of expanding the vocabulary
-        # Save the vocab only in the master
-        if not is_distributed() or is_master():
+        # Save the vocab only in the master. In the degenerate non-distributed
+        # case, we're trivially the master.
+        if is_master():
             vocab.save_to_files(os.path.join(serialization_dir, "vocabulary"))
 
         iterator = DataIterator.from_params(params.pop("iterator"))


### PR DESCRIPTION
- One can't call `distributed.is_initialized()` if `not distributed.is_available()`.
- This caused test failures on macOS High Sierra.