### PR TITLE
Add coref + bert training config

### DIFF
--- a/allennlp/tests/fixtures/coref/coref_bert_lstm_small.jsonnet
+++ b/allennlp/tests/fixtures/coref/coref_bert_lstm_small.jsonnet
@@ -47,14 +47,14 @@ local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
     "mention_feedforward": {
         "input_dim": span_embedding_dim,
         "num_layers": 2,
-        "hidden_dims": 150,
+        "hidden_dims": 8,
         "activations": "relu",
         "dropout": 0.2
     },
     "antecedent_feedforward": {
         "input_dim": span_pair_embedding_dim,
         "num_layers": 2,
-        "hidden_dims": 150,
+        "hidden_dims": 8,
         "activations": "relu",
         "dropout": 0.2
     },
@@ -81,7 +81,7 @@ local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
   "trainer": {
     "num_epochs": 1,
     "grad_norm": 5.0,
-    "patience" : 3,
+    "patience" : 2,
     "cuda_device" : -1,
     "validation_metric": "+coref_f1",
     "learning_rate_scheduler": {

--- a/allennlp/tests/fixtures/coref/coref_bert_lstm_small.jsonnet
+++ b/allennlp/tests/fixtures/coref/coref_bert_lstm_small.jsonnet
@@ -1,0 +1,102 @@
+// Configuration for a coreference resolution model based on:
+//   Lee, Kenton et al. “End-to-end Neural Coreference Resolution.” EMNLP (2017).
+//   + BERT
+
+local bert_model = "albert-base-v2";
+local max_length = 128;
+local feature_size = 20;
+local max_span_width = 5;
+
+local bert_dim = 768;  # uniquely determined by bert_model
+local lstm_dim = 32;
+local span_embedding_dim = 4 * lstm_dim + bert_dim + feature_size;
+local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
+
+{
+  "dataset_reader": {
+    "type": "coref",
+    "token_indexers": {
+      "tokens": {
+        "type": "pretrained_transformer_mismatched",
+        "model_name": bert_model,
+        "max_length": max_length
+      },
+    },
+    "max_span_width": max_span_width
+  },
+  "train_data_path": "allennlp/tests/fixtures/coref/coref.gold_conll",
+  "validation_data_path": "allennlp/tests/fixtures/coref/coref.gold_conll",
+  "model": {
+    "type": "coref",
+    "text_field_embedder": {
+      "token_embedders": {
+        "tokens": {
+            "type": "pretrained_transformer_mismatched",
+            "model_name": bert_model,
+            "max_length": max_length
+        }
+      }
+    },
+    "context_layer": {
+        "type": "lstm",
+        "bidirectional": true,
+        "hidden_size": lstm_dim,
+        "input_size": bert_dim,
+        "num_layers": 1
+    },
+    "mention_feedforward": {
+        "input_dim": span_embedding_dim,
+        "num_layers": 2,
+        "hidden_dims": 150,
+        "activations": "relu",
+        "dropout": 0.2
+    },
+    "antecedent_feedforward": {
+        "input_dim": span_pair_embedding_dim,
+        "num_layers": 2,
+        "hidden_dims": 150,
+        "activations": "relu",
+        "dropout": 0.2
+    },
+    "initializer": [
+        [".*linear_layers.*weight", {"type": "xavier_normal"}],
+        [".*scorer._module.weight", {"type": "xavier_normal"}],
+        ["_distance_embedding.weight", {"type": "xavier_normal"}],
+        ["_span_width_embedding.weight", {"type": "xavier_normal"}],
+        ["_context_layer._module.weight_ih.*", {"type": "xavier_normal"}],
+        ["_context_layer._module.weight_hh.*", {"type": "orthogonal"}]
+    ],
+    "lexical_dropout": 0.5,
+    "feature_size": feature_size,
+    "max_span_width": max_span_width,
+    "spans_per_word": 0.4,
+    "max_antecedents": 50
+  },
+  "iterator": {
+    "type": "bucket",
+    "sorting_keys": [["text", "tokens___token_ids"]],
+    "padding_noise": 0.0,
+    "batch_size": 1
+  },
+  "trainer": {
+    "num_epochs": 1,
+    "grad_norm": 5.0,
+    "patience" : 3,
+    "cuda_device" : -1,
+    "validation_metric": "+coref_f1",
+    "learning_rate_scheduler": {
+      "type": "reduce_on_plateau",
+      "factor": 0.5,
+      "mode": "max",
+      "patience": 2
+    },
+    "optimizer": {
+      "type": "huggingface_adamw",
+      "lr": 1e-3,
+      "weight_decay": 0.01,
+      "parameter_groups": [
+        [[".*transformer.*"], {"lr": 1e-5}]
+      ]
+    }
+  }
+}

--- a/allennlp/tests/models/coreference_resolution/coref_test.py
+++ b/allennlp/tests/models/coreference_resolution/coref_test.py
@@ -26,7 +26,7 @@ class CorefTest(ModelTestCase):
                 ".transformer_model.pooler.weight",
                 "_text_field_embedder.token_embedder_tokens._matched_embedder"
                 ".transformer_model.pooler.bias",
-            }
+            },
         )
 
     def test_decode(self):

--- a/allennlp/tests/models/coreference_resolution/coref_test.py
+++ b/allennlp/tests/models/coreference_resolution/coref_test.py
@@ -14,6 +14,21 @@ class CorefTest(ModelTestCase):
     def test_coref_model_can_train_save_and_load(self):
         self.ensure_model_can_train_save_and_load(self.param_file)
 
+    def test_coref_bert_model_can_train_save_and_load(self):
+        self.set_up_model(
+            self.FIXTURES_ROOT / "coref" / "coref_bert_lstm_small.jsonnet",
+            self.FIXTURES_ROOT / "coref" / "coref.gold_conll",
+        )
+        self.ensure_model_can_train_save_and_load(
+            self.param_file,
+            gradients_to_ignore={
+                "_text_field_embedder.token_embedder_tokens._matched_embedder"
+                ".transformer_model.pooler.weight",
+                "_text_field_embedder.token_embedder_tokens._matched_embedder"
+                ".transformer_model.pooler.bias",
+            }
+        )
+
     def test_decode(self):
 
         spans = torch.LongTensor([[1, 2], [3, 4], [3, 7], [5, 6], [14, 56], [17, 80]])

--- a/training_config/coref_bert_lstm.jsonnet
+++ b/training_config/coref_bert_lstm.jsonnet
@@ -1,0 +1,103 @@
+// Configuration for a coreference resolution model based on:
+//   Lee, Kenton et al. “End-to-end Neural Coreference Resolution.” EMNLP (2017).
+//   + BERT
+
+local bert_model = "bert-base-uncased";
+local max_length = 128;
+local feature_size = 20;
+local max_span_width = 30;
+
+local bert_dim = 768;  # uniquely determined by bert_model
+local lstm_dim = 200;
+local span_embedding_dim = 4 * lstm_dim + bert_dim + feature_size;
+local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
+
+{
+  "dataset_reader": {
+    "type": "coref",
+    "token_indexers": {
+      "tokens": {
+        "type": "pretrained_transformer_mismatched",
+        "model_name": bert_model,
+        "max_length": max_length
+      },
+    },
+    "max_span_width": max_span_width
+  },
+  "train_data_path": std.extVar("COREF_TRAIN_DATA_PATH"),
+  "validation_data_path": std.extVar("COREF_DEV_DATA_PATH"),
+  "test_data_path": std.extVar("COREF_TEST_DATA_PATH"),
+  "model": {
+    "type": "coref",
+    "text_field_embedder": {
+      "token_embedders": {
+        "tokens": {
+            "type": "pretrained_transformer_mismatched",
+            "model_name": bert_model,
+            "max_length": max_length
+        }
+      }
+    },
+    "context_layer": {
+        "type": "lstm",
+        "bidirectional": true,
+        "hidden_size": lstm_dim,
+        "input_size": bert_dim,
+        "num_layers": 1
+    },
+    "mention_feedforward": {
+        "input_dim": span_embedding_dim,
+        "num_layers": 2,
+        "hidden_dims": 150,
+        "activations": "relu",
+        "dropout": 0.2
+    },
+    "antecedent_feedforward": {
+        "input_dim": span_pair_embedding_dim,
+        "num_layers": 2,
+        "hidden_dims": 150,
+        "activations": "relu",
+        "dropout": 0.2
+    },
+    "initializer": [
+        [".*linear_layers.*weight", {"type": "xavier_normal"}],
+        [".*scorer._module.weight", {"type": "xavier_normal"}],
+        ["_distance_embedding.weight", {"type": "xavier_normal"}],
+        ["_span_width_embedding.weight", {"type": "xavier_normal"}],
+        ["_context_layer._module.weight_ih.*", {"type": "xavier_normal"}],
+        ["_context_layer._module.weight_hh.*", {"type": "orthogonal"}]
+    ],
+    "lexical_dropout": 0.5,
+    "feature_size": feature_size,
+    "max_span_width": max_span_width,
+    "spans_per_word": 0.4,
+    "max_antecedents": 100
+  },
+  "iterator": {
+    "type": "bucket",
+    "sorting_keys": [["text", "tokens___token_ids"]],
+    "padding_noise": 0.0,
+    "batch_size": 1
+  },
+  "trainer": {
+    "num_epochs": 150,
+    "grad_norm": 5.0,
+    "patience" : 10,
+    "cuda_device" : 0,
+    "validation_metric": "+coref_f1",
+    "learning_rate_scheduler": {
+      "type": "reduce_on_plateau",
+      "factor": 0.5,
+      "mode": "max",
+      "patience": 2
+    },
+    "optimizer": {
+      "type": "huggingface_adamw",
+      "lr": 1e-3,
+      "weight_decay": 0.01,
+      "parameter_groups": [
+        [[".*transformer.*"], {"lr": 1e-5}]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
E2E-coref + `bert-base-uncased`. Keeping LSTM. Limited hyperparameter tuning.

Trained model at https://storage.cloud.google.com/allennlp-public-models/coref-bert-lstm-2020.02.04.tar.gz