### PR TITLE
Add label distribution logic to coref

### DIFF
--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -192,6 +192,10 @@ class ConllCorefReader(DatasetReader):
                     end = offsets[end][1]
 
                     # `enumerate_spans` uses word-level width limit; here we apply it to wordpieces
+                    # We have to do this check here because we use a span width embedding that has
+                    # only `self._max_span_width` entries, and since we are doing wordpiece
+                    # modeling, the span width embedding operates on wordpiece lengths. So a check
+                    # here is necessary or else we wouldn't know how many entries there would be.
                     if end - start + 1 > self._max_span_width:
                         continue
                     # We also don't generate spans that contain special tokens

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -191,7 +191,7 @@ class ConllCorefReader(DatasetReader):
                     start = offsets[start][0]
                     end = offsets[end][1]
 
-                    # `enumerate_spans` uses word-level width limit; we need to be stricter here
+                    # `enumerate_spans` uses word-level width limit; here we apply it to wordpieces
                     if end - start + 1 > self._max_span_width:
                         continue
                     # We also don't generate spans that contain special tokens

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -15,7 +15,7 @@ from allennlp.data.fields import (
     SequenceLabelField,
 )
 from allennlp.data.instance import Instance
-from allennlp.data.tokenizers import Token
+from allennlp.data.tokenizers import Token, PretrainedTransformerTokenizer
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenIndexer
 from allennlp.data.dataset_readers.dataset_utils import Ontonotes, enumerate_spans
 
@@ -79,14 +79,25 @@ class ConllCorefReader(DatasetReader):
     token_indexers : `Dict[str, TokenIndexer]`, optional
         This is used to index the words in the document.  See :class:`TokenIndexer`.
         Default is `{"tokens": SingleIdTokenIndexer()}`.
+    wordpiece_modeling_tokenizer: `PretrainedTransformerTokenizer`, optional (default = None)
+        If not None, this dataset reader does subword tokenization using the supplied tokenizer
+        and distribute the labels to the resulting wordpieces. All the modeling will be based on
+        wordpieces. If this is set to `False` (default), the user is expected to use
+        `PretrainedTransformerMismatchedIndexer` and `PretrainedTransformerMismatchedEmbedder`,
+        and the modeling will be on the word-level.
     """
 
     def __init__(
-        self, max_span_width: int, token_indexers: Dict[str, TokenIndexer] = None, **kwargs,
+        self,
+        max_span_width: int,
+        token_indexers: Dict[str, TokenIndexer] = None,
+        wordpiece_modeling_tokenizer: Optional[PretrainedTransformerTokenizer] = None,
+        **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self._max_span_width = max_span_width
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
+        self._wordpiece_modeling_tokenizer = wordpiece_modeling_tokenizer
 
     @overrides
     def _read(self, file_path: str):
@@ -145,11 +156,15 @@ class ConllCorefReader(DatasetReader):
             self._normalize_word(word) for sentence in sentences for word in sentence
         ]
 
-        metadata: Dict[str, Any] = {"original_text": flattened_sentences}
-        if gold_clusters is not None:
-            metadata["clusters"] = gold_clusters
+        if self._wordpiece_modeling_tokenizer is not None:
+            flat_sentences_tokens, offsets = self._wordpiece_modeling_tokenizer.intra_word_tokenize(
+                flattened_sentences
+            )
+            flattened_sentences = [t.text for t in flat_sentences_tokens]
+        else:
+            flat_sentences_tokens = [Token(word) for word in flattened_sentences]
 
-        text_field = TextField([Token(word) for word in flattened_sentences], self._token_indexers)
+        text_field = TextField(flat_sentences_tokens, self._token_indexers)
 
         cluster_dict = {}
         if gold_clusters is not None:
@@ -171,10 +186,24 @@ class ConllCorefReader(DatasetReader):
                     else:
                         span_labels.append(-1)
 
+                if self._wordpiece_modeling_tokenizer is not None:
+                    start = offsets[start][0]
+                    end = offsets[end][1]
+
                 spans.append(SpanField(start, end, text_field))
             sentence_offset += len(sentence)
 
         span_field = ListField(spans)
+
+        metadata: Dict[str, Any] = {"original_text": flattened_sentences}
+        if gold_clusters is not None:
+            if self._wordpiece_modeling_tokenizer is not None:
+                for cluster in gold_clusters:
+                    for mention_id, mention in enumerate(cluster):
+                        start = offsets[mention[0]][0]
+                        end = offsets[mention[1]][1]
+                        cluster[mention_id] = (start, end)
+            metadata["clusters"] = gold_clusters
         metadata_field = MetadataField(metadata)
 
         fields: Dict[str, Field] = {

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -190,7 +190,18 @@ class ConllCorefReader(DatasetReader):
                 if self._wordpiece_modeling_tokenizer is not None:
                     start = offsets[start][0]
                     end = offsets[end][1]
+
+                    # `enumerate_spans` uses word-level width limit; we need to be stricter here
                     if end - start + 1 > self._max_span_width:
+                        continue
+                    # We also don't generate spans that contain special tokens
+                    if start < self._wordpiece_modeling_tokenizer.num_added_start_tokens:
+                        continue
+                    if (
+                        end >=
+                        len(flat_sentences_tokens)
+                        - self._wordpiece_modeling_tokenizer.num_added_end_tokens
+                    ):
                         continue
 
                 if span_labels is not None:

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -198,8 +198,8 @@ class ConllCorefReader(DatasetReader):
                     if start < self._wordpiece_modeling_tokenizer.num_added_start_tokens:
                         continue
                     if (
-                        end >=
-                        len(flat_sentences_tokens)
+                        end
+                        >= len(flat_sentences_tokens)
                         - self._wordpiece_modeling_tokenizer.num_added_end_tokens
                     ):
                         continue

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -201,7 +201,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
     def __eq__(self, other):
         if isinstance(other, PretrainedTransformerIndexer):
             for key in self.__dict__:
-                if key == "tokenizer":
+                if key == "_tokenizer":
                     # This is a reference to a function in the huggingface code, which we can't
                     # really modify to make this clean.  So we special-case it.
                     continue

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -64,7 +64,7 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
         output: IndexedTokenList = {
             "token_ids": [t.text_id for t in tokens],
             "mask": [1] * len(tokens),  # for original tokens (i.e. word-level)
-            "type_ids": [t.type_id for t in tokens],,
+            "type_ids": [t.type_id for t in tokens],
             "offsets": offsets,
             "wordpiece_mask": [1] * len(indices),  # for wordpieces (i.e. subword-level)
         }
@@ -99,7 +99,7 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
     def __eq__(self, other):
         if isinstance(other, PretrainedTransformerMismatchedIndexer):
             for key in self.__dict__:
-                if key == "tokenizer":
+                if key == "_tokenizer":
                     # This is a reference to a function in the huggingface code, which we can't
                     # really modify to make this clean.  So we special-case it.
                     continue

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List
 import logging
 
 from overrides import overrides
@@ -60,13 +60,13 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
     def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary) -> IndexedTokenList:
         self._matched_indexer._add_encoding_to_vocabulary_if_needed(vocabulary)
 
-        tokens, offsets = self._allennlp_tokenizer.intra_word_tokenize([t.text for t in tokens])
+        wordpieces, offsets = self._allennlp_tokenizer.intra_word_tokenize([t.text for t in tokens])
         output: IndexedTokenList = {
-            "token_ids": [t.text_id for t in tokens],
+            "token_ids": [t.text_id for t in wordpieces],
             "mask": [1] * len(tokens),  # for original tokens (i.e. word-level)
-            "type_ids": [t.type_id for t in tokens],
+            "type_ids": [t.type_id for t in wordpieces],
             "offsets": offsets,
-            "wordpiece_mask": [1] * len(indices),  # for wordpieces (i.e. subword-level)
+            "wordpiece_mask": [1] * len(wordpieces),  # for wordpieces (i.e. subword-level)
         }
 
         return self._matched_indexer._postprocess_output(output)

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -60,15 +60,11 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
     def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary) -> IndexedTokenList:
         self._matched_indexer._add_encoding_to_vocabulary_if_needed(vocabulary)
 
-        indices, offsets = self._allennlp_tokenizer.intra_word_tokenize([t.text for t in tokens])
-        # `create_token_type_ids_from_sequences()` inserts special tokens
-        type_ids = self._tokenizer.create_token_type_ids_from_sequences(
-            indices[self._num_added_start_tokens : -self._num_added_end_tokens]
-        )
+        tokens, offsets = self._allennlp_tokenizer.intra_word_tokenize([t.text for t in tokens])
         output: IndexedTokenList = {
-            "token_ids": indices,
+            "token_ids": [t.text_id for t in tokens],
             "mask": [1] * len(tokens),  # for original tokens (i.e. word-level)
-            "type_ids": type_ids,
+            "type_ids": [t.type_id for t in tokens],,
             "offsets": offsets,
             "wordpiece_mask": [1] * len(indices),  # for wordpieces (i.e. subword-level)
         }

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -209,7 +209,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         wp_tokens = [
             Token(text, text_id=text_id, type_id=type_id)
-            for text, text_id, type_id in zip(wordpieces, texts, type_ids)
+            for text, text_id, type_id in zip(texts, wordpieces, type_ids)
         ]
 
         return wp_tokens, offsets

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -188,7 +188,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         """
         wordpieces: List[int] = []
         offsets = []
-        cumulative = self._num_added_start_tokens
+        cumulative = self.num_added_start_tokens
         for token in tokens:
             subword_wordpieces = self.tokenizer.encode(token, add_special_tokens=False)
             wordpieces.extend(subword_wordpieces)
@@ -198,8 +198,8 @@ class PretrainedTransformerTokenizer(Tokenizer):
             end_offset = cumulative - 1  # inclusive
             offsets.append((start_offset, end_offset))
 
-        wordpieces = self._tokenizer.build_inputs_with_special_tokens(wordpieces)
-        assert cumulative + self._num_added_end_tokens == len(wordpieces)
+        wordpieces = self.tokenizer.build_inputs_with_special_tokens(wordpieces)
+        assert cumulative + self.num_added_end_tokens == len(wordpieces)
 
         return wordpieces, offsets
 

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -7,7 +7,6 @@ from transformers.modeling_auto import AutoModel
 import torch
 import torch.nn.functional as F
 
-from allennlp.data.token_indexers import PretrainedTransformerIndexer
 from allennlp.data.tokenizers import PretrainedTransformerTokenizer
 from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 from allennlp.nn.util import batched_index_select

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -3,11 +3,12 @@ from typing import Optional, Tuple
 
 from overrides import overrides
 from transformers.modeling_auto import AutoModel
-from transformers.tokenization_auto import AutoTokenizer
+
 import torch
 import torch.nn.functional as F
 
 from allennlp.data.token_indexers import PretrainedTransformerIndexer
+from allennlp.data.tokenizer import PretrainedTransformerTokenizer
 from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 from allennlp.nn.util import batched_index_select
 
@@ -37,11 +38,9 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         # where it doesn't work.
         self.output_dim = self.transformer_model.config.hidden_size
 
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
-        (
-            self._num_added_start_tokens,
-            self._num_added_end_tokens,
-        ) = PretrainedTransformerIndexer.determine_num_special_tokens_added(tokenizer)
+        tokenizer = PretrainedTransformerTokenizer(model_name)
+        self._num_added_start_tokens = tokenizer.num_added_start_tokens
+        self._num_added_end_tokens = tokenizer.num_added_end_tokens
         self._num_added_tokens = self._num_added_start_tokens + self._num_added_end_tokens
 
     @overrides

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn.functional as F
 
 from allennlp.data.token_indexers import PretrainedTransformerIndexer
-from allennlp.data.tokenizer import PretrainedTransformerTokenizer
+from allennlp.data.tokenizers import PretrainedTransformerTokenizer
 from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 from allennlp.nn.util import batched_index_select
 

--- a/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
@@ -18,7 +18,7 @@ class TestCorefReader:
             conll_reader.read(str(AllenNlpTestCase.FIXTURES_ROOT / "coref" / "coref.gold_conll"))
         )
 
-        assert len(instances) == 3
+        assert len(instances) == 4
 
         fields = instances[0].fields
         text = [x.text for x in fields["text"].tokens]
@@ -114,7 +114,7 @@ class TestCorefReader:
             1,
         ) not in gold_mentions_with_ids
 
-        fields = instances[1].fields
+        fields = instances[2].fields
         text = [x.text for x in fields["text"].tokens]
         assert text == [
             "The",
@@ -194,9 +194,9 @@ class TestCorefReader:
             conll_reader.read(str(AllenNlpTestCase.FIXTURES_ROOT / "coref" / "coref.gold_conll"))
         )
 
-        assert len(instances) == 3
+        assert len(instances) == 4
 
-        fields = instances[2].fields
+        fields = instances[3].fields
         text = [x.text for x in fields["text"].tokens]
 
         assert text == [
@@ -259,6 +259,23 @@ class TestCorefReader:
         assert (["Hong", "Kong"], 0) in gold_mentions_with_ids
         # Within span_width before wordpiece splitting but exceeds afterwards
         assert (["the", "Hong", "Kong", "SA", "##R", "government"], 0) not in gold_mentions_with_ids
+
+        fields = instances[1].fields
+        text = [x.text for x in fields["text"].tokens]
+        spans = fields["spans"].field_list
+        span_starts, span_ends = zip(*[(field.span_start, field.span_end) for field in spans])
+        candidate_mentions = self.check_candidate_mentions_are_well_defined(
+            span_starts, span_ends, text
+        )
+
+        gold_span_labels = fields["span_labels"]
+        gold_indices_with_ids = [(i, x) for i, x in enumerate(gold_span_labels.labels) if x != -1]
+        gold_mentions_with_ids: List[Tuple[List[str], int]] = [
+            (candidate_mentions[i], x) for i, x in gold_indices_with_ids
+        ]
+
+        # Prior to wordpiece tokenization, 's was one token; wordpiece tokenization splits it into 2
+        assert (["the", "city", "'", "s"], 0) in gold_mentions_with_ids
 
     def check_candidate_mentions_are_well_defined(self, span_starts, span_ends, text):
         candidate_mentions = []

--- a/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
@@ -18,7 +18,7 @@ class TestCorefReader:
             conll_reader.read(str(AllenNlpTestCase.FIXTURES_ROOT / "coref" / "coref.gold_conll"))
         )
 
-        assert len(instances) == 2
+        assert len(instances) == 3
 
         fields = instances[0].fields
         text = [x.text for x in fields["text"].tokens]
@@ -194,78 +194,47 @@ class TestCorefReader:
             conll_reader.read(str(AllenNlpTestCase.FIXTURES_ROOT / "coref" / "coref.gold_conll"))
         )
 
-        assert len(instances) == 2
+        assert len(instances) == 3
 
-        fields = instances[0].fields
+        fields = instances[2].fields
         text = [x.text for x in fields["text"].tokens]
 
         assert text == [
             "[CLS]",
-            "In",
-            "the",
-            "summer",
-            "of",
-            "2005",
-            ",",
-            "a",
-            "picture",
-            "that",
-            "people",
-            "have",
-            "long",
-            "been",
-            "looking",
-            "forward",
-            "to",
-            "started",
-            "emerging",
-            "with",
-            "frequency",
-            "in",
-            "various",
-            "major",
             "Hong",
             "Kong",
-            "media",
-            ".",
-            "With",
-            "their",
-            "unique",
-            "charm",
+            "Wet",
+            "##land",
+            "Park",
             ",",
-            "these",
-            "well",
-            "-",
-            "known",
-            "cartoon",
-            "images",
-            "once",
-            "again",
-            "caused",
+            "which",
+            "is",
+            "currently",
+            "under",
+            "construction",
+            ",",
+            "is",
+            "also",
+            "one",
+            "of",
+            "the",
+            "designated",
+            "new",
+            "projects",
+            "of",
+            "the",
             "Hong",
             "Kong",
-            "to",
-            "be",
-            "a",
-            "focus",
-            "of",
-            "worldwide",
-            "attention",
-            ".",
-            "The",
-            "world",
-            "'",
-            "s",
-            "fifth",
-            "Disney",
-            "park",
-            "will",
-            "soon",
-            "open",
-            "to",
+            "SA",
+            "##R",
+            "government",
+            "for",
+            "advancing",
             "the",
-            "public",
-            "here",
+            "Hong",
+            "Kong",
+            "tourism",
+            "industry",
             ".",
             "[SEP]",
         ]
@@ -280,8 +249,16 @@ class TestCorefReader:
         # Asserts special tokens aren't included in the spans
         assert all(span_start > 0 for span_start in span_starts)
         assert all(span_end < len(text) - 1 for span_end in span_ends)
-        # This is a span which exceeds our max_span_width, so it should not be considered.
-        assert ["world", "'", "s", "fifth", "Disney", "park"] not in candidate_mentions
+
+        gold_span_labels = fields["span_labels"]
+        gold_indices_with_ids = [(i, x) for i, x in enumerate(gold_span_labels.labels) if x != -1]
+        gold_mentions_with_ids: List[Tuple[List[str], int]] = [
+            (candidate_mentions[i], x) for i, x in gold_indices_with_ids
+        ]
+
+        assert (["Hong", "Kong"], 0) in gold_mentions_with_ids
+        # Within span_width before wordpiece splitting but exceeds afterwards
+        assert (["the", "Hong", "Kong", "SA", "##R", "government"], 0) not in gold_mentions_with_ids
 
     def check_candidate_mentions_are_well_defined(self, span_starts, span_ends, text):
         candidate_mentions = []

--- a/allennlp/tests/data/dataset_readers/dataset_utils/ontonotes_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_utils/ontonotes_test.py
@@ -475,4 +475,4 @@ class TestOntonotes(AllenNlpTestCase):
         reader = Ontonotes()
         file_path = self.FIXTURES_ROOT / "coref" / "coref.gold_conll"
         documents = list(reader.dataset_document_iterator(file_path))
-        assert len(documents) == 2
+        assert len(documents) == 3

--- a/allennlp/tests/data/dataset_readers/dataset_utils/ontonotes_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_utils/ontonotes_test.py
@@ -475,4 +475,4 @@ class TestOntonotes(AllenNlpTestCase):
         reader = Ontonotes()
         file_path = self.FIXTURES_ROOT / "coref" / "coref.gold_conll"
         documents = list(reader.dataset_document_iterator(file_path))
-        assert len(documents) == 3
+        assert len(documents) == 4

--- a/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/allennlp/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -129,10 +129,6 @@ class TestPretrainedTransformerIndexer(AllenNlpTestCase):
             padding_suffix = [allennlp_tokenizer.tokenizer.pad_token_id] * padding_length
             assert padded_tokens["token_ids"][-padding_length:].tolist() == padding_suffix
 
-    def test_determine_num_special_tokens_added(self):
-        tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-        assert PretrainedTransformerIndexer.determine_num_special_tokens_added(tokenizer) == (1, 1)
-
     def test_long_sequence_splitting(self):
         tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
         allennlp_tokenizer = PretrainedTransformerTokenizer("bert-base-uncased")

--- a/allennlp/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -305,3 +305,7 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
             idxs[first_sentence_end_index] + len(tokens[first_sentence_end_index])
             == idxs[second_sentence_start_index]
         )
+
+    def test_determine_num_special_tokens_added(self):
+        tokenizer = PretrainedTransformerTokenizer("bert-base-cased")
+        assert tokenizer._determine_num_special_tokens_added() == (1, 1)

--- a/allennlp/tests/fixtures/coref/coref.gold_conll
+++ b/allennlp/tests/fixtures/coref/coref.gold_conll
@@ -26,7 +26,7 @@ bc/cctv/00/cctv_0000   0   23         Hong   NNP         (NML*         -    -   
 bc/cctv/00/cctv_0000   0   24         Kong   NNP             *)        -    -   -   Speaker#1        *)     *      *             *            *            *    23)
 bc/cctv/00/cctv_0000   0   25        media   NNS         *)))))        -    -   -   Speaker#1        *      *      *             *            *)           *)    -
 bc/cctv/00/cctv_0000   0   26            .     .            *))        -    -   -   Speaker#1        *      *      *             *            *            *     -
- 
+
 bc/cctv/00/cctv_0000   0    0         With     IN  (TOP(S(PP*       -    -   -   Speaker#1       *             *   (ARGM-MNR*        *      -
 bc/cctv/00/cctv_0000   0    1        their   PRP$        (NP*       -    -   -   Speaker#1       *             *            *        *    (18)
 bc/cctv/00/cctv_0000   0    2       unique     JJ           *       -    -   -   Speaker#1       *             *            *        *      -
@@ -51,7 +51,7 @@ bc/cctv/00/cctv_0000   0   20           of     IN        (PP*       -    -   -  
 bc/cctv/00/cctv_0000   0   21    worldwide     JJ        (NP*       -    -   -   Speaker#1       *             *            *        *      -
 bc/cctv/00/cctv_0000   0   22    attention     NN     *)))))))      -    -   -   Speaker#1       *             *            *)       *)     -
 bc/cctv/00/cctv_0000   0   23            .      .          *))      -    -   -   Speaker#1       *             *            *        *      -
- 
+
 bc/cctv/00/cctv_0000   0    0       The    DT  (TOP(S(NP(NP*      -    -   -   Speaker#1           *        (ARG1*      -
 bc/cctv/00/cctv_0000   0    1     world    NN              *      -    -   -   Speaker#1           *             *      -
 bc/cctv/00/cctv_0000   0    2        's   POS              *)     -    -   -   Speaker#1           *             *      -
@@ -66,7 +66,7 @@ bc/cctv/00/cctv_0000   0   10       the    DT           (NP*      -    -   -   S
 bc/cctv/00/cctv_0000   0   11    public    NN             *))     -    -   -   Speaker#1           *             *)     -
 bc/cctv/00/cctv_0000   0   12      here    RB       (ADVP*)))     -    -   -   Speaker#1           *    (ARGM-LOC*)     -
 bc/cctv/00/cctv_0000   0   13         .     .             *))     -    -   -   Speaker#1           *             *      -
- 
+
 #end document
 #begin document (bc/cctv/00/cctv_0000); part 003
 bc/cctv/00/cctv_0000   3    0           The     DT  (TOP(S(NP(NP*    -    -   -   Speaker#1            *   (ARG1*    -
@@ -83,20 +83,20 @@ bc/cctv/00/cctv_0000   3   10          plus     CC              *)   -    -   - 
 bc/cctv/00/cctv_0000   3   11        square     JJ              *    -    -   -   Speaker#1            *        *    -
 bc/cctv/00/cctv_0000   3   12    kilometers    NNS             *))   -    -   -   Speaker#1            *)       *)   -
 bc/cctv/00/cctv_0000   3   13             .      .             *))   -    -   -   Speaker#1            *        *    -
- 
+
 bc/cctv/00/cctv_0000   3   0           The    DT  (TOP(S(NP*    -    -   -   Speaker#1   *    (ARG1*   -
 bc/cctv/00/cctv_0000   3   1    population    NN           *)   -    -   -   Speaker#1   *         *)  -
 bc/cctv/00/cctv_0000   3   2            is   VBZ        (VP*    be  01   1   Speaker#1   *       (V*)  -
 bc/cctv/00/cctv_0000   3   3         dense    JJ     (ADJP*))   -    -   -   Speaker#1   *    (ARG2*)  -
 bc/cctv/00/cctv_0000   3   4             .     .          *))   -    -   -   Speaker#1   *         *   -
- 
+
 bc/cctv/00/cctv_0000   3   0       Natural    JJ  (TOP(S(NP*    -    -   -   Speaker#1   *   (ARG1*   -
 bc/cctv/00/cctv_0000   3   1     resources   NNS           *)   -    -   -   Speaker#1   *        *)  -
 bc/cctv/00/cctv_0000   3   2           are   VBP        (VP*    be  01   1   Speaker#1   *      (V*)  -
 bc/cctv/00/cctv_0000   3   3    relatively    RB      (ADJP*    -    -   -   Speaker#1   *   (ARG2*   -
 bc/cctv/00/cctv_0000   3   4        scarce    JJ          *))   -    -   -   Speaker#1   *        *)  -
 bc/cctv/00/cctv_0000   3   5             .     .          *))   -    -   -   Speaker#1   *        *   -
- 
+
 bc/cctv/00/cctv_0000   3    0       However    RB   (TOP(S(ADVP*)        -    -   -   Speaker#1       *    (ARGM-DIS*)     *         *        *      -
 bc/cctv/00/cctv_0000   3    1             ,     ,              *         -    -   -   Speaker#1       *             *      *         *        *      -
 bc/cctv/00/cctv_0000   3    2           the    DT           (NP*         -    -   -   Speaker#1       *        (ARG0*      *         *   (ARG0*    (44
@@ -119,5 +119,42 @@ bc/cctv/00/cctv_0000   3   18          Kong   NNP              *)        -    - 
 bc/cctv/00/cctv_0000   3   19       tourism    NN              *         -    -   -   Speaker#1       *             *      *         *        *      -
 bc/cctv/00/cctv_0000   3   20      industry    NN         *))))))        -    -   -   Speaker#1       *             *)     *         *        *)     -
 bc/cctv/00/cctv_0000   3   21             .     .             *))        -    -   -   Speaker#1       *             *      *         *        *      -
- 
+
+#end document
+
+#begin document (bc/cctv/00/cctv_0000); part 005
+bc/cctv/00/cctv_0000   5    0            Hong   NNP  (TOP(S(NP(NP(NML*           -    -   -   Speaker#1   (FAC*        (ARG1*        (ARG1*           *        *   (45
+bc/cctv/00/cctv_0000   5    1            Kong   NNP                  *)          -    -   -   Speaker#1       *             *             *           *        *     -
+bc/cctv/00/cctv_0000   5    2         Wetland   NNP                  *           -    -   -   Speaker#1       *             *             *           *        *     -
+bc/cctv/00/cctv_0000   5    3            Park   NNP                  *)          -    -   -   Speaker#1       *)            *)            *           *        *     -
+bc/cctv/00/cctv_0000   5    4               ,     ,                  *           -    -   -   Speaker#1       *             *             *           *        *     -
+bc/cctv/00/cctv_0000   5    5           which   WDT        (SBAR(WHNP*)          -    -   -   Speaker#1       *      (R-ARG1*)            *           *        *     -
+bc/cctv/00/cctv_0000   5    6              is   VBZ             (S(VP*           be  01   1   Speaker#1       *           (V*)            *           *        *     -
+bc/cctv/00/cctv_0000   5    7       currently    RB             (ADVP*)          -    -   -   Speaker#1       *    (ARGM-TMP*)            *           *        *     -
+bc/cctv/00/cctv_0000   5    8           under    IN               (PP*           -    -   -   Speaker#1       *        (ARG2*             *           *        *     -
+bc/cctv/00/cctv_0000   5    9    construction    NN          (NP*))))))          -    -   -   Speaker#1       *             *)            *)          *        *    45)
+bc/cctv/00/cctv_0000   5   10               ,     ,                  *           -    -   -   Speaker#1       *             *             *           *        *     -
+bc/cctv/00/cctv_0000   5   11              is   VBZ               (VP*           be  01   2   Speaker#1       *             *           (V*)          *        *     -
+bc/cctv/00/cctv_0000   5   12            also    RB             (ADVP*)          -    -   -   Speaker#1       *             *    (ARGM-ADV*)          *        *     -
+bc/cctv/00/cctv_0000   5   13             one    CD            (NP(NP*)          -    -   -   Speaker#1       *             *        (ARG2*           *        *     -
+bc/cctv/00/cctv_0000   5   14              of    IN               (PP*           -    -   -   Speaker#1       *             *             *           *        *     -
+bc/cctv/00/cctv_0000   5   15             the    DT            (NP(NP*           -    -   -   Speaker#1       *             *             *           *        *     -
+bc/cctv/00/cctv_0000   5   16      designated   VBN                  *    designate  01   -   Speaker#1       *             *             *         (V*)       *     -
+bc/cctv/00/cctv_0000   5   17             new    JJ                  *           -    -   -   Speaker#1       *             *             *      (ARG1*)       *     -
+bc/cctv/00/cctv_0000   5   18        projects   NNS                  *)     project   -   -   Speaker#1       *             *             *    (C-ARG1*)       *     -
+bc/cctv/00/cctv_0000   5   19              of    IN               (PP*           -    -   -   Speaker#1       *             *             *           *        *     -
+bc/cctv/00/cctv_0000   5   20             the    DT               (NP*           -    -   -   Speaker#1       *             *             *           *        *   (19
+bc/cctv/00/cctv_0000   5   21            Hong   NNP              (NML*           -    -   -   Speaker#1   (GPE*             *             *           *        *     -
+bc/cctv/00/cctv_0000   5   22            Kong   NNP                  *)          -    -   -   Speaker#1       *             *             *           *        *     -
+bc/cctv/00/cctv_0000   5   23             SAR   NNP                  *           -    -   -   Speaker#1       *)            *             *           *        *     -
+bc/cctv/00/cctv_0000   5   24      government    NN                 *))          -    -   -   Speaker#1       *             *             *           *        *    19)
+bc/cctv/00/cctv_0000   5   25             for    IN               (PP*           -    -   -   Speaker#1       *             *             *           *        *     -
+bc/cctv/00/cctv_0000   5   26       advancing   VBG             (S(VP*      advance  01   3   Speaker#1       *             *             *           *      (V*)    -
+bc/cctv/00/cctv_0000   5   27             the    DT               (NP*           -    -   -   Speaker#1       *             *             *           *   (ARG1*     -
+bc/cctv/00/cctv_0000   5   28            Hong   NNP              (NML*           -    -   -   Speaker#1   (GPE*             *             *           *        *   (19
+bc/cctv/00/cctv_0000   5   29            Kong   NNP                  *)          -    -   -   Speaker#1       *)            *             *           *        *    19)
+bc/cctv/00/cctv_0000   5   30         tourism    NN                  *           -    -   -   Speaker#1       *             *             *           *        *     -
+bc/cctv/00/cctv_0000   5   31        industry    NN           *))))))))          -    -   -   Speaker#1       *             *             *)          *        *)    -
+bc/cctv/00/cctv_0000   5   32               .     .                 *))          -    -   -   Speaker#1       *             *             *           *        *     -
+
 #end document

--- a/allennlp/tests/fixtures/coref/coref.gold_conll
+++ b/allennlp/tests/fixtures/coref/coref.gold_conll
@@ -68,6 +68,38 @@ bc/cctv/00/cctv_0000   0   12      here    RB       (ADVP*)))     -    -   -   S
 bc/cctv/00/cctv_0000   0   13         .     .             *))     -    -   -   Speaker#1           *             *      -
 
 #end document
+
+#begin document (bc/cctv/00/cctv_0000); part 001
+bc/cctv/00/cctv_0000   1    0         Or    CC      (TOP(S*        -    -   -   Speaker#1        *    (ARGM-DIS*)   (ARGM-DIS*)    -
+bc/cctv/00/cctv_0000   1    1        hop    VB      (VP(VP*       hop  01   1   Speaker#1        *           (V*)            *     -
+bc/cctv/00/cctv_0000   1    2       onto    IN         (PP*        -    -   -   Speaker#1        *    (ARGM-DIR*             *     -
+bc/cctv/00/cctv_0000   1    3          a    DT      (NP(NP*        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1    4    trolley    NN            *)       -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1    5       with    IN         (PP*        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1    6       over    RB   (NP(NP(QP*        -    -   -   Speaker#1   (DATE*             *             *     -
+bc/cctv/00/cctv_0000   1    7          a    DT            *)       -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1    8    century    NN            *)       -    -   -   Speaker#1        *)            *             *     -
+bc/cctv/00/cctv_0000   1    9         of    IN         (PP*        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   10    history    NN   (NP*)))))))       -    -   -   Speaker#1        *             *)            *     -
+bc/cctv/00/cctv_0000   1   11          ,     ,            *        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   12        and    CC            *        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   13       feel    VB         (VP*      feel  03   1   Speaker#1        *             *           (V*)    -
+bc/cctv/00/cctv_0000   1   14        the    DT   (NP(NP(NP*        -    -   -   Speaker#1        *             *        (ARG1*   (19
+bc/cctv/00/cctv_0000   1   15       city    NN            *        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   16         's   POS            *)       -    -   -   Speaker#1        *             *             *    19)
+bc/cctv/00/cctv_0000   1   17      blend    NN            *)    blend   -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   18         of    IN         (PP*        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   19        the    DT      (NP(NP*        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   20        old    JJ            *)       -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   21        and    CC            *        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   22        the    DT         (NP*        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   23     modern    JJ         *))))       -    -   -   Speaker#1        *             *             *)    -
+bc/cctv/00/cctv_0000   1   24         in    IN         (PP*        -    -   -   Speaker#1        *             *    (ARGM-MNR*     -
+bc/cctv/00/cctv_0000   1   25       slow    JJ         (NP*        -    -   -   Speaker#1        *             *             *     -
+bc/cctv/00/cctv_0000   1   26     motion    NN         *))))   motion   -   -   Speaker#1        *             *             *)    -
+bc/cctv/00/cctv_0000   1   27          .     .           *))       -    -   -   Speaker#1        *             *             *     -
+#end document
+
 #begin document (bc/cctv/00/cctv_0000); part 003
 bc/cctv/00/cctv_0000   3    0           The     DT  (TOP(S(NP(NP*    -    -   -   Speaker#1            *   (ARG1*    -
 bc/cctv/00/cctv_0000   3    1          area     NN              *)   -    -   -   Speaker#1            *        *    -


### PR DESCRIPTION
Add label distribution logic to Conll dataset reader and move some logic to `PretrainedTransformerTokenizer` for better reuse.