### PR TITLE
Support splitting long sequences into multiple segments for transformers

### DIFF
--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -138,10 +138,10 @@ class PretrainedTransformerIndexer(TokenIndexer):
             # TODO(zhaofengw): we aren't respecting word boundaries when segmenting wordpieces.
 
             # Strips original special tokens
-            indices = indices[self._num_added_start_tokens:-self._num_added_end_tokens]
+            indices = indices[self._num_added_start_tokens : -self._num_added_end_tokens]
             # Folds indices
             wrapped_indices = [
-                indices[i:i + self._effective_max_len]
+                indices[i : i + self._effective_max_len]
                 for i in range(0, len(indices), self._effective_max_len)
             ]
             # Adds special tokens to each segment

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -159,7 +159,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
 
     @overrides
     def get_empty_token_list(self) -> IndexedTokenList:
-        result = {"token_ids": [], "mask": [], "type_ids": []}
+        result: IndexedTokenList = {"token_ids": [], "mask": [], "type_ids": []}
         if self._max_len > 0:
             result["segment_concat_mask"] = []
         return result

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -107,7 +107,8 @@ class PretrainedTransformerIndexer(TokenIndexer):
 
     def _extract_token_and_type_ids(self, tokens: List[Token]) -> List[int]:
         """
-        Essentially returns `[token.text_id for token in tokens]`, with some checks.
+        Roughly equivalent to `zip(*[(token.text_id, token.type_id) for token in tokens])`,
+        with some checks.
         """
         indices: List[int] = []
         type_ids: List[int] = []

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -94,7 +94,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
     ) -> IndexedTokenList:
         """
         `tokens` may already be indices, in which case the token -> index step is a no-op, but other
-        logic still takes place, e.g. long sequence wrapping.
+        logic still takes place, e.g. long sequence splitting.
 
         `tokens` should have special tokens already inserted.
         """
@@ -140,17 +140,17 @@ class PretrainedTransformerIndexer(TokenIndexer):
             # Strips original special tokens
             indices = indices[self._num_added_start_tokens : -self._num_added_end_tokens]
             # Folds indices
-            wrapped_indices = [
+            folded_indices = [
                 indices[i : i + self._effective_max_len]
                 for i in range(0, len(indices), self._effective_max_len)
             ]
             # Adds special tokens to each segment
-            wrapped_indices = [
+            folded_indices = [
                 self._tokenizer.build_inputs_with_special_tokens(segment)
-                for segment in wrapped_indices
+                for segment in folded_indices
             ]
             # Flattens
-            indices = [i for segment in wrapped_indices for i in segment]
+            indices = [i for segment in folded_indices for i in segment]
 
             result["token_ids"] = indices
             result["segment_concat_mask"] = [1] * len(indices)

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 import logging
 import torch
 from allennlp.common.util import pad_sequence_to_length
@@ -105,7 +105,9 @@ class PretrainedTransformerIndexer(TokenIndexer):
 
         return self._postprocess_output(output)
 
-    def _extract_token_and_type_ids(self, tokens: List[Token]) -> List[int]:
+    def _extract_token_and_type_ids(
+        self, tokens: List[Token]
+    ) -> Tuple[List[int], Optional[List[int]]]:
         """
         Roughly equivalent to `zip(*[(token.text_id, token.type_id) for token in tokens])`,
         with some checks.

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Union
 import logging
 import torch
 from allennlp.common.util import pad_sequence_to_length
@@ -31,13 +31,35 @@ class PretrainedTransformerIndexer(TokenIndexer):
         We use a somewhat confusing default value of `tags` so that we do not add padding or UNK
         tokens to this namespace, which would break on loading because we wouldn't find our default
         OOV token.
+    max_len: `int`, optional (default = -1)
+        If positive, split the document into segments of this many tokens (including special tokens)
+        before feeding into the embedder. The embedder embeds these segments independently and
+        concatenate the results to get the original document representation. Should be set to
+        the same value as the `max_len` option on the `PretrainedTransformerEmbedder`.
     """
 
-    def __init__(self, model_name: str, namespace: str = "tags", **kwargs) -> None:
+    def __init__(
+        self, model_name: str, namespace: str = "tags", max_len: int = -1, **kwargs
+    ) -> None:
         super().__init__(**kwargs)
         self._namespace = namespace
         self._tokenizer = AutoTokenizer.from_pretrained(model_name)
         self._added_to_vocabulary = False
+
+        (
+            self._num_added_start_tokens,
+            self._num_added_end_tokens,
+        ) = self._determine_num_special_tokens_added()
+
+        self._max_len = max_len
+        if self._max_len > 0:
+            self._effective_max_len = (  # we need to take into account special tokens
+                self._max_len - self._tokenizer.num_added_tokens()
+            )
+            if self._effective_max_len <= 0:
+                raise ValueError(
+                    "max_len needs to be greater than the number of special tokens inserted."
+                )
 
     def _add_encoding_to_vocabulary(self, vocab: Vocabulary) -> None:
         """
@@ -67,7 +89,15 @@ class PretrainedTransformerIndexer(TokenIndexer):
         pass
 
     @overrides
-    def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary) -> IndexedTokenList:
+    def tokens_to_indices(
+        self, tokens: List[Union[Token, int]], vocabulary: Vocabulary
+    ) -> IndexedTokenList:
+        """
+        `tokens` may already be indices, in which case the token -> index step is a no-op, but other
+        logic still takes place, e.g. long sequence wrapping.
+
+        `tokens` should have special tokens already inserted.
+        """
         if not self._added_to_vocabulary:
             self._add_encoding_to_vocabulary(vocabulary)
             self._added_to_vocabulary = True
@@ -75,7 +105,9 @@ class PretrainedTransformerIndexer(TokenIndexer):
         indices: List[int] = []
         type_ids: List[int] = []
         for token in tokens:
-            if getattr(token, "text_id", None) is not None:
+            if isinstance(token, int):
+                indices.append(token)
+            elif getattr(token, "text_id", None) is not None:
                 # `text_id` being set on the token means that we aren't using the vocab, we just use
                 # this id instead. Id comes from the pretrained vocab.
                 # It is computed in PretrainedTransformerTokenizer.
@@ -97,11 +129,40 @@ class PretrainedTransformerIndexer(TokenIndexer):
         result = {"token_ids": indices, "mask": mask}
         if type_ids is not None:
             result["type_ids"] = type_ids
+
+        if self._max_len > 0:
+            # We prepare long indices by converting them to (assuming max_len == 5)
+            # [CLS] A B C [SEP] [CLS] D E F [SEP] ...
+            # Embedder is responsible for folding this 1-d sequence to 2-d and feed to the
+            # transformer model.
+            # TODO(zhaofengw): we aren't respecting word boundaries when segmenting wordpieces.
+
+            # Strips original special tokens
+            indices = indices[self._num_added_start_tokens:-self._num_added_end_tokens]
+            # Folds indices
+            wrapped_indices = [
+                indices[i:i + self._effective_max_len]
+                for i in range(0, len(indices), self._effective_max_len)
+            ]
+            # Adds special tokens to each segment
+            wrapped_indices = [
+                self._tokenizer.build_inputs_with_special_tokens(segment)
+                for segment in wrapped_indices
+            ]
+            # Flattens
+            indices = [i for segment in wrapped_indices for i in segment]
+
+            result["token_ids"] = indices
+            result["segment_concat_mask"] = [1] * len(indices)
+
         return result
 
     @overrides
     def get_empty_token_list(self) -> IndexedTokenList:
-        return {"token_ids": [], "mask": [], "type_ids": []}
+        result = {"token_ids": [], "mask": [], "type_ids": []}
+        if self._max_len > 0:
+            result["segment_concat_mask"] = []
+        return result
 
     @overrides
     def as_padded_tensor_dict(
@@ -133,3 +194,33 @@ class PretrainedTransformerIndexer(TokenIndexer):
                     return False
             return True
         return NotImplemented
+
+    def _determine_num_special_tokens_added(self) -> Tuple[int, int]:
+        """
+        Determines the number of tokens self._tokenizer adds to a sequence (currently doesn't
+        consider sequence pairs) in the start & end.
+
+        # Returns
+        The number of tokens (`int`) that are inserted in the start & end of a sequence.
+        """
+        # Uses a slightly higher index to avoid tokenizer doing special things to lower-indexed
+        # tokens which might be special.
+        dummy = [1000]
+        inserted = self._tokenizer.build_inputs_with_special_tokens(dummy)
+
+        num_start = num_end = 0
+        seen_dummy = False
+        for idx in inserted:
+            if idx == dummy[0]:
+                if seen_dummy:  # seeing it twice
+                    raise ValueError("Cannot auto-determine the number of special tokens added.")
+                seen_dummy = True
+                continue
+
+            if not seen_dummy:
+                num_start += 1
+            else:
+                num_end += 1
+
+        assert num_start + num_end == self._tokenizer.num_added_tokens()
+        return num_start, num_end

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -31,15 +31,15 @@ class PretrainedTransformerIndexer(TokenIndexer):
         We use a somewhat confusing default value of `tags` so that we do not add padding or UNK
         tokens to this namespace, which would break on loading because we wouldn't find our default
         OOV token.
-    max_length : `int`, optional (default = -1)
-        If positive, split the document into segments of this many tokens (including special tokens)
+    max_length : `int`, optional (default = None)
+        If not None, split the document into segments of this many tokens (including special tokens)
         before feeding into the embedder. The embedder embeds these segments independently and
         concatenate the results to get the original document representation. Should be set to
         the same value as the `max_length` option on the `PretrainedTransformerEmbedder`.
     """
 
     def __init__(
-        self, model_name: str, namespace: str = "tags", max_length: int = -1, **kwargs
+        self, model_name: str, namespace: str = "tags", max_length: int = None, **kwargs
     ) -> None:
         super().__init__(**kwargs)
         self._namespace = namespace
@@ -52,7 +52,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
         ) = self.__class__.determine_num_special_tokens_added(self._tokenizer)
 
         self._max_length = max_length
-        if self._max_length > 0:
+        if self._max_length is not None:
             self._effective_max_length = (  # we need to take into account special tokens
                 self._max_length - self._tokenizer.num_added_tokens()
             )
@@ -130,7 +130,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
         if type_ids is not None:
             result["type_ids"] = type_ids
 
-        if self._max_length > 0:
+        if self._max_length is not None:
             # We prepare long indices by converting them to (assuming max_length == 5)
             # [CLS] A B C [SEP] [CLS] D E F [SEP] ...
             # Embedder is responsible for folding this 1-d sequence to 2-d and feed to the
@@ -160,7 +160,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
     @overrides
     def get_empty_token_list(self) -> IndexedTokenList:
         result: IndexedTokenList = {"token_ids": [], "mask": [], "type_ids": []}
-        if self._max_length > 0:
+        if self._max_length is not None:
             result["segment_concat_mask"] = []
         return result
 

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -163,7 +163,10 @@ class PretrainedTransformerIndexer(TokenIndexer):
             indices = [i for segment in folded_indices for i in segment]
 
             output["token_ids"] = indices
-            output["type_ids"] = self._tokenizer.create_token_type_ids_from_sequences(indices)
+            # `create_token_type_ids_from_sequences()` inserts special tokens
+            output["type_ids"] = self._tokenizer.create_token_type_ids_from_sequences(
+                indices[self._num_added_start_tokens:-self._num_added_end_tokens]
+            )
             output["segment_concat_mask"] = [1] * len(indices)
 
         return output

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -165,7 +165,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
             output["token_ids"] = indices
             # `create_token_type_ids_from_sequences()` inserts special tokens
             output["type_ids"] = self._tokenizer.create_token_type_ids_from_sequences(
-                indices[self._num_added_start_tokens:-self._num_added_end_tokens]
+                indices[self._num_added_start_tokens : -self._num_added_end_tokens]
             )
             output["segment_concat_mask"] = [1] * len(indices)
 

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -163,6 +163,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
             indices = [i for segment in folded_indices for i in segment]
 
             output["token_ids"] = indices
+            output["type_ids"] = self._tokenizer.create_token_type_ids_from_sequences(indices)
             output["segment_concat_mask"] = [1] * len(indices)
 
         return output

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -101,7 +101,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
         # The mask has 1 for real tokens and 0 for padding tokens. Only real tokens are attended to.
         output = {"token_ids": indices, "mask": [1] * len(indices)}
         if type_ids is not None:
-            result["type_ids"] = type_ids
+            output["type_ids"] = type_ids
 
         return self._postprocess_output(output)
 
@@ -162,17 +162,17 @@ class PretrainedTransformerIndexer(TokenIndexer):
             # Flattens
             indices = [i for segment in folded_indices for i in segment]
 
-            result["token_ids"] = indices
-            result["segment_concat_mask"] = [1] * len(indices)
+            output["token_ids"] = indices
+            output["segment_concat_mask"] = [1] * len(indices)
 
-        return result
+        return output
 
     @overrides
     def get_empty_token_list(self) -> IndexedTokenList:
-        result: IndexedTokenList = {"token_ids": [], "mask": [], "type_ids": []}
+        output: IndexedTokenList = {"token_ids": [], "mask": [], "type_ids": []}
         if self._max_length is not None:
-            result["segment_concat_mask"] = []
-        return result
+            output["segment_concat_mask"] = []
+        return output
 
     @overrides
     def as_padded_tensor_dict(

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 import logging
 import torch
 from allennlp.common.util import pad_sequence_to_length

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -107,7 +107,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
 
     def _extract_token_and_type_ids(self, tokens: List[Token]) -> List[int]:
         """
-        `tokens` should have special tokens already inserted.
+        Essentially returns `[token.text_id for token in tokens]`, with some checks.
         """
         indices: List[int] = []
         type_ids: List[int] = []
@@ -131,6 +131,13 @@ class PretrainedTransformerIndexer(TokenIndexer):
         return indices, type_ids
 
     def _postprocess_output(self, output: IndexedTokenList) -> IndexedTokenList:
+        """
+        Takes an IndexedTokenList about to be returned by `tokens_to_indices()` and adds any
+        necessary postprocessing, e.g. long sequence splitting.
+
+        The input should have a `"token_ids"` key corresponding to the token indices. They should
+        have special tokens already inserted.
+        """
         if self._max_length is not None:
             # We prepare long indices by converting them to (assuming max_length == 5)
             # [CLS] A B C [SEP] [CLS] D E F [SEP] ...

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -106,9 +106,7 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
             return True
         return NotImplemented
 
-    def _intra_word_tokenize(
-        self, tokens: List[Token]
-    ) -> Tuple[List[int], List[Tuple[int, int]]]:
+    def _intra_word_tokenize(self, tokens: List[Token]) -> Tuple[List[int], List[Tuple[int, int]]]:
         """
         Tokenizes each word into wordpieces separately and returns the wordpiece IDs.
         Also calculates offsets such that wordpices[offsets[i][0]:offsets[i][1] + 1]

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -62,7 +62,7 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
         indices, offsets = self._intra_word_tokenize(tokens)
         # `create_token_type_ids_from_sequences()` inserts special tokens
         type_ids = self._tokenizer.create_token_type_ids_from_sequences(
-            indices[self._num_added_start_tokens:-self._num_added_end_tokens]
+            indices[self._num_added_start_tokens : -self._num_added_end_tokens]
         )
         output: IndexedTokenList = {
             "token_ids": indices,

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -33,7 +33,7 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
         We use a somewhat confusing default value of `tags` so that we do not add padding or UNK
         tokens to this namespace, which would break on loading because we wouldn't find our default
         OOV token.
-    max_len: `int`, optional (default = -1)
+    max_len : `int`, optional (default = -1)
         If positive, split the document into segments of this many tokens (including special tokens)
         before feeding into the embedder. The embedder embeds these segments independently and
         concatenate the results to get the original document representation. Should be set to

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -32,20 +32,20 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
         We use a somewhat confusing default value of `tags` so that we do not add padding or UNK
         tokens to this namespace, which would break on loading because we wouldn't find our default
         OOV token.
-    max_len : `int`, optional (default = -1)
+    max_length : `int`, optional (default = -1)
         If positive, split the document into segments of this many tokens (including special tokens)
         before feeding into the embedder. The embedder embeds these segments independently and
         concatenate the results to get the original document representation. Should be set to
-        the same value as the `max_len` option on the `PretrainedTransformerMismatchedEmbedder`.
+        the same value as the `max_length` option on the `PretrainedTransformerMismatchedEmbedder`.
     """
 
     def __init__(
-        self, model_name: str, namespace: str = "tags", max_len: int = -1, **kwargs
+        self, model_name: str, namespace: str = "tags", max_length: int = -1, **kwargs
     ) -> None:
         super().__init__(**kwargs)
         # The matched version v.s. mismatched
         self._matched_indexer = PretrainedTransformerIndexer(
-            model_name, namespace, max_len, **kwargs
+            model_name, namespace, max_length, **kwargs
         )
         self._tokenizer = self._matched_indexer._tokenizer
         self._num_added_start_tokens = self._matched_indexer._num_added_start_tokens

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -58,7 +58,7 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
     @overrides
     def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary) -> IndexedTokenList:
         orig_token_mask = [1] * len(tokens)
-        tokens, offsets = self._intra_word_tokenize(tokens)
+        tokens, offsets = self._intra_word_tokenize(tokens)  # type: ignore
         wordpiece_mask = [1] * len(tokens)
 
         # {"token_ids": ..., "mask": ...}

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -47,9 +47,9 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
         self._matched_indexer = PretrainedTransformerIndexer(
             model_name, namespace, max_len, **kwargs
         )
+        self._tokenizer = self._matched_indexer._tokenizer
         self._num_added_start_tokens = self._matched_indexer._num_added_start_tokens
         self._num_added_end_tokens = self._matched_indexer._num_added_end_tokens
-        self._tokenizer = self._matched_indexer._tokenizer
 
     @overrides
     def count_vocab_items(self, token: Token, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -32,7 +32,7 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
         We use a somewhat confusing default value of `tags` so that we do not add padding or UNK
         tokens to this namespace, which would break on loading because we wouldn't find our default
         OOV token.
-    max_length : `int`, optional (default = -1)
+    max_length : `int`, optional (default = None)
         If positive, split the document into segments of this many tokens (including special tokens)
         before feeding into the embedder. The embedder embeds these segments independently and
         concatenate the results to get the original document representation. Should be set to
@@ -40,7 +40,7 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
     """
 
     def __init__(
-        self, model_name: str, namespace: str = "tags", max_length: int = -1, **kwargs
+        self, model_name: str, namespace: str = "tags", max_length: int = None, **kwargs
     ) -> None:
         super().__init__(**kwargs)
         # The matched version v.s. mismatched

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -60,10 +60,14 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
         self._matched_indexer._add_encoding_to_vocabulary_if_needed(vocabulary)
 
         indices, offsets = self._intra_word_tokenize(tokens)
+        # `create_token_type_ids_from_sequences()` inserts special tokens
+        type_ids = self._tokenizer.create_token_type_ids_from_sequences(
+            indices[self._num_added_start_tokens:-self._num_added_end_tokens]
+        )
         output: IndexedTokenList = {
             "token_ids": indices,
             "mask": [1] * len(tokens),  # for original tokens (i.e. word-level)
-            "type_ids": self._tokenizer.create_token_type_ids_from_sequences(indices),
+            "type_ids": type_ids,
             "offsets": offsets,
             "wordpiece_mask": [1] * len(indices),  # for wordpieces (i.e. subword-level)
         }

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -33,23 +33,24 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
         We use a somewhat confusing default value of `tags` so that we do not add padding or UNK
         tokens to this namespace, which would break on loading because we wouldn't find our default
         OOV token.
+    max_len: `int`, optional (default = -1)
+        If positive, split the document into segments of this many tokens (including special tokens)
+        before feeding into the embedder. The embedder embeds these segments independently and
+        concatenate the results to get the original document representation. Should be set to
+        the same value as the `max_len` option on the `PretrainedTransformerMismatchedEmbedder`.
     """
 
-    def __init__(self, model_name: str, namespace: str = "tags", **kwargs) -> None:
+    def __init__(
+        self, model_name: str, namespace: str = "tags", max_len: int = -1, **kwargs
+    ) -> None:
         super().__init__(**kwargs)
         # The matched version v.s. mismatched
-        self._matched_indexer = PretrainedTransformerIndexer(model_name, namespace, **kwargs)
-
-        # add_special_tokens=False since we don't want wordpieces to be surrounded by special tokens
-        self._allennlp_tokenizer = PretrainedTransformerTokenizer(
-            model_name, add_special_tokens=False
+        self._matched_indexer = PretrainedTransformerIndexer(
+            model_name, namespace, max_len, **kwargs
         )
-        self._tokenizer = self._allennlp_tokenizer.tokenizer
-
-        (
-            self._num_added_start_tokens,
-            self._num_added_end_tokens,
-        ) = self._determine_num_special_tokens_added()
+        self._num_added_start_tokens = self._matched_indexer._num_added_start_tokens
+        self._num_added_end_tokens = self._matched_indexer._num_added_end_tokens
+        self._tokenizer = self._matched_indexer._tokenizer
 
     @overrides
     def count_vocab_items(self, token: Token, counter: Dict[str, Dict[str, int]]):
@@ -59,22 +60,14 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
     def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary) -> IndexedTokenList:
         orig_token_mask = [1] * len(tokens)
         tokens, offsets = self._intra_word_tokenize(tokens)
+        wordpiece_mask = [1] * len(tokens)
 
         # {"token_ids": ..., "mask": ...}
         output = self._matched_indexer.tokens_to_indices(tokens, vocabulary)
 
-        # Insert type ids for the special tokens.
-        output["type_ids"] = self._tokenizer.create_token_type_ids_from_sequences(
-            output["token_ids"]
-        )
-        # Insert the special tokens themselves.
-        output["token_ids"] = self._tokenizer.build_inputs_with_special_tokens(output["token_ids"])
         output["mask"] = orig_token_mask
-        output["offsets"] = [
-            (start + self._num_added_start_tokens, end + self._num_added_start_tokens)
-            for start, end in offsets
-        ]
-        output["wordpiece_mask"] = [1] * len(output["token_ids"])
+        output["offsets"] = offsets
+        output["wordpiece_mask"] = wordpiece_mask
         return output
 
     @overrides
@@ -116,17 +109,19 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
 
     def _intra_word_tokenize(
         self, tokens: List[Token]
-    ) -> Tuple[List[Token], List[Tuple[int, int]]]:
+    ) -> Tuple[List[int], List[Tuple[int, int]]]:
         """
-        Tokenizes each word into wordpieces separately. Also calculates offsets such that
-        wordpices[offsets[i][0]:offsets[i][1] + 1] corresponds to the original i-th token.
-        Does not insert special tokens.
+        Tokenizes each word into wordpieces separately and returns the wordpiece IDs.
+        Also calculates offsets such that wordpices[offsets[i][0]:offsets[i][1] + 1]
+        corresponds to the original i-th token.
+
+        This function inserts special tokens.
         """
-        wordpieces: List[Token] = []
+        wordpieces: List[int] = []
         offsets = []
-        cumulative = 0
+        cumulative = self._num_added_start_tokens
         for token in tokens:
-            subword_wordpieces = self._allennlp_tokenizer.tokenize(token.text)
+            subword_wordpieces = self._tokenizer.encode(token.text, add_special_tokens=False)
             wordpieces.extend(subword_wordpieces)
 
             start_offset = cumulative
@@ -134,34 +129,7 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
             end_offset = cumulative - 1  # inclusive
             offsets.append((start_offset, end_offset))
 
+        wordpieces = self._tokenizer.build_inputs_with_special_tokens(wordpieces)
+        assert cumulative + self._num_added_end_tokens == len(wordpieces)
+
         return wordpieces, offsets
-
-    def _determine_num_special_tokens_added(self) -> Tuple[int, int]:
-        """
-        Determines the number of tokens self._tokenizer adds to a sequence (currently doesn't
-        consider sequence pairs) in the start & end.
-
-        # Returns
-        The number of tokens (`int`) that are inserted in the start & end of a sequence.
-        """
-        # Uses a slightly higher index to avoid tokenizer doing special things to lower-indexed
-        # tokens which might be special.
-        dummy = [1000]
-        inserted = self._tokenizer.build_inputs_with_special_tokens(dummy)
-
-        num_start = num_end = 0
-        seen_dummy = False
-        for idx in inserted:
-            if idx == dummy[0]:
-                if seen_dummy:  # seeing it twice
-                    raise ValueError("Cannot auto-determine the number of special tokens added.")
-                seen_dummy = True
-                continue
-
-            if not seen_dummy:
-                num_start += 1
-            else:
-                num_end += 1
-
-        assert num_start + num_end == self._tokenizer.num_added_tokens()
-        return num_start, num_end

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -9,7 +9,6 @@ from allennlp.data.vocabulary import Vocabulary
 from allennlp.data.tokenizers.token import Token
 from allennlp.data.token_indexers import PretrainedTransformerIndexer, TokenIndexer
 from allennlp.data.token_indexers.token_indexer import IndexedTokenList
-from allennlp.data.tokenizers import PretrainedTransformerTokenizer
 
 logger = logging.getLogger(__name__)
 

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -21,17 +21,17 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
     model_name : `str`
         The name of the `transformers` model to use. Should be the same as the corresponding
         `PretrainedTransformerIndexer`.
-    max_len : `int`, optional (default = -1)
+    max_length : `int`, optional (default = -1)
         If positive, folds input token IDs into multiple segments of this length, pass them
         through the transformer model independently, and concatenate the final representations.
-        Should be set to the same value as the `max_len` option on the
+        Should be set to the same value as the `max_length` option on the
         `PretrainedTransformerIndexer`.
     """
 
-    def __init__(self, model_name: str, max_len: int = -1) -> None:
+    def __init__(self, model_name: str, max_length: int = -1) -> None:
         super().__init__()
         self.transformer_model = AutoModel.from_pretrained(model_name)
-        self._max_len = max_len
+        self._max_length = max_length
         # I'm not sure if this works for all models; open an issue on github if you find a case
         # where it doesn't work.
         self.output_dim = self.transformer_model.config.hidden_size
@@ -59,7 +59,9 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         # Parameters
 
         token_ids: torch.LongTensor
-            Shape: [batch_size, num_wordpieces if max_len <= 0 else num_segment_concat_wordpieces].
+            Shape: [
+                batch_size, num_wordpieces if max_length <= 0 else num_segment_concat_wordpieces
+            ].
             num_segment_concat_wordpieces is num_wordpieces plus special tokens inserted in the
             middle, i.e. the length of: "[CLS] A B C [SEP] [CLS] D E F [SEP]" (see indexer logic).
         mask: torch.LongTensor
@@ -81,35 +83,35 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
 
         batch_size = token_ids.size(0)
 
-        if self._max_len > 0:
+        if self._max_length > 0:
             # [ [CLS] A B C [SEP] [CLS] D E F [SEP] ] ->
             # [ [ [CLS] A B C [SEP] ], [ [CLS] D E F [SEP] ] ]
             num_segment_concat_wordpieces = token_ids.size(1)
-            num_segments = math.ceil(num_segment_concat_wordpieces / self._max_len)
-            padded_length = num_segments * self._max_len
+            num_segments = math.ceil(num_segment_concat_wordpieces / self._max_length)
+            padded_length = num_segments * self._max_length
             length_to_pad = padded_length - num_segment_concat_wordpieces
 
             def fold(tensor):  # Shape: [batch_size, num_segment_concat_wordpieces]
-                # Shape: [batch_size, num_segments * self._max_len]
+                # Shape: [batch_size, num_segments * self._max_length]
                 tensor = F.pad(tensor, [0, length_to_pad], value=0)
-                # Shape: [batch_size * num_segments, self._max_len]
-                return tensor.reshape(-1, self._max_len)
+                # Shape: [batch_size * num_segments, self._max_length]
+                return tensor.reshape(-1, self._max_length)
 
             token_ids = fold(token_ids)
             segment_concat_mask = fold(segment_concat_mask)
 
-        transformer_mask = segment_concat_mask if self._max_len > 0 else mask
+        transformer_mask = segment_concat_mask if self._max_length > 0 else mask
         # Shape: [batch_size, num_wordpieces, embedding_size],
-        # or if self._max_len > 0: [batch_size * num_segments, self._max_len, embedding_size]
+        # or if self._max_length > 0: [batch_size * num_segments, self._max_len, embedding_size]
         embeddings = self.transformer_model(
             input_ids=token_ids, token_type_ids=type_ids, attention_mask=transformer_mask
         )[0]
         embedding_size = embeddings.size(2)
 
-        if self._max_len > 0:
+        if self._max_length > 0:
             # We truncate the start and end tokens for all segments, recombine the segments,
             # and manually add back the start tokens. We generally don't need to add back
-            # the end tokens -- because the last segment is usually shorter than self._max_len,
+            # the end tokens -- because the last segment is usually shorter than self._max_length,
             # the final end tokens usually won't be touched in our truncation process.
             #
             # There are special cases where sequences have a full last segment. The only issue
@@ -124,7 +126,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             )
 
             embeddings = embeddings.reshape(
-                batch_size, num_segments * self._max_len, embedding_size
+                batch_size, num_segments * self._max_length, embedding_size
             )
             # Shape: (batch_size, self._num_added_start_tokens, embedding_size)
             start_token_embeddings = embeddings[:, : self._num_added_start_tokens, :]
@@ -133,7 +135,9 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             # Shape: (batch_size, self._num_added_end_tokens, embedding_size)
             last_token_embeddings = embeddings[:, -self._num_added_end_tokens :, :]
 
-            embeddings = embeddings.reshape(batch_size, num_segments, self._max_len, embedding_size)
+            embeddings = embeddings.reshape(
+                batch_size, num_segments, self._max_length, embedding_size
+            )
             embeddings = embeddings[
                 :, :, self._num_added_start_tokens : -self._num_added_end_tokens, :
             ]  # truncate segment-level start/end tokens

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -135,7 +135,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
 
             embeddings = embeddings.reshape(batch_size, num_segments, self._max_len, embedding_size)
             embeddings = embeddings[
-                :, :, self._num_added_start_tokens:self._num_added_end_tokens, :
+                :, :, self._num_added_start_tokens:-self._num_added_end_tokens, :
             ]  # truncate segment-level start/end tokens
             embeddings = embeddings.reshape(batch_size, -1, embedding_size)  # flatten
             embeddings = torch.cat([start_token_embeddings, embeddings, last_token_embeddings], 1)

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -3,6 +3,7 @@ from typing import Optional
 from overrides import overrides
 from transformers.modeling_auto import AutoModel
 import torch
+import torch.nn.functional as F
 
 from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 
@@ -11,11 +12,22 @@ from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 class PretrainedTransformerEmbedder(TokenEmbedder):
     """
     Uses a pretrained model from `transformers` as a `TokenEmbedder`.
+
+    # Parameters
+
+    model_name : `str`
+        The name of the `transformers` model to use.
+    max_len: `int`, optional (default = -1)
+        If positive, folds input token IDs into multiple segments of this length, pass them
+        through the transformer model independently, and concatenate the final representations.
+        Should be set to the same value as the `max_len` option on the
+        `PretrainedTransformerIndexer`.
     """
 
-    def __init__(self, model_name: str) -> None:
+    def __init__(self, model_name: str, max_len: int = -1) -> None:
         super().__init__()
         self.transformer_model = AutoModel.from_pretrained(model_name)
+        self._max_len = max_len
         # I'm not sure if this works for all models; open an issue on github if you find a case
         # where it doesn't work.
         self.output_dim = self.transformer_model.config.hidden_size
@@ -30,14 +42,19 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         token_ids: torch.LongTensor,
         mask: torch.LongTensor,
         type_ids: Optional[torch.LongTensor] = None,
+        segment_concat_mask: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:  # type: ignore
         """
         # Parameters
 
         token_ids: torch.LongTensor
-            Shape: [batch_size, num_wordpieces].
+            Shape: [batch_size, num_wordpieces if max_len <= 0 else num_segment_concat_wordpieces].
+            num_segment_concat_wordpieces is num_wordpieces plus special tokens inserted in the
+            middle, i.e. the length of: "[CLS] A B C [SEP] [CLS] D E F [SEP]" (see indexer logic).
         mask: torch.LongTensor
-            Shape: [batch_size, num_wordpieces].
+             Shape: [batch_size, num_wordpieces].
+        segment_concat_mask: torch.LongTensor, optional.
+            Shape: [batch_size, num_segment_concat_wordpieces].
 
         # Returns:
 
@@ -50,6 +67,67 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             == 1
         ):
             raise ValueError("Found type ids too large for the chosen transformer model.")
-        return self.transformer_model(
-            input_ids=token_ids, token_type_ids=type_ids, attention_mask=mask
+
+        batch_size = token_ids.size(0)
+
+        if self._max_len > 0:
+            # [ [CLS] A B C [SEP] [CLS] D E F [SEP] ] ->
+            # [ [ [CLS] A B C [SEP] ], [ [CLS] D E F [SEP] ] ]
+            num_segment_concat_wordpieces = token_ids.size(1)
+            num_segments = (num_segment_concat_wordpieces / self._max_len).ceil()
+            padded_length = num_segments * self._max_len
+            length_to_pad = padded_length - num_segment_concat_wordpieces
+
+            def fold(tensor):  # Shape: [batch_size, num_segment_concat_wordpieces]
+                # Shape: [batch_size, num_segments * self._max_len]
+                tensor = F.pad(tensor, [0, length_to_pad])
+                # Shape: [batch_size * num_segments, self._max_len]
+                return tensor.reshape(-1, self._max_len)
+
+            token_ids = fold(token_ids)
+            segment_concat_mask = fold(segment_concat_mask)
+
+        transformer_mask = segment_concat_mask if self._max_len > 0 else mask
+        # Shape: [batch_size, num_wordpieces, embedding_size],
+        # or if self._max_len > 0: [batch_size * num_segments, self._max_len, embedding_size]
+        embeddings = self.transformer_model(
+            input_ids=token_ids, token_type_ids=type_ids, attention_mask=transformer_mask
         )[0]
+        embedding_size = embeddings.size(2)
+
+        if self._max_len > 0:
+            # We truncate the start and end tokens for all segments, recombine the segments,
+            # and manually add back the start tokens. We generally don't need to add back
+            # the end tokens -- because the last segment is usually shorter than self._max_len,
+            # the final end tokens usually won't be touched in our truncation process.
+            #
+            # There are special cases where sequences have a full last segment. The only issue
+            # in this case is that the [SEP] embedding will be wrong. Nevertheless, [SEP] embeddings
+            # are rarely, if ever, used, so it shouldn't be a huge problem. However, we do remedy
+            # this case when such sequences with a full last segment are the longest ones in a batch
+            # by adding back the last token representations.
+
+            # We want to remove all segment-level special tokens but maintain sequence-level ones
+            num_wordpieces = (
+                num_segment_concat_wordpieces - (num_segments - 1) * self._num_added_tokens
+            )
+
+            embeddings = embeddings.reshape(
+                batch_size, num_segments * self._max_len, embedding_size
+            )
+            # Shape: (batch_size, self._num_added_start_tokens, embedding_size)
+            start_token_embeddings = embeddings[:, :self._num_added_start_tokens, :]
+            # See comment above -- remedy when the longest sequences have full last segments.
+            # This is not necessarily the end token embeddings when sequences aren't full.
+            # Shape: (batch_size, self._num_added_end_tokens, embedding_size)
+            last_token_embeddings = embeddings[:, -self._num_added_end_tokens:, :]
+
+            embeddings = embeddings.reshape(batch_size, num_segments, self._max_len, embedding_size)
+            embeddings = embeddings[
+                :, :, self._num_added_start_tokens:self._num_added_end_tokens, :
+            ]  # truncate segment-level start/end tokens
+            embeddings = embeddings.reshape(batch_size, -1, embedding_size)  # flatten
+            embeddings = torch.cat([start_token_embeddings, embeddings, last_token_embeddings], 1)
+            embeddings = embeddings[:, :num_wordpieces, :]
+
+        return embeddings

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -185,13 +185,9 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         embedding_size = embeddings.size(2)
 
         # We want to remove all segment-level special tokens but maintain sequence-level ones
-        num_wordpieces = (
-            num_segment_concat_wordpieces - (num_segments - 1) * self._num_added_tokens
-        )
+        num_wordpieces = num_segment_concat_wordpieces - (num_segments - 1) * self._num_added_tokens
 
-        embeddings = embeddings.reshape(
-            batch_size, num_segments * self._max_length, embedding_size
-        )
+        embeddings = embeddings.reshape(batch_size, num_segments * self._max_length, embedding_size)
         # Shape: (batch_size, self._num_added_start_tokens, embedding_size)
         start_token_embeddings = embeddings[:, : self._num_added_start_tokens, :]
         # See comment above -- remedy when the longest sequences have full last segments.
@@ -199,9 +195,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         # Shape: (batch_size, self._num_added_end_tokens, embedding_size)
         last_token_embeddings = embeddings[:, -self._num_added_end_tokens :, :]
 
-        embeddings = embeddings.reshape(
-            batch_size, num_segments, self._max_length, embedding_size
-        )
+        embeddings = embeddings.reshape(batch_size, num_segments, self._max_length, embedding_size)
         embeddings = embeddings[
             :, :, self._num_added_start_tokens : -self._num_added_end_tokens, :
         ]  # truncate segment-level start/end tokens

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -91,7 +91,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
 
             def fold(tensor):  # Shape: [batch_size, num_segment_concat_wordpieces]
                 # Shape: [batch_size, num_segments * self._max_len]
-                tensor = F.pad(tensor, [0, length_to_pad])
+                tensor = F.pad(tensor, [0, length_to_pad], value=0)
                 # Shape: [batch_size * num_segments, self._max_len]
                 return tensor.reshape(-1, self._max_len)
 

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -67,7 +67,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
                 batch_size, num_wordpieces if max_length is None else num_segment_concat_wordpieces
             ].
             num_segment_concat_wordpieces is num_wordpieces plus special tokens inserted in the
-            middle, i.e. the length of: "[CLS] A B C [SEP] [CLS] D E F [SEP]" (see indexer logic).
+            middle, e.g. the length of: "[CLS] A B C [SEP] [CLS] D E F [SEP]" (see indexer logic).
         mask: torch.LongTensor
              Shape: [batch_size, num_wordpieces].
         segment_concat_mask: torch.LongTensor, optional.

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -180,11 +180,11 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         embeddings: `torch.FloatTensor`
             Shape: [batch_size, self._num_wordpieces, embedding_size].
         """
+
         def lengths_to_mask(lengths, max_len, device):
-            return (
-                torch.arange(max_len, device=device).expand(lengths.size(0), max_len)
-                < lengths.unsqueeze(1)
-            )
+            return torch.arange(max_len, device=device).expand(
+                lengths.size(0), max_len
+            ) < lengths.unsqueeze(1)
 
         device = embeddings.device
         num_segments = int(embeddings.size(0) / batch_size)

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -213,7 +213,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         seq_lengths = mask.sum(-1)
         if not (lengths_to_mask(seq_lengths, mask.size(1), device) == mask).all():
             raise ValueError(
-                'Long sequence splitting only supports masks with all 1s preceding all 0s.'
+                "Long sequence splitting only supports masks with all 1s preceding all 0s."
             )
         # Shape: (batch_size, self._num_added_end_tokens); this is a broadcast op
         end_token_indices = (

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -204,7 +204,9 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             lengths_to_mask(seq_lengths, segment_concat_mask.size(1), device) == segment_concat_mask
         ).all()
         # Shape: (batch_size, self._num_added_end_tokens); this is a broadcast op
-        end_token_indices = seq_lengths.unsqueeze(-1) - torch.arange(self._num_added_end_tokens) - 1
+        end_token_indices = (
+            seq_lengths.unsqueeze(-1) - torch.arange(self._num_added_end_tokens, device=device) - 1
+        )
 
         # Shape: (batch_size, self._num_added_start_tokens, embedding_size)
         start_token_embeddings = embeddings[:, : self._num_added_start_tokens, :]

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -127,15 +127,15 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
                 batch_size, num_segments * self._max_len, embedding_size
             )
             # Shape: (batch_size, self._num_added_start_tokens, embedding_size)
-            start_token_embeddings = embeddings[:, :self._num_added_start_tokens, :]
+            start_token_embeddings = embeddings[:, : self._num_added_start_tokens, :]
             # See comment above -- remedy when the longest sequences have full last segments.
             # This is not necessarily the end token embeddings when sequences aren't full.
             # Shape: (batch_size, self._num_added_end_tokens, embedding_size)
-            last_token_embeddings = embeddings[:, -self._num_added_end_tokens:, :]
+            last_token_embeddings = embeddings[:, -self._num_added_end_tokens :, :]
 
             embeddings = embeddings.reshape(batch_size, num_segments, self._max_len, embedding_size)
             embeddings = embeddings[
-                :, :, self._num_added_start_tokens:-self._num_added_end_tokens, :
+                :, :, self._num_added_start_tokens : -self._num_added_end_tokens, :
             ]  # truncate segment-level start/end tokens
             embeddings = embeddings.reshape(batch_size, -1, embedding_size)  # flatten
             embeddings = torch.cat([start_token_embeddings, embeddings, last_token_embeddings], 1)

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -114,7 +114,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         that are in reality multiple segments concatenated together, to 2D tensors, i.e.
 
         [ [CLS] A B C [SEP] [CLS] D E [SEP] ]
-        -> [ [ [CLS] A B C [SEP] ], [ [CLS] D E [PAD] [SEP] ] ]
+        -> [ [ [CLS] A B C [SEP] ], [ [CLS] D E [SEP] [PAD] ] ]
         The [PAD] positions can be found in the returned `segment_concat_mask`.
 
         # Parameters
@@ -153,7 +153,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         We take 2D segments of a long sequence and flatten them out to get the whole sequence
         representation while remove unnecessary special tokens.
 
-        [ [ [CLS]_emb A_emb B_emb C_emb [SEP]_emb ], [ [CLS]_emb D_emb E_emb [PAD]_emb [SEP]_emb ] ]
+        [ [ [CLS]_emb A_emb B_emb C_emb [SEP]_emb ], [ [CLS]_emb D_emb E_emb [SEP]_emb [PAD]_emb ] ]
         -> [ [CLS]_emb A_emb B_emb C_emb D_emb E_emb [SEP]_emb ]
 
         We truncate the start and end tokens for all segments, recombine the segments,

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -1,9 +1,5 @@
 import math
-<<<<<<< HEAD
-from typing import Optional
-=======
-from typing import Tuple
->>>>>>> Factor out long sequence handling logic in embedder in separate functions
+from typing import Optional, Tuple
 
 from overrides import overrides
 from transformers.modeling_auto import AutoModel
@@ -70,9 +66,11 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             num_segment_concat_wordpieces is num_wordpieces plus special tokens inserted in the
             middle, e.g. the length of: "[CLS] A B C [SEP] [CLS] D E F [SEP]" (see indexer logic).
         mask: torch.LongTensor
-             Shape: [batch_size, num_wordpieces].
+            Shape: [batch_size, num_wordpieces].
         type_ids: Optional[torch.LongTensor]
-             Shape: [batch_size, num_wordpieces].
+            Shape: [
+                batch_size, num_wordpieces if max_length is None else num_segment_concat_wordpieces
+            ].
         segment_concat_mask: Optional[torch.LongTensor]
             Shape: [batch_size, num_segment_concat_wordpieces].
 
@@ -87,6 +85,9 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             == 1
         ):
             raise ValueError("Found type ids too large for the chosen transformer model.")
+
+        if type_ids is not None:
+            assert token_ids.shape == type_ids.shape
 
         if self._max_length is not None:
             batch_size, num_segment_concat_wordpieces = token_ids.size()

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -115,7 +115,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         token_ids: torch.LongTensor,
         segment_concat_mask: torch.LongTensor,
         type_ids: Optional[torch.LongTensor] = None,
-    ) -> Tuple[torch.LongTensor, torch.LongTensor]:
+    ) -> Tuple[torch.LongTensor, torch.LongTensor, Optional[torch.LongTensor]]:
         """
         We fold 1D sequences (for each element in batch), returned by `PretrainedTransformerIndexer`
         that are in reality multiple segments concatenated together, to 2D tensors, i.e.

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -74,7 +74,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
 
         # span_embeddings: (batch_size, num_orig_tokens, max_span_length, embedding_size)
         # span_mask: (batch_size, num_orig_tokens, max_span_length)
-        span_embeddings, span_mask = util.batched_span_select(embeddings, offsets)
+        span_embeddings, span_mask = util.batched_span_select(embeddings.contiguous(), offsets)
         span_mask = span_mask.unsqueeze(-1)
         span_embeddings *= span_mask  # zero out paddings
 

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -18,17 +18,17 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
     model_name : `str`
         The name of the `transformers` model to use. Should be the same as the corresponding
         `PretrainedTransformerMismatchedIndexer`.
-    max_len : `int`, optional (default = -1)
+    max_length : `int`, optional (default = -1)
         If positive, folds input token IDs into multiple segments of this length, pass them
         through the transformer model independently, and concatenate the final representations.
-        Should be set to the same value as the `max_len` option on the
+        Should be set to the same value as the `max_length` option on the
         `PretrainedTransformerMismatchedIndexer`.
     """
 
-    def __init__(self, model_name: str, max_len: int = -1) -> None:
+    def __init__(self, model_name: str, max_length: int = -1) -> None:
         super().__init__()
         # The matched version v.s. mismatched
-        self._matched_embedder = PretrainedTransformerEmbedder(model_name, max_len)
+        self._matched_embedder = PretrainedTransformerEmbedder(model_name, max_length)
 
     @overrides
     def get_output_dim(self):

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -18,14 +18,14 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
     model_name : `str`
         The name of the `transformers` model to use. Should be the same as the corresponding
         `PretrainedTransformerMismatchedIndexer`.
-    max_length : `int`, optional (default = -1)
+    max_length : `int`, optional (default = None)
         If positive, folds input token IDs into multiple segments of this length, pass them
         through the transformer model independently, and concatenate the final representations.
         Should be set to the same value as the `max_length` option on the
         `PretrainedTransformerMismatchedIndexer`.
     """
 
-    def __init__(self, model_name: str, max_length: int = -1) -> None:
+    def __init__(self, model_name: str, max_length: int = None) -> None:
         super().__init__()
         # The matched version v.s. mismatched
         self._matched_embedder = PretrainedTransformerEmbedder(model_name, max_length)

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -16,8 +16,9 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
     # Parameters
 
     model_name : `str`
-        The name of the `transformers` model to use.
-    max_len: `int`, optional (default = -1)
+        The name of the `transformers` model to use. Should be the same as the corresponding
+        `PretrainedTransformerMismatchedIndexer`.
+    max_len : `int`, optional (default = -1)
         If positive, folds input token IDs into multiple segments of this length, pass them
         through the transformer model independently, and concatenate the final representations.
         Should be set to the same value as the `max_len` option on the

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -59,9 +59,9 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         wordpiece_mask: torch.LongTensor
             Shape: [batch_size, num_wordpieces].
         type_ids: Optional[torch.LongTensor]
-            Shape: [batch_size, num_wordpieces]
+            Shape: [batch_size, num_wordpieces].
         segment_concat_mask: Optional[torch.LongTensor]
-            Not directly used here. See `PretrainedTransformerEmbedder`.
+            See `PretrainedTransformerEmbedder`.
 
         # Returns:
 

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -1250,7 +1250,7 @@ def batched_index_select(
         flattened_indices = flatten_and_batch_shift_indices(indices, target.size(1))
 
     # Shape: (batch_size * sequence_length, embedding_size)
-    flattened_target = target.view(-1, target.size(-1))
+    flattened_target = target.reshape(-1, target.size(-1))
 
     # Shape: (batch_size * d_1 * ... * d_n, embedding_size)
     flattened_selected = flattened_target.index_select(0, flattened_indices)

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -1250,7 +1250,7 @@ def batched_index_select(
         flattened_indices = flatten_and_batch_shift_indices(indices, target.size(1))
 
     # Shape: (batch_size * sequence_length, embedding_size)
-    flattened_target = target.reshape(-1, target.size(-1))
+    flattened_target = target.view(-1, target.size(-1))
 
     # Shape: (batch_size * d_1 * ... * d_n, embedding_size)
     flattened_selected = flattened_target.index_select(0, flattened_indices)

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -144,8 +144,11 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
         assert len(expected_ids) == 7  # just to make sure it's what we're expecting
         cls_id, sep_id = expected_ids[0], expected_ids[-1]
         expected_ids = (
-            expected_ids[:3] + [sep_id, cls_id]
-            + expected_ids[3:5] + [sep_id, cls_id] + expected_ids[5:]
+            expected_ids[:3]
+            + [sep_id, cls_id]
+            + expected_ids[3:5]
+            + [sep_id, cls_id]
+            + expected_ids[5:]
         )
 
         allennlp_tokens = allennlp_tokenizer.tokenize(string_no_specials)

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -128,3 +128,7 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
             assert len(padded_tokens["token_ids"]) == max_length
             padding_suffix = [allennlp_tokenizer.tokenizer.pad_token_id] * padding_length
             assert padded_tokens["token_ids"][-padding_length:].tolist() == padding_suffix
+
+    def test_auto_determining_num_tokens_added(self):
+        indexer = PretrainedTransformerIndexer("bert-base-cased")
+        assert indexer._determine_num_special_tokens_added() == (1, 1)

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -136,7 +136,7 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
     def test_long_sequence_splitting(self):
         tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
         allennlp_tokenizer = PretrainedTransformerTokenizer("bert-base-uncased")
-        indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased", max_len=4)
+        indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased", max_length=4)
         string_specials = "[CLS] AllenNLP is great [SEP]"
         string_no_specials = "AllenNLP is great"
         tokens = tokenizer.tokenize(string_specials)

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -133,7 +133,7 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
         tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
         assert PretrainedTransformerIndexer.determine_num_special_tokens_added(tokenizer) == (1, 1)
 
-    def test_long_sequence_folding(self):
+    def test_long_sequence_splitting(self):
         tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
         allennlp_tokenizer = PretrainedTransformerTokenizer("bert-base-uncased")
         indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased", max_len=4)

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -129,9 +129,9 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
             padding_suffix = [allennlp_tokenizer.tokenizer.pad_token_id] * padding_length
             assert padded_tokens["token_ids"][-padding_length:].tolist() == padding_suffix
 
-    def test_auto_determining_num_tokens_added(self):
-        indexer = PretrainedTransformerIndexer("bert-base-cased")
-        assert indexer._determine_num_special_tokens_added() == (1, 1)
+    def test_determine_num_special_tokens_added(self):
+        tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+        assert PretrainedTransformerIndexer.determine_num_special_tokens_added(tokenizer) == (1, 1)
 
     def test_long_sequence_folding(self):
         tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -132,3 +132,25 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
     def test_auto_determining_num_tokens_added(self):
         indexer = PretrainedTransformerIndexer("bert-base-cased")
         assert indexer._determine_num_special_tokens_added() == (1, 1)
+
+    def test_long_sequence_folding(self):
+        tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+        allennlp_tokenizer = PretrainedTransformerTokenizer("bert-base-uncased")
+        indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased", max_len=4)
+        string_specials = "[CLS] AllenNLP is great [SEP]"
+        string_no_specials = "AllenNLP is great"
+        tokens = tokenizer.tokenize(string_specials)
+        expected_ids = tokenizer.convert_tokens_to_ids(tokens)
+        assert len(expected_ids) == 7  # just to make sure it's what we're expecting
+        cls_id, sep_id = expected_ids[0], expected_ids[-1]
+        expected_ids = (
+            expected_ids[:3] + [sep_id, cls_id]
+            + expected_ids[3:5] + [sep_id, cls_id] + expected_ids[5:]
+        )
+
+        allennlp_tokens = allennlp_tokenizer.tokenize(string_no_specials)
+        vocab = Vocabulary()
+        indexed = indexer.tokens_to_indices(allennlp_tokens, vocab)
+        assert indexed["token_ids"] == expected_ids
+        assert indexed["segment_concat_mask"] == [1] * len(expected_ids)
+        assert indexed["mask"] == [1] * 7  # original length

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
@@ -35,7 +35,7 @@ class TestPretrainedTransformerMismatchedIndexer(AllenNlpTestCase):
                 expected_value = [list(t) for t in expected_value]
             assert padded_tokens[key].tolist() == expected_value
 
-    def test_long_sequence_folding(self):
+    def test_long_sequence_splitting(self):
         tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
         indexer = PretrainedTransformerMismatchedIndexer("bert-base-uncased", max_len=4)
         text = ["AllenNLP", "is", "great"]

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
@@ -34,7 +34,3 @@ class TestPretrainedTransformerMismatchedIndexer(AllenNlpTestCase):
             if key == "offsets":
                 expected_value = [list(t) for t in expected_value]
             assert padded_tokens[key].tolist() == expected_value
-
-    def test_auto_determining_num_tokens_added(self):
-        indexer = PretrainedTransformerMismatchedIndexer("bert-base-cased")
-        assert indexer._determine_num_special_tokens_added() == (1, 1)

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
@@ -34,3 +34,27 @@ class TestPretrainedTransformerMismatchedIndexer(AllenNlpTestCase):
             if key == "offsets":
                 expected_value = [list(t) for t in expected_value]
             assert padded_tokens[key].tolist() == expected_value
+
+    def test_long_sequence_folding(self):
+        tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+        indexer = PretrainedTransformerMismatchedIndexer("bert-base-uncased", max_len=4)
+        text = ["AllenNLP", "is", "great"]
+        tokens = tokenizer.tokenize(" ".join(["[CLS]"] + text + ["[SEP]"]))
+        expected_ids = tokenizer.convert_tokens_to_ids(tokens)
+        assert len(expected_ids) == 7  # just to make sure it's what we're expecting
+        cls_id, sep_id = expected_ids[0], expected_ids[-1]
+        expected_ids = (
+            expected_ids[:3] + [sep_id, cls_id]
+            + expected_ids[3:5] + [sep_id, cls_id] + expected_ids[5:]
+        )
+
+        vocab = Vocabulary()
+        indexed = indexer.tokens_to_indices([Token(word) for word in text], vocab)
+
+        assert indexed["token_ids"] == expected_ids
+        # [CLS] allen ##nl [SEP] [CLS] #p is [SEP] [CLS] great [SEP]
+        assert indexed["segment_concat_mask"] == [1] * len(expected_ids)
+        # allennlp is great
+        assert indexed["mask"] == [1] * len(text)
+        # [CLS] allen #nl #p is great [SEP]
+        assert indexed["wordpiece_mask"] == [1] * 7

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
@@ -37,7 +37,7 @@ class TestPretrainedTransformerMismatchedIndexer(AllenNlpTestCase):
 
     def test_long_sequence_splitting(self):
         tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
-        indexer = PretrainedTransformerMismatchedIndexer("bert-base-uncased", max_len=4)
+        indexer = PretrainedTransformerMismatchedIndexer("bert-base-uncased", max_length=4)
         text = ["AllenNLP", "is", "great"]
         tokens = tokenizer.tokenize(" ".join(["[CLS]"] + text + ["[SEP]"]))
         expected_ids = tokenizer.convert_tokens_to_ids(tokens)

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
@@ -44,8 +44,11 @@ class TestPretrainedTransformerMismatchedIndexer(AllenNlpTestCase):
         assert len(expected_ids) == 7  # just to make sure it's what we're expecting
         cls_id, sep_id = expected_ids[0], expected_ids[-1]
         expected_ids = (
-            expected_ids[:3] + [sep_id, cls_id]
-            + expected_ids[3:5] + [sep_id, cls_id] + expected_ids[5:]
+            expected_ids[:3]
+            + [sep_id, cls_id]
+            + expected_ids[3:5]
+            + [sep_id, cls_id]
+            + expected_ids[5:]
         )
 
         vocab = Vocabulary()

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -190,11 +190,12 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
                 [0, 0, 0, 0, 0, 0],
             ]
         ).unsqueeze(-1)
+        mask = (embeddings > 0).long()
 
         unfolded_embeddings = torch.LongTensor(
             [
                 [1, 101, 102, 103, 104, 105, 106, 107, 108, 109, 2],
-                [1, 201, 202, 203, 204, 205, 206, 207, 208, 0, 0],
+                [1, 201, 202, 203, 204, 205, 206, 207, 208, 2, 0],
                 [1, 301, 2, 0, 0, 0, 0, 0, 0, 0, 0],
             ]
         ).unsqueeze(-1)
@@ -202,6 +203,6 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
         token_embedder = PretrainedTransformerEmbedder("bert-base-uncased", max_length=6)
 
         unfolded_embeddings_out = token_embedder._unfold_long_sequences(
-            embeddings, unfolded_embeddings.size(0), 15
+            embeddings, mask, unfolded_embeddings.size(0), 15
         )
         assert (unfolded_embeddings_out == unfolded_embeddings).all()

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -142,24 +142,28 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
 
     def test_fold_long_sequences(self):
         # Let's just say [PAD] is 0, [CLS] is 1, and [SEP] is 2
-        token_ids = torch.LongTensor([
-            [1, 101, 102, 103, 104, 2, 1, 105, 106, 107, 108, 2, 1, 109, 2],
-            [1, 201, 202, 203, 204, 2, 1, 205, 206, 207, 208, 2, 0, 0, 0],
-            [1, 301, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        ])  # Shape: [3, 15]
+        token_ids = torch.LongTensor(
+            [
+                [1, 101, 102, 103, 104, 2, 1, 105, 106, 107, 108, 2, 1, 109, 2],
+                [1, 201, 202, 203, 204, 2, 1, 205, 206, 207, 208, 2, 0, 0, 0],
+                [1, 301, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ]
+        )  # Shape: [3, 15]
         segment_concat_mask = (token_ids > 0).long()
 
-        folded_token_ids = torch.LongTensor([
-            [1, 101, 102, 103, 104, 2],
-            [1, 105, 106, 107, 108, 2],
-            [1, 109, 2, 0, 0, 0],
-            [1, 201, 202, 203, 204, 2],
-            [1, 205, 206, 207, 208, 2],
-            [0, 0, 0, 0, 0, 0],
-            [1, 301, 2, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-        ])
+        folded_token_ids = torch.LongTensor(
+            [
+                [1, 101, 102, 103, 104, 2],
+                [1, 105, 106, 107, 108, 2],
+                [1, 109, 2, 0, 0, 0],
+                [1, 201, 202, 203, 204, 2],
+                [1, 205, 206, 207, 208, 2],
+                [0, 0, 0, 0, 0, 0],
+                [1, 301, 2, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0],
+            ]
+        )
         folded_segment_concat_mask = (folded_token_ids > 0).long()
 
         token_embedder = PretrainedTransformerEmbedder("bert-base-uncased", max_length=6)
@@ -173,23 +177,27 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
     def test_unfold_long_sequences(self):
         # Let's just say [PAD] is 0, [CLS] is 1, and [SEP] is 2
         # We assume embeddings are 1-dim and are the same as indices
-        embeddings = torch.LongTensor([
-            [1, 101, 102, 103, 104, 2],
-            [1, 105, 106, 107, 108, 2],
-            [1, 109, 2, 0, 0, 0],
-            [1, 201, 202, 203, 204, 2],
-            [1, 205, 206, 207, 208, 2],
-            [0, 0, 0, 0, 0, 0],
-            [1, 301, 2, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-        ]).unsqueeze(-1)
+        embeddings = torch.LongTensor(
+            [
+                [1, 101, 102, 103, 104, 2],
+                [1, 105, 106, 107, 108, 2],
+                [1, 109, 2, 0, 0, 0],
+                [1, 201, 202, 203, 204, 2],
+                [1, 205, 206, 207, 208, 2],
+                [0, 0, 0, 0, 0, 0],
+                [1, 301, 2, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0],
+            ]
+        ).unsqueeze(-1)
 
-        unfolded_embeddings = torch.LongTensor([
-            [1, 101, 102, 103, 104, 105, 106, 107, 108, 109, 2],
-            [1, 201, 202, 203, 204, 205, 206, 207, 208, 0, 0],
-            [1, 301, 2, 0, 0, 0, 0, 0, 0, 0, 0],
-        ]).unsqueeze(-1)
+        unfolded_embeddings = torch.LongTensor(
+            [
+                [1, 101, 102, 103, 104, 105, 106, 107, 108, 109, 2],
+                [1, 201, 202, 203, 204, 205, 206, 207, 208, 0, 0],
+                [1, 301, 2, 0, 0, 0, 0, 0, 0, 0, 0],
+            ]
+        ).unsqueeze(-1)
 
         token_embedder = PretrainedTransformerEmbedder("bert-base-uncased", max_length=6)
 

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -1,9 +1,6 @@
-<<<<<<< HEAD
-import pytest
-=======
 import math
 
->>>>>>> Add tests
+import pytest
 import torch
 
 from allennlp.common import Params
@@ -168,9 +165,11 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
 
         token_embedder = PretrainedTransformerEmbedder("bert-base-uncased", max_length=6)
 
-        folded_token_ids_out, folded_segment_concat_mask_out = token_embedder._fold_long_sequences(
-            token_ids, segment_concat_mask
-        )
+        (
+            folded_token_ids_out,
+            folded_segment_concat_mask_out,
+            _,
+        ) = token_embedder._fold_long_sequences(token_ids, segment_concat_mask)
         assert (folded_token_ids_out == folded_token_ids).all()
         assert (folded_segment_concat_mask_out == folded_segment_concat_mask).all()
 

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -175,17 +175,17 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
         assert (folded_segment_concat_mask_out == folded_segment_concat_mask).all()
 
     def test_unfold_long_sequences(self):
-        # Let's just say [PAD] is 0, [CLS] is 1, and [SEP] is 2
+        # Let's just say [PAD] is 0, [CLS] is xxx1, and [SEP] is xxx2
         # We assume embeddings are 1-dim and are the same as indices
         embeddings = torch.LongTensor(
             [
-                [1, 101, 102, 103, 104, 2],
-                [1, 105, 106, 107, 108, 2],
-                [1, 109, 2, 0, 0, 0],
-                [1, 201, 202, 203, 204, 2],
-                [1, 205, 206, 207, 208, 2],
+                [1001, 101, 102, 103, 104, 1002],
+                [1011, 105, 106, 107, 108, 1012],
+                [1021, 109, 1022, 0, 0, 0],
+                [2001, 201, 202, 203, 204, 2002],
+                [2011, 205, 206, 207, 208, 2012],
                 [0, 0, 0, 0, 0, 0],
-                [1, 301, 2, 0, 0, 0],
+                [3001, 301, 3002, 0, 0, 0],
                 [0, 0, 0, 0, 0, 0],
                 [0, 0, 0, 0, 0, 0],
             ]
@@ -194,9 +194,9 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
 
         unfolded_embeddings = torch.LongTensor(
             [
-                [1, 101, 102, 103, 104, 105, 106, 107, 108, 109, 2],
-                [1, 201, 202, 203, 204, 205, 206, 207, 208, 2, 0],
-                [1, 301, 2, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1001, 101, 102, 103, 104, 105, 106, 107, 108, 109, 1022],
+                [2001, 201, 202, 203, 204, 205, 206, 207, 208, 2012, 0],
+                [3001, 301, 3002, 0, 0, 0, 0, 0, 0, 0, 0],
             ]
         ).unsqueeze(-1)
 

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -85,9 +85,9 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
         with pytest.raises(ValueError):
             token_embedder(token_ids, mask, type_ids)
 
-    def test_long_sequence_folding_end_to_end(self):
+    def test_long_sequence_splitting_end_to_end(self):
         # Mostly the same as the end_to_end test (except for adding max_len=4),
-        # because we don't want this folding behavior to change input/output format.
+        # because we don't want this splitting behavior to change input/output format.
 
         tokenizer = PretrainedTransformerTokenizer(model_name="bert-base-uncased")
         token_indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased", max_len=4)

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -86,11 +86,11 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
             token_embedder(token_ids, mask, type_ids)
 
     def test_long_sequence_splitting_end_to_end(self):
-        # Mostly the same as the end_to_end test (except for adding max_len=4),
+        # Mostly the same as the end_to_end test (except for adding max_length=4),
         # because we don't want this splitting behavior to change input/output format.
 
         tokenizer = PretrainedTransformerTokenizer(model_name="bert-base-uncased")
-        token_indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased", max_len=4)
+        token_indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased", max_length=4)
 
         sentence1 = "A, AllenNLP sentence."
         tokens1 = tokenizer.tokenize(sentence1)
@@ -105,7 +105,7 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
                     "bert": {
                         "type": "pretrained_transformer",
                         "model_name": "bert-base-uncased",
-                        "max_len": 4,
+                        "max_length": 4,
                     }
                 }
             }

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
@@ -53,7 +53,7 @@ class TestPretrainedTransformerMismatchedEmbedder(AllenNlpTestCase):
         assert bert_vectors.size() == (2, max(len(sentence1), len(sentence2)), 768)
         assert not torch.isnan(bert_vectors).any()
 
-    def test_long_sequence_folding_end_to_end(self):
+    def test_long_sequence_splitting_end_to_end(self):
         token_indexer = PretrainedTransformerMismatchedIndexer("bert-base-uncased", max_len=4)
 
         sentence1 = ["A", ",", "AllenNLP", "sentence", "."]

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
@@ -54,7 +54,7 @@ class TestPretrainedTransformerMismatchedEmbedder(AllenNlpTestCase):
         assert not torch.isnan(bert_vectors).any()
 
     def test_long_sequence_splitting_end_to_end(self):
-        token_indexer = PretrainedTransformerMismatchedIndexer("bert-base-uncased", max_len=4)
+        token_indexer = PretrainedTransformerMismatchedIndexer("bert-base-uncased", max_length=4)
 
         sentence1 = ["A", ",", "AllenNLP", "sentence", "."]
         sentence2 = ["AllenNLP", "is", "great"]
@@ -69,7 +69,7 @@ class TestPretrainedTransformerMismatchedEmbedder(AllenNlpTestCase):
                     "bert": {
                         "type": "pretrained_transformer_mismatched",
                         "model_name": "bert-base-uncased",
-                        "max_len": 4,
+                        "max_length": 4,
                     }
                 }
             }

--- a/allennlp/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
@@ -52,3 +52,50 @@ class TestPretrainedTransformerMismatchedEmbedder(AllenNlpTestCase):
         bert_vectors = token_embedder(tokens)
         assert bert_vectors.size() == (2, max(len(sentence1), len(sentence2)), 768)
         assert not torch.isnan(bert_vectors).any()
+
+    def test_long_sequence_folding_end_to_end(self):
+        token_indexer = PretrainedTransformerMismatchedIndexer("bert-base-uncased", max_len=4)
+
+        sentence1 = ["A", ",", "AllenNLP", "sentence", "."]
+        sentence2 = ["AllenNLP", "is", "great"]
+        tokens1 = [Token(word) for word in sentence1]
+        tokens2 = [Token(word) for word in sentence2]
+
+        vocab = Vocabulary()
+
+        params = Params(
+            {
+                "token_embedders": {
+                    "bert": {
+                        "type": "pretrained_transformer_mismatched",
+                        "model_name": "bert-base-uncased",
+                        "max_len": 4,
+                    }
+                }
+            }
+        )
+        token_embedder = BasicTextFieldEmbedder.from_params(vocab=vocab, params=params)
+
+        instance1 = Instance({"tokens": TextField(tokens1, {"bert": token_indexer})})
+        instance2 = Instance({"tokens": TextField(tokens2, {"bert": token_indexer})})
+
+        batch = Batch([instance1, instance2])
+        batch.index_instances(vocab)
+
+        padding_lengths = batch.get_padding_lengths()
+        tensor_dict = batch.as_tensor_dict(padding_lengths)
+        tokens = tensor_dict["tokens"]
+
+        assert tokens["bert"]["mask"].tolist() == [
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 0, 0],
+        ]
+        assert tokens["bert"]["offsets"].tolist() == [
+            [[1, 1], [2, 2], [3, 5], [6, 6], [7, 7]],
+            [[1, 3], [4, 4], [5, 5], [0, 0], [0, 0]],
+        ]
+
+        # Attention mask
+        bert_vectors = token_embedder(tokens)
+        assert bert_vectors.size() == (2, max(len(sentence1), len(sentence2)), 768)
+        assert not torch.isnan(bert_vectors).any()


### PR DESCRIPTION
Split, independently embed, and finally concatenate back to get to original sequence representation.