### PR TITLE
Update gpu_memory_mb() not to log at error level

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -513,8 +513,10 @@ def gpu_memory_mb() -> Dict[int, int]:
     except:  # noqa
         # Catch *all* exceptions, because this memory check is a nice-to-have
         # and we'd never want a training run to fail because of it.
-        logger.warning("unable to check gpu_memory_mb() due to "
-                       "occasional failure, continuing", exc_info=True)
+        logger.warning(
+            "unable to check gpu_memory_mb() due to occasional failure, continuing",
+            exc_info=True,
+        )
         return {}
 
 

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -514,8 +514,7 @@ def gpu_memory_mb() -> Dict[int, int]:
         # Catch *all* exceptions, because this memory check is a nice-to-have
         # and we'd never want a training run to fail because of it.
         logger.warning(
-            "unable to check gpu_memory_mb() due to occasional failure, continuing",
-            exc_info=True,
+            "unable to check gpu_memory_mb() due to occasional failure, continuing", exc_info=True
         )
         return {}
 

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -513,7 +513,8 @@ def gpu_memory_mb() -> Dict[int, int]:
     except:  # noqa
         # Catch *all* exceptions, because this memory check is a nice-to-have
         # and we'd never want a training run to fail because of it.
-        logger.exception("unable to check gpu_memory_mb(), continuing")
+        logger.warning("unable to check gpu_memory_mb() due to "
+                       "occasional failure, continuing", exc_info=True)
         return {}
 
 


### PR DESCRIPTION
According to the discussion in #2167 , there are known occasional failures in this non-critical function.
Log as a warning with the stack trace and error information.