### PR TITLE
Fix AutoRegressiveSeqDecoder annotations and refactor to use get_token_ids_from_text_field_tensors

### DIFF
--- a/allennlp/modules/seq2seq_decoders/auto_regressive_seq_decoder.py
+++ b/allennlp/modules/seq2seq_decoders/auto_regressive_seq_decoder.py
@@ -9,7 +9,7 @@ from torch.nn import Linear
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.util import END_SYMBOL, START_SYMBOL
 from allennlp.modules.seq2seq_decoders.seq_decoder import SeqDecoder
-from allennlp.data import Vocabulary
+from allennlp.data import TextFieldTensors, Vocabulary
 from allennlp.modules import Embedding
 from allennlp.modules.seq2seq_decoders.decoder_net import DecoderNet
 from allennlp.nn import util
@@ -136,7 +136,7 @@ class AutoRegressiveSeqDecoder(SeqDecoder):
         return output_dict
 
     def _forward_loss(
-        self, state: Dict[str, torch.Tensor], target_tokens: Dict[str, torch.LongTensor]
+        self, state: Dict[str, torch.Tensor], target_tokens: TextFieldTensors
     ) -> Dict[str, torch.Tensor]:
         """
         Make forward pass during training or do greedy search during prediction.
@@ -396,9 +396,7 @@ class AutoRegressiveSeqDecoder(SeqDecoder):
 
     @overrides
     def forward(
-        self,
-        encoder_out: Dict[str, torch.LongTensor],
-        target_tokens: Dict[str, torch.LongTensor] = None,
+        self, encoder_out: Dict[str, torch.LongTensor], target_tokens: TextFieldTensors = None,
     ) -> Dict[str, torch.Tensor]:
         state = encoder_out
         decoder_init_state = self._decoder_net.init_decoder_state(state)


### PR DESCRIPTION
I noticed that the annotations for `target_tokens` in `AutoRegressiveSeqDecoder` could/should be swapped from `Dict[str, torch.Tensor]` to the newer `TextFieldTensors`.

I also saw a few places where `target_tokens["tokens"]["tokens"]` could/should be replaced with the new `allennlp.nn.util.get_token_ids_from_text_field_tensors(...)` function.

I hope this is helpful.