### PR TITLE
Better parameter inference for kwargs

### DIFF
--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -110,9 +110,7 @@ def remove_optional(annotation: type):
         return annotation
 
 
-def infer_params(cls: Type[T],
-                 constructor: Callable[..., T] = None,
-                 ):
+def infer_params(cls: Type[T], constructor: Callable[..., T] = None):
     if constructor is None:
         constructor = cls.__init__
 
@@ -130,10 +128,7 @@ def infer_params(cls: Type[T],
     super_class = cls.mro()[1]
     super_parameters = infer_params(super_class)
 
-    return {
-        **super_parameters,
-        **parameters  # Subclass parameters overwrite superclass ones
-    }
+    return {**super_parameters, **parameters}  # Subclass parameters overwrite superclass ones
 
 
 def create_kwargs(

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -110,6 +110,32 @@ def remove_optional(annotation: type):
         return annotation
 
 
+def infer_params(cls: Type[T],
+                 constructor: Callable[..., T] = None,
+                 ):
+    if constructor is None:
+        constructor = cls.__init__
+
+    signature = inspect.signature(constructor)
+    parameters = dict(signature.parameters)
+
+    has_kwargs = False
+    for param in parameters.values():
+        if param.kind == param.VAR_KEYWORD:
+            has_kwargs = True
+
+    if not has_kwargs:
+        return parameters
+
+    super_class = cls.mro()[1]
+    super_parameters = infer_params(super_class)
+
+    return {
+        **super_parameters,
+        **parameters  # Subclass parameters overwrite superclass ones
+    }
+
+
 def create_kwargs(
     constructor: Callable[..., T], cls: Type[T], params: Params, **extras
 ) -> Dict[str, Any]:
@@ -125,28 +151,10 @@ def create_kwargs(
     For instance, you might provide an existing `Vocabulary` this way.
     """
     # Get the signature of the constructor.
-    signature = inspect.signature(constructor)
+
     kwargs: Dict[str, Any] = {}
 
-    parameters = dict(signature.parameters)
-
-    # First we check for the presence of a **kwargs parameter.  If we find one, we look in the
-    # superclass constructor, to see if there are arguments there that we should try to also
-    # constructor.
-    has_kwargs = False
-    for param in parameters.values():
-        if param.kind == param.VAR_KEYWORD:
-            has_kwargs = True
-    if has_kwargs:
-        # "mro" is "method resolution order".  The first one is the current class, the next is the
-        # first superclass, and so on.  Taking the first superclass should work in all cases that
-        # we're looking for here.
-        superclass = cls.mro()[1]
-        superclass_signature = inspect.signature(superclass.__init__)  # type: ignore
-        for param_name, param in superclass_signature.parameters.items():
-            if param_name == "self":
-                continue
-            parameters[param_name] = param
+    parameters = infer_params(cls, constructor)
 
     # Iterate over all the constructor parameters and their annotations.
     for param_name, param in parameters.items():
@@ -163,6 +171,9 @@ def create_kwargs(
         # it will have an __origin__ field indicating `typing.Dict`
         # and an __args__ field indicating `(str, int)`. We capture both.
         annotation = remove_optional(param.annotation)
+        # TODO(mahnerak) Not sure what to do with if one of parameters of
+        # superclass is optional, has a default value, but provided `params`
+        # does not have it. Better way will be to omit this params from kwargs.
         kwargs[param_name] = construct_arg(
             cls.__name__, param_name, annotation, param.default, params, **extras
         )


### PR DESCRIPTION
This PR:
* Makes parameter inference recursive:
If the super-class constructor also has **kwargs, we need to dive deeper to infer parameters. 
* Fixes param overwriting issue when inspecting super-class constructor
In the example below, if original the parameters are overwritten by the super-class constructor parameters, allennlp will infer the correct type, but incorrectly assume that `some_param` is the required parameter. 
```python
class SomeDatasetReader(DatasetReader):
    def __init__(self, some_param: str, **kwargs):
        super().__init__(**kwargs)
        self._some_param = some_param

class InheritedDatasetReader(SomeDatasetReader):
    def __init__(self, some_param: str = 'default_value', **kwargs):
        super().__init__(some_param=some_param, **kwargs)
```
