### PR TITLE
New transformers version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "flaky",
         "responses>=0.7",
         "conllu==2.2.1",
-        "transformers>=2.1.1,!=2.2.1,!=2.2.2",
+        "transformers>=2.4.0",
         "jsonpickle",
     ],
     entry_points={"console_scripts": ["allennlp=allennlp.run:run"]},


### PR DESCRIPTION
`roberta-large` in the `transformers` library has some bugs involving token type ids. They are fixed in 2.4.0 and above.

I'm getting the feeling I'm the only person in the world using token type ids for anything.