### PR TITLE
Replace Sphynx class/function syntax with Markdown

### DIFF
--- a/allennlp/commands/__init__.py
+++ b/allennlp/commands/__init__.py
@@ -97,7 +97,7 @@ def create_parser(
 
 def main(prog: str = None, subcommand_overrides: Dict[str, Subcommand] = None) -> None:
     """
-    The :mod:`~allennlp.run` command only knows about the registered classes in the ``allennlp``
+    The `allennlp.run` command only knows about the registered classes in the ``allennlp``
     codebase. In particular, once you start creating your own ``Model`` s and so forth, it won't
     work for them, unless you use the ``--include-package`` flag.
     """

--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -258,11 +258,11 @@ def search_learning_rate(
     stopping_factor: float = None,
 ) -> Tuple[List[float], List[float]]:
     """
-    Runs training loop on the model using :class:`~allennlp.training.trainer.Trainer`
+    Runs training loop on the model using `allennlp.training.trainer.Trainer`
     increasing learning rate from ``start_lr`` to ``end_lr`` recording the losses.
     # Parameters
 
-    trainer: :class:`~allennlp.training.trainer.Trainer`
+    trainer: `allennlp.training.trainer.Trainer`
     start_lr : ``float``
         The learning rate to start the search.
     end_lr : ``float``

--- a/allennlp/commands/fine_tune.py
+++ b/allennlp/commands/fine_tune.py
@@ -175,7 +175,7 @@ def fine_tune_model_from_file_paths(
     embedding_sources_mapping: Dict[str, str] = None,
 ) -> Model:
     """
-    A wrapper around :func:`fine_tune_model` which loads the model archive from a file.
+    A wrapper around `fine_tune_model` which loads the model archive from a file.
 
     # Parameters
 
@@ -187,14 +187,14 @@ def fine_tune_model_from_file_paths(
         ignored (as we are using the provided model archive instead).
     serialization_dir : ``str``
         The directory in which to save results and logs. We just pass this along to
-        :func:`fine_tune_model`.
+        `fine_tune_model`.
     overrides : ``str``
         A JSON string that we will use to override values in the input parameter file.
     extend_vocab : ``bool``, optional (default=False)
         If ``True``, we use the new instances to extend your vocabulary.
     file_friendly_logging : ``bool``, optional (default=False)
         If ``True``, we make our output more friendly to saved model files.  We just pass this
-        along to :func:`fine_tune_model`.
+        along to `fine_tune_model`.
     recover : ``bool``, optional (default=False)
         If ``True``, we will try to recover a training run from an existing serialization
         directory.  This is only intended for use when something actually crashed during the middle

--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -1,7 +1,7 @@
 """
 The ``predict`` subcommand allows you to make bulk JSON-to-JSON
 or dataset to JSON predictions using a trained model and its
-:class:`~allennlp.predictors.predictor.Predictor` wrapper.
+`allennlp.predictors.predictor.Predictor` wrapper.
 
 .. code-block:: bash
 

--- a/allennlp/commands/subcommand.py
+++ b/allennlp/commands/subcommand.py
@@ -12,7 +12,7 @@ class Subcommand:
     ``allennlp special-evaluate ...``
 
     you would create a ``Subcommand`` subclass and then pass it as an override to
-    :func:`~allennlp.commands.main` .
+    `allennlp.commands.main` .
     """
 
     def add_subparser(

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -150,7 +150,7 @@ def train_model_from_file(
     include_package: List[str] = None,
 ) -> Model:
     """
-    A wrapper around :func:`train_model` which loads the params from a file.
+    A wrapper around `train_model` which loads the params from a file.
 
     # Parameters
 
@@ -158,12 +158,12 @@ def train_model_from_file(
         A json parameter file specifying an AllenNLP experiment.
     serialization_dir : ``str``
         The directory in which to save results and logs. We just pass this along to
-        :func:`train_model`.
+        `train_model`.
     overrides : ``str``
         A JSON string that we will use to override values in the input parameter file.
     file_friendly_logging : ``bool``, optional (default=False)
         If ``True``, we make our output more friendly to saved model files.  We just pass this
-        along to :func:`train_model`.
+        along to `train_model`.
     recover : ``bool`, optional (default=False)
         If ``True``, we will try to recover a training run from an existing serialization
         directory.  This is only intended for use when something actually crashed during the middle
@@ -203,7 +203,7 @@ def train_model(
     embedding_sources_mapping: Dict[str, str] = None,
 ) -> Model:
     """
-    Trains the model specified in the given :class:`Params` object, using the data and training
+    Trains the model specified in the given `Params` object, using the data and training
     parameters also specified in that object, and saves the results in ``serialization_dir``.
 
     # Parameters

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -4,10 +4,11 @@ declarative language (JSON) for defining experiments and models.
 
 This is implemented by giving each AllenNLP class a method
 
-.. code-block
+```
     @classmethod
     def from_params(cls, params: Params, **extras) -> 'ClassName':
         ...
+```
 
 that contains the logic for instantiating a class instance from a JSON-like
 `Params` object. Historically you had to implement your own `from_params`

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -204,7 +204,7 @@ def construct_arg(
     class_name: str, param_name: str, annotation: Type, default: Any, params: Params, **extras
 ) -> Any:
     """
-    Does the work of actually constructing an individual argument for :func:`create_kwargs`.
+    Does the work of actually constructing an individual argument for `create_kwargs`.
 
     Here we're in the inner loop of iterating over the parameters to a particular constructor,
     trying to construct just one of them.  The information we get for that parameter is its name,

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -1,5 +1,5 @@
 """
-The :class:`~allennlp.common.params.Params` class represents a dictionary of
+The `allennlp.common.params.Params` class represents a dictionary of
 parameters (e.g. for configuring a model), with added functionality around
 logging and validation.
 """
@@ -203,10 +203,10 @@ class Params(MutableMapping):
     There are currently two benefits of a `Params` object over a plain dictionary for parameter
     passing:
 
-    #. We handle a few kinds of parameter validation, including making sure that parameters
+    1. We handle a few kinds of parameter validation, including making sure that parameters
        representing discrete choices actually have acceptable values, and making sure no extra
        parameters are passed.
-    #. We log all parameter reads, including default values.  This gives a more complete
+    2. We log all parameter reads, including default values.  This gives a more complete
        specification of the actual parameters used than is given in a JSON file, because
        those may not specify what default values were used, whereas this will log them.
 

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -214,7 +214,7 @@ class Params(MutableMapping):
     as you read them, so that there are none left when you've read everything you expect.  This
     lets us easily validate that you didn't pass in any `extra` parameters, just by making sure
     that the parameter dictionary is empty.  You should do this when you're done handling
-    parameters, by calling :func:`Params.assert_empty`.
+    parameters, by calling `Params.assert_empty`.
     """
 
     # This allows us to check for the presence of "None" as a default argument,
@@ -606,12 +606,12 @@ def pop_choice(
     allow_class_names: bool = True,
 ) -> Any:
     """
-    Performs the same function as :func:`Params.pop_choice`, but is required in order to deal with
+    Performs the same function as `Params.pop_choice`, but is required in order to deal with
     places that the Params object is not welcome, such as inside Keras layers.  See the docstring
     of that method for more detail on how this function works.
 
     This method adds a `history` parameter, in the off-chance that you know it, so that we can
-    reproduce :func:`Params.pop_choice` exactly.  We default to using "?." if you don't know the
+    reproduce `Params.pop_choice` exactly.  We default to using "?." if you don't know the
     history, so you'll have to fix that in the log if you want to actually recover the logged
     parameters.
     """

--- a/allennlp/common/registrable.py
+++ b/allennlp/common/registrable.py
@@ -1,5 +1,5 @@
 """
-:class:`~allennlp.common.registrable.Registrable` is a "mixin" for endowing
+`allennlp.common.registrable.Registrable` is a "mixin" for endowing
 any base class with a named registry for its subclasses and a decorator
 for registering them.
 """

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -14,8 +14,8 @@ from allennlp.models import Model, load_archive
 
 class ModelTestCase(AllenNlpTestCase):
     """
-    A subclass of :class:`~allennlp.common.testing.test_case.AllenNlpTestCase`
-    with added methods for testing :class:`~allennlp.models.model.Model` subclasses.
+    A subclass of `allennlp.common.testing.test_case.AllenNlpTestCase`
+    with added methods for testing `allennlp.models.model.Model` subclasses.
     """
 
     def set_up_model(self, param_file, dataset_file):

--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -12,7 +12,7 @@ TEST_DIR = tempfile.mkdtemp(prefix="allennlp_tests")
 
 class AllenNlpTestCase(TestCase):
     """
-    A custom subclass of :class:`~unittest.TestCase` that disables some of the
+    A custom subclass of `unittest.TestCase` that disables some of the
     more verbose AllenNLP logging and that creates and destroys a temp directory
     as a test fixture.
     """

--- a/allennlp/common/tqdm.py
+++ b/allennlp/common/tqdm.py
@@ -1,5 +1,5 @@
 """
-:class:`~allennlp.common.tqdm.Tqdm` wraps tqdm so we can add configurable
+`allennlp.common.tqdm.Tqdm` wraps tqdm so we can add configurable
 global defaults for certain tqdm parameters.
 """
 

--- a/allennlp/data/batch.py
+++ b/allennlp/data/batch.py
@@ -1,5 +1,5 @@
 """
-A :class:`~Batch` represents a collection of `Instance` s to be fed
+A `Batch` represents a collection of `Instance` s to be fed
 through a model.
 """
 

--- a/allennlp/data/dataset_readers/__init__.py
+++ b/allennlp/data/dataset_readers/__init__.py
@@ -1,7 +1,7 @@
 """
-A :class:`~allennlp.data.dataset_readers.dataset_reader.DatasetReader`
+A `allennlp.data.dataset_readers.dataset_reader.DatasetReader`
 reads a file and converts it to a collection of
-:class:`~allennlp.data.instance.Instance` s.
+`allennlp.data.instance.Instance` s.
 The various subclasses know how to read specific filetypes
 and produce datasets in the formats required by specific models.
 """

--- a/allennlp/data/dataset_readers/babi.py
+++ b/allennlp/data/dataset_readers/babi.py
@@ -28,7 +28,7 @@ class BabiReader(DatasetReader):
         Whether to keep each sentence in the context or to concatenate them.
         Default is `False` that corresponds to concatenation.
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
-        We use this to define the input representation for the text.  See :class:`TokenIndexer`.
+        We use this to define the input representation for the text.  See `TokenIndexer`.
     """
 
     def __init__(

--- a/allennlp/data/dataset_readers/ccgbank.py
+++ b/allennlp/data/dataset_readers/ccgbank.py
@@ -37,7 +37,7 @@ class CcgBankDatasetReader(DatasetReader):
     # Parameters
 
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
-        We use this to define the input representation for the text.  See :class:`TokenIndexer`.
+        We use this to define the input representation for the text.  See `TokenIndexer`.
         Note that the `output` tags will always correspond to single token IDs based on how they
         are pre-tokenised in the data file.
     tag_label : `str`, optional (default=`ccg`)

--- a/allennlp/data/dataset_readers/conll2000.py
+++ b/allennlp/data/dataset_readers/conll2000.py
@@ -39,7 +39,7 @@ class Conll2000DatasetReader(DatasetReader):
     # Parameters
 
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
-        We use this to define the input representation for the text.  See :class:`TokenIndexer`.
+        We use this to define the input representation for the text.  See `TokenIndexer`.
     tag_label : `str`, optional (default=`chunk`)
         Specify `pos`, or `chunk` to have that tag loaded into the instance field `tag`.
     feature_labels : `Sequence[str]`, optional (default=`()`)

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -53,7 +53,7 @@ class Conll2003DatasetReader(DatasetReader):
     # Parameters
 
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
-        We use this to define the input representation for the text.  See :class:`TokenIndexer`.
+        We use this to define the input representation for the text.  See `TokenIndexer`.
     tag_label : `str`, optional (default=`ner`)
         Specify `ner`, `pos`, or `chunk` to have that tag loaded into the instance field `tag`.
     feature_labels : `Sequence[str]`, optional (default=`()`)

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -60,7 +60,7 @@ def canonicalize_clusters(
 class ConllCorefReader(DatasetReader):
     """
     Reads a single CoNLL-formatted file. This is the same file format as used in the
-    :class:`~allennlp.data.dataset_readers.semantic_role_labelling.SrlReader`, but is preprocessed
+    `allennlp.data.dataset_readers.semantic_role_labelling.SrlReader`, but is preprocessed
     to dump all documents into a single file per train, dev and test split. See
     scripts/compile_coref_data.sh for more details of how to pre-process the Ontonotes 5.0 data
     into the correct format.
@@ -77,7 +77,7 @@ class ConllCorefReader(DatasetReader):
     max_span_width : `int`, required.
         The maximum width of candidate spans to consider.
     token_indexers : `Dict[str, TokenIndexer]`, optional
-        This is used to index the words in the document.  See :class:`TokenIndexer`.
+        This is used to index the words in the document.  See `TokenIndexer`.
         Default is `{"tokens": SingleIdTokenIndexer()}`.
     """
 

--- a/allennlp/data/dataset_readers/coreference_resolution/winobias.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/winobias.py
@@ -52,7 +52,7 @@ class WinobiasReader(DatasetReader):
     max_span_width : `int`, required.
         The maximum width of candidate spans to consider.
     token_indexers : `Dict[str, TokenIndexer]`, optional
-        This is used to index the words in the sentence.  See :class:`TokenIndexer`.
+        This is used to index the words in the sentence.  See `TokenIndexer`.
         Default is `{"tokens": SingleIdTokenIndexer()}`.
     """
 

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -72,11 +72,11 @@ class DatasetReader(Registrable):
         reloads the dataset each time it's called. Otherwise, `instances()` returns a list.
     cache_directory : `str`, optional (default=None)
         If given, we will use this directory to store a cache of already-processed `Instances` in
-        every file passed to :func:`read`, serialized (by default, though you can override this) as
+        every file passed to `read`, serialized (by default, though you can override this) as
         one string-formatted `Instance` per line.  If the cache file for a given `file_path` exists,
         we read the `Instances` from the cache instead of re-processing the data (using
-        :func:`_instances_from_cache_file`).  If the cache file does _not_ exist, we will _create_
-        it on our first pass through the data (using :func:`_instances_to_cache_file`).
+        `_instances_from_cache_file`).  If the cache file does _not_ exist, we will _create_
+        it on our first pass through the data (using `_instances_to_cache_file`).
 
         IMPORTANT CAVEAT: It is the _caller's_ responsibility to make sure that this directory is
         unique for any combination of code and parameters that you use.  That is, if you pass a
@@ -179,10 +179,10 @@ class DatasetReader(Registrable):
         """
         Does whatever tokenization or processing is necessary to go from textual input to an
         `Instance`.  The primary intended use for this is with a
-        :class:`~allennlp.predictors.predictor.Predictor`, which gets text input as a JSON
+        `allennlp.predictors.predictor.Predictor`, which gets text input as a JSON
         object and needs to process it to be input to a model.
 
-        The intent here is to share code between :func:`_read` and what happens at
+        The intent here is to share code between `_read` and what happens at
         model serving time, or any other time you want to make a prediction from new data.  We need
         to process the data in the same way it was done at training time.  Allowing the
         `DatasetReader` to process new text lets us accomplish this, as we can just call

--- a/allennlp/data/dataset_readers/masked_language_modeling.py
+++ b/allennlp/data/dataset_readers/masked_language_modeling.py
@@ -23,7 +23,7 @@ class MaskedLanguageModelingReader(DatasetReader):
     Reads a text file and converts it into a `Dataset` suitable for training a masked language
     model.
 
-    The :class:`Field` s that we create are the following: an input `TextField`, a mask position
+    The `Field` s that we create are the following: an input `TextField`, a mask position
     `ListField[IndexField]`, and a target token `TextField` (the target tokens aren't a single
     string of text, but we use a `TextField` so we can index the target tokens the same way as
     our input, typically with a single `PretrainedTransformerIndexer`).  The mask position and
@@ -38,10 +38,10 @@ class MaskedLanguageModelingReader(DatasetReader):
     # Parameters
 
     tokenizer : `Tokenizer`, optional (default=`WhitespaceTokenizer()`)
-        We use this `Tokenizer` for the text.  See :class:`Tokenizer`.
+        We use this `Tokenizer` for the text.  See `Tokenizer`.
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
         We use this to define the input representation for the text, and to get ids for the mask
-        targets.  See :class:`TokenIndexer`.
+        targets.  See `TokenIndexer`.
     """
 
     def __init__(

--- a/allennlp/data/dataset_readers/next_token_lm.py
+++ b/allennlp/data/dataset_readers/next_token_lm.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class NextTokenLmReader(DatasetReader):
     """
     Creates `Instances` suitable for use in predicting a single next token using a language
-    model.  The :class:`Field` s that we create are the following: an input `TextField` and a
+    model.  The `Field` s that we create are the following: an input `TextField` and a
     target token `TextField` (we only ver have a single token, but we use a `TextField` so we
     can index it the same way as our input, typically with a single
     `PretrainedTransformerIndexer`).
@@ -34,10 +34,10 @@ class NextTokenLmReader(DatasetReader):
     # Parameters
 
     tokenizer : `Tokenizer`, optional (default=`WhitespaceTokenizer()`)
-        We use this `Tokenizer` for the text.  See :class:`Tokenizer`.
+        We use this `Tokenizer` for the text.  See `Tokenizer`.
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
         We use this to define the input representation for the text, and to get ids for the mask
-        targets.  See :class:`TokenIndexer`.
+        targets.  See `TokenIndexer`.
     """
 
     def __init__(

--- a/allennlp/data/dataset_readers/ontonotes_ner.py
+++ b/allennlp/data/dataset_readers/ontonotes_ner.py
@@ -42,7 +42,7 @@ class OntonotesNamedEntityRecognition(DatasetReader):
     # Parameters
 
     token_indexers : `Dict[str, TokenIndexer]`, optional
-        We similarly use this for both the premise and the hypothesis.  See :class:`TokenIndexer`.
+        We similarly use this for both the premise and the hypothesis.  See `TokenIndexer`.
         Default is `{"tokens": SingleIdTokenIndexer()}`.
     domain_identifier : `str`, (default = None)
         A string denoting a sub-domain of the Ontonotes 5.0 dataset to use. If present, only

--- a/allennlp/data/dataset_readers/penn_tree_bank.py
+++ b/allennlp/data/dataset_readers/penn_tree_bank.py
@@ -47,7 +47,7 @@ class PennTreeBankConstituencySpanDatasetReader(DatasetReader):
     # Parameters
 
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
-        We use this to define the input representation for the text.  See :class:`TokenIndexer`.
+        We use this to define the input representation for the text.  See `TokenIndexer`.
         Note that the `output` tags will always correspond to single token IDs based on how they
         are pre-tokenised in the data file.
     use_pos_tags : `bool`, optional, (default = `True`)

--- a/allennlp/data/dataset_readers/semantic_role_labeling.py
+++ b/allennlp/data/dataset_readers/semantic_role_labeling.py
@@ -109,7 +109,7 @@ class SrlReader(DatasetReader):
     # Parameters
 
     token_indexers : `Dict[str, TokenIndexer]`, optional
-        We similarly use this for both the premise and the hypothesis.  See :class:`TokenIndexer`.
+        We similarly use this for both the premise and the hypothesis.  See `TokenIndexer`.
         Default is `{"tokens": SingleIdTokenIndexer()}`.
     domain_identifier : `str`, (default = None)
         A string denoting a sub-domain of the Ontonotes 5.0 dataset to use. If present, only

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -33,7 +33,7 @@ class SequenceTaggingDatasetReader(DatasetReader):
         The text that separates each WORD-TAG pair from the next pair. If `None`
         then the line will just be split on whitespace.
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
-        We use this to define the input representation for the text.  See :class:`TokenIndexer`.
+        We use this to define the input representation for the text.  See `TokenIndexer`.
         Note that the `output` tags will always correspond to single token IDs based on how they
         are pre-tokenised in the data file.
     """

--- a/allennlp/data/dataset_readers/snli.py
+++ b/allennlp/data/dataset_readers/snli.py
@@ -26,9 +26,9 @@ class SnliReader(DatasetReader):
     # Parameters
 
     tokenizer : `Tokenizer`, optional (default=`SpacyTokenizer()`)
-        We use this `Tokenizer` for both the premise and the hypothesis.  See :class:`Tokenizer`.
+        We use this `Tokenizer` for both the premise and the hypothesis.  See `Tokenizer`.
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
-        We similarly use this for both the premise and the hypothesis.  See :class:`TokenIndexer`.
+        We similarly use this for both the premise and the hypothesis.  See `TokenIndexer`.
     """
 
     def __init__(

--- a/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
+++ b/allennlp/data/dataset_readers/stanford_sentiment_tree_bank.py
@@ -40,7 +40,7 @@ class StanfordSentimentTreeBankDatasetReader(DatasetReader):
     # Parameters
 
     token_indexers : `Dict[str, TokenIndexer]`, optional (default=`{"tokens": SingleIdTokenIndexer()}`)
-        We use this to define the input representation for the text.  See :class:`TokenIndexer`.
+        We use this to define the input representation for the text.  See `TokenIndexer`.
     use_subtrees : `bool`, optional, (default = `False`)
         Whether or not to use sentiment-tagged subtrees.
     granularity : `str`, optional (default = `"5-class"`)

--- a/allennlp/data/dataset_readers/text_classification_json.py
+++ b/allennlp/data/dataset_readers/text_classification_json.py
@@ -28,7 +28,7 @@ class TextClassificationJsonReader(DatasetReader):
     token_indexers : `Dict[str, TokenIndexer]`, optional
         optional (default=`{"tokens": SingleIdTokenIndexer()}`)
         We use this to define the input representation for the text.
-        See :class:`TokenIndexer`.
+        See `TokenIndexer`.
     tokenizer : `Tokenizer`, optional (default = `{"tokens": SpacyTokenizer()}`)
         Tokenizer to use to split the input text into words or other kinds of tokens.
     segment_sentences : `bool`, optional (default = `False`)

--- a/allennlp/data/fields/__init__.py
+++ b/allennlp/data/fields/__init__.py
@@ -1,5 +1,5 @@
 """
-A :class:`~allennlp.data.fields.field.Field` is some piece of data instance
+A `allennlp.data.fields.field.Field` is some piece of data instance
 that ends up as an array in a model.
 """
 

--- a/allennlp/data/fields/adjacency_field.py
+++ b/allennlp/data/fields/adjacency_field.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class AdjacencyField(Field[torch.Tensor]):
     """
     A `AdjacencyField` defines directed adjacency relations between elements
-    in a :class:`~allennlp.data.fields.sequence_field.SequenceField`.
+    in a `allennlp.data.fields.sequence_field.SequenceField`.
     Because it's a labeling of some other field, we take that field as input here
     and use it to determine our padding and other things.
 

--- a/allennlp/data/fields/field.py
+++ b/allennlp/data/fields/field.py
@@ -28,7 +28,7 @@ class Field(Generic[DataArray]):
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):
         """
         If there are strings in this field that need to be converted into integers through a
-        :class:`Vocabulary`, here is where we count them, to determine which tokens are in or out
+        `Vocabulary`, here is where we count them, to determine which tokens are in or out
         of the vocabulary.
 
         If your `Field` does not have any strings that need to be converted into indices, you do
@@ -52,7 +52,7 @@ class Field(Generic[DataArray]):
 
     def index(self, vocab: Vocabulary):
         """
-        Given a :class:`Vocabulary`, converts all strings in this field into (typically) integers.
+        Given a `Vocabulary`, converts all strings in this field into (typically) integers.
         This `modifies` the `Field` object, it does not return anything.
 
         If your `Field` does not have any strings that need to be converted into indices, you do
@@ -67,7 +67,7 @@ class Field(Generic[DataArray]):
         everything to that length (or use a pre-specified maximum length).  The return value is a
         dictionary mapping keys to lengths, like {'num_tokens': 13}.
 
-        This is always called after :func:`index`.
+        This is always called after `index`.
         """
         raise NotImplementedError
 
@@ -81,7 +81,7 @@ class Field(Generic[DataArray]):
 
         padding_lengths : `Dict[str, int]`
             This dictionary will have the same keys that were produced in
-            :func:`get_padding_lengths`.  The values specify the lengths to use when padding each
+            `get_padding_lengths`.  The values specify the lengths to use when padding each
             relevant dimension, aggregated across all instances in a batch.
         """
         raise NotImplementedError
@@ -91,7 +91,7 @@ class Field(Generic[DataArray]):
         So that `ListField` can pad the number of fields in a list (e.g., the number of answer
         option `TextFields`), we need a representation of an empty field of each type.  This
         returns that.  This will only ever be called when we're to the point of calling
-        :func:`as_tensor`, so you don't need to worry about `get_padding_lengths`,
+        `as_tensor`, so you don't need to worry about `get_padding_lengths`,
         `count_vocab_items`, etc., being called on this empty field.
 
         We make this an instance method instead of a static method so that if there is any state

--- a/allennlp/data/fields/index_field.py
+++ b/allennlp/data/fields/index_field.py
@@ -11,15 +11,15 @@ from allennlp.common.checks import ConfigurationError
 class IndexField(Field[torch.Tensor]):
     """
     An `IndexField` is an index into a
-    :class:`~allennlp.data.fields.sequence_field.SequenceField`, as might be used for representing
+    `allennlp.data.fields.sequence_field.SequenceField`, as might be used for representing
     a correct answer option in a list, or a span begin and span end position in a passage, for
-    example.  Because it's an index into a :class:`SequenceField`, we take one of those as input
+    example.  Because it's an index into a `SequenceField`, we take one of those as input
     and use it to compute padding lengths.
 
     # Parameters
 
     index : `int`
-        The index of the answer in the :class:`SequenceField`.  This is typically the "correct
+        The index of the answer in the `SequenceField`.  This is typically the "correct
         answer" in some classification decision over the sequence, like where an answer span starts
         in SQuAD, or which answer option is correct in a multiple choice question.  A value of
         `-1` means there is no label, which can be used for padding or other purposes.

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -15,7 +15,7 @@ class LabelField(Field[torch.Tensor]):
     """
     A `LabelField` is a categorical label of some kind, where the labels are either strings of
     text or 0-indexed integers (if you wish to skip indexing by passing skip_indexing=True).
-    If the labels need indexing, we will use a :class:`Vocabulary` to convert the string labels
+    If the labels need indexing, we will use a `Vocabulary` to convert the string labels
     into integers.
 
     This field will get converted into an integer index representing the class label.

--- a/allennlp/data/fields/multilabel_field.py
+++ b/allennlp/data/fields/multilabel_field.py
@@ -13,11 +13,11 @@ logger = logging.getLogger(__name__)
 
 class MultiLabelField(Field[torch.Tensor]):
     """
-    A `MultiLabelField` is an extension of the :class:`LabelField` that allows for multiple labels.
+    A `MultiLabelField` is an extension of the `LabelField` that allows for multiple labels.
     It is particularly useful in multi-label classification where more than one label can be correct.
-    As with the :class:`LabelField`, labels are either strings of text or 0-indexed integers (if you wish
+    As with the `LabelField`, labels are either strings of text or 0-indexed integers (if you wish
     to skip indexing by passing skip_indexing=True).
-    If the labels need indexing, we will use a :class:`Vocabulary` to convert the string labels
+    If the labels need indexing, we will use a `Vocabulary` to convert the string labels
     into integers.
 
     This field will get converted into a vector of length equal to the vocabulary size with

--- a/allennlp/data/fields/sequence_field.py
+++ b/allennlp/data/fields/sequence_field.py
@@ -4,7 +4,7 @@ from allennlp.data.fields.field import DataArray, Field
 class SequenceField(Field[DataArray]):
     """
     A `SequenceField` represents a sequence of things.  This class just adds a method onto
-    `Field`: :func:`sequence_length`.  It exists so that `SequenceLabelField`, `IndexField` and other
+    `Field`: `sequence_length`.  It exists so that `SequenceLabelField`, `IndexField` and other
     similar `Fields` can have a single type to require, with a consistent API, whether they are
     pointing to words in a `TextField`, items in a `ListField`, or something else.
     """

--- a/allennlp/data/fields/sequence_label_field.py
+++ b/allennlp/data/fields/sequence_label_field.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class SequenceLabelField(Field[torch.Tensor]):
     """
     A `SequenceLabelField` assigns a categorical label to each element in a
-    :class:`~allennlp.data.fields.sequence_field.SequenceField`.
+    `allennlp.data.fields.sequence_field.SequenceField`.
     Because it's a labeling of some other field, we take that field as input here, and we use it to
     determine our padding and other things.
 

--- a/allennlp/data/fields/span_field.py
+++ b/allennlp/data/fields/span_field.py
@@ -10,16 +10,16 @@ from allennlp.data.fields.sequence_field import SequenceField
 class SpanField(Field[torch.Tensor]):
     """
     A `SpanField` is a pair of inclusive, zero-indexed (start, end) indices into a
-    :class:`~allennlp.data.fields.sequence_field.SequenceField`, used to represent a span of text.
-    Because it's a pair of indices into a :class:`SequenceField`, we take one of those as input
+    `allennlp.data.fields.sequence_field.SequenceField`, used to represent a span of text.
+    Because it's a pair of indices into a `SequenceField`, we take one of those as input
     to make the span's dependence explicit and to validate that the span is well defined.
 
     # Parameters
 
     span_start : `int`, required.
-        The index of the start of the span in the :class:`SequenceField`.
+        The index of the start of the span in the `SequenceField`.
     span_end : `int`, required.
-        The inclusive index of the end of the span in the :class:`SequenceField`.
+        The inclusive index of the end of the span in the `SequenceField`.
     sequence_field : `SequenceField`, required.
         A field containing the sequence that this `SpanField` is a span inside.
     """

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -28,10 +28,10 @@ TextFieldTensors = Dict[str, Dict[str, torch.Tensor]]
 class TextField(SequenceField[TextFieldTensors]):
     """
     This `Field` represents a list of string tokens.  Before constructing this object, you need
-    to tokenize raw strings using a :class:`~allennlp.data.tokenizers.tokenizer.Tokenizer`.
+    to tokenize raw strings using a `allennlp.data.tokenizers.tokenizer.Tokenizer`.
 
     Because string tokens can be represented as indexed arrays in a number of ways, we also take a
-    dictionary of :class:`~allennlp.data.token_indexers.token_indexer.TokenIndexer`
+    dictionary of `allennlp.data.token_indexers.token_indexer.TokenIndexer`
     objects that will be used to convert the tokens into indices.
     Each `TokenIndexer` could represent each token as a single ID, or a list of character IDs, or
     something else.

--- a/allennlp/data/instance.py
+++ b/allennlp/data/instance.py
@@ -6,7 +6,7 @@ from allennlp.data.vocabulary import Vocabulary
 
 class Instance(Mapping[str, Field]):
     """
-    An `Instance` is a collection of :class:`~allennlp.data.fields.field.Field` objects,
+    An `Instance` is a collection of `allennlp.data.fields.field.Field` objects,
     specifying the inputs and outputs to
     some model.  We don't make a distinction between inputs and outputs here, though - all
     operations are done on all fields, and when we return arrays, we return them as dictionaries
@@ -88,7 +88,7 @@ class Instance(Mapping[str, Field]):
         """
         Pads each `Field` in this instance to the lengths given in `padding_lengths` (which is
         keyed by field name, then by padding key, the same as the return value in
-        :func:`get_padding_lengths`), returning a list of torch tensors for each field.
+        `get_padding_lengths`), returning a list of torch tensors for each field.
 
         If `padding_lengths` is omitted, we will call `self.get_padding_lengths()` to get the
         sizes of the tensors to create.

--- a/allennlp/data/iterators/__init__.py
+++ b/allennlp/data/iterators/__init__.py
@@ -1,5 +1,5 @@
 """
-The various :class:`~allennlp.data.iterators.data_iterator.DataIterator` subclasses
+The various `allennlp.data.iterators.data_iterator.DataIterator` subclasses
 can be used to iterate over datasets with different batching and padding schemes.
 """
 

--- a/allennlp/data/iterators/basic_iterator.py
+++ b/allennlp/data/iterators/basic_iterator.py
@@ -16,7 +16,7 @@ class BasicIterator(DataIterator):
     """
     A very basic iterator that takes a dataset, possibly shuffles it, and creates fixed sized batches.
 
-    It takes the same parameters as :class:`allennlp.data.iterators.DataIterator`
+    It takes the same parameters as `allennlp.data.iterators.DataIterator`
     """
 
     def _create_batches(self, instances: Iterable[Instance], shuffle: bool) -> Iterable[Batch]:

--- a/allennlp/data/iterators/bucket_iterator.py
+++ b/allennlp/data/iterators/bucket_iterator.py
@@ -52,11 +52,11 @@ class BucketIterator(DataIterator):
     batch_size : int, optional, (default = 32)
         The size of each batch of instances yielded when calling the iterator.
     instances_per_epoch : int, optional, (default = None)
-        See :class:`BasicIterator`.
+        See `BasicIterator`.
     max_instances_in_memory : int, optional, (default = None)
-        See :class:`BasicIterator`.
+        See `BasicIterator`.
     maximum_samples_per_batch : `Tuple[str, int]`, (default = None)
-        See :class:`BasicIterator`.
+        See `BasicIterator`.
     skip_smaller_batches : bool, optional, (default = False)
         When the number of data samples is not dividable by `batch_size`,
         some batches might be smaller than `batch_size`.

--- a/allennlp/data/iterators/same_language_iterator.py
+++ b/allennlp/data/iterators/same_language_iterator.py
@@ -28,7 +28,7 @@ class SameLanguageIterator(BucketIterator):
     The language of each instance is determined by looking at the 'lang' value
     in the metadata.
 
-    It takes the same parameters as :class:`allennlp.data.iterators.BucketIterator`
+    It takes the same parameters as `allennlp.data.iterators.BucketIterator`
     """
 
     def _create_batches(self, instances: Iterable[Instance], shuffle: bool) -> Iterable[Batch]:

--- a/allennlp/data/token_indexers/dep_label_indexer.py
+++ b/allennlp/data/token_indexers/dep_label_indexer.py
@@ -13,15 +13,15 @@ logger = logging.getLogger(__name__)
 @TokenIndexer.register("dependency_label")
 class DepLabelIndexer(TokenIndexer):
     """
-    This :class:`TokenIndexer` represents tokens by their syntactic dependency label, as determined
+    This `TokenIndexer` represents tokens by their syntactic dependency label, as determined
     by the `dep_` field on `Token`.
 
     # Parameters
 
     namespace : `str`, optional (default=`dep_labels`)
-        We will use this namespace in the :class:`Vocabulary` to map strings to indices.
+        We will use this namespace in the `Vocabulary` to map strings to indices.
     token_min_padding_length : `int`, optional (default=`0`)
-        See :class:`TokenIndexer`.
+        See `TokenIndexer`.
     """
 
     def __init__(self, namespace: str = "dep_labels", token_min_padding_length: int = 0) -> None:

--- a/allennlp/data/token_indexers/elmo_indexer.py
+++ b/allennlp/data/token_indexers/elmo_indexer.py
@@ -107,7 +107,7 @@ class ELMoTokenCharactersIndexer(TokenIndexer):
         ids. When using pre-trained models, then the character id must be
         less then 261, and we recommend using un-used ids (e.g. 1-32).
     token_min_padding_length : `int`, optional (default=`0`)
-        See :class:`TokenIndexer`.
+        See `TokenIndexer`.
     """
 
     def __init__(

--- a/allennlp/data/token_indexers/ner_tag_indexer.py
+++ b/allennlp/data/token_indexers/ner_tag_indexer.py
@@ -13,15 +13,15 @@ logger = logging.getLogger(__name__)
 @TokenIndexer.register("ner_tag")
 class NerTagIndexer(TokenIndexer):
     """
-    This :class:`TokenIndexer` represents tokens by their entity type (i.e., their NER tag), as
+    This `TokenIndexer` represents tokens by their entity type (i.e., their NER tag), as
     determined by the `ent_type_` field on `Token`.
 
     # Parameters
 
     namespace : `str`, optional (default=`ner_tokens`)
-        We will use this namespace in the :class:`Vocabulary` to map strings to indices.
+        We will use this namespace in the `Vocabulary` to map strings to indices.
     token_min_padding_length : `int`, optional (default=`0`)
-        See :class:`TokenIndexer`.
+        See `TokenIndexer`.
     """
 
     def __init__(self, namespace: str = "ner_tokens", token_min_padding_length: int = 0) -> None:

--- a/allennlp/data/token_indexers/pos_tag_indexer.py
+++ b/allennlp/data/token_indexers/pos_tag_indexer.py
@@ -13,18 +13,18 @@ logger = logging.getLogger(__name__)
 @TokenIndexer.register("pos_tag")
 class PosTagIndexer(TokenIndexer):
     """
-    This :class:`TokenIndexer` represents tokens by their part of speech tag, as determined by
+    This `TokenIndexer` represents tokens by their part of speech tag, as determined by
     the `pos_` or `tag_` fields on `Token` (corresponding to spacy's coarse-grained and
     fine-grained POS tags, respectively).
 
     # Parameters
 
     namespace : `str`, optional (default=`pos_tokens`)
-        We will use this namespace in the :class:`Vocabulary` to map strings to indices.
+        We will use this namespace in the `Vocabulary` to map strings to indices.
     coarse_tags : `bool`, optional (default=`False`)
         If `True`, we will use coarse POS tags instead of the default fine-grained POS tags.
     token_min_padding_length : `int`, optional (default=`0`)
-        See :class:`TokenIndexer`.
+        See `TokenIndexer`.
     """
 
     def __init__(

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -17,7 +17,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
     This `TokenIndexer` assumes that Tokens already have their indexes in them (see `text_id` field).
     We still require `model_name` because we want to form allennlp vocabulary from pretrained one.
     This `Indexer` is only really appropriate to use if you've also used a
-    corresponding :class:`PretrainedTransformerTokenizer` to tokenize your input.  Otherwise you'll
+    corresponding `PretrainedTransformerTokenizer` to tokenize your input.  Otherwise you'll
     have a mismatch between your tokens and your vocabulary, and you'll get a lot of UNK tokens.
 
     # Parameters

--- a/allennlp/data/token_indexers/single_id_token_indexer.py
+++ b/allennlp/data/token_indexers/single_id_token_indexer.py
@@ -11,12 +11,12 @@ from allennlp.data.token_indexers.token_indexer import TokenIndexer, IndexedToke
 @TokenIndexer.register("single_id")
 class SingleIdTokenIndexer(TokenIndexer):
     """
-    This :class:`TokenIndexer` represents tokens as single integers.
+    This `TokenIndexer` represents tokens as single integers.
 
     # Parameters
 
     namespace : `str`, optional (default=`tokens`)
-        We will use this namespace in the :class:`Vocabulary` to map strings to indices.
+        We will use this namespace in the `Vocabulary` to map strings to indices.
     lowercase_tokens : `bool`, optional (default=`False`)
         If `True`, we will call `token.lower()` before getting an index for the token from the
         vocabulary.
@@ -25,7 +25,7 @@ class SingleIdTokenIndexer(TokenIndexer):
     end_tokens : `List[str]`, optional (default=`None`)
         These are appended to the tokens provided to `tokens_to_indices`.
     token_min_padding_length : `int`, optional (default=`0`)
-        See :class:`TokenIndexer`.
+        See `TokenIndexer`.
     """
 
     def __init__(

--- a/allennlp/data/token_indexers/spacy_indexer.py
+++ b/allennlp/data/token_indexers/spacy_indexer.py
@@ -14,7 +14,7 @@ from allennlp.data.token_indexers.token_indexer import TokenIndexer, IndexedToke
 @TokenIndexer.register("spacy")
 class SpacyTokenIndexer(TokenIndexer):
     """
-    This :class:`SpacyTokenIndexer` represents tokens as word vectors
+    This `SpacyTokenIndexer` represents tokens as word vectors
     from a spacy model. You might want to do this for two main reasons;
     easier integration with a spacy pipeline and no out of vocabulary
     tokens.
@@ -25,7 +25,7 @@ class SpacyTokenIndexer(TokenIndexer):
         The dimension of the vectors that spacy generates for
         representing words.
     token_min_padding_length : `int`, optional (default=`0`)
-        See :class:`TokenIndexer`.
+        See `TokenIndexer`.
     """
 
     def __init__(self, hidden_dim: int = 96, token_min_padding_length: int = 0) -> None:

--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -16,15 +16,15 @@ from allennlp.data.vocabulary import Vocabulary
 @TokenIndexer.register("characters")
 class TokenCharactersIndexer(TokenIndexer):
     """
-    This :class:`TokenIndexer` represents tokens as lists of character indices.
+    This `TokenIndexer` represents tokens as lists of character indices.
 
     # Parameters
 
     namespace : `str`, optional (default=`token_characters`)
-        We will use this namespace in the :class:`Vocabulary` to map the characters in each token
+        We will use this namespace in the `Vocabulary` to map the characters in each token
         to indices.
     character_tokenizer : `CharacterTokenizer`, optional (default=`CharacterTokenizer()`)
-        We use a :class:`CharacterTokenizer` to handle splitting tokens into characters, as it has
+        We use a `CharacterTokenizer` to handle splitting tokens into characters, as it has
         options for byte encoding and other things.  The default here is to instantiate a
         `CharacterTokenizer` with its default parameters, which uses unicode characters and
         retains casing.
@@ -33,10 +33,10 @@ class TokenCharactersIndexer(TokenIndexer):
     end_tokens : `List[str]`, optional (default=`None`)
         These are appended to the tokens provided to `tokens_to_indices`.
     min_padding_length : `int`, optional (default=`0`)
-        We use this value as the minimum length of padding. Usually used with :class:`CnnEncoder`, its
+        We use this value as the minimum length of padding. Usually used with `CnnEncoder`, its
         value should be set to the maximum value of `ngram_filter_sizes` correspondingly.
     token_min_padding_length : `int`, optional (default=`0`)
-        See :class:`TokenIndexer`.
+        See `TokenIndexer`.
     """
 
     def __init__(

--- a/allennlp/data/token_indexers/token_indexer.py
+++ b/allennlp/data/token_indexers/token_indexer.py
@@ -21,7 +21,7 @@ class TokenIndexer(Registrable):
     """
     A `TokenIndexer` determines how string tokens get represented as arrays of indices in a model.
     This class both converts strings into numerical values, with the help of a
-    :class:`~allennlp.data.vocabulary.Vocabulary`, and it produces actual arrays.
+    `allennlp.data.vocabulary.Vocabulary`, and it produces actual arrays.
 
     Tokens can be represented as single IDs (e.g., the word "cat" gets represented by the number
     34), or as lists of character IDs (e.g., "cat" gets represented by the numbers [23, 10, 18]),
@@ -31,11 +31,11 @@ class TokenIndexer(Registrable):
     # Parameters
 
     token_min_padding_length : `int`, optional (default=`0`)
-        The minimum padding length required for the :class:`TokenIndexer`. For example,
-        the minimum padding length of :class:`SingleIdTokenIndexer` is the largest size of
-        filter when using :class:`CnnEncoder`.
+        The minimum padding length required for the `TokenIndexer`. For example,
+        the minimum padding length of `SingleIdTokenIndexer` is the largest size of
+        filter when using `CnnEncoder`.
         Note that if you set this for one TokenIndexer, you likely have to set it for all
-        :class:`TokenIndexer` for the same field, otherwise you'll get mismatched tensor sizes.
+        `TokenIndexer` for the same field, otherwise you'll get mismatched tensor sizes.
     """
 
     default_implementation = "single_id"
@@ -46,7 +46,7 @@ class TokenIndexer(Registrable):
 
     def count_vocab_items(self, token: Token, counter: Dict[str, Dict[str, int]]):
         """
-        The :class:`Vocabulary` needs to assign indices to whatever strings we see in the training
+        The `Vocabulary` needs to assign indices to whatever strings we see in the training
         data (possibly doing some frequency filtering and using an OOV, or out of vocabulary,
         token).  This method takes a token and a dictionary of counts and increments counts for
         whatever vocabulary items are present in the token.  If this is a single token ID

--- a/allennlp/data/token_indexers/wordpiece_indexer.py
+++ b/allennlp/data/token_indexers/wordpiece_indexer.py
@@ -59,7 +59,7 @@ class WordpieceIndexer(TokenIndexer):
         length. Otherwise, they will be split apart and batched using a
         sliding window.
     token_min_padding_length : `int`, optional (default=`0`)
-        See :class:`TokenIndexer`.
+        See `TokenIndexer`.
     """
 
     def __init__(

--- a/allennlp/data/tokenizers/sentence_splitter.py
+++ b/allennlp/data/tokenizers/sentence_splitter.py
@@ -16,7 +16,7 @@ class SentenceSplitter(Registrable):
 
     def split_sentences(self, text: str) -> List[str]:
         """
-        Splits a `text` :class:`str` paragraph into a list of :class:`str`, where each is a sentence.
+        Splits a `text` `str` paragraph into a list of `str`, where each is a sentence.
         """
         raise NotImplementedError
 

--- a/allennlp/data/tokenizers/spacy_tokenizer.py
+++ b/allennlp/data/tokenizers/spacy_tokenizer.py
@@ -28,13 +28,13 @@ class SpacyTokenizer(Tokenizer):
         Spacy model name.
     pos_tags : `bool`, optional, (default=False)
         If `True`, performs POS tagging with spacy model on the tokens.
-        Generally used in conjunction with :class:`~allennlp.data.token_indexers.pos_tag_indexer.PosTagIndexer`.
+        Generally used in conjunction with `allennlp.data.token_indexers.pos_tag_indexer.PosTagIndexer`.
     parse : `bool`, optional, (default=False)
         If `True`, performs dependency parsing with spacy model on the tokens.
-        Generally used in conjunction with :class:`~allennlp.data.token_indexers.pos_tag_indexer.DepLabelIndexer`.
+        Generally used in conjunction with `allennlp.data.token_indexers.pos_tag_indexer.DepLabelIndexer`.
     ner : `bool`, optional, (default=False)
         If `True`, performs dependency parsing with spacy model on the tokens.
-        Generally used in conjunction with :class:`~allennlp.data.token_indexers.ner_tag_indexer.NerTagIndexer`.
+        Generally used in conjunction with `allennlp.data.token_indexers.ner_tag_indexer.NerTagIndexer`.
     keep_spacy_tokens : `bool`, optional, (default=False)
         If `True`, will preserve spacy token objects, We copy spacy tokens into our own class by default instead
         because spacy Cython Tokens can't be pickled.

--- a/allennlp/data/tokenizers/tokenizer.py
+++ b/allennlp/data/tokenizers/tokenizer.py
@@ -16,13 +16,13 @@ class Tokenizer(Registrable):
     here, though you could imagine wanting to do other kinds of tokenization for structured or
     other inputs.
 
-    See the parameters to, e.g., :class:`~.SpacyTokenizer`, or whichever tokenizer
+    See the parameters to, e.g., `.SpacyTokenizer`, or whichever tokenizer
     you want to use.
 
-    If the base input to your model is words, you should use a :class:`~.SpacyTokenizer`, even if
+    If the base input to your model is words, you should use a `.SpacyTokenizer`, even if
     you also want to have a character-level encoder to get an additional vector for each word
     token.  Splitting word tokens into character arrays is handled separately, in the
-    :class:`..token_representations.TokenRepresentation` class.
+    `..token_representations.TokenRepresentation` class.
     """
 
     default_implementation = "spacy"

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -33,7 +33,7 @@ class _NamespaceDependentDefaultDict(defaultdict):
     (https://docs.python.org/2/library/collections.html#collections.defaultdict) where the
     default value is dependent on the key that is passed.
 
-    We use "namespaces" in the :class:`Vocabulary` object to keep track of several different
+    We use "namespaces" in the `Vocabulary` object to keep track of several different
     mappings from strings to integers, so that we have a consistent API for mapping words, tags,
     labels, characters, or whatever else you want, into integers.  The issue is that some of those
     namespaces (words and characters) should have integers reserved for padding and
@@ -51,7 +51,7 @@ class _NamespaceDependentDefaultDict(defaultdict):
 
     non_padded_namespaces : `Iterable[str]`
         A set / list / tuple of strings describing which namespaces are not padded.  If a namespace
-        (key) is missing from this dictionary, we will use :func:`namespace_match` to see whether
+        (key) is missing from this dictionary, we will use `namespace_match` to see whether
         the namespace should be padded.  If the given namespace matches any of the strings in this
         list, we will use `non_padded_function` to initialize the value for that namespace, and
         we will use `padded_function` otherwise.
@@ -129,7 +129,7 @@ class Vocabulary(Registrable):
 
     Vocabularies also allow for several different namespaces, so you can have separate indices for
     'a' as a word, and 'a' as a character, for instance, and so we can use this object to also map
-    tag and label strings to indices, for a unified :class:`~.fields.field.Field` API.  Most of the
+    tag and label strings to indices, for a unified `.fields.field.Field` API.  Most of the
     methods on this class allow you to pass in a namespace; by default we use the 'tokens'
     namespace, and you can omit the namespace argument everywhere and just use the default.
 
@@ -252,7 +252,7 @@ class Vocabulary(Registrable):
         """
         Constructs a vocabulary given a collection of `Instances` and some parameters.
         We count all of the vocabulary items in the instances, then pass those counts
-        and the other parameters, to :func:`__init__`.  See that method for a description
+        and the other parameters, to `__init__`.  See that method for a description
         of what the other parameters do.
         """
         logger.info("Fitting token dictionary from dataset.")

--- a/allennlp/interpret/attackers/hotflip.py
+++ b/allennlp/interpret/attackers/hotflip.py
@@ -181,7 +181,7 @@ class Hotflip(Attacker):
         grad_input_field : `str`, optional (default='grad_input_1')
             If there is more than one field that gets embedded in your model (e.g., a question and
             a passage, or a premise and a hypothesis), this tells us the key to use to get the
-            correct gradients.  This selects from the output of :func:`Predictor.get_gradients`.
+            correct gradients.  This selects from the output of `Predictor.get_gradients`.
         ignore_tokens : `List[str]`, optional (default=DEFAULT_IGNORE_TOKENS)
             These tokens will not be flipped.  The default list includes some simple punctuation,
             OOV and padding tokens, and common control tokens for BERT, etc.

--- a/allennlp/interpret/saliency_interpreters/integrated_gradient.py
+++ b/allennlp/interpret/saliency_interpreters/integrated_gradient.py
@@ -60,7 +60,7 @@ class IntegratedGradient(SaliencyInterpreter):
 
     def _integrate_gradients(self, instance: Instance) -> Dict[str, numpy.ndarray]:
         """
-        Returns integrated gradients for the given :class:`~allennlp.data.instance.Instance`
+        Returns integrated gradients for the given `allennlp.data.instance.Instance`
         """
         ig_grads: Dict[str, Any] = {}
 

--- a/allennlp/models/__init__.py
+++ b/allennlp/models/__init__.py
@@ -1,6 +1,6 @@
 """
 These submodules contain the classes for AllenNLP models,
-all of which are subclasses of :class:`~allennlp.models.model.Model`.
+all of which are subclasses of `allennlp.models.model.Model`.
 """
 
 from allennlp.models.model import Model

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -329,7 +329,7 @@ class CoreferenceResolver(Model):
         # Parameters
 
         output_dict : `Dict[str, torch.Tensor]`, required.
-            The result of calling :func:`forward` on an instance or batch of instances.
+            The result of calling `forward` on an instance or batch of instances.
 
         # Returns
 

--- a/allennlp/models/decomposable_attention.py
+++ b/allennlp/models/decomposable_attention.py
@@ -22,7 +22,7 @@ class DecomposableAttention(Model):
     by Parikh et al., 2016, with some optional enhancements before the decomposable attention
     actually happens.  Parikh's original model allowed for computing an "intra-sentence" attention
     before doing the decomposable entailment step.  We generalize this to any
-    :class:`Seq2SeqEncoder` that can be applied to the premise and/or the hypothesis before
+    `Seq2SeqEncoder` that can be applied to the premise and/or the hypothesis before
     computing entailment.
 
     The basic outline of this model is to get an embedded representation of each word in the

--- a/allennlp/models/encoder_decoders/composed_seq2seq.py
+++ b/allennlp/models/encoder_decoders/composed_seq2seq.py
@@ -15,7 +15,7 @@ from allennlp.nn import util, InitializerApplicator, RegularizerApplicator
 @Model.register("composed_seq2seq")
 class ComposedSeq2Seq(Model):
     """
-    This `ComposedSeq2Seq` class is a :class:`Model` which takes a sequence, encodes it, and then
+    This `ComposedSeq2Seq` class is a `Model` which takes a sequence, encodes it, and then
     uses the encoded representations to decode another sequence.  You can use this as the basis for
     a neural machine translation system, an abstractive summarization system, or any other common
     seq2seq problem.  The model here is simple, but should be a decent starting place for

--- a/allennlp/models/encoder_decoders/simple_seq2seq.py
+++ b/allennlp/models/encoder_decoders/simple_seq2seq.py
@@ -23,7 +23,7 @@ from allennlp.training.metrics import BLEU
 @Model.register("simple_seq2seq")
 class SimpleSeq2Seq(Model):
     """
-    This `SimpleSeq2Seq` class is a :class:`Model` which takes a sequence, encodes it, and then
+    This `SimpleSeq2Seq` class is a `Model` which takes a sequence, encodes it, and then
     uses the encoded representations to decode another sequence.  You can use this as the basis for
     a neural machine translation system, an abstractive summarization system, or any other common
     seq2seq problem.  The model here is simple, but should be a decent starting place for

--- a/allennlp/models/event2mind.py
+++ b/allennlp/models/event2mind.py
@@ -24,7 +24,7 @@ from allennlp.training.metrics import UnigramRecall
 @Model.register("event2mind")
 class Event2Mind(Model):
     """
-    This `Event2Mind` class is a :class:`Model` which takes an event
+    This `Event2Mind` class is a `Model` which takes an event
     sequence, encodes it, and then uses the encoded representation to decode
     several mental state sequences.
 

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -1,5 +1,5 @@
 """
-:py:class:`Model` is an abstract class representing
+:py`Model` is an abstract class representing
 an AllenNLP model.
 """
 
@@ -37,14 +37,14 @@ class Model(torch.nn.Module, Registrable):
     interleave the models with a wrapper module which unpacks the dictionary into
     a list of tensors.
 
-    In order for your model to be trained using the :class:`~allennlp.training.Trainer`
+    In order for your model to be trained using the `allennlp.training.Trainer`
     api, the output dictionary of your Model must include a "loss" key, which will be
     optimised during the training process.
 
-    Finally, you can optionally implement :func:`Model.get_metrics` in order to make use
+    Finally, you can optionally implement `Model.get_metrics` in order to make use
     of early stopping and best-model serialization based on a validation metric in
-    :class:`~allennlp.training.Trainer`. Metrics that begin with "_" will not be logged
-    to the progress bar by :class:`~allennlp.training.Trainer`.
+    `allennlp.training.Trainer`. Metrics that begin with "_" will not be logged
+    to the progress bar by `allennlp.training.Trainer`.
     """
 
     _warn_for_unseparable_batches: Set[str] = set()
@@ -106,16 +106,16 @@ class Model(torch.nn.Module, Registrable):
 
         output_dict : `Dict[str, torch.Tensor]`
             The outputs from the model. In order to train a model using the
-            :class:`~allennlp.training.Trainer` api, you must provide a "loss" key pointing to a
+            `allennlp.training.Trainer` api, you must provide a "loss" key pointing to a
             scalar `torch.Tensor` representing the loss to be optimized.
         """
         raise NotImplementedError
 
     def forward_on_instance(self, instance: Instance) -> Dict[str, numpy.ndarray]:
         """
-        Takes an :class:`~allennlp.data.instance.Instance`, which typically has raw text in it,
-        converts that text into arrays using this model's :class:`Vocabulary`, passes those arrays
-        through :func:`self.forward()` and :func:`self.decode()` (which by default does nothing)
+        Takes an `allennlp.data.instance.Instance`, which typically has raw text in it,
+        converts that text into arrays using this model's `Vocabulary`, passes those arrays
+        through `self.forward()` and `self.decode()` (which by default does nothing)
         and returns the result.  Before returning the result, we convert any
         `torch.Tensors` into numpy arrays and remove the batch dimension.
         """
@@ -123,14 +123,14 @@ class Model(torch.nn.Module, Registrable):
 
     def forward_on_instances(self, instances: List[Instance]) -> List[Dict[str, numpy.ndarray]]:
         """
-        Takes a list of  :class:`~allennlp.data.instance.Instance`s, converts that text into
-        arrays using this model's :class:`Vocabulary`, passes those arrays through
-        :func:`self.forward()` and :func:`self.decode()` (which by default does nothing)
+        Takes a list of  `allennlp.data.instance.Instance`s, converts that text into
+        arrays using this model's `Vocabulary`, passes those arrays through
+        `self.forward()` and `self.decode()` (which by default does nothing)
         and returns the result.  Before returning the result, we convert any
         `torch.Tensors` into numpy arrays and separate the
         batched output into a list of individual dicts per instance. Note that typically
         this will be faster on a GPU (and conditionally, on a CPU) than repeated calls to
-        :func:`forward_on_instance`.
+        `forward_on_instance`.
 
         # Parameters
 
@@ -172,7 +172,7 @@ class Model(torch.nn.Module, Registrable):
 
     def decode(self, output_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         """
-        Takes the result of :func:`forward` and runs inference / decoding / whatever
+        Takes the result of `forward` and runs inference / decoding / whatever
         post-processing you need to do your model.  The intent is that `model.forward()` should
         produce potentials or probabilities, and then `model.decode()` can take those results and
         run some kind of beam search or constrained inference or whatever is necessary.  This does
@@ -190,13 +190,13 @@ class Model(torch.nn.Module, Registrable):
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         """
         Returns a dictionary of metrics. This method will be called by
-        :class:`allennlp.training.Trainer` in order to compute and use model metrics for early
+        `allennlp.training.Trainer` in order to compute and use model metrics for early
         stopping and model serialization.  We return an empty dictionary here rather than raising
         as it is not required to implement metrics for a new model.  A boolean `reset` parameter is
         passed, as frequently a metric accumulator will have some state which should be reset
-        between epochs. This is also compatible with :class:`~allennlp.training.Metric`s. Metrics
+        between epochs. This is also compatible with `allennlp.training.Metric`s. Metrics
         should be populated during the call to `forward`, with the
-        :class:`~allennlp.training.Metric` handling the accumulation of the metric until this
+        `allennlp.training.Metric` handling the accumulation of the metric until this
         method is called.
         """
 

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -210,7 +210,7 @@ class SemanticRoleLabeler(Model):
     @overrides
     def decode(self, output_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         """
-        Does constrained viterbi decoding on class probabilities output in :func:`forward`.  The
+        Does constrained viterbi decoding on class probabilities output in `forward`.  The
         constraint simply specifies that the output tags must be a valid BIO sequence.  We add a
         `"tags"` key to the dictionary with the result.
         """

--- a/allennlp/models/srl_bert.py
+++ b/allennlp/models/srl_bert.py
@@ -169,7 +169,7 @@ class SrlBert(Model):
     @overrides
     def decode(self, output_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         """
-        Does constrained viterbi decoding on class probabilities output in :func:`forward`.  The
+        Does constrained viterbi decoding on class probabilities output in `forward`.  The
         constraint simply specifies that the output tags must be a valid BIO sequence.  We add a
         `"tags"` key to the dictionary with the result.
 

--- a/allennlp/modules/__init__.py
+++ b/allennlp/modules/__init__.py
@@ -2,7 +2,7 @@
 Custom PyTorch
 `Module <https://pytorch.org/docs/master/nn.html#torch.nn.Module>`_ s
 that are used as components in AllenNLP
-:class:`~allennlp.models.model.Model` s.
+`allennlp.models.model.Model` s.
 """
 
 from allennlp.modules.conditional_random_field import ConditionalRandomField

--- a/allennlp/modules/augmented_lstm.py
+++ b/allennlp/modules/augmented_lstm.py
@@ -68,7 +68,7 @@ class AugmentedLstm(torch.nn.Module):
         use_input_projection_bias: bool = True,
     ) -> None:
         super().__init__()
-        # Required to be wrapped with a :class:`PytorchSeq2SeqWrapper`.
+        # Required to be wrapped with a `PytorchSeq2SeqWrapper`.
         self.input_size = input_size
         self.hidden_size = hidden_size
 

--- a/allennlp/modules/elmo_lstm.py
+++ b/allennlp/modules/elmo_lstm.py
@@ -21,7 +21,7 @@ from allennlp.common.file_utils import cached_path
 class ElmoLstm(_EncoderBase):
     """
     A stacked, bidirectional LSTM which uses
-    :class:`~allennlp.modules.lstm_cell_with_projection.LstmCellWithProjection`'s
+    `allennlp.modules.lstm_cell_with_projection.LstmCellWithProjection`'s
     with highway layers between the inputs to layers.
     The inputs to the forward and backward directions are independent - forward and backward
     states are not concatenated between layers.
@@ -41,7 +41,7 @@ class ElmoLstm(_EncoderBase):
         The dimension of the outputs of the LSTM.
     cell_size : `int`, required.
         The dimension of the memory cell of the
-        :class:`~allennlp.modules.lstm_cell_with_projection.LstmCellWithProjection`.
+        `allennlp.modules.lstm_cell_with_projection.LstmCellWithProjection`.
     num_layers : `int`, required
         The number of bidirectional LSTMs to use.
     requires_grad : `bool`, optional
@@ -69,7 +69,7 @@ class ElmoLstm(_EncoderBase):
     ) -> None:
         super().__init__(stateful=True)
 
-        # Required to be wrapped with a :class:`PytorchSeq2SeqWrapper`.
+        # Required to be wrapped with a `PytorchSeq2SeqWrapper`.
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.num_layers = num_layers

--- a/allennlp/modules/encoder_base.py
+++ b/allennlp/modules/encoder_base.py
@@ -16,8 +16,8 @@ class _EncoderBase(torch.nn.Module):
 
     """
     This abstract class serves as a base for the 3 `Encoder` abstractions in AllenNLP.
-    - :class:`~allennlp.modules.seq2seq_encoders.Seq2SeqEncoders`
-    - :class:`~allennlp.modules.seq2vec_encoders.Seq2VecEncoders`
+    - `allennlp.modules.seq2seq_encoders.Seq2SeqEncoders`
+    - `allennlp.modules.seq2vec_encoders.Seq2VecEncoders`
 
     Additionally, this class provides functionality for sorting sequences by length
     so they can be consumed by Pytorch RNN classes, which require their inputs to be

--- a/allennlp/modules/highway.py
+++ b/allennlp/modules/highway.py
@@ -12,9 +12,9 @@ from overrides import overrides
 class Highway(torch.nn.Module):
     """
     A [Highway layer](https://arxiv.org/abs/1505.00387) does a gated combination of a linear
-    transformation and a non-linear transformation of its input.  :math:`y = g * x + (1 - g) *
-    f(A(x))`, where :math:`A` is a linear transformation, :math:`f` is an element-wise
-    non-linearity, and :math:`g` is an element-wise gate, computed as :math:`sigmoid(B(x))`.
+    transformation and a non-linear transformation of its input.  `y = g * x + (1 - g) *
+    f(A(x))`, where `A` is a linear transformation, `f` is an element-wise
+    non-linearity, and `g` is an element-wise gate, computed as `sigmoid(B(x))`.
 
     This module will apply a fixed number of highway layers to its input, returning the final
     result.
@@ -22,7 +22,7 @@ class Highway(torch.nn.Module):
     # Parameters
 
     input_dim : `int`, required
-        The dimensionality of :math:`x`.  We assume the input has shape `(batch_size, ...,
+        The dimensionality of `x`.  We assume the input has shape `(batch_size, ...,
         input_dim)`.
     num_layers : `int`, optional (default=`1`)
         The number of highway layers to apply to the input.

--- a/allennlp/modules/lstm_cell_with_projection.py
+++ b/allennlp/modules/lstm_cell_with_projection.py
@@ -65,7 +65,7 @@ class LstmCellWithProjection(torch.nn.Module):
         state_projection_clip_value: Optional[float] = None,
     ) -> None:
         super().__init__()
-        # Required to be wrapped with a :class:`PytorchSeq2SeqWrapper`.
+        # Required to be wrapped with a `PytorchSeq2SeqWrapper`.
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.cell_size = cell_size

--- a/allennlp/modules/seq2seq_decoders/__init__.py
+++ b/allennlp/modules/seq2seq_decoders/__init__.py
@@ -4,7 +4,7 @@ into a sequence of output vectors.
 
 The available Seq2Seq decoders are
 
-* :class:`"auto_regressive_seq_decoder"
+* `"auto_regressive_seq_decoder"
   <allennlp.modules.seq2seq_decoders.auto_regressive_seq_decoder.AutoRegressiveSeqDecoder>`
 
 """

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -9,13 +9,13 @@ The available Seq2Seq encoders are
 * `"gru" <https://pytorch.org/docs/master/nn.html#torch.nn.GRU>`_
 * `"lstm" <https://pytorch.org/docs/master/nn.html#torch.nn.LSTM>`_
 * `"rnn" <https://pytorch.org/docs/master/nn.html#torch.nn.RNN>`_
-* :class:`"augmented_lstm" <allennlp.modules.augmented_lstm.AugmentedLstm>`
-* :class:`"alternating_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`
-* :class:`"alternating_highway_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm> (GPU only)`
-* :class:`"stacked_self_attention" <allennlp.modules.stacked_self_attention.StackedSelfAttentionEncoder>`
-* :class:`"multi_head_self_attention" <allennlp.modules.multi_head_self_attention.MultiHeadSelfAttention>`
-* :class:`"pass_through" <allennlp.modules.pass_through_encoder.PassThroughEncoder>`
-* :class:`"feedforward" <allennlp.modules.feedforward_encoder.FeedforwardEncoder>`
+* `"augmented_lstm" <allennlp.modules.augmented_lstm.AugmentedLstm>`
+* `"alternating_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`
+* `"alternating_highway_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm> (GPU only)`
+* `"stacked_self_attention" <allennlp.modules.stacked_self_attention.StackedSelfAttentionEncoder>`
+* `"multi_head_self_attention" <allennlp.modules.multi_head_self_attention.MultiHeadSelfAttention>`
+* `"pass_through" <allennlp.modules.pass_through_encoder.PassThroughEncoder>`
+* `"feedforward" <allennlp.modules.feedforward_encoder.FeedforwardEncoder>`
 """
 
 from typing import Type
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 class _Seq2SeqWrapper:
     """
-    For :class:`Registrable` we need to have a `Type[Seq2SeqEncoder]` as the value registered for each
+    For `Registrable` we need to have a `Type[Seq2SeqEncoder]` as the value registered for each
     key.  What that means is that we need to be able to `__call__` these values (as is done with
     `__init__` on the class), and be able to call `from_params()` on the value.
 
@@ -57,7 +57,7 @@ class _Seq2SeqWrapper:
     the registry; or (2) we wrap pytorch's RNNs with something that `mimics` the required
     API.  We've gone with the second option here.
 
-    This is a two-step approach: first, we have the :class:`PytorchSeq2SeqWrapper` class that handles
+    This is a two-step approach: first, we have the `PytorchSeq2SeqWrapper` class that handles
     the interface between a pytorch RNN and our `Seq2SeqEncoder` API.  Our `PytorchSeq2SeqWrapper`
     takes an instantiated pytorch RNN and just does some interface changes.  Second, we need a way
     to create one of these `PytorchSeq2SeqWrappers`, with an instantiated pytorch RNN, from the

--- a/allennlp/modules/seq2seq_encoders/intra_sentence_attention.py
+++ b/allennlp/modules/seq2seq_encoders/intra_sentence_attention.py
@@ -13,12 +13,12 @@ from allennlp.nn import util
 @Seq2SeqEncoder.register("intra_sentence_attention")
 class IntraSentenceAttentionEncoder(Seq2SeqEncoder):
     """
-    An `IntraSentenceAttentionEncoder` is a :class:`Seq2SeqEncoder` that merges the original word
+    An `IntraSentenceAttentionEncoder` is a `Seq2SeqEncoder` that merges the original word
     representations with an attention (for each word) over other words in the sentence.  As a
-    :class:`Seq2SeqEncoder`, the input to this module is of shape `(batch_size, num_tokens,
+    `Seq2SeqEncoder`, the input to this module is of shape `(batch_size, num_tokens,
     input_dim)`, and the output is of shape `(batch_size, num_tokens, output_dim)`.
 
-    We compute the attention using a configurable :class:`SimilarityFunction`, which could have
+    We compute the attention using a configurable `SimilarityFunction`, which could have
     multiple attention heads.  The operation for merging the original representations with the
     attended representations is also configurable (e.g., you can concatenate them, add them,
     multiply them, etc.).
@@ -40,7 +40,7 @@ class IntraSentenceAttentionEncoder(Seq2SeqEncoder):
     combination : `str`, optional
         This string defines how we merge the original word representations with the result of the
         intra-sentence attention.  This will be passed to
-        :func:`~allennlp.nn.util.combine_tensors`; see that function for more detail on exactly how
+        `allennlp.nn.util.combine_tensors`; see that function for more detail on exactly how
         this works, but some simple examples are `"1,2"` for concatenation (the default),
         `"1+2"` for adding the two, or `"2"` for only keeping the attention representation.
     output_dim : `int`, optional (default = None)

--- a/allennlp/modules/seq2seq_encoders/pytorch_seq2seq_wrapper.py
+++ b/allennlp/modules/seq2seq_encoders/pytorch_seq2seq_wrapper.py
@@ -10,7 +10,7 @@ class PytorchSeq2SeqWrapper(Seq2SeqEncoder):
     """
     Pytorch's RNNs have two outputs: the hidden state for every time step, and the hidden state at
     the last time step for every layer.  We just want the first one as a single output.  This
-    wrapper pulls out that output, and adds a :func:`get_output_dim` method, which is useful if you
+    wrapper pulls out that output, and adds a `get_output_dim` method, which is useful if you
     want to, e.g., define a linear + softmax layer on top of this to get some distribution over a
     set of labels.  The linear layer needs to know its input dimension before it is called, and you
     can get that from `get_output_dim`.

--- a/allennlp/modules/seq2seq_encoders/seq2seq_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/seq2seq_encoder.py
@@ -8,7 +8,7 @@ class Seq2SeqEncoder(_EncoderBase, Registrable):
     modified sequence of vectors.  Input shape : `(batch_size, sequence_length, input_dim)`; output
     shape : `(batch_size, sequence_length, output_dim)`.
 
-    We add two methods to the basic `Module` API: :func:`get_input_dim()` and :func:`get_output_dim()`.
+    We add two methods to the basic `Module` API: `get_input_dim()` and `get_output_dim()`.
     You might need this if you want to construct a `Linear` layer using the output of this encoder,
     or to raise sensible errors for mis-matching input dimensions.
     """

--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -9,10 +9,10 @@ The available Seq2Vec encoders are
 * `"gru" <https://pytorch.org/docs/master/nn.html#torch.nn.GRU>`_
 * `"lstm" <https://pytorch.org/docs/master/nn.html#torch.nn.LSTM>`_
 * `"rnn" <https://pytorch.org/docs/master/nn.html#torch.nn.RNN>`_
-* :class:`"cnn" <allennlp.modules.seq2vec_encoders.cnn_encoder.CnnEncoder>`
-* :class:`"augmented_lstm" <allennlp.modules.augmented_lstm.AugmentedLstm>`
-* :class:`"alternating_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`
-* :class:`"stacked_bidirectional_lstm" <allennlp.modules.stacked_bidirectional_lstm.StackedBidirectionalLstm>`
+* `"cnn" <allennlp.modules.seq2vec_encoders.cnn_encoder.CnnEncoder>`
+* `"augmented_lstm" <allennlp.modules.augmented_lstm.AugmentedLstm>`
+* `"alternating_lstm" <allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm>`
+* `"stacked_bidirectional_lstm" <allennlp.modules.stacked_bidirectional_lstm.StackedBidirectionalLstm>`
 """
 
 from typing import Type
@@ -34,7 +34,7 @@ from allennlp.modules.stacked_bidirectional_lstm import StackedBidirectionalLstm
 
 class _Seq2VecWrapper:
     """
-    For :class:`Registrable` we need to have a `Type[Seq2VecEncoder]` as the value registered for each
+    For `Registrable` we need to have a `Type[Seq2VecEncoder]` as the value registered for each
     key.  What that means is that we need to be able to `__call__` these values (as is done with
     `__init__` on the class), and be able to call `from_params()` on the value.
 
@@ -43,7 +43,7 @@ class _Seq2VecWrapper:
     the registry; or (2) we wrap pytorch's RNNs with something that `mimics` the required
     API.  We've gone with the second option here.
 
-    This is a two-step approach: first, we have the :class:`PytorchSeq2VecWrapper` class that handles
+    This is a two-step approach: first, we have the `PytorchSeq2VecWrapper` class that handles
     the interface between a pytorch RNN and our `Seq2VecEncoder` API.  Our `PytorchSeq2VecWrapper`
     takes an instantiated pytorch RNN and just does some interface changes.  Second, we need a way
     to create one of these `PytorchSeq2VecWrappers`, with an instantiated pytorch RNN, from the

--- a/allennlp/modules/seq2vec_encoders/boe_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/boe_encoder.py
@@ -10,7 +10,7 @@ from allennlp.nn.util import get_lengths_from_binary_sequence_mask
 @Seq2VecEncoder.register("bag_of_embeddings")
 class BagOfEmbeddingsEncoder(Seq2VecEncoder):
     """
-    A `BagOfEmbeddingsEncoder` is a simple :class:`Seq2VecEncoder` which simply sums the embeddings
+    A `BagOfEmbeddingsEncoder` is a simple `Seq2VecEncoder` which simply sums the embeddings
     of a sequence across the time dimension. The input to this module is of shape `(batch_size, num_tokens,
     embedding_dim)`, and the output is of shape `(batch_size, embedding_dim)`.
 

--- a/allennlp/modules/seq2vec_encoders/cnn_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/cnn_encoder.py
@@ -12,7 +12,7 @@ from allennlp.nn import Activation
 class CnnEncoder(Seq2VecEncoder):
     """
     A `CnnEncoder` is a combination of multiple convolution layers and max pooling layers.  As a
-    :class:`Seq2VecEncoder`, the input to this module is of shape `(batch_size, num_tokens,
+    `Seq2VecEncoder`, the input to this module is of shape `(batch_size, num_tokens,
     input_dim)`, and the output is of shape `(batch_size, output_dim)`.
 
     The CNN has one convolution layer for each ngram filter size. Each convolution operation gives

--- a/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
+++ b/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py
@@ -8,7 +8,7 @@ class PytorchSeq2VecWrapper(Seq2VecEncoder):
     """
     Pytorch's RNNs have two outputs: the hidden state for every time step, and the hidden state at
     the last time step for every layer.  We just want the second one as a single output.  This
-    wrapper pulls out that output, and adds a :func:`get_output_dim` method, which is useful if you
+    wrapper pulls out that output, and adds a `get_output_dim` method, which is useful if you
     want to, e.g., define a linear + softmax layer on top of this to get some distribution over a
     set of labels.  The linear layer needs to know its input dimension before it is called, and you
     can get that from `get_output_dim`.

--- a/allennlp/modules/seq2vec_encoders/seq2vec_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/seq2vec_encoder.py
@@ -8,7 +8,7 @@ class Seq2VecEncoder(_EncoderBase, Registrable):
     single vector.  Input shape : `(batch_size, sequence_length, input_dim)`; output shape:
     `(batch_size, output_dim)`.
 
-    We add two methods to the basic `Module` API: :func:`get_input_dim()` and :func:`get_output_dim()`.
+    We add two methods to the basic `Module` API: `get_input_dim()` and `get_output_dim()`.
     You might need this if you want to construct a `Linear` layer using the output of this encoder,
     or to raise sensible errors for mis-matching input dimensions.
     """

--- a/allennlp/modules/similarity_functions/similarity_function.py
+++ b/allennlp/modules/similarity_functions/similarity_function.py
@@ -16,7 +16,7 @@ class SimilarityFunction(torch.nn.Module, Registrable):
 
     If you want to compute a similarity between tensors of different sizes, you need to first tile
     them in the appropriate dimensions to make them the same before you can use these functions.
-    The :class:`~allennlp.modules.Attention` and :class:`~allennlp.modules.MatrixAttention` modules
+    The `allennlp.modules.Attention` and `allennlp.modules.MatrixAttention` modules
     do this.
     """
 

--- a/allennlp/modules/stacked_alternating_lstm.py
+++ b/allennlp/modules/stacked_alternating_lstm.py
@@ -56,7 +56,7 @@ class StackedAlternatingLstm(torch.nn.Module):
     ) -> None:
         super().__init__()
 
-        # Required to be wrapped with a :class:`PytorchSeq2SeqWrapper`.
+        # Required to be wrapped with a `PytorchSeq2SeqWrapper`.
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.num_layers = num_layers

--- a/allennlp/modules/stacked_bidirectional_lstm.py
+++ b/allennlp/modules/stacked_bidirectional_lstm.py
@@ -53,7 +53,7 @@ class StackedBidirectionalLstm(torch.nn.Module):
     ) -> None:
         super().__init__()
 
-        # Required to be wrapped with a :class:`PytorchSeq2SeqWrapper`.
+        # Required to be wrapped with a `PytorchSeq2SeqWrapper`.
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.num_layers = num_layers

--- a/allennlp/modules/text_field_embedders/__init__.py
+++ b/allennlp/modules/text_field_embedders/__init__.py
@@ -1,7 +1,7 @@
 """
-A :class:`~allennlp.modules.text_field_embedders.text_field_embedder.TextFieldEmbedder`
+A `allennlp.modules.text_field_embedders.text_field_embedder.TextFieldEmbedder`
 is a `Module` that takes as input the `dict` of NumPy arrays
-produced by a :class:`~allennlp.data.fields.text_field.TextField` and
+produced by a `allennlp.data.fields.text_field.TextField` and
 returns as output an embedded representation of the tokens in that field.
 """
 

--- a/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/basic_text_field_embedder.py
@@ -14,10 +14,10 @@ from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 @TextFieldEmbedder.register("basic")
 class BasicTextFieldEmbedder(TextFieldEmbedder):
     """
-    This is a `TextFieldEmbedder` that wraps a collection of :class:`TokenEmbedder` objects.  Each
+    This is a `TextFieldEmbedder` that wraps a collection of `TokenEmbedder` objects.  Each
     `TokenEmbedder` embeds or encodes the representation output from one
-    :class:`~allennlp.data.TokenIndexer`.  As the data produced by a
-    :class:`~allennlp.data.fields.TextField` is a dictionary mapping names to these
+    `allennlp.data.TokenIndexer`.  As the data produced by a
+    `allennlp.data.fields.TextField` is a dictionary mapping names to these
     representations, we take `TokenEmbedders` with corresponding names.  Each `TokenEmbedders`
     embeds its input, and the result is concatenated in an arbitrary (but consistent) order.
 

--- a/allennlp/modules/text_field_embedders/text_field_embedder.py
+++ b/allennlp/modules/text_field_embedders/text_field_embedder.py
@@ -7,17 +7,17 @@ from allennlp.data import TextFieldTensors
 class TextFieldEmbedder(torch.nn.Module, Registrable):
     """
     A `TextFieldEmbedder` is a `Module` that takes as input the
-    :class:`~allennlp.data.DataArray` produced by a :class:`~allennlp.data.fields.TextField` and
+    `allennlp.data.DataArray` produced by a `allennlp.data.fields.TextField` and
     returns as output an embedded representation of the tokens in that field.
 
     The `DataArrays` produced by `TextFields` are _dictionaries_ with named representations, like
     "words" and "characters".  When you create a `TextField`, you pass in a dictionary of
-    :class:`~allennlp.data.TokenIndexer` objects, telling the field how exactly the tokens in the
+    `allennlp.data.TokenIndexer` objects, telling the field how exactly the tokens in the
     field should be represented.  This class changes the type signature of `Module.forward`,
     restricting `TextFieldEmbedders` to take inputs corresponding to a single `TextField`, which is
     a dictionary of tensors with the same names as were passed to the `TextField`.
 
-    We also add a method to the basic `Module` API: :func:`get_output_dim()`.  You might need this
+    We also add a method to the basic `Module` API: `get_output_dim()`.  You might need this
     if you want to construct a `Linear` layer using the output of this embedder, for instance.
     """
 

--- a/allennlp/modules/token_embedders/__init__.py
+++ b/allennlp/modules/token_embedders/__init__.py
@@ -1,5 +1,5 @@
 """
-A :class:`~allennlp.modules.token_embedders.token_embedder.TokenEmbedder` is a `Module` that
+A `allennlp.modules.token_embedders.token_embedder.TokenEmbedder` is a `Module` that
 embeds one-hot-encoded tokens as vectors.
 """
 

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -40,8 +40,8 @@ class Embedding(TokenEmbedder, Registrable):
         5. build all of this easily `from_params`
 
     Note that if you are using our data API and are trying to embed a
-    :class:`~allennlp.data.fields.TextField`, you should use a
-    :class:`~allennlp.modules.TextFieldEmbedder` instead of using this directly.
+    `allennlp.data.fields.TextField`, you should use a
+    `allennlp.modules.TextFieldEmbedder` instead of using this directly.
 
     # Parameters
 

--- a/allennlp/modules/token_embedders/token_characters_encoder.py
+++ b/allennlp/modules/token_embedders/token_characters_encoder.py
@@ -10,7 +10,7 @@ from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 class TokenCharactersEncoder(TokenEmbedder):
     """
     A `TokenCharactersEncoder` takes the output of a
-    :class:`~allennlp.data.token_indexers.TokenCharactersIndexer`, which is a tensor of shape
+    `allennlp.data.token_indexers.TokenCharactersIndexer`, which is a tensor of shape
     (batch_size, num_tokens, num_characters), embeds the characters, runs a token-level encoder, and
     returns the result, which is a tensor of shape (batch_size, num_tokens, encoding_dim).  We also
     optionally apply dropout after the token-level encoder.

--- a/allennlp/modules/token_embedders/token_embedder.py
+++ b/allennlp/modules/token_embedders/token_embedder.py
@@ -6,14 +6,14 @@ from allennlp.common import Registrable
 class TokenEmbedder(torch.nn.Module, Registrable):
     """
     A `TokenEmbedder` is a `Module` that takes as input a tensor with integer ids that have
-    been output from a :class:`~allennlp.data.TokenIndexer` and outputs a vector per token in the
+    been output from a `allennlp.data.TokenIndexer` and outputs a vector per token in the
     input.  The input typically has shape `(batch_size, num_tokens)` or `(batch_size,
     num_tokens, num_characters)`, and the output is of shape `(batch_size, num_tokens,
     output_dim)`.  The simplest `TokenEmbedder` is just an embedding layer, but for
     character-level input, it could also be some kind of character encoder.
 
-    We add a single method to the basic `Module` API: :func:`get_output_dim()`.  This lets us
-    more easily compute output dimensions for the :class:`~allennlp.modules.TextFieldEmbedder`,
+    We add a single method to the basic `Module` API: `get_output_dim()`.  This lets us
+    more easily compute output dimensions for the `allennlp.modules.TextFieldEmbedder`,
     which we might need when defining model parameters such as LSTMs or linear layers, which need
     to know their input dimension before the layers are called.
     """

--- a/allennlp/nn/activations.py
+++ b/allennlp/nn/activations.py
@@ -1,5 +1,5 @@
 """
-An :class:`Activation` is just a function
+An `Activation` is just a function
 that takes some parameters and returns an element-wise activation function.
 For the most part we just use
 `PyTorch activations <https://pytorch.org/docs/master/nn.html#non-linear-activations>`_.

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -19,9 +19,9 @@ The available initialization functions are
 * `"kaiming_normal" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.kaiming_normal_>`_
 * `"orthogonal" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.orthogonal_>`_
 * `"sparse" <https://pytorch.org/docs/master/nn.html?highlight=orthogonal#torch.nn.init.sparse_>`_
-* :func:`"block_orthogonal" <block_orthogonal>`
-* :func:`"uniform_unit_scaling" <uniform_unit_scaling>`
-* :class:`"pretrained" <PretrainedModelInitializer>`
+* `"block_orthogonal" <block_orthogonal>`
+* `"uniform_unit_scaling" <uniform_unit_scaling>`
+* `"pretrained" <PretrainedModelInitializer>`
 """
 import logging
 import re
@@ -215,7 +215,7 @@ class PretrainedModelInitializer(Initializer):
     weights file and use a regex to match all of the new parameters which need to be
     initialized.
 
-    The below entry in the :class:`InitializerApplicator` parameters will initialize
+    The below entry in the `InitializerApplicator` parameters will initialize
     `linear_1.weight` and `linear_2.weight` using a pretrained model.
     `linear_1.weight` will be initialized to the pretrained
     parameters called `linear_1.weight`, but `linear_2.weight` will be initialized

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -716,7 +716,7 @@ def sequence_cross_entropy_with_logits(
     """
     Computes the cross entropy loss of a sequence, weighted with respect to
     some user provided weights. Note that the weighting here is not the same as
-    in the :func:`torch.nn.CrossEntropyLoss()` criterion, which is weighting
+    in the `torch.nn.CrossEntropyLoss()` criterion, which is weighting
     classes; here we are weighting the loss contribution from particular elements
     in the sequence. This allows loss computations for models which use padding.
 
@@ -1001,7 +1001,7 @@ def combine_tensors_and_multiply(
     combination: str, tensors: List[torch.Tensor], weights: torch.nn.Parameter
 ) -> torch.Tensor:
     """
-    Like :func:`combine_tensors`, but does a weighted (linear) multiplication while combining.
+    Like `combine_tensors`, but does a weighted (linear) multiplication while combining.
     This is a separate function from `combine_tensors` because we try to avoid instantiating
     large intermediate tensors during the combination, which is possible because we know that we're
     going to be multiplying by a weight vector in the end.
@@ -1009,7 +1009,7 @@ def combine_tensors_and_multiply(
     # Parameters
 
     combination : `str`
-        Same as in :func:`combine_tensors`
+        Same as in `combine_tensors`
     tensors : `List[torch.Tensor]`
         A list of tensors to combine, where the integers in the `combination` are (1-indexed)
         positions in this list of tensors.  These tensors are all expected to have either three or
@@ -1017,7 +1017,7 @@ def combine_tensors_and_multiply(
         dimensions, one of them must have length 1.
     weights : `torch.nn.Parameter`
         A vector of weights to use for the combinations.  This should have shape (combined_dim,),
-        as calculated by :func:`get_combined_dim`.
+        as calculated by `get_combined_dim`.
     """
     if len(tensors) > 9:
         raise ConfigurationError("Double-digit tensor lists not currently supported")
@@ -1089,7 +1089,7 @@ def _get_combination_and_multiply(
 
 def get_combined_dim(combination: str, tensor_dims: List[int]) -> int:
     """
-    For use with :func:`combine_tensors`.  This function computes the resultant dimension when
+    For use with `combine_tensors`.  This function computes the resultant dimension when
     calling `combine_tensors(combination, tensors)`, when the tensor dimension is known.  This is
     necessary for knowing the sizes of weight matrices when building models that use
     `combine_tensors`.
@@ -1098,10 +1098,10 @@ def get_combined_dim(combination: str, tensor_dims: List[int]) -> int:
 
     combination : `str`
         A comma-separated list of combination pieces, like `"1,2,1*2"`, specified identically to
-        `combination` in :func:`combine_tensors`.
+        `combination` in `combine_tensors`.
     tensor_dims : `List[int]`
         A list of tensor dimensions, where each dimension is from the `last axis` of the tensors
-        that will be input to :func:`combine_tensors`.
+        that will be input to `combine_tensors`.
     """
     if len(tensor_dims) > 9:
         raise ConfigurationError("Double-digit tensor lists not currently supported")
@@ -1159,7 +1159,7 @@ def get_device_of(tensor: torch.Tensor) -> int:
 
 def flatten_and_batch_shift_indices(indices: torch.Tensor, sequence_length: int) -> torch.Tensor:
     """
-    This is a subroutine for :func:`~batched_index_select`. The given `indices` of size
+    This is a subroutine for `batched_index_select`. The given `indices` of size
     `(batch_size, d_1, ..., d_n)` indexes into dimension 2 of a target tensor, which has size
     `(batch_size, sequence_length, embedding_size)`. This function returns a vector that
     correctly indexes into the flattened target. The sequence length of the target must be
@@ -1216,11 +1216,11 @@ def batched_index_select(
 
     This function returns selected values in the target with respect to the provided indices, which
     have size `(batch_size, d_1, ..., d_n, embedding_size)`. This can use the optionally
-    precomputed :func:`~flattened_indices` with size `(batch_size * d_1 * ... * d_n)` if given.
+    precomputed `flattened_indices` with size `(batch_size * d_1 * ... * d_n)` if given.
 
     An example use case of this function is looking up the start and end indices of spans in a
     sequence tensor. This is used in the
-    :class:`~allennlp.models.coreference_resolution.CoreferenceResolver`. Model to select
+    `allennlp.models.coreference_resolution.CoreferenceResolver`. Model to select
     contextual word representations corresponding to the start and end indices of mentions. The key
     reason this can't be done with basic torch functions is that we want to be able to use look-up
     tensors with an arbitrary number of dimensions (for example, in the coref model, we don't know

--- a/allennlp/predictors/__init__.py
+++ b/allennlp/predictors/__init__.py
@@ -1,5 +1,5 @@
 """
-A :class:`~allennlp.predictors.predictor.Predictor` is
+A `allennlp.predictors.predictor.Predictor` is
 a wrapper for an AllenNLP `Model`
 that makes JSON predictions using JSON inputs. If you
 want to serve up a model through the web service

--- a/allennlp/predictors/biaffine_dependency_parser.py
+++ b/allennlp/predictors/biaffine_dependency_parser.py
@@ -79,7 +79,7 @@ LINK_TO_POSITION["acomp"] = "right"
 @Predictor.register("biaffine-dependency-parser")
 class BiaffineDependencyParserPredictor(Predictor):
     """
-    Predictor for the :class:`~allennlp.models.BiaffineDependencyParser` model.
+    Predictor for the `allennlp.models.BiaffineDependencyParser` model.
     """
 
     def __init__(

--- a/allennlp/predictors/constituency_parser.py
+++ b/allennlp/predictors/constituency_parser.py
@@ -60,7 +60,7 @@ NODE_TYPE_TO_STYLE["UCP"] = ["color5"]
 @Predictor.register("constituency-parser")
 class ConstituencyParserPredictor(Predictor):
     """
-    Predictor for the :class:`~allennlp.models.SpanConstituencyParser` model.
+    Predictor for the `allennlp.models.SpanConstituencyParser` model.
     """
 
     def __init__(

--- a/allennlp/predictors/coref.py
+++ b/allennlp/predictors/coref.py
@@ -16,7 +16,7 @@ from allennlp.predictors.predictor import Predictor
 @Predictor.register("coreference-resolution")
 class CorefPredictor(Predictor):
     """
-    Predictor for the :class:`~allennlp.models.coreference_resolution.CoreferenceResolver` model.
+    Predictor for the `allennlp.models.coreference_resolution.CoreferenceResolver` model.
     """
 
     def __init__(

--- a/allennlp/predictors/decomposable_attention.py
+++ b/allennlp/predictors/decomposable_attention.py
@@ -13,7 +13,7 @@ from allennlp.data.fields import LabelField
 @Predictor.register("textual-entailment")
 class DecomposableAttentionPredictor(Predictor):
     """
-    Predictor for the :class:`~allennlp.models.DecomposableAttention` model.
+    Predictor for the `allennlp.models.DecomposableAttention` model.
     """
 
     def predict(self, premise: str, hypothesis: str) -> JsonDict:

--- a/allennlp/predictors/event2mind.py
+++ b/allennlp/predictors/event2mind.py
@@ -8,7 +8,7 @@ from allennlp.predictors.predictor import Predictor
 @Predictor.register("event2mind")
 class Event2MindPredictor(Predictor):
     """
-    Predictor for the :class:`~allennlp.models.event2mind` model.
+    Predictor for the `allennlp.models.event2mind` model.
     """
 
     def predict(self, source: str) -> JsonDict:

--- a/allennlp/predictors/predictor.py
+++ b/allennlp/predictors/predictor.py
@@ -65,13 +65,13 @@ class Predictor(Registrable):
 
     def json_to_labeled_instances(self, inputs: JsonDict) -> List[Instance]:
         """
-        Converts incoming json to a :class:`~allennlp.data.instance.Instance`,
+        Converts incoming json to a `allennlp.data.instance.Instance`,
         runs the model on the newly created instance, and adds labels to the
-        :class:`~allennlp.data.instance.Instance`s given by the model's output.
+        `allennlp.data.instance.Instance`s given by the model's output.
         # Returns
 
         List[instance]
-        A list of :class:`~allennlp.data.instance.Instance`
+        A list of `allennlp.data.instance.Instance`
         """
 
         instance = self._json_to_instance(inputs)
@@ -97,9 +97,9 @@ class Predictor(Registrable):
         Notes
         -----
         Takes a `JsonDict` representing the inputs of the model and converts
-        them to :class:`~allennlp.data.instance.Instance`s, sends these through
-        the model :func:`forward` function after registering hooks on the embedding
-        layer of the model. Calls :func:`backward` on the loss and then removes the
+        them to `allennlp.data.instance.Instance`s, sends these through
+        the model `forward` function after registering hooks on the embedding
+        layer of the model. Calls `backward` on the loss and then removes the
         hooks.
         """
         embedding_gradients: List[Tensor] = []
@@ -131,7 +131,7 @@ class Predictor(Registrable):
     def _register_embedding_gradient_hooks(self, embedding_gradients):
         """
         Registers a backward hook on the
-        :class:`~allennlp.modules.text_field_embedder.basic_text_field_embbedder.BasicTextFieldEmbedder`
+        `allennlp.modules.text_field_embedder.basic_text_field_embbedder.BasicTextFieldEmbedder`
         class. Used to save the gradients of the embeddings for use in get_gradients()
 
         When there are multiple inputs (e.g., a passage and question), the hook
@@ -203,7 +203,7 @@ class Predictor(Registrable):
 
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:
         """
-        Converts a JSON object into an :class:`~allennlp.data.instance.Instance`
+        Converts a JSON object into an `allennlp.data.instance.Instance`
         and a `JsonDict` of information which the `Predictor` should pass through,
         such as tokenised inputs.
         """
@@ -219,10 +219,10 @@ class Predictor(Registrable):
 
     def _batch_json_to_instances(self, json_dicts: List[JsonDict]) -> List[Instance]:
         """
-        Converts a list of JSON objects into a list of :class:`~allennlp.data.instance.Instance`s.
+        Converts a list of JSON objects into a list of `allennlp.data.instance.Instance`s.
         By default, this expects that a "batch" consists of a list of JSON blobs which would
-        individually be predicted by :func:`predict_json`. In order to use this method for
-        batch prediction, :func:`_json_to_instance` should be implemented by the subclass, or
+        individually be predicted by `predict_json`. In order to use this method for
+        batch prediction, `_json_to_instance` should be implemented by the subclass, or
         if the instances have some dependency on each other, this method should be overridden
         directly.
         """
@@ -240,7 +240,7 @@ class Predictor(Registrable):
         dataset_reader_to_load: str = "validation",
     ) -> "Predictor":
         """
-        Instantiate a :class:`Predictor` from an archive path.
+        Instantiate a `Predictor` from an archive path.
 
         If you need more detailed configuration options, such as overrides,
         please use `from_archive`.
@@ -277,11 +277,11 @@ class Predictor(Registrable):
         dataset_reader_to_load: str = "validation",
     ) -> "Predictor":
         """
-        Instantiate a :class:`Predictor` from an :class:`~allennlp.models.archival.Archive`;
+        Instantiate a `Predictor` from an `allennlp.models.archival.Archive`;
         that is, from the result of training a model. Optionally specify which `Predictor`
         subclass; otherwise, we try to find a corresponding predictor in `DEFAULT_PREDICTORS`, or if
-        one is not found, the base class (i.e. :class:`Predictor`) will be used. Optionally specify
-        which :class:`DatasetReader` should be loaded; otherwise, the validation one will be used
+        one is not found, the base class (i.e. `Predictor`) will be used. Optionally specify
+        which `DatasetReader` should be loaded; otherwise, the validation one will be used
         if it exists followed by the training dataset reader.
         """
         # Duplicate the config so that the config inside the archive doesn't get consumed

--- a/allennlp/predictors/semantic_role_labeler.py
+++ b/allennlp/predictors/semantic_role_labeler.py
@@ -13,7 +13,7 @@ from allennlp.predictors.predictor import Predictor
 @Predictor.register("semantic-role-labeling")
 class SemanticRoleLabelerPredictor(Predictor):
     """
-    Predictor for the :class:`~allennlp.models.SemanticRoleLabeler` model.
+    Predictor for the `allennlp.models.SemanticRoleLabeler` model.
     """
 
     def __init__(

--- a/allennlp/predictors/sentence_tagger.py
+++ b/allennlp/predictors/sentence_tagger.py
@@ -17,9 +17,9 @@ class SentenceTaggerPredictor(Predictor):
     """
     Predictor for any model that takes in a sentence and returns
     a single set of tags for it.  In particular, it can be used with
-    the :class:`~allennlp.models.crf_tagger.CrfTagger` model
+    the `allennlp.models.crf_tagger.CrfTagger` model
     and also
-    the :class:`~allennlp.models.simple_tagger.SimpleTagger` model.
+    the `allennlp.models.simple_tagger.SimpleTagger` model.
     """
 
     def __init__(

--- a/allennlp/predictors/seq2seq.py
+++ b/allennlp/predictors/seq2seq.py
@@ -9,9 +9,9 @@ from allennlp.predictors.predictor import Predictor
 class Seq2SeqPredictor(Predictor):
     """
     Predictor for sequence to sequence models, including
-    :class:`~allennlp.models.encoder_decoder.composed_seq2seq` and
-    :class:`~allennlp.models.encoder_decoder.simple_seq2seq` and
-    :class:`~allennlp.models.encoder_decoder.copynet_seq2seq`.
+    `allennlp.models.encoder_decoder.composed_seq2seq` and
+    `allennlp.models.encoder_decoder.simple_seq2seq` and
+    `allennlp.models.encoder_decoder.copynet_seq2seq`.
     """
 
     def predict(self, source: str) -> JsonDict:

--- a/allennlp/predictors/simple_seq2seq.py
+++ b/allennlp/predictors/simple_seq2seq.py
@@ -9,7 +9,7 @@ from allennlp.predictors.seq2seq import Seq2SeqPredictor
 @Predictor.register("simple_seq2seq")
 class SimpleSeq2SeqPredictor(Seq2SeqPredictor):
     """
-    Predictor for the :class:`~allennlp.models.encoder_decoder.simple_seq2seq` model.
+    Predictor for the `allennlp.models.encoder_decoder.simple_seq2seq` model.
     """
 
     def __init__(self, model: Model, dataset_reader: DatasetReader) -> None:

--- a/allennlp/predictors/text_classifier.py
+++ b/allennlp/predictors/text_classifier.py
@@ -16,7 +16,7 @@ class TextClassifierPredictor(Predictor):
     """
     Predictor for any model that takes in a sentence and returns
     a single class for it.  In particular, it can be used with
-    the :class:`~allennlp.models.basic_classifier.BasicClassifier` model
+    the `allennlp.models.basic_classifier.BasicClassifier` model
     """
 
     def predict(self, sentence: str) -> JsonDict:

--- a/allennlp/training/metrics/__init__.py
+++ b/allennlp/training/metrics/__init__.py
@@ -1,5 +1,5 @@
 """
-A :class:`~allennlp.training.metrics.metric.Metric` is some quantity or quantities
+A `allennlp.training.metrics.metric.Metric` is some quantity or quantities
 that can be accumulated during training or evaluation; for example,
 accuracy or F1 score.
 """

--- a/allennlp/training/metrics/average.py
+++ b/allennlp/training/metrics/average.py
@@ -6,7 +6,7 @@ from allennlp.training.metrics.metric import Metric
 @Metric.register("average")
 class Average(Metric):
     """
-    This :class:`Metric` breaks with the typical `Metric` API and just stores values that were
+    This `Metric` breaks with the typical `Metric` API and just stores values that were
     computed in some fashion outside of a `Metric`.  If you have some external code that computes
     the metric for you, for instance, you can use this to report the average result using our
     `Metric` API.

--- a/allennlp/training/metrics/boolean_accuracy.py
+++ b/allennlp/training/metrics/boolean_accuracy.py
@@ -16,11 +16,11 @@ class BooleanAccuracy(Metric):
     that are totally masked are ignored (in which case the denominator is the number of predictions that have
     at least one unmasked element).
 
-    This is similar to :class:`CategoricalAccuracy`, if you've already done a `.max()` on your
+    This is similar to `CategoricalAccuracy`, if you've already done a `.max()` on your
     predictions.  If you have categorical output, though, you should typically just use
-    :class:`CategoricalAccuracy`.  The reason you might want to use this instead is if you've done
+    `CategoricalAccuracy`.  The reason you might want to use this instead is if you've done
     some kind of constrained inference and don't have a prediction tensor that matches the API of
-    :class:`CategoricalAccuracy`, which assumes a final dimension of size `num_classes`.
+    `CategoricalAccuracy`, which assumes a final dimension of size `num_classes`.
     """
 
     def __init__(self) -> None:

--- a/allennlp/training/metrics/metric.py
+++ b/allennlp/training/metrics/metric.py
@@ -30,7 +30,7 @@ class Metric(Registrable):
         self, reset: bool
     ) -> Union[float, Tuple[float, ...], Dict[str, float], Dict[str, List[float]]]:
         """
-        Compute and return the metric. Optionally also call :func:`self.reset`.
+        Compute and return the metric. Optionally also call `self.reset`.
         """
         raise NotImplementedError
 

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -142,7 +142,7 @@ class Trainer(TrainerBase):
         learning_rate_scheduler : `LearningRateScheduler`, optional (default = None)
             If specified, the learning rate will be decayed with respect to
             this schedule at the end of each epoch (or batch, if the scheduler implements
-            the `step_batch` method). If you use :class:`torch.optim.lr_scheduler.ReduceLROnPlateau`,
+            the `step_batch` method). If you use `torch.optim.lr_scheduler.ReduceLROnPlateau`,
             this will use the `validation_metric` provided to determine if learning has plateaued.
             To support updating the learning rate on every batch, this can optionally implement
             `step_batch(batch_num_total)` which updates the learning rate given the batch number.

--- a/allennlp/training/trainer_base.py
+++ b/allennlp/training/trainer_base.py
@@ -1,9 +1,9 @@
 """
-A :class:`~allennlp.training.trainer.Trainer` is responsible for training a
-:class:`~allennlp.models.model.Model`.
+A `allennlp.training.trainer.Trainer` is responsible for training a
+`allennlp.models.model.Model`.
 
 Typically you might create a configuration file specifying the model and
-training parameters and then use :mod:`~allennlp.commands.train`
+training parameters and then use `allennlp.commands.train`
 rather than instantiating a `Trainer` yourself.
 """
 


### PR DESCRIPTION
1.  I manually cleaned up `common/`.
2.  I ran `find . -name '*.py' -exec gsed -i 's/:[a-z][a-z]*:`\~*/`/g' \{\} \;` to change syntax like ```:class:`~``` to simply a backtick.