### PR TITLE
Add bulldozer configuration to allennlp.

### DIFF
--- a/.bulldozer.yml
+++ b/.bulldozer.yml
@@ -1,0 +1,66 @@
+# "version" is the configuration version, currently "1".
+version: 1
+
+# "merge" defines how and when pull requests are merged. If the section is
+# missing, bulldozer will consider all pull requests and use default settings.
+merge:
+  # "whitelist" defines the set of pull requests considered by bulldozer. If
+  # the section is missing, bulldozer considers all pull requests not excluded
+  # by the blacklist.
+  whitelist:
+    # Pull requests with any of these labels (case-insensitive) are added to
+    # the whitelist.
+    labels: ["merge when ready"]
+
+  # "blacklist" defines the set of pull request ignored by bulldozer. If the
+  # section is missing, bulldozer considers all pull requests. It takes the
+  # same keys as the "whitelist" section.
+  blacklist:
+    labels: ["do not merge"]
+    comment_substrings: ["==DO_NOT_MERGE==", "WIP"]
+
+  # "method" defines the merge method. The available options are "merge",
+  # "rebase", and "squash".
+  method: squash
+
+  # Allows the merge method that is used when auto-merging a PR to be different based on the
+  # target branch. The keys of the hash are the target branch name, and the values are the merge method that
+  # will be used for PRs targeting that branch. The valid values are the same as for the "method" key.
+  # Note: If the target branch does not match any of the specified keys, the "method" key is used instead.
+  branch_method:
+    master: squash
+
+  # "options" defines additional options for the individual merge methods.
+  options:
+    # "squash" options are only used when the merge method is "squash"
+    squash:
+      # "body" defines how the body of the commit message is created when
+      # generating a squash commit. The options are "pull_request_body",
+      # "summarize_commits", and "empty_body".
+      body: "pull_request_body"
+      # if "body" is "pull_request_body" then the commit message will be part
+      # of the pull request body delinated by "message_delimiter" string
+      message_delimiter: ==COMMIT_MSG==
+
+  # "required_status" is a list of additional status contexts that must pass
+  # before bulldozer can merge a pull request. This is useful if you want to
+  # require extra testing for automated merges, but not for manual merges.
+  #required_statuses:
+  #  - "ci/circleci: ete-tests"
+
+  # If true, bulldozer will delete branches after their pull requests merge.
+  delete_after_merge: true
+
+## "update" defines how and when to update pull request branches. Unlike with
+## merges, if this section is missing, bulldozer will not update any pull requests.
+#update:
+#  # "whitelist" defines the set of pull requests that should be updated by
+#  # bulldozer. It accepts the same keys as the whitelist in the "merge" block.
+#  whitelist:
+#    labels: ["WIP", "Update Me"]
+#
+#  # "blacklist" defines the set of pull requests that should not be updated by
+#  # bulldozer. It accepts the same keys as the blacklist in the "merge" block.
+#  blacklist:
+#    labels: ["Do Not Update"]
+


### PR DESCRIPTION
I hope that this tool will help address the problem where we want to merge a PR after we update master, but forget to check back.  With `bulldozer` we just add the `merge when ready` label and it will merge the PR automatically after all the CI tests are green.

I enabled bulldozer for `allenai/allennlp` but I don't think it will do anything until we merge in a `.bulldozer.yml`.