### PR TITLE
Unpins the version of datautil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,6 @@ setup(
         "pytorch-pretrained-bert>=0.6.0",
         "transformers>=2.1.1,!=2.2.1,!=2.2.2",
         "jsonpickle",
-        "python-dateutil<2.8.1",
     ],
     entry_points={"console_scripts": ["allennlp=allennlp.run:run"]},
     setup_requires=setup_requirements,


### PR DESCRIPTION
See the discussion at https://github.com/allenai/allennlp/pull/3509.

This is uncomfortable. The root problem was a bug in `pip`. This undoes the workaround. The workaround breaks the library for people like @AlJohri, but without the workaround, people with an old version of boto are broken.

On balance, I think it's more important to have this work for future versions than for past ones, so I'm removing the workaround.