### PR TITLE
[WIP] remove sorting in encoders

### DIFF
--- a/allennlp/modules/encoder_base.py
+++ b/allennlp/modules/encoder_base.py
@@ -111,10 +111,6 @@ class _EncoderBase(torch.nn.Module):
         # Actually call the module on the sorted PackedSequence.
         module_output, final_states = module(packed_sequence_input, initial_states)
 
-        broadcastable_zero_length_sequences = zero_length_seqs.view(1, -1, 1).bool()
-        for state in final_states:
-            state.masked_fill_(broadcastable_zero_length_sequences, 0.0)
-
         return module_output, final_states
 
     def _get_initial_states(self, batch_size: int) -> Optional[RnnState]:

--- a/allennlp/modules/encoder_base.py
+++ b/allennlp/modules/encoder_base.py
@@ -110,6 +110,11 @@ class _EncoderBase(torch.nn.Module):
 
         # Actually call the module on the sorted PackedSequence.
         module_output, final_states = module(packed_sequence_input, initial_states)
+
+        broadcastable_zero_length_sequences = zero_length_seqs.view(1, -1, 1).bool()
+        for state in final_states:
+            state.masked_fill_(broadcastable_zero_length_sequences, 0.0)
+
         return module_output, final_states
 
     def _get_initial_states(self, batch_size: int) -> Optional[RnnState]:

--- a/allennlp/modules/encoder_base.py
+++ b/allennlp/modules/encoder_base.py
@@ -100,7 +100,7 @@ class _EncoderBase(torch.nn.Module):
             inputs,
             sequence_lengths + zero_length_seqs,  # TODO(Mark: remember to fix this output)
             batch_first=True,
-            enforce_sorted=False
+            enforce_sorted=False,
         )
         # Prepare the initial states.
         if not self.stateful:

--- a/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
+++ b/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
@@ -67,36 +67,17 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
             # at the end of the max sequence length, so we have to use the state of the RNN below.
             return self._module(inputs, hidden_state)[0][:, -1, :]
 
-        batch_size = mask.size(0)
-
-        _, state, restoration_indices, = self.sort_and_run_forward(
-            self._module, inputs, mask, hidden_state
-        )
+        _, state = self.sort_and_run_forward(self._module, inputs, mask, hidden_state)
 
         # Deal with the fact the LSTM state is a tuple of (state, memory).
         if isinstance(state, tuple):
             state = state[0]
 
-        num_layers_times_directions, num_valid, encoding_dim = state.size()
-        # Add back invalid rows.
-        if num_valid < batch_size:
-            # batch size is the second dimension here, because pytorch
-            # returns RNN state as a tensor of shape (num_layers * num_directions,
-            # batch_size, hidden_size)
-            zeros = state.new_zeros(
-                num_layers_times_directions, batch_size - num_valid, encoding_dim
-            )
-            state = torch.cat([state, zeros], 1)
-
-        # Restore the original indices and return the final state of the
-        # top layer. Pytorch's recurrent layers return state in the form
+        # Pytorch's recurrent layers return state in the form
         # (num_layers * num_directions, batch_size, hidden_size) regardless
-        # of the 'batch_first' flag, so we transpose, extract the relevant
-        # layer state (both forward and backward if using bidirectional layers)
-        # and return them as a single (batch_size, self.get_output_dim()) tensor.
-
-        # now of shape: (batch_size, num_layers * num_directions, hidden_size).
-        unsorted_state = state.transpose(0, 1).index_select(0, restoration_indices)
+        # of the 'batch_first' flag, so we transpose and return them as a single
+        # (batch_size, self.get_output_dim()) tensor.
+        transposed_state = state.transpose(0, 1)
 
         # Extract the last hidden vector, including both forward and backward states
         # if the cell is bidirectional. Then reshape by concatenation (in the case
@@ -106,5 +87,5 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
             last_state_index = 2 if self._module.bidirectional else 1
         except AttributeError:
             last_state_index = 1
-        last_layer_state = unsorted_state[:, -last_state_index:, :]
+        last_layer_state = transposed_state[:, -last_state_index:, :]
         return last_layer_state.contiguous().view([-1, self.get_output_dim()])

--- a/allennlp/tests/modules/encoder_base_test.py
+++ b/allennlp/tests/modules/encoder_base_test.py
@@ -43,32 +43,22 @@ class TestEncoderBase(AllenNlpTestCase):
         # Check that we sort the state for non-stateful encoders. To test
         # we'll just use a "pass through" encoder, as we aren't actually testing
         # the functionality of the encoder here anyway.
-        _, states, restoration_indices = encoder_base.sort_and_run_forward(
+        _, states = encoder_base.sort_and_run_forward(
             lambda *x: x, self.tensor, self.mask, initial_states
         )
-        # Our input tensor had 2 zero length sequences, so we need
-        # to concat a tensor of shape
-        # (num_layers * num_directions, batch_size - num_valid, hidden_dim),
-        # to the output before unsorting it.
-        zeros = torch.zeros([6, 2, 7])
-
-        # sort_and_run_forward strips fully-padded instances from the batch;
-        # in order to use the restoration_indices we need to add back the two
-        #  that got stripped. What we get back should match what we started with.
+        # What we get back should match what we started with.
         for state, original in zip(states, initial_states):
-            assert list(state.size()) == [6, 3, 7]
-            state_with_zeros = torch.cat([state, zeros], 1)
-            unsorted_state = state_with_zeros.index_select(1, restoration_indices)
+            assert list(state.size()) == [6, 5, 7]
             for index in [0, 1, 3]:
                 numpy.testing.assert_array_equal(
-                    unsorted_state[:, index, :].data.numpy(), original[:, index, :].data.numpy()
+                    state[:, index, :].data.numpy(), original[:, index, :].data.numpy()
                 )
 
     def test_get_initial_states(self):
         # First time we call it, there should be no state, so we should return None.
         assert (
             self.encoder_base._get_initial_states(
-                self.batch_size, self.num_valid, self.sorting_indices
+                self.batch_size
             )
             is None
         )
@@ -77,8 +67,8 @@ class TestEncoderBase(AllenNlpTestCase):
         initial_states = (torch.randn([1, 3, 7]), torch.randn([1, 3, 7]))
         self.encoder_base._states = initial_states
         # sorting indices are: [0, 1, 3, 2, 4]
-        returned_states = self.encoder_base._get_initial_states(
-            self.batch_size, self.num_valid, self.sorting_indices
+        _ = self.encoder_base._get_initial_states(
+            self.batch_size
         )
 
         correct_expanded_states = [
@@ -92,28 +82,12 @@ class TestEncoderBase(AllenNlpTestCase):
             self.encoder_base._states[1].data.numpy(), correct_expanded_states[1].data.numpy()
         )
 
-        # The returned states should be of shape (1, num_valid, hidden_size) and
-        # they also should have been sorted with respect to the indices.
-        # sorting indices are: [0, 1, 3, 2, 4]
-
-        correct_returned_states = [
-            state.index_select(1, self.sorting_indices)[:, : self.num_valid, :]
-            for state in correct_expanded_states
-        ]
-
-        numpy.testing.assert_array_equal(
-            returned_states[0].data.numpy(), correct_returned_states[0].data.numpy()
-        )
-        numpy.testing.assert_array_equal(
-            returned_states[1].data.numpy(), correct_returned_states[1].data.numpy()
-        )
-
         # Now test the case that the previous state is larger:
         original_states = (torch.randn([1, 10, 7]), torch.randn([1, 10, 7]))
         self.encoder_base._states = original_states
         # sorting indices are: [0, 1, 3, 2, 4]
-        returned_states = self.encoder_base._get_initial_states(
-            self.batch_size, self.num_valid, self.sorting_indices
+        _ = self.encoder_base._get_initial_states(
+            self.batch_size
         )
         # State should not have changed, as they were larger
         # than the batch size of the requested states.
@@ -124,113 +98,86 @@ class TestEncoderBase(AllenNlpTestCase):
             self.encoder_base._states[1].data.numpy(), original_states[1].data.numpy()
         )
 
-        # The returned states should be of shape (1, num_valid, hidden_size) and they
-        # also should have been sorted with respect to the indices.
-        correct_returned_state = [
-            x.index_select(1, self.sorting_indices)[:, : self.num_valid, :] for x in original_states
-        ]
-        numpy.testing.assert_array_equal(
-            returned_states[0].data.numpy(), correct_returned_state[0].data.numpy()
-        )
-        numpy.testing.assert_array_equal(
-            returned_states[1].data.numpy(), correct_returned_state[1].data.numpy()
-        )
-
     def test_update_states(self):
         assert self.encoder_base._states is None
         initial_states = torch.randn([1, 5, 7]), torch.randn([1, 5, 7])
 
-        index_selected_initial_states = (
-            initial_states[0].index_select(1, self.restoration_indices),
-            initial_states[1].index_select(1, self.restoration_indices),
-        )
-
-        self.encoder_base._update_states(initial_states, self.restoration_indices)
+        self.encoder_base._update_states(initial_states)
         # State was None, so the updated state should just be the sorted given state.
         numpy.testing.assert_array_equal(
-            self.encoder_base._states[0].data.numpy(), index_selected_initial_states[0].data.numpy()
+            self.encoder_base._states[0].data.numpy(), initial_states[0].data.numpy()
         )
         numpy.testing.assert_array_equal(
-            self.encoder_base._states[1].data.numpy(), index_selected_initial_states[1].data.numpy()
+            self.encoder_base._states[1].data.numpy(), initial_states[1].data.numpy()
         )
 
         new_states = torch.randn([1, 5, 7]), torch.randn([1, 5, 7])
-        # tensor has 2 completely masked rows, so the last 2 rows of the _sorted_ states
+        # tensor has 2 completely masked rows, so the last 2 rows of the states
         # will be completely zero, having been appended after calling the respective encoder.
         new_states[0][:, -2:, :] = 0
         new_states[1][:, -2:, :] = 0
 
-        index_selected_new_states = (
-            new_states[0].index_select(1, self.restoration_indices),
-            new_states[1].index_select(1, self.restoration_indices),
-        )
-
-        self.encoder_base._update_states(new_states, self.restoration_indices)
+        self.encoder_base._update_states(new_states)
         # Check that the update _preserved_ the state for the rows which were
-        # completely masked (2 and 4):
-        for index in [2, 4]:
+        # completely masked (3 and 4):
+        for index in [3, 4]:
             numpy.testing.assert_array_equal(
                 self.encoder_base._states[0][:, index, :].data.numpy(),
-                index_selected_initial_states[0][:, index, :].data.numpy(),
+                initial_states[0][:, index, :].data.numpy(),
             )
             numpy.testing.assert_array_equal(
                 self.encoder_base._states[1][:, index, :].data.numpy(),
-                index_selected_initial_states[1][:, index, :].data.numpy(),
+                initial_states[1][:, index, :].data.numpy(),
             )
         # Now the states which were updated:
-        for index in [0, 1, 3]:
+        for index in [0, 1, 2]:
             numpy.testing.assert_array_equal(
                 self.encoder_base._states[0][:, index, :].data.numpy(),
-                index_selected_new_states[0][:, index, :].data.numpy(),
+                new_states[0][:, index, :].data.numpy(),
             )
             numpy.testing.assert_array_equal(
                 self.encoder_base._states[1][:, index, :].data.numpy(),
-                index_selected_new_states[1][:, index, :].data.numpy(),
+                new_states[1][:, index, :].data.numpy(),
             )
 
         # Now test the case that the new state is smaller:
         small_new_states = torch.randn([1, 3, 7]), torch.randn([1, 3, 7])
-        # pretend the 2nd sequence in the batch was fully masked.
-        small_restoration_indices = torch.LongTensor([2, 0, 1])
+        # pretend the 1st sequence in the batch was fully masked.
         small_new_states[0][:, 0, :] = 0
         small_new_states[1][:, 0, :] = 0
 
-        index_selected_small_states = (
-            small_new_states[0].index_select(1, small_restoration_indices),
-            small_new_states[1].index_select(1, small_restoration_indices),
-        )
-        self.encoder_base._update_states(small_new_states, small_restoration_indices)
+        self.encoder_base._update_states(small_new_states)
 
         # Check the index for the row we didn't update is the same as the previous step:
-        for index in [1, 3]:
+        for index in [0, 3]:
             numpy.testing.assert_array_equal(
                 self.encoder_base._states[0][:, index, :].data.numpy(),
-                index_selected_new_states[0][:, index, :].data.numpy(),
+                new_states[0][:, index, :].data.numpy(),
             )
             numpy.testing.assert_array_equal(
                 self.encoder_base._states[1][:, index, :].data.numpy(),
-                index_selected_new_states[1][:, index, :].data.numpy(),
+                new_states[1][:, index, :].data.numpy(),
             )
         # Indices we did update:
-        for index in [0, 2]:
+        for index in [1, 2]:
             numpy.testing.assert_array_equal(
                 self.encoder_base._states[0][:, index, :].data.numpy(),
-                index_selected_small_states[0][:, index, :].data.numpy(),
+                small_new_states[0][:, index, :].data.numpy(),
             )
             numpy.testing.assert_array_equal(
                 self.encoder_base._states[1][:, index, :].data.numpy(),
-                index_selected_small_states[1][:, index, :].data.numpy(),
+                small_new_states[1][:, index, :].data.numpy(),
             )
 
         # We didn't update index 4 in the previous step either, so it should be equal to the
         # 4th index of initial states.
         numpy.testing.assert_array_equal(
             self.encoder_base._states[0][:, 4, :].data.numpy(),
-            index_selected_initial_states[0][:, 4, :].data.numpy(),
+            initial_states[0][:, 4, :].data.numpy(),
         )
         numpy.testing.assert_array_equal(
             self.encoder_base._states[1][:, 4, :].data.numpy(),
-            index_selected_initial_states[1][:, 4, :].data.numpy(),
+            initial_states[1][:, 4, :].data.numpy(),
         )
 
     def test_reset_states(self):
@@ -238,10 +185,10 @@ class TestEncoderBase(AllenNlpTestCase):
         assert self.encoder_base._states is None
         initial_states = torch.randn([1, 5, 7]), torch.randn([1, 5, 7])
         index_selected_initial_states = (
-            initial_states[0].index_select(1, self.restoration_indices),
-            initial_states[1].index_select(1, self.restoration_indices),
+            initial_states[0],
+            initial_states[1],
         )
-        self.encoder_base._update_states(initial_states, self.restoration_indices)
+        self.encoder_base._update_states(initial_states)
 
         # Check that only some of the states are reset when a mask is provided.
         mask = torch.FloatTensor([1, 1, 0, 0, 0])
@@ -303,11 +250,11 @@ class TestEncoderBase(AllenNlpTestCase):
         final_states = initial_states
         # Check LSTM
         encoder_base = _EncoderBase(stateful=True)
-        encoder_base._update_states(final_states, self.restoration_indices)
+        encoder_base._update_states(final_states)
         encoder_base.sort_and_run_forward(self.lstm, self.tensor, self.mask)
         # Check RNN
         encoder_base.reset_states()
-        encoder_base._update_states([final_states[0]], self.restoration_indices)
+        encoder_base._update_states([final_states[0]])
         encoder_base.sort_and_run_forward(self.rnn, self.tensor, self.mask)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
@@ -347,9 +294,9 @@ class TestEncoderBase(AllenNlpTestCase):
         final_states = initial_states
         # Check LSTM
         encoder_base = _EncoderBase(stateful=True).cuda()
-        encoder_base._update_states(final_states, self.restoration_indices.cuda())
+        encoder_base._update_states(final_states)
         encoder_base.sort_and_run_forward(self.lstm.cuda(), self.tensor.cuda(), self.mask.cuda())
         # Check RNN
         encoder_base.reset_states()
-        encoder_base._update_states([final_states[0]], self.restoration_indices.cuda())
+        encoder_base._update_states([final_states[0]])
         encoder_base.sort_and_run_forward(self.rnn.cuda(), self.tensor.cuda(), self.mask.cuda())

--- a/allennlp/tests/modules/encoder_base_test.py
+++ b/allennlp/tests/modules/encoder_base_test.py
@@ -32,10 +32,6 @@ class TestEncoderBase(AllenNlpTestCase):
 
         self.batch_size = 5
         self.num_valid = 3
-        sequence_lengths = get_lengths_from_binary_sequence_mask(mask)
-        _, _, restoration_indices, sorting_indices = sort_batch_by_length(tensor, sequence_lengths)
-        self.sorting_indices = sorting_indices
-        self.restoration_indices = restoration_indices
 
     def test_non_stateful_states_are_sorted_correctly(self):
         encoder_base = _EncoderBase(stateful=False)
@@ -56,20 +52,13 @@ class TestEncoderBase(AllenNlpTestCase):
 
     def test_get_initial_states(self):
         # First time we call it, there should be no state, so we should return None.
-        assert (
-            self.encoder_base._get_initial_states(
-                self.batch_size
-            )
-            is None
-        )
+        assert self.encoder_base._get_initial_states(self.batch_size) is None
 
         # First test the case that the previous state is _smaller_ than the current state input.
         initial_states = (torch.randn([1, 3, 7]), torch.randn([1, 3, 7]))
         self.encoder_base._states = initial_states
         # sorting indices are: [0, 1, 3, 2, 4]
-        _ = self.encoder_base._get_initial_states(
-            self.batch_size
-        )
+        _ = self.encoder_base._get_initial_states(self.batch_size)
 
         correct_expanded_states = [
             torch.cat([state, torch.zeros([1, 2, 7])], 1) for state in initial_states
@@ -86,9 +75,7 @@ class TestEncoderBase(AllenNlpTestCase):
         original_states = (torch.randn([1, 10, 7]), torch.randn([1, 10, 7]))
         self.encoder_base._states = original_states
         # sorting indices are: [0, 1, 3, 2, 4]
-        _ = self.encoder_base._get_initial_states(
-            self.batch_size
-        )
+        _ = self.encoder_base._get_initial_states(self.batch_size)
         # State should not have changed, as they were larger
         # than the batch size of the requested states.
         numpy.testing.assert_array_equal(


### PR DESCRIPTION
`torch.nn.utils.rnn.pack_padded_sequence` now accepts unsorted sequence tensors, which means we no-longer have to sort them upfront, meaning we can remove loads of hideously complicated indexing code 👍 

Changes:

- we no longer sort input tensors by sequence length
- we no longer remove tensors which are completely padded. Instead, we (slightly hackily) set their sequence length to 1, and then mask out the output.
- we no longer have to manually append padding onto the sequence length dimension, because this can now be specified in the `total_length` argument to `pad_packed_sequence`.
