### PR TITLE
Adds a utility function to open potentially compressed files

### DIFF
--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -295,10 +295,7 @@ def get_file_extension(path: str, dot=True, lower: bool = True):
 
 
 def open_compressed(
-    filename: Union[str, Path],
-    mode: str = "rt",
-    encoding: Optional[str] = "UTF-8",
-    **kwargs
+    filename: Union[str, Path], mode: str = "rt", encoding: Optional[str] = "UTF-8", **kwargs
 ):
     if isinstance(filename, Path):
         filename = str(filename)

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -292,3 +292,20 @@ def get_file_extension(path: str, dot=True, lower: bool = True):
     ext = os.path.splitext(path)[1]
     ext = ext if dot else ext[1:]
     return ext.lower() if lower else ext
+
+
+def open_compressed(
+    filename: str,
+    mode: str = "rt",
+    encoding: Optional[str] = "UTF-8",
+    **kwargs
+):
+    if filename.endswith(".gz"):
+        import gzip
+        open_fn = gzip.open
+    elif filename.endswith(".bz2"):
+        import bz2
+        open_fn = bz2.open
+    else:
+        open_fn = open
+    return open_fn(filename, mode=mode, encoding=encoding, **kwargs)

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -294,7 +294,14 @@ def get_file_extension(path: str, dot=True, lower: bool = True):
     return ext.lower() if lower else ext
 
 
-def open_compressed(filename: str, mode: str = "rt", encoding: Optional[str] = "UTF-8", **kwargs):
+def open_compressed(
+    filename: Union[str, Path],
+    mode: str = "rt",
+    encoding: Optional[str] = "UTF-8",
+    **kwargs
+):
+    if isinstance(filename, Path):
+        filename = str(filename)
     open_fn: Callable = open
 
     if filename.endswith(".gz"):

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -294,18 +294,15 @@ def get_file_extension(path: str, dot=True, lower: bool = True):
     return ext.lower() if lower else ext
 
 
-def open_compressed(
-    filename: str,
-    mode: str = "rt",
-    encoding: Optional[str] = "UTF-8",
-    **kwargs
-):
+def open_compressed(filename: str, mode: str = "rt", encoding: Optional[str] = "UTF-8", **kwargs):
+    open_fn: Callable = open
+
     if filename.endswith(".gz"):
         import gzip
+
         open_fn = gzip.open
     elif filename.endswith(".bz2"):
         import bz2
+
         open_fn = bz2.open
-    else:
-        open_fn = open
     return open_fn(filename, mode=mode, encoding=encoding, **kwargs)

--- a/allennlp/tests/common/file_utils_test.py
+++ b/allennlp/tests/common/file_utils_test.py
@@ -12,7 +12,8 @@ from allennlp.common.file_utils import (
     get_from_cache,
     cached_path,
     split_s3_path,
-    open_compressed)
+    open_compressed,
+)
 from allennlp.common.testing import AllenNlpTestCase
 
 

--- a/allennlp/tests/common/file_utils_test.py
+++ b/allennlp/tests/common/file_utils_test.py
@@ -12,7 +12,7 @@ from allennlp.common.file_utils import (
     get_from_cache,
     cached_path,
     split_s3_path,
-)
+    open_compressed)
 from allennlp.common.testing import AllenNlpTestCase
 
 
@@ -196,3 +196,14 @@ class TestFileUtils(AllenNlpTestCase):
 
         with open(filename, "rb") as cached_file:
             assert cached_file.read() == self.glove_bytes
+
+    def test_open_compressed(self):
+        uncompressed_file = self.FIXTURES_ROOT / "embeddings/fake_embeddings.5d.txt"
+        with open_compressed(uncompressed_file) as f:
+            uncompressed_lines = [line.strip() for line in f]
+
+        for suffix in ["bz2", "gz"]:
+            compressed_file = f"{uncompressed_file}.{suffix}"
+            with open_compressed(compressed_file) as f:
+                compressed_lines = [line.strip() for line in f]
+            assert compressed_lines == uncompressed_lines


### PR DESCRIPTION
I want to use this in https://github.com/allenai/allennlp-reading-comprehension/pull/19.

Once this got promoted to being a general utility, I had to take care of some differences in the default arguments to `open` and `gzip.open`. Hence the extra parameters.