### PR TITLE
Remove code for a previous PyTorch version

### DIFF
--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -160,19 +160,6 @@ Registrable._registry[Optimizer] = {
 }
 
 
-def _safe_sparse_mask(tensor: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
-    """
-    In PyTorch 1.0, Tensor._sparse_mask was changed to Tensor.sparse_mask.
-    This wrapper allows AllenNLP to (temporarily) work with both 1.0 and 0.4.1.
-    """
-
-    try:
-        return tensor.sparse_mask(mask)
-    except AttributeError:
-        # TODO(joelgrus): remove this and/or warn at some point
-        return tensor._sparse_mask(mask)
-
-
 @Optimizer.register("dense_sparse_adam")
 class DenseSparseAdam(torch.optim.Optimizer):
     """
@@ -256,10 +243,10 @@ class DenseSparseAdam(torch.optim.Optimizer):
                     # Decay the first and second moment running average coefficient
                     #      old <- b * old + (1 - b) * new
                     # <==> old += (1 - b) * (new - old)
-                    old_exp_avg_values = _safe_sparse_mask(exp_avg, grad)._values()
+                    old_exp_avg_values = exp_avg.sparse_mask(grad)._values()
                     exp_avg_update_values = grad_values.sub(old_exp_avg_values).mul_(1 - beta1)
                     exp_avg.add_(make_sparse(exp_avg_update_values))
-                    old_exp_avg_sq_values = _safe_sparse_mask(exp_avg_sq, grad)._values()
+                    old_exp_avg_sq_values = exp_avg_sq.sparse_mask(grad)._values()
                     exp_avg_sq_update_values = (
                         grad_values.pow(2).sub_(old_exp_avg_sq_values).mul_(1 - beta2)
                     )


### PR DESCRIPTION
The minimum PyTorch version is now 1.2.0, so keeping this code doesn't make sense.