### PR TITLE
Fix handling of TokenCharactersIndexer in Hotflip

### DIFF
--- a/allennlp/interpret/attackers/hotflip.py
+++ b/allennlp/interpret/attackers/hotflip.py
@@ -128,12 +128,9 @@ class Hotflip(Attacker):
                 max_token_length = max(len(x) for x in all_tokens)
                 # sometime max_token_length is too short for cnn encoder
                 max_token_length = max(max_token_length, token_indexer._min_padding_length)
-                indexed_tokens = token_indexer.tokens_to_indices(
-                    tokens, self.vocab, "token_characters"
-                )
-                padded_tokens = token_indexer.as_padded_tensor_dict(
-                    indexed_tokens, {"token_characters": len(tokens)}
-                )
+                indexed_tokens = token_indexer.tokens_to_indices(tokens, self.vocab)
+                padding_lengths = token_indexer.get_padding_lengths(indexed_tokens)
+                padded_tokens = token_indexer.as_padded_tensor_dict(indexed_tokens, padding_lengths)
                 inputs[indexer_name] = {
                     "token_characters": torch.LongTensor(
                         padded_tokens["token_characters"]

--- a/allennlp/tests/interpret/hotflip_test.py
+++ b/allennlp/tests/interpret/hotflip_test.py
@@ -1,4 +1,5 @@
 from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.token_indexers import TokenCharactersIndexer
 from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
 from allennlp.interpret.attackers import Hotflip
@@ -18,6 +19,30 @@ class TestHotflip(AllenNlpTestCase):
             self.FIXTURES_ROOT / "decomposable_attention" / "serialization" / "model.tar.gz"
         )
         predictor = Predictor.from_archive(archive, "textual-entailment")
+
+        hotflipper = Hotflip(predictor)
+        hotflipper.initialize()
+        attack = hotflipper.attack_from_json(inputs, "hypothesis", "grad_input_1")
+        assert attack is not None
+        assert "final" in attack
+        assert "original" in attack
+        assert "outputs" in attack
+        assert len(attack["final"][0]) == len(
+            attack["original"]
+        )  # hotflip replaces words without removing
+
+    def test_with_token_characters_indexer(self):
+
+        inputs = {
+            "premise": "I always write unit tests for my code.",
+            "hypothesis": "One time I didn't write any unit tests for my code.",
+        }
+
+        archive = load_archive(
+            self.FIXTURES_ROOT / "decomposable_attention" / "serialization" / "model.tar.gz"
+        )
+        predictor = Predictor.from_archive(archive, "textual-entailment")
+        predictor._dataset_reader._token_indexers["token_characters"] = TokenCharactersIndexer()
 
         hotflipper = Hotflip(predictor)
         hotflipper.initialize()

--- a/allennlp/tests/interpret/hotflip_test.py
+++ b/allennlp/tests/interpret/hotflip_test.py
@@ -1,6 +1,7 @@
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data.token_indexers import TokenCharactersIndexer
 from allennlp.models.archival import load_archive
+from allennlp.modules.token_embedders import EmptyEmbedder
 from allennlp.predictors import Predictor
 from allennlp.interpret.attackers import Hotflip
 from allennlp.interpret.attackers.hotflip import DEFAULT_IGNORE_TOKENS
@@ -42,7 +43,10 @@ class TestHotflip(AllenNlpTestCase):
             self.FIXTURES_ROOT / "decomposable_attention" / "serialization" / "model.tar.gz"
         )
         predictor = Predictor.from_archive(archive, "textual-entailment")
-        predictor._dataset_reader._token_indexers["token_characters"] = TokenCharactersIndexer()
+        predictor._dataset_reader._token_indexers["chars"] = TokenCharactersIndexer(
+            min_padding_length=1
+        )
+        predictor._model._text_field_embedder._token_embedders["chars"] = EmptyEmbedder()
 
         hotflipper = Hotflip(predictor)
         hotflipper.initialize()


### PR DESCRIPTION
I'm working on fixing breakages in allennlp-reading-comprehension, and this came up.  I need to fix this here in order for tests to pass there (and I added a test here that would have caught the issue in this repo).