### PR TITLE
Guess sorting keys when none are given to BucketIterator

### DIFF
--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -159,8 +159,8 @@ class BucketIterator(DataIterator):
         instances_with_lengths.sort(key=lambda x: x[0])
         return [instance_with_lengths[-1] for instance_with_lengths in instances_with_lengths]
 
-    def _guess_sorting_key(self, instances: List[Instance]) -> None:
-        max_length = 0
+    def _guess_sorting_keys(self, instances: List[Instance]) -> None:
+        max_length = 0.0
         longest_padding_key: Tuple[str, str] = None
         for instance in instances:
             instance.index_fields(self.vocab)

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -135,7 +135,9 @@ class BucketIterator(DataIterator):
         ``(field_name, padding_key)`` tuples.
         """
         if not self._sorting_keys:
+            logger.info("No sorting keys given; trying to guess a good one")
             self._guess_sorting_keys(instances)
+            logger.info(f"Using {self._sorting_keys} as the sorting keys")
         instances_with_lengths = []
         for instance in instances:
             # Make sure instance is indexed before calling .get_padding
@@ -171,7 +173,10 @@ class BucketIterator(DataIterator):
                         max_length = length
                         longest_padding_key = (field_name, padding_key)
         if not longest_padding_key:
-            raise ValueError(
-                "Found no field that needed padding; why are you using a bucket iterator?"
+            # This shouldn't ever happen (you basically have to have an empty instance list), but
+            # just in case...
+            raise AssertionError(
+                "Found no field that needed padding; we are surprised you got this error, please "
+                "open an issue on github"
             )
         self._sorting_keys = [longest_padding_key]

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -5,12 +5,10 @@ from typing import List, Tuple, Iterable, cast, Dict, Deque
 
 from overrides import overrides
 
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.util import lazy_groups_of, add_noise_to_dict_values
 from allennlp.data.dataset import Batch
 from allennlp.data.instance import Instance
 from allennlp.data.iterators.data_iterator import DataIterator
-from allennlp.data.vocabulary import Vocabulary
 
 logger = logging.getLogger(__name__)
 

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -15,39 +15,6 @@ from allennlp.data.vocabulary import Vocabulary
 logger = logging.getLogger(__name__)
 
 
-def sort_by_padding(
-    instances: List[Instance],
-    sorting_keys: List[Tuple[str, str]],
-    vocab: Vocabulary,
-    padding_noise: float = 0.0,
-) -> List[Instance]:
-    """
-    Sorts the instances by their padding lengths, using the keys in
-    ``sorting_keys`` (in the order in which they are provided).  ``sorting_keys`` is a list of
-    ``(field_name, padding_key)`` tuples.
-    """
-    instances_with_lengths = []
-    for instance in instances:
-        # Make sure instance is indexed before calling .get_padding
-        instance.index_fields(vocab)
-        padding_lengths = cast(Dict[str, Dict[str, float]], instance.get_padding_lengths())
-        if padding_noise > 0.0:
-            noisy_lengths = {}
-            for field_name, field_lengths in padding_lengths.items():
-                noisy_lengths[field_name] = add_noise_to_dict_values(field_lengths, padding_noise)
-            padding_lengths = noisy_lengths
-        instance_with_lengths = (
-            [
-                padding_lengths[field_name][padding_key]
-                for (field_name, padding_key) in sorting_keys
-            ],
-            instance,
-        )
-        instances_with_lengths.append(instance_with_lengths)
-    instances_with_lengths.sort(key=lambda x: x[0])
-    return [instance_with_lengths[-1] for instance_with_lengths in instances_with_lengths]
-
-
 @DataIterator.register("bucket")
 class BucketIterator(DataIterator):
     """
@@ -59,16 +26,19 @@ class BucketIterator(DataIterator):
 
     Parameters
     ----------
-    sorting_keys : List[Tuple[str, str]]
+    sorting_keys : List[Tuple[str, str]], optional
         To bucket inputs into batches, we want to group the instances by padding length, so that we
         minimize the amount of padding necessary per batch. In order to do this, we need to know
         which fields need what type of padding, and in what order.
 
-        For example, ``[("sentence1", "num_tokens"), ("sentence2", "num_tokens"), ("sentence1",
-        "num_token_characters")]`` would sort a dataset first by the "num_tokens" of the
-        "sentence1" field, then by the "num_tokens" of the "sentence2" field, and finally by the
-        "num_token_characters" of the "sentence1" field.  TODO(mattg): we should have some
-        documentation somewhere that gives the standard padding keys used by different fields.
+        Specifying the right keys for this is a bit cryptic, so if this is not given we try to
+        auto-detect the right keys by iterating once through the data up front, reading all of the
+        padding keys and seeing which one has the longest length.  We use that one for padding.
+        This should give reasonable results in most cases.
+
+        When you need to specify this yourself, you can create an instance from your dataset and
+        call ``Instance.get_padding_lengths()`` to see a list of all keys used in your data.  You
+        should give one or more of those as the sorting keys here.
     padding_noise : float, optional (default=.1)
         When sorting by padding length, we add a bit of noise to the lengths, so that the sorting
         isn't deterministic.  This parameter determines how much noise we add, as a percentage of
@@ -97,7 +67,7 @@ class BucketIterator(DataIterator):
 
     def __init__(
         self,
-        sorting_keys: List[Tuple[str, str]],
+        sorting_keys: List[Tuple[str, str]] = None,
         padding_noise: float = 0.1,
         biggest_batch_first: bool = False,
         batch_size: int = 32,
@@ -108,9 +78,6 @@ class BucketIterator(DataIterator):
         maximum_samples_per_batch: Tuple[str, int] = None,
         skip_smaller_batches: bool = False,
     ) -> None:
-        if not sorting_keys:
-            raise ConfigurationError("BucketIterator requires sorting_keys to be specified")
-
         super().__init__(
             cache_instances=cache_instances,
             track_epoch=track_epoch,
@@ -128,9 +95,7 @@ class BucketIterator(DataIterator):
     def _create_batches(self, instances: Iterable[Instance], shuffle: bool) -> Iterable[Batch]:
         for instance_list in self._memory_sized_lists(instances):
 
-            instance_list = sort_by_padding(
-                instance_list, self._sorting_keys, self.vocab, self._padding_noise
-            )
+            instance_list = self._sort_by_padding(instance_list)
 
             batches = []
             excess: Deque[Instance] = deque()
@@ -164,3 +129,51 @@ class BucketIterator(DataIterator):
                 batches.insert(0, last_batch)
 
             yield from batches
+
+    def _sort_by_padding(self, instances: List[Instance]) -> List[Instance]:
+        """
+        Sorts the instances by their padding lengths, using the keys in
+        ``sorting_keys`` (in the order in which they are provided).  ``sorting_keys`` is a list of
+        ``(field_name, padding_key)`` tuples.
+        """
+        if not self._sorting_keys:
+            self._guess_sorting_keys(instances)
+        instances_with_lengths = []
+        for instance in instances:
+            # Make sure instance is indexed before calling .get_padding
+            instance.index_fields(self.vocab)
+            padding_lengths = cast(Dict[str, Dict[str, float]], instance.get_padding_lengths())
+            if self._padding_noise > 0.0:
+                noisy_lengths = {}
+                for field_name, field_lengths in padding_lengths.items():
+                    noisy_lengths[field_name] = add_noise_to_dict_values(
+                        field_lengths, self._padding_noise
+                    )
+                padding_lengths = noisy_lengths
+            instance_with_lengths = (
+                [
+                    padding_lengths[field_name][padding_key]
+                    for (field_name, padding_key) in self._sorting_keys
+                ],
+                instance,
+            )
+            instances_with_lengths.append(instance_with_lengths)
+        instances_with_lengths.sort(key=lambda x: x[0])
+        return [instance_with_lengths[-1] for instance_with_lengths in instances_with_lengths]
+
+    def _guess_sorting_key(self, instances: List[Instance]) -> None:
+        max_length = 0
+        longest_padding_key: Tuple[str, str] = None
+        for instance in instances:
+            instance.index_fields(self.vocab)
+            padding_lengths = cast(Dict[str, Dict[str, float]], instance.get_padding_lengths())
+            for field_name, field_padding in padding_lengths.items():
+                for padding_key, length in field_padding.items():
+                    if length > max_length:
+                        max_length = length
+                        longest_padding_key = (field_name, padding_key)
+        if not longest_padding_key:
+            raise ValueError(
+                "Found no field that needed padding; why are you using a bucket iterator?"
+            )
+        self._sorting_keys = [longest_padding_key]

--- a/allennlp/tests/data/iterators/bucket_iterator_test.py
+++ b/allennlp/tests/data/iterators/bucket_iterator_test.py
@@ -23,20 +23,35 @@ class TestBucketIterator(IteratorTest):
         ]
 
     def test_guess_sorting_key_picks_the_longest_key(self):
-        iterator = BucketIterator(
-            batch_size=2,
-            padding_noise=0,
-        )
+        iterator = BucketIterator(batch_size=2, padding_noise=0)
         iterator.index_with(self.vocab)
         instances = []
         short_tokens = [Token(t) for t in ["what", "is", "this", "?"]]
         long_tokens = [Token(t) for t in ["this", "is", "a", "not", "very", "long", "passage"]]
-        instances.append(Instance({"question": TextField(short_tokens, self.token_indexers),
-                                   "passage": TextField(long_tokens, self.token_indexers)}))
-        instances.append(Instance({"question": TextField(short_tokens, self.token_indexers),
-                                   "passage": TextField(long_tokens, self.token_indexers)}))
-        instances.append(Instance({"question": TextField(short_tokens, self.token_indexers),
-                                   "passage": TextField(long_tokens, self.token_indexers)}))
+        instances.append(
+            Instance(
+                {
+                    "question": TextField(short_tokens, self.token_indexers),
+                    "passage": TextField(long_tokens, self.token_indexers),
+                }
+            )
+        )
+        instances.append(
+            Instance(
+                {
+                    "question": TextField(short_tokens, self.token_indexers),
+                    "passage": TextField(long_tokens, self.token_indexers),
+                }
+            )
+        )
+        instances.append(
+            Instance(
+                {
+                    "question": TextField(short_tokens, self.token_indexers),
+                    "passage": TextField(long_tokens, self.token_indexers),
+                }
+            )
+        )
         assert iterator._sorting_keys is None
         iterator._guess_sorting_key(instances)
         assert iterator._sorting_keys == [("passage", "tokens_length")]

--- a/allennlp/tests/data/iterators/bucket_iterator_test.py
+++ b/allennlp/tests/data/iterators/bucket_iterator_test.py
@@ -2,6 +2,8 @@ import pytest
 
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
+from allennlp.data import Instance, Token
+from allennlp.data.fields import TextField
 from allennlp.data.iterators import BucketIterator
 from allennlp.tests.data.iterators.basic_iterator_test import IteratorTest
 
@@ -19,6 +21,25 @@ class TestBucketIterator(IteratorTest):
             [self.instances[0], self.instances[1]],
             [self.instances[3]],
         ]
+
+    def test_guess_sorting_key_picks_the_longest_key(self):
+        iterator = BucketIterator(
+            batch_size=2,
+            padding_noise=0,
+        )
+        iterator.index_with(self.vocab)
+        instances = []
+        short_tokens = [Token(t) for t in ["what", "is", "this", "?"]]
+        long_tokens = [Token(t) for t in ["this", "is", "a", "not", "very", "long", "passage"]]
+        instances.append(Instance({"question": TextField(short_tokens, self.token_indexers),
+                                   "passage": TextField(long_tokens, self.token_indexers)}))
+        instances.append(Instance({"question": TextField(short_tokens, self.token_indexers),
+                                   "passage": TextField(long_tokens, self.token_indexers)}))
+        instances.append(Instance({"question": TextField(short_tokens, self.token_indexers),
+                                   "passage": TextField(long_tokens, self.token_indexers)}))
+        assert iterator._sorting_keys is None
+        iterator._guess_sorting_key(instances)
+        assert iterator._sorting_keys == [("passage", "tokens_length")]
 
     def test_create_batches_groups_correctly_with_max_instances(self):
         # If we knew all the instances, the correct order is 4 -> 2 -> 0 -> 1 -> 3.
@@ -60,9 +81,6 @@ class TestBucketIterator(IteratorTest):
     def test_from_params(self):
 
         params = Params({})
-
-        with pytest.raises(ConfigurationError):
-            iterator = BucketIterator.from_params(params)
 
         sorting_keys = [("s1", "nt"), ("s2", "nt2")]
         params["sorting_keys"] = sorting_keys

--- a/allennlp/tests/data/iterators/bucket_iterator_test.py
+++ b/allennlp/tests/data/iterators/bucket_iterator_test.py
@@ -53,7 +53,7 @@ class TestBucketIterator(IteratorTest):
             )
         )
         assert iterator._sorting_keys is None
-        iterator._guess_sorting_key(instances)
+        iterator._guess_sorting_keys(instances)
         assert iterator._sorting_keys == [("passage", "tokens_length")]
 
     def test_create_batches_groups_correctly_with_max_instances(self):


### PR DESCRIPTION
In refactoring the TokenIndexer stuff, I had to change how padding keys are determined, to make things a bit more sane.  That change makes figuring out which keys to use even more annoying than it was.  As I was thinking of how to fix that, it occurred to me that we could just guess which key to use and be right basically every time, by just finding the padding key with the longest value.

One potential failure case is when you have a large embedding matrix that's preprocessed (e.g., spacy vectors) and we use that length instead of the number of tokens, or something.  That's a rare case, and we could still handle it by taking the top k keys instead of the top 1, as the top one should be equal for all instances.

I guess we could detect variance of the keys and use that instead of just the max length...  But I'd vote to worry about that if we run into cases where this simpler logic fails.  My guess is that this does the right thing basically all of the time.