### PR TITLE
Remove RegularizerApplicator.from_params, move models to **kwargs

### DIFF
--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -125,6 +125,32 @@ def remove_optional(annotation: type):
         return annotation
 
 
+def infer_params(cls: Type[T],
+                 constructor: Callable[..., T] = None,
+                 ):
+    if constructor is None:
+        constructor = cls.__init__
+
+    signature = inspect.signature(constructor)
+    parameters = dict(signature.parameters)
+
+    has_kwargs = False
+    for param in parameters.values():
+        if param.kind == param.VAR_KEYWORD:
+            has_kwargs = True
+
+    if not has_kwargs:
+        return parameters
+
+    super_class = cls.mro()[1]
+    super_parameters = infer_params(super_class)
+
+    return {
+        **super_parameters,
+        **parameters  # Subclass parameters overwrite superclass ones
+    }
+
+
 def create_kwargs(
     constructor: Callable[..., T], cls: Type[T], params: Params, **extras
 ) -> Dict[str, Any]:
@@ -140,28 +166,10 @@ def create_kwargs(
     For instance, you might provide an existing `Vocabulary` this way.
     """
     # Get the signature of the constructor.
-    signature = inspect.signature(constructor)
+
     kwargs: Dict[str, Any] = {}
 
-    parameters = dict(signature.parameters)
-
-    # First we check for the presence of a **kwargs parameter.  If we find one, we look in the
-    # superclass constructor, to see if there are arguments there that we should try to also
-    # constructor.
-    has_kwargs = False
-    for param in parameters.values():
-        if param.kind == param.VAR_KEYWORD:
-            has_kwargs = True
-    if has_kwargs:
-        # "mro" is "method resolution order".  The first one is the current class, the next is the
-        # first superclass, and so on.  Taking the first superclass should work in all cases that
-        # we're looking for here.
-        superclass = cls.mro()[1]
-        superclass_signature = inspect.signature(superclass.__init__)  # type: ignore
-        for param_name, param in superclass_signature.parameters.items():
-            if param_name == "self":
-                continue
-            parameters[param_name] = param
+    parameters = infer_params(cls, constructor)
 
     # Iterate over all the constructor parameters and their annotations.
     for param_name, param in parameters.items():
@@ -178,6 +186,7 @@ def create_kwargs(
         # it will have an __origin__ field indicating `typing.Dict`
         # and an __args__ field indicating `(str, int)`. We capture both.
         annotation = remove_optional(param.annotation)
+
         kwargs[param_name] = pop_and_construct_arg(
             cls.__name__, param_name, annotation, param.default, params, **extras
         )

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -429,7 +429,9 @@ def construct_arg(
         return Lazy(constructor)  # type: ignore
     else:
         # Pass it on as is and hope for the best.   ¯\_(ツ)_/¯
-        return popped_params.as_dict(quiet=True)
+        if isinstance(popped_params, Params):
+            return popped_params.as_dict(quiet=True)
+        return popped_params
 
 
 class FromParams:

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -433,23 +433,6 @@ def construct_arg(
         return popped_params.as_dict(quiet=True)
 
 
-def construct_from_params(value_cls: Type[T], value_params: Params, extras: Dict[str, Any]) -> T:
-    """
-    At this point we know that we need to use `from_params` to construct an object that will be
-    (part of) an argument to a constructor.  This does the logic of actually calling that
-    `from_params` method.
-
-    This is normally as simple as just `value_cls.from_params`, but we first call `create_extras` to
-    pass along any **kwargs that we got as input, and we also have some special handling for `Lazy`
-    annotations here - we don't want to recurse on `Lazy.from_params`, we want to bypass that.
-    """
-    origin = getattr(value_cls, "__origin__", None)
-    if origin == Lazy:
-        value_cls = value_cls.__args__[0]  # type: ignore
-    else:
-        return value_cls.from_params(params=value_params, **subextras)
-
-
 class FromParams:
     """
     Mixin to give a from_params method to classes. We create a distinct base class for this

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -398,7 +398,7 @@ def construct_arg(
         # succeeds.
         for arg_annotation in args:
             try:
-                a = construct_arg(
+                return construct_arg(
                     str(arg_annotation),
                     argument_name,
                     popped_params,
@@ -406,7 +406,6 @@ def construct_arg(
                     default,
                     **extras,
                 )
-                return a
             except (ValueError, TypeError, ConfigurationError, AttributeError) as e:
                 # Our attempt to construct the argument may have modified popped_params, so we
                 # restore it here.

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -182,9 +182,15 @@ def create_kwargs(
         # and an __args__ field indicating `(str, int)`. We capture both.
         annotation = remove_optional(param.annotation)
 
-        kwargs[param_name] = pop_and_construct_arg(
+        constructed_arg = pop_and_construct_arg(
             cls.__name__, param_name, annotation, param.default, params, **extras
         )
+
+        # If we just ended up constructing the default value for the parameter, we can just omit it.
+        # Leaving it in can cause issues with **kwargs in some corner cases, where you might end up
+        # with multiple values for a single parameter.
+        if constructed_arg is not param.default:
+            kwargs[param_name] = constructed_arg
 
     params.assert_empty(cls.__name__)
     return kwargs

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -329,14 +329,13 @@ def construct_arg(
         value_dict = {}
 
         for key, value_params in popped_params.items():
-            subextras = create_extras(value_cls, extras)
             value_dict[key] = construct_arg(
-                value_cls.__name__,
+                str(value_cls),
                 argument_name + "." + key,
                 value_params,
                 value_cls,
                 _NO_DEFAULT,
-                **subextras,
+                **extras,
             )
 
         return value_dict
@@ -364,7 +363,7 @@ def construct_arg(
 
         for i, (value_cls, value_params) in enumerate(zip(annotation.__args__, popped_params)):
             value = construct_arg(
-                value_cls.__name__,
+                str(value_cls),
                 argument_name + f".{i}",
                 value_params,
                 value_cls,
@@ -382,7 +381,7 @@ def construct_arg(
 
         for i, value_params in enumerate(popped_params):
             value = construct_arg(
-                value_cls.__name__,
+                str(value_cls),
                 argument_name + f".{i}",
                 value_params,
                 value_cls,

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -324,11 +324,11 @@ def construct_arg(
     elif annotation == str:
         return popped_params
     elif annotation == int:
-        return int(popped_params)
+        return int(popped_params)  # type: ignore
     elif annotation == bool:
         return bool(popped_params)
     elif annotation == float:
-        return float(popped_params)
+        return float(popped_params)  # type: ignore
 
     # This is special logic for handling types like Dict[str, TokenIndexer],
     # List[TokenIndexer], Tuple[TokenIndexer, Tokenizer], and Set[TokenIndexer],
@@ -418,7 +418,7 @@ def construct_arg(
                     default,
                     **extras,
                 )
-            except (ValueError, TypeError, ConfigurationError, AttributeError) as e:
+            except (ValueError, TypeError, ConfigurationError, AttributeError):
                 # Our attempt to construct the argument may have modified popped_params, so we
                 # restore it here.
                 popped_params = deepcopy(backup_params)

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -98,9 +98,18 @@ def takes_kwargs(obj) -> bool:
 
 
 def can_construct_from_params(type_: Type) -> bool:
+    if type_ in [str, int, float, bool]:
+        return True
     origin = getattr(type_, "__origin__", None)
+    print(f"can construct?: {type_} {origin}")
     if origin == Lazy:
         return True
+    elif origin:
+        if hasattr(type_, "from_params"):
+            return True
+        args = getattr(type_, "__args__")
+        print(f"Recursing: {args}")
+        return all([can_construct_from_params(arg) for arg in args])
     return hasattr(type_, "from_params")
 
 
@@ -235,6 +244,8 @@ def construct_arg(
     # The parameter is optional if its default value is not the "no default" sentinel.
     optional = default != _NO_DEFAULT
 
+    print(origin)
+    print(args)
     # Some constructors expect extra non-parameter items, e.g. vocab: Vocabulary.
     # We check the provided `extras` for these and just use them if they exist.
     if name in extras:
@@ -356,6 +367,7 @@ def construct_arg(
     else:
         # Pass it on as is and hope for the best.   ¯\_(ツ)_/¯
         if optional:
+            print(params)
             value = params.pop(name, default, keep_as_dict=True)
         else:
             value = params.pop(name, keep_as_dict=True)

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -125,9 +125,7 @@ def remove_optional(annotation: type):
         return annotation
 
 
-def infer_params(cls: Type[T],
-                 constructor: Callable[..., T] = None,
-                 ):
+def infer_params(cls: Type[T], constructor: Callable[..., T] = None):
     if constructor is None:
         constructor = cls.__init__
 
@@ -145,10 +143,7 @@ def infer_params(cls: Type[T],
     super_class = cls.mro()[1]
     super_parameters = infer_params(super_class)
 
-    return {
-        **super_parameters,
-        **parameters  # Subclass parameters overwrite superclass ones
-    }
+    return {**super_parameters, **parameters}  # Subclass parameters overwrite superclass ones
 
 
 def create_kwargs(

--- a/allennlp/models/basic_classifier.py
+++ b/allennlp/models/basic_classifier.py
@@ -6,7 +6,7 @@ import torch
 from allennlp.data import TextFieldTensors, Vocabulary
 from allennlp.models.model import Model
 from allennlp.modules import FeedForward, Seq2SeqEncoder, Seq2VecEncoder, TextFieldEmbedder
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 from allennlp.nn.util import get_text_field_mask
 from allennlp.training.metrics import CategoricalAccuracy
 

--- a/allennlp/models/basic_classifier.py
+++ b/allennlp/models/basic_classifier.py
@@ -43,8 +43,6 @@ class BasicClassifier(Model):
         Vocabulary namespace corresponding to labels. By default, we use the "labels" namespace.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         If provided, will be used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -58,10 +56,10 @@ class BasicClassifier(Model):
         num_labels: int = None,
         label_namespace: str = "labels",
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
 
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
         self._text_field_embedder = text_field_embedder
 
         if seq2seq_encoder:

--- a/allennlp/models/bert_for_classification.py
+++ b/allennlp/models/bert_for_classification.py
@@ -43,8 +43,6 @@ class BertForClassification(Model):
         Otherwise, they will be frozen and only the final linear layer will be trained.
     initializer : `InitializerApplicator`, optional
         If provided, will be used to initialize the final linear layer *only*.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -57,9 +55,9 @@ class BertForClassification(Model):
         label_namespace: str = "labels",
         trainable: bool = True,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         if isinstance(bert_model, str):
             self.bert_model = PretrainedBertModel.load(bert_model)

--- a/allennlp/models/bert_for_classification.py
+++ b/allennlp/models/bert_for_classification.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, Optional
+from typing import Dict, Union
 
 from overrides import overrides
 import torch
@@ -8,7 +8,6 @@ from allennlp.data import TextFieldTensors, Vocabulary
 from allennlp.models.model import Model
 from allennlp.modules.token_embedders.bert_token_embedder import PretrainedBertModel
 from allennlp.nn.initializers import InitializerApplicator
-from allennlp.nn import RegularizerApplicator
 from allennlp.training.metrics import CategoricalAccuracy
 
 

--- a/allennlp/models/biaffine_dependency_parser.py
+++ b/allennlp/models/biaffine_dependency_parser.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple, Any, List
+from typing import Dict, Tuple, Any, List
 import logging
 import copy
 
@@ -14,7 +14,7 @@ from allennlp.modules import Seq2SeqEncoder, TextFieldEmbedder, Embedding, Input
 from allennlp.modules.matrix_attention.bilinear_matrix_attention import BilinearMatrixAttention
 from allennlp.modules import FeedForward
 from allennlp.models.model import Model
-from allennlp.nn import InitializerApplicator, RegularizerApplicator, Activation
+from allennlp.nn import InitializerApplicator, Activation
 from allennlp.nn.util import get_text_field_mask, get_range_vector
 from allennlp.nn.util import (
     get_device_of,

--- a/allennlp/models/biaffine_dependency_parser.py
+++ b/allennlp/models/biaffine_dependency_parser.py
@@ -75,8 +75,6 @@ class BiaffineDependencyParser(Model):
         The dropout applied to the embedded text input.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -93,9 +91,9 @@ class BiaffineDependencyParser(Model):
         dropout: float = 0.0,
         input_dropout: float = 0.0,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self.text_field_embedder = text_field_embedder
         self.encoder = encoder

--- a/allennlp/models/biaffine_dependency_parser_multilang.py
+++ b/allennlp/models/biaffine_dependency_parser_multilang.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Any, List
+from typing import Dict, Any, List
 import logging
 
 from collections import defaultdict
@@ -12,7 +12,7 @@ from allennlp.modules import Seq2SeqEncoder, TextFieldEmbedder, Embedding
 from allennlp.modules import FeedForward
 from allennlp.models.model import Model
 from allennlp.models.biaffine_dependency_parser import BiaffineDependencyParser
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 from allennlp.nn.util import get_text_field_mask
 from allennlp.training.metrics import AttachmentScores
 

--- a/allennlp/models/biaffine_dependency_parser_multilang.py
+++ b/allennlp/models/biaffine_dependency_parser_multilang.py
@@ -71,8 +71,6 @@ class BiaffineDependencyParserMultiLang(BiaffineDependencyParser):
         The dropout applied to the embedded text input.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -90,7 +88,7 @@ class BiaffineDependencyParserMultiLang(BiaffineDependencyParser):
         dropout: float = 0.0,
         input_dropout: float = 0.0,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
         super().__init__(
             vocab,
@@ -105,7 +103,7 @@ class BiaffineDependencyParserMultiLang(BiaffineDependencyParser):
             dropout,
             input_dropout,
             initializer,
-            regularizer,
+            **kwargs,
         )
 
         self._langs_for_early_stop = langs_for_early_stop or []

--- a/allennlp/models/biattentive_classification_network.py
+++ b/allennlp/models/biattentive_classification_network.py
@@ -66,8 +66,6 @@ class BiattentiveClassificationNetwork(Model):
         If true, concatenate pretrained ELMo representations to the integrator output.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -84,9 +82,9 @@ class BiattentiveClassificationNetwork(Model):
         use_input_elmo: bool = False,
         use_integrator_output_elmo: bool = False,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self._text_field_embedder = text_field_embedder
         if "elmo" in self._text_field_embedder._token_embedders.keys():

--- a/allennlp/models/biattentive_classification_network.py
+++ b/allennlp/models/biattentive_classification_network.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 import numpy
 from overrides import overrides
@@ -10,7 +10,7 @@ from allennlp.common.checks import check_dimensions_match, ConfigurationError
 from allennlp.data import TextFieldTensors, Vocabulary
 from allennlp.modules import Elmo, FeedForward, Maxout, Seq2SeqEncoder, TextFieldEmbedder
 from allennlp.models.model import Model
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 from allennlp.nn import util
 from allennlp.training.metrics import CategoricalAccuracy
 

--- a/allennlp/models/bidirectional_lm.py
+++ b/allennlp/models/bidirectional_lm.py
@@ -1,11 +1,10 @@
-from typing import Optional
 
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.models.language_model import LanguageModel
 from allennlp.models.model import Model
 from allennlp.modules.text_field_embedders import TextFieldEmbedder
 from allennlp.modules.seq2seq_encoders import Seq2SeqEncoder
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 
 
 @Model.register("bidirectional-language-model")

--- a/allennlp/models/bidirectional_lm.py
+++ b/allennlp/models/bidirectional_lm.py
@@ -39,8 +39,6 @@ class BidirectionalLanguageModel(LanguageModel):
         the full `_SoftmaxLoss` defined above.
     sparse_embeddings : `bool`, optional (default: False)
         Passed on to `SampledSoftmaxLoss` if True.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -52,7 +50,7 @@ class BidirectionalLanguageModel(LanguageModel):
         num_samples: int = None,
         sparse_embeddings: bool = False,
         initializer: InitializerApplicator = None,
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
         super().__init__(
             vocab=vocab,
@@ -63,5 +61,5 @@ class BidirectionalLanguageModel(LanguageModel):
             sparse_embeddings=sparse_embeddings,
             bidirectional=True,
             initializer=initializer,
-            regularizer=regularizer,
+            **kwargs,
         )

--- a/allennlp/models/bidirectional_lm.py
+++ b/allennlp/models/bidirectional_lm.py
@@ -1,4 +1,3 @@
-
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.models.language_model import LanguageModel
 from allennlp.models.model import Model

--- a/allennlp/models/bimpm.py
+++ b/allennlp/models/bimpm.py
@@ -55,8 +55,6 @@ class BiMpm(Model):
         Dropout percentage to use.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         If provided, will be used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -74,9 +72,9 @@ class BiMpm(Model):
         classifier_feedforward: FeedForward,
         dropout: float = 0.1,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self.text_field_embedder = text_field_embedder
 

--- a/allennlp/models/bimpm.py
+++ b/allennlp/models/bimpm.py
@@ -2,7 +2,7 @@
 BiMPM (Bilateral Multi-Perspective Matching) model implementation.
 """
 
-from typing import Dict, Optional, List, Any
+from typing import Dict, List, Any
 
 from overrides import overrides
 import torch
@@ -12,7 +12,7 @@ from allennlp.common.checks import check_dimensions_match
 from allennlp.data import TextFieldTensors, Vocabulary
 from allennlp.modules import FeedForward, Seq2SeqEncoder, Seq2VecEncoder, TextFieldEmbedder
 from allennlp.models.model import Model
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 from allennlp.nn import util
 from allennlp.training.metrics import CategoricalAccuracy
 

--- a/allennlp/models/constituency_parser.py
+++ b/allennlp/models/constituency_parser.py
@@ -69,8 +69,6 @@ class SpanConstituencyParser(Model):
         Used to embed the `pos_tags` `SequenceLabelField` we get as input to the model.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     evalb_directory_path : `str`, optional (default=`DEFAULT_EVALB_DIR`)
         The path to the directory containing the EVALB executable used to score
         bracketed parses. By default, will use the EVALB included with allennlp,
@@ -87,10 +85,10 @@ class SpanConstituencyParser(Model):
         feedforward: FeedForward = None,
         pos_tag_embedding: Embedding = None,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
         evalb_directory_path: str = DEFAULT_EVALB_DIR,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self.text_field_embedder = text_field_embedder
         self.span_extractor = span_extractor

--- a/allennlp/models/constituency_parser.py
+++ b/allennlp/models/constituency_parser.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, List, Optional, NamedTuple, Any
+from typing import Dict, Tuple, List, NamedTuple, Any
 from overrides import overrides
 
 import torch
@@ -11,7 +11,7 @@ from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder,
 from allennlp.modules.token_embedders import Embedding
 from allennlp.modules.span_extractors.span_extractor import SpanExtractor
 from allennlp.models.model import Model
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 from allennlp.nn.util import masked_softmax, get_lengths_from_binary_sequence_mask
 from allennlp.training.metrics import CategoricalAccuracy

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -57,8 +57,6 @@ class CoreferenceResolver(Model):
         The probability of dropping out dimensions of the embedded text.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -74,9 +72,9 @@ class CoreferenceResolver(Model):
         max_antecedents: int,
         lexical_dropout: float = 0.2,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self._text_field_embedder = text_field_embedder
         self._context_layer = context_layer

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -12,7 +12,7 @@ from allennlp.modules.token_embedders import Embedding
 from allennlp.modules import FeedForward
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder, Pruner
 from allennlp.modules.span_extractors import SelfAttentiveSpanExtractor, EndpointSpanExtractor
-from allennlp.nn import util, InitializerApplicator, RegularizerApplicator
+from allennlp.nn import util, InitializerApplicator
 from allennlp.training.metrics import MentionRecall, ConllCorefScores
 
 logger = logging.getLogger(__name__)

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -59,8 +59,6 @@ class CrfTagger(Model):
         to the overall statistics.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     top_k : `int`, optional (default=`1`)
         If provided, the number of parses to return from the crf in output_dict['top_k_tags'].
         Top k parses are returned as a list of dicts, where each dictionary is of the form:
@@ -83,10 +81,10 @@ class CrfTagger(Model):
         dropout: Optional[float] = None,
         verbose_metrics: bool = False,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
         top_k: int = 1,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self.label_namespace = label_namespace
         self.text_field_embedder = text_field_embedder

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -10,7 +10,7 @@ from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder
 from allennlp.modules import ConditionalRandomField, FeedForward
 from allennlp.modules.conditional_random_field import allowed_transitions
 from allennlp.models.model import Model
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 import allennlp.nn.util as util
 from allennlp.training.metrics import CategoricalAccuracy, SpanBasedF1Measure
 

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -163,7 +163,7 @@ class CrfTagger(Model):
         tokens: TextFieldTensors,
         tags: torch.LongTensor = None,
         metadata: List[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict[str, torch.Tensor]:
 
         """

--- a/allennlp/models/decomposable_attention.py
+++ b/allennlp/models/decomposable_attention.py
@@ -57,8 +57,6 @@ class DecomposableAttention(Model):
         is also `None`).
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -72,9 +70,9 @@ class DecomposableAttention(Model):
         premise_encoder: Optional[Seq2SeqEncoder] = None,
         hypothesis_encoder: Optional[Seq2SeqEncoder] = None,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self._text_field_embedder = text_field_embedder
         self._attend_feedforward = TimeDistributed(attend_feedforward)

--- a/allennlp/models/decomposable_attention.py
+++ b/allennlp/models/decomposable_attention.py
@@ -8,7 +8,7 @@ from allennlp.models.model import Model
 from allennlp.modules import FeedForward
 from allennlp.modules import Seq2SeqEncoder, SimilarityFunction, TimeDistributed, TextFieldEmbedder
 from allennlp.modules.matrix_attention.legacy_matrix_attention import LegacyMatrixAttention
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 from allennlp.nn.util import get_text_field_mask, masked_softmax, weighted_sum
 from allennlp.training.metrics import CategoricalAccuracy
 

--- a/allennlp/models/encoder_decoders/composed_seq2seq.py
+++ b/allennlp/models/encoder_decoders/composed_seq2seq.py
@@ -41,8 +41,6 @@ class ComposedSeq2Seq(Model):
         the weights are shared/tied with the decoder's target embedding weights.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -53,10 +51,10 @@ class ComposedSeq2Seq(Model):
         decoder: SeqDecoder,
         tied_source_embedder_key: Optional[str] = None,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
 
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self._source_text_embedder = source_text_embedder
         self._encoder = encoder

--- a/allennlp/models/encoder_decoders/composed_seq2seq.py
+++ b/allennlp/models/encoder_decoders/composed_seq2seq.py
@@ -9,7 +9,7 @@ from allennlp.models.model import Model
 from allennlp.modules import TextFieldEmbedder, Seq2SeqEncoder, Embedding
 from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
 from allennlp.modules.seq2seq_decoders.seq_decoder import SeqDecoder
-from allennlp.nn import util, InitializerApplicator, RegularizerApplicator
+from allennlp.nn import util, InitializerApplicator
 
 
 @Model.register("composed_seq2seq")

--- a/allennlp/models/esim.py
+++ b/allennlp/models/esim.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List, Any
+from typing import Dict, List, Any
 
 import torch
 
@@ -8,7 +8,7 @@ from allennlp.models.model import Model
 from allennlp.modules import FeedForward, InputVariationalDropout
 from allennlp.modules.matrix_attention.legacy_matrix_attention import LegacyMatrixAttention
 from allennlp.modules import Seq2SeqEncoder, SimilarityFunction, TextFieldEmbedder
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 from allennlp.nn.util import (
     get_text_field_mask,
     masked_softmax,

--- a/allennlp/models/esim.py
+++ b/allennlp/models/esim.py
@@ -48,8 +48,6 @@ class ESIM(Model):
         Dropout percentage to use.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -64,9 +62,9 @@ class ESIM(Model):
         output_logit: FeedForward,
         dropout: float = 0.5,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self._text_field_embedder = text_field_embedder
         self._encoder = encoder

--- a/allennlp/models/event2mind.py
+++ b/allennlp/models/event2mind.py
@@ -17,7 +17,6 @@ from allennlp.modules.token_embedders import Embedding
 from allennlp.models.model import Model
 from allennlp.nn.beam_search import BeamSearch
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
-from allennlp.nn import RegularizerApplicator
 from allennlp.training.metrics import UnigramRecall
 
 

--- a/allennlp/models/event2mind.py
+++ b/allennlp/models/event2mind.py
@@ -56,8 +56,6 @@ class Event2Mind(Model):
     target_embedding_dim : int, optional (default = source_embedding_dim)
         You can specify an embedding dimensionality for the target side. If not, we'll use the same
         value as the source embedder's.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -71,9 +69,9 @@ class Event2Mind(Model):
         target_names: List[str] = None,
         target_namespace: str = "tokens",
         target_embedding_dim: int = None,
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
         target_names = target_names or ["xintent", "xreact", "oreact"]
 
         # Note: The original tweaks the embeddings for "personx" to be the mean

--- a/allennlp/models/graph_parser.py
+++ b/allennlp/models/graph_parser.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple, Any, List
+from typing import Dict, Tuple, Any, List
 import logging
 import copy
 
@@ -13,7 +13,7 @@ from allennlp.modules import Seq2SeqEncoder, TextFieldEmbedder, Embedding, Input
 from allennlp.modules.matrix_attention.bilinear_matrix_attention import BilinearMatrixAttention
 from allennlp.modules import FeedForward
 from allennlp.models.model import Model
-from allennlp.nn import InitializerApplicator, RegularizerApplicator, Activation
+from allennlp.nn import InitializerApplicator, Activation
 from allennlp.nn.util import get_text_field_mask
 from allennlp.nn.util import get_lengths_from_binary_sequence_mask
 from allennlp.training.metrics import F1Measure

--- a/allennlp/models/graph_parser.py
+++ b/allennlp/models/graph_parser.py
@@ -56,8 +56,6 @@ class GraphParser(Model):
         in the decoded graph. Must be between 0 and 1.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -74,9 +72,9 @@ class GraphParser(Model):
         input_dropout: float = 0.0,
         edge_prediction_threshold: float = 0.5,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self.text_field_embedder = text_field_embedder
         self.encoder = encoder

--- a/allennlp/models/language_model.py
+++ b/allennlp/models/language_model.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Union, Optional
+from typing import Dict, List, Tuple, Union
 
 import torch
 import numpy as np
@@ -10,7 +10,7 @@ from allennlp.modules.text_field_embedders import TextFieldEmbedder
 from allennlp.modules.sampled_softmax_loss import SampledSoftmaxLoss
 from allennlp.modules.seq2seq_encoders import Seq2SeqEncoder
 from allennlp.nn.util import get_text_field_mask
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 from allennlp.training.metrics import Perplexity
 
 

--- a/allennlp/models/language_model.py
+++ b/allennlp/models/language_model.py
@@ -86,8 +86,6 @@ class LanguageModel(Model):
         Train a bidirectional language model, where the contextualizer
         is used to predict the next and previous token for each input token.
         This must match the bidirectionality of the contextualizer.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -100,9 +98,9 @@ class LanguageModel(Model):
         sparse_embeddings: bool = False,
         bidirectional: bool = False,
         initializer: InitializerApplicator = None,
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
         self._text_field_embedder = text_field_embedder
 
         if contextualizer.is_bidirectional() is not bidirectional:

--- a/allennlp/models/masked_language_model.py
+++ b/allennlp/models/masked_language_model.py
@@ -51,8 +51,9 @@ class MaskedLanguageModel(Model):
         target_namespace: str = "bert",
         dropout: float = 0.0,
         initializer: InitializerApplicator = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab)
+        super().__init__(vocab, **kwargs)
         self._text_field_embedder = text_field_embedder
         self._contextualizer = contextualizer
         if contextualizer:

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -45,6 +45,16 @@ class Model(torch.nn.Module, Registrable):
     of early stopping and best-model serialization based on a validation metric in
     `Trainer`. Metrics that begin with "_" will not be logged
     to the progress bar by `Trainer`.
+
+    # Parameters
+
+    vocab: `Vocabulary`
+        There are two typical use-cases for the `Vocabulary` in a `Model`: getting vocabulary sizes
+        when constructing embedding matrices or output classifiers (as the vocabulary holds the
+        number of classes in your output, also), and translating model output into human-readable
+        form.
+    regularizer: `RegularizerApplicator`, optional
+        If given, the `Trainer` will use this to regularize model parameters.
     """
 
     _warn_for_unseparable_batches: Set[str] = set()

--- a/allennlp/models/next_token_lm.py
+++ b/allennlp/models/next_token_lm.py
@@ -52,8 +52,9 @@ class NextTokenLM(Model):
         target_namespace: str = "bert",
         dropout: float = 0.0,
         initializer: InitializerApplicator = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab)
+        super().__init__(vocab, **kwargs)
         self._text_field_embedder = text_field_embedder
         self._contextualizer = contextualizer
         if contextualizer:

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -50,8 +50,6 @@ class SemanticRoleLabeler(Model):
         The dimensionality of the embedding of the binary verb predicate features.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     label_smoothing : `float`, optional (default = 0.0)
         Whether or not to use label smoothing on the labels when computing cross entropy loss.
     ignore_span_metric : `bool`, optional (default = False)
@@ -69,12 +67,12 @@ class SemanticRoleLabeler(Model):
         binary_feature_dim: int,
         embedding_dropout: float = 0.0,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
         label_smoothing: float = None,
         ignore_span_metric: bool = False,
         srl_eval_path: str = DEFAULT_SRL_EVAL_PATH,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self.text_field_embedder = text_field_embedder
         self.num_classes = self.vocab.get_vocab_size("labels")

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -15,7 +15,7 @@ from allennlp.models.srl_util import (
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder
 from allennlp.modules.token_embedders import Embedding
 from allennlp.models.model import Model
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 from allennlp.nn.util import get_lengths_from_binary_sequence_mask, viterbi_decode
 from allennlp.training.metrics.srl_eval_scorer import SrlEvalScorer, DEFAULT_SRL_EVAL_PATH

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -48,8 +48,6 @@ class SimpleTagger(Model):
         to the overall statistics.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     """
 
     def __init__(
@@ -62,9 +60,9 @@ class SimpleTagger(Model):
         label_namespace: str = "labels",
         verbose_metrics: bool = False,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         self.label_namespace = label_namespace
         self.text_field_embedder = text_field_embedder

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -10,7 +10,7 @@ from allennlp.common.checks import check_dimensions_match, ConfigurationError
 from allennlp.data import TextFieldTensors, Vocabulary
 from allennlp.modules import Seq2SeqEncoder, TimeDistributed, TextFieldEmbedder
 from allennlp.models.model import Model
-from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn import InitializerApplicator
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 from allennlp.training.metrics import CategoricalAccuracy, SpanBasedF1Measure
 

--- a/allennlp/models/srl_bert.py
+++ b/allennlp/models/srl_bert.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Any, Union
+from typing import Dict, List, Any, Union
 
 from overrides import overrides
 import torch
@@ -9,7 +9,7 @@ from transformers.modeling_bert import BertModel
 from allennlp.data import TextFieldTensors, Vocabulary
 from allennlp.models.model import Model
 from allennlp.models.srl_util import convert_bio_tags_to_conll_format
-from allennlp.nn import InitializerApplicator, RegularizerApplicator, util
+from allennlp.nn import InitializerApplicator, util
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 from allennlp.nn.util import get_lengths_from_binary_sequence_mask, viterbi_decode
 from allennlp.training.metrics.srl_eval_scorer import SrlEvalScorer, DEFAULT_SRL_EVAL_PATH

--- a/allennlp/models/srl_bert.py
+++ b/allennlp/models/srl_bert.py
@@ -27,8 +27,6 @@ class SrlBert(Model):
         A string describing the BERT model to load or an already constructed BertModel.
     initializer : `InitializerApplicator`, optional (default=`InitializerApplicator()`)
         Used to initialize the model parameters.
-    regularizer : `RegularizerApplicator`, optional (default=`None`)
-        If provided, will be used to calculate the regularization penalty during training.
     label_smoothing : `float`, optional (default = 0.0)
         Whether or not to use label smoothing on the labels when computing cross entropy loss.
     ignore_span_metric : `bool`, optional (default = False)
@@ -44,12 +42,12 @@ class SrlBert(Model):
         bert_model: Union[str, BertModel],
         embedding_dropout: float = 0.0,
         initializer: InitializerApplicator = InitializerApplicator(),
-        regularizer: Optional[RegularizerApplicator] = None,
         label_smoothing: float = None,
         ignore_span_metric: bool = False,
         srl_eval_path: str = DEFAULT_SRL_EVAL_PATH,
+        **kwargs,
     ) -> None:
-        super().__init__(vocab, regularizer)
+        super().__init__(vocab, **kwargs)
 
         if isinstance(bert_model, str):
             self.bert_model = BertModel.from_pretrained(bert_model)

--- a/allennlp/nn/regularizers/regularizer_applicator.py
+++ b/allennlp/nn/regularizers/regularizer_applicator.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Tuple, Optional, Iterable
+from typing import List, Tuple
 
 import torch
 

--- a/allennlp/nn/regularizers/regularizer_applicator.py
+++ b/allennlp/nn/regularizers/regularizer_applicator.py
@@ -1,27 +1,27 @@
 import re
-from typing import Sequence, Tuple, Optional, Iterable
+from typing import List, Tuple, Optional, Iterable
 
 import torch
 
-from allennlp.common.params import Params
+from allennlp.common import FromParams
 from allennlp.nn.regularizers.regularizer import Regularizer
 
 
-class RegularizerApplicator:
+class RegularizerApplicator(FromParams):
     """
     Applies regularizers to the parameters of a Module based on regex matches.
     """
 
-    def __init__(self, regularizers: Sequence[Tuple[str, Regularizer]] = ()) -> None:
+    def __init__(self, regexes: List[Tuple[str, Regularizer]] = None) -> None:
         """
         # Parameters
 
-        regularizers : Sequence[Tuple[str, Regularizer]], optional (default = ())
+        regexes : List[Tuple[str, Regularizer]], optional (default = None)
             A sequence of pairs (regex, Regularizer), where each Regularizer
             applies to the parameters its regex matches (and that haven't previously
             been matched).
         """
-        self._regularizers = regularizers
+        self._regularizers = regexes or []
 
     def __call__(self, module: torch.nn.Module) -> torch.Tensor:
         """
@@ -41,45 +41,3 @@ class RegularizerApplicator:
                         accumulator = accumulator + penalty
                         break
         return accumulator
-
-    # Requires custom from_params because of complex logic.
-    @classmethod
-    def from_params(
-        cls, params: Iterable[Tuple[str, Params]] = ()
-    ) -> Optional["RegularizerApplicator"]:
-        """
-        Converts a List of pairs (regex, params) into an RegularizerApplicator.
-        This list should look like
-
-        [["regex1", {"type": "l2", "alpha": 0.01}], ["regex2", "l1"]]
-
-        where each parameter receives the penalty corresponding to the first regex
-        that matches its name (which may be no regex and hence no penalty).
-        The values can either be strings, in which case they correspond to the names
-        of regularizers, or dictionaries, in which case they must contain the "type"
-        key, corresponding to the name of a regularizer. In addition, they may contain
-        auxiliary named parameters which will be fed to the regularizer itself.
-        To determine valid auxiliary parameters, please refer to the torch.nn.init documentation.
-
-        # Parameters
-
-        params : `Params`, required.
-            A Params object containing a "regularizers" key.
-
-        # Returns
-
-        A RegularizerApplicator containing the specified Regularizers,
-        or `None` if no Regularizers are specified.
-        """
-        if not params:
-            return None
-
-        instantiated_regularizers = []
-        for parameter_regex, regularizer_params in params:
-            if isinstance(regularizer_params, str):
-                regularizer = Regularizer.by_name(regularizer_params)()
-            else:
-                regularizer_type = Regularizer.by_name(regularizer_params.pop("type"))
-                regularizer = regularizer_type(**regularizer_params)  # type: ignore
-            instantiated_regularizers.append((parameter_regex, regularizer))
-        return RegularizerApplicator(instantiated_regularizers)

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -626,7 +626,7 @@ class TestFromParams(AllenNlpTestCase):
                 super().__init__(**kwargs)
                 self.c = c
 
-        params = Params({"type": "c", "a": "a_value", "b": "b_value", "c": "c_value",})
+        params = Params({"type": "c", "a": "a_value", "b": "b_value", "c": "c_value"})
 
         instance = BaseClass.from_params(params)
         assert instance.a == "a_value"

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -588,20 +588,15 @@ class TestFromParams(AllenNlpTestCase):
             def __init__(self, a: str, x: int = 42, **kwargs):
                 super().__init__(x=x, a=-1, raw_a=a, **kwargs)
 
-        params = Params(
-            {
-                "type": "b",
-                "a": "123"
-            }
-        )
+        params = Params({"type": "b", "a": "123"})
         # The param `x` should not be required as it has default value in `B`
         # The correct type of the param `a` should be inferred from `B` as well.
         instance = BaseClass.from_params(params)
         assert instance.x == 42
         assert instance.a == -1
         assert len(instance.rest) == 1
-        assert type(instance.rest['raw_a']) == str
-        assert instance.rest['raw_a'] == "123"
+        assert type(instance.rest["raw_a"]) == str
+        assert instance.rest["raw_a"] == "123"
 
     def test_kwargs_are_passed_to_deeper_superclasses(self):
 
@@ -631,14 +626,7 @@ class TestFromParams(AllenNlpTestCase):
                 super().__init__(**kwargs)
                 self.c = c
 
-        params = Params(
-            {
-                "type": "c",
-                "a": "a_value",
-                "b": "b_value",
-                "c": "c_value",
-            }
-        )
+        params = Params({"type": "c", "a": "a_value", "b": "b_value", "c": "c_value",})
 
         instance = BaseClass.from_params(params)
         assert instance.a == "a_value"

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -276,12 +276,6 @@ class TestFromParams(AllenNlpTestCase):
                 # this test we'll ignore that.
                 self.b = b
 
-        class C(FromParams):
-            def __init__(self, c: Union[A, B, Dict[str, A]]) -> None:
-                # Really you would want to be sure that `self.c` has a consistent type, but for
-                # this test we'll ignore that.
-                self.c = c
-
         params = Params({"a": 3})
         a = A.from_params(params)
         assert a.a == 3
@@ -300,6 +294,23 @@ class TestFromParams(AllenNlpTestCase):
         assert isinstance(b.b, list)
         assert b.b[0].a == 3
         assert b.b[1].a == [4, 5]
+
+    def test_crazy_nested_union(self):
+        class A(FromParams):
+            def __init__(self, a: Union[int, List[int]]) -> None:
+                self.a = a
+
+        class B(FromParams):
+            def __init__(self, b: Union[A, List[A]]) -> None:
+                # Really you would want to be sure that `self.b` has a consistent type, but for
+                # this test we'll ignore that.
+                self.b = b
+
+        class C(FromParams):
+            def __init__(self, c: Union[A, B, Dict[str, A]]) -> None:
+                # Really you would want to be sure that `self.c` has a consistent type, but for
+                # this test we'll ignore that.
+                self.c = c
 
         # This is a contrived, ugly example (why would you want to duplicate names in a nested
         # structure like this??), but it demonstrates a potential bug when dealing with mutatable

--- a/allennlp/tests/common/from_params_test.py
+++ b/allennlp/tests/common/from_params_test.py
@@ -564,3 +564,83 @@ class TestFromParams(AllenNlpTestCase):
         reader = DatasetReader.from_params(params)
         assert reader.lazy is True
         assert str(reader._cache_directory) == "tmp"
+
+    def test_only_infer_superclass_params_if_unknown(self):
+
+        from allennlp.common.registrable import Registrable
+
+        class BaseClass(Registrable):
+            def __init__(self):
+                self.x = None
+                self.a = None
+                self.rest = None
+
+        @BaseClass.register("a")
+        class A(BaseClass):
+            def __init__(self, a: int, x: int, **kwargs):
+                super().__init__()
+                self.x = x
+                self.a = a
+                self.rest = kwargs
+
+        @BaseClass.register("b")
+        class B(A):
+            def __init__(self, a: str, x: int = 42, **kwargs):
+                super().__init__(x=x, a=-1, raw_a=a, **kwargs)
+
+        params = Params(
+            {
+                "type": "b",
+                "a": "123"
+            }
+        )
+        # The param `x` should not be required as it has default value in `B`
+        # The correct type of the param `a` should be inferred from `B` as well.
+        instance = BaseClass.from_params(params)
+        assert instance.x == 42
+        assert instance.a == -1
+        assert len(instance.rest) == 1
+        assert type(instance.rest['raw_a']) == str
+        assert instance.rest['raw_a'] == "123"
+
+    def test_kwargs_are_passed_to_deeper_superclasses(self):
+
+        from allennlp.common.registrable import Registrable
+
+        class BaseClass(Registrable):
+            def __init__(self):
+                self.a = None
+                self.b = None
+                self.c = None
+
+        @BaseClass.register("a")
+        class A(BaseClass):
+            def __init__(self, a: str):
+                super().__init__()
+                self.a = a
+
+        @BaseClass.register("b")
+        class B(A):
+            def __init__(self, b: str, **kwargs):
+                super().__init__(**kwargs)
+                self.b = b
+
+        @BaseClass.register("c")
+        class C(B):
+            def __init__(self, c, **kwargs):
+                super().__init__(**kwargs)
+                self.c = c
+
+        params = Params(
+            {
+                "type": "c",
+                "a": "a_value",
+                "b": "b_value",
+                "c": "c_value",
+            }
+        )
+
+        instance = BaseClass.from_params(params)
+        assert instance.a == "a_value"
+        assert instance.b == "b_value"
+        assert instance.c == "c_value"

--- a/allennlp/tests/fixtures/crf_tagger/experiment.json
+++ b/allennlp/tests/fixtures/crf_tagger/experiment.json
@@ -51,9 +51,11 @@
       "dropout": 0.0,
       "bidirectional": true
     },
-    "regularizer": [
-      ["transitions$", {"type": "l2", "alpha": 0.01}]
-    ]
+    "regularizer": {
+      "regexes": [
+        ["transitions$", {"type": "l2", "alpha": 0.01}]
+      ]
+    }
   },
   "iterator": {"type": "basic", "batch_size": 32},
   "trainer": {

--- a/allennlp/tests/fixtures/crf_tagger/experiment_ccgbank.json
+++ b/allennlp/tests/fixtures/crf_tagger/experiment_ccgbank.json
@@ -48,9 +48,11 @@
       "dropout": 0.0,
       "bidirectional": true
     },
-    "regularizer": [
-      ["transitions$", {"type": "l2", "alpha": 0.01}]
-    ]
+    "regularizer": {
+      "regexes": [
+        ["transitions$", {"type": "l2", "alpha": 0.01}]
+      ]
+    }
   },
   "iterator": {"type": "basic", "batch_size": 32},
   "trainer": {

--- a/allennlp/tests/fixtures/crf_tagger/experiment_conll2000.json
+++ b/allennlp/tests/fixtures/crf_tagger/experiment_conll2000.json
@@ -50,9 +50,11 @@
       "dropout": 0.0,
       "bidirectional": true
     },
-    "regularizer": [
-      ["transitions$", {"type": "l2", "alpha": 0.01}]
-    ]
+    "regularizer": {
+      "regexes": [
+        ["transitions$", {"type": "l2", "alpha": 0.01}]
+      ]
+    }
   },
   "iterator": {"type": "basic", "batch_size": 32},
   "trainer": {

--- a/allennlp/tests/fixtures/elmo/config/characters_token_embedder.json
+++ b/allennlp/tests/fixtures/elmo/config/characters_token_embedder.json
@@ -37,9 +37,11 @@
               "dropout": 0.5,
               "bidirectional": true
       },
-      "regularizer": [
-        ["transitions$", {"type": "l2", "alpha": 0.01}]
-      ]
+      "regularizer": {
+        "regexes": [
+          ["transitions$", {"type": "l2", "alpha": 0.01}]
+        ]
+      }
     },
     "iterator": {"type": "basic", "batch_size": 32},
     "trainer": {

--- a/allennlp/tests/fixtures/language_model/characters_token_embedder.json
+++ b/allennlp/tests/fixtures/language_model/characters_token_embedder.json
@@ -40,9 +40,11 @@
               "dropout": 0.5,
               "bidirectional": true
       },
-      "regularizer": [
-        ["transitions$", {"type": "l2", "alpha": 0.01}]
-      ]
+      "regularizer": {
+        "regexes": [
+          ["transitions$", {"type": "l2", "alpha": 0.01}]
+        ]
+      }
     },
     "iterator": {"type": "basic", "batch_size": 32},
     "trainer": {

--- a/allennlp/tests/fixtures/simple_tagger/experiment_with_regularization.json
+++ b/allennlp/tests/fixtures/simple_tagger/experiment_with_regularization.json
@@ -21,10 +21,12 @@
         "hidden_size": 4,
         "num_layers": 1
       },
-      "regularizer": [
-        ["weight$", {"type": "l2", "alpha": 10}],
-        ["bias$", {"type": "l1", "alpha": 5}]
-      ]
+      "regularizer": {
+        "regexes": [
+          ["weight$", {"type": "l2", "alpha": 10}],
+          ["bias$", {"type": "l1", "alpha": 5}]
+        ]
+      }
     },
     "iterator": {
       "type": "bucket",

--- a/allennlp/tests/nn/regularizers_test.py
+++ b/allennlp/tests/nn/regularizers_test.py
@@ -36,8 +36,8 @@ class TestRegularizers(AllenNlpTestCase):
         assert value.data.numpy() == 65.0
 
     def test_from_params(self):
-        params = Params({"regularizers": [("conv", "l1"), ("linear", {"type": "l2", "alpha": 10})]})
-        regularizer_applicator = RegularizerApplicator.from_params(params.pop("regularizers"))
+        params = Params({"regexes": [("conv", "l1"), ("linear", {"type": "l2", "alpha": 10})]})
+        regularizer_applicator = RegularizerApplicator.from_params(params)
         regularizers = regularizer_applicator._regularizers
 
         conv = linear = None


### PR DESCRIPTION
Getting this right required fixing some of the recursion that happens in `FromParams`, so there are more changes there than you would have expected.  The main changes are some logic fixes in `FromParams` and removing `RegularizerApplicator.from_params`.  The rest of the files that were touched are just updating our models to use newer, better functionality.

This requires a minor change to config files, where for regularizers you need to specify it as `"model": {"regularizer": {"regexes": [("conv", "l1", ...]}}`.  There's a new "regexes" key needed.  This seems reasonable to me, but if you disagree, we can maybe see if there's a way around this (there probably isn't a reasonable one, if we want to remove custom `from_params` methods).