### PR TITLE
Remove default None in dict get calls

### DIFF
--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -186,7 +186,7 @@ def find_learning_rate_model(
 
     cuda_device = params.params.get("trainer").get("cuda_device", -1)
     check_for_gpu(cuda_device)
-    distributed_params = params.params.get("distributed", None)
+    distributed_params = params.params.get("distributed")
     # See https://github.com/allenai/allennlp/issues/3658
     assert not distributed_params, "find-lr is not compatible with DistributedDataParallel."
 

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -242,9 +242,7 @@ class Params(MutableMapping):
             try:
                 value = self.params.pop(key)
             except KeyError:
-                raise ConfigurationError(
-                    'key "{}" is required at location "{}"'.format(key, self.history)
-                )
+                raise ConfigurationError(f'key "{key}" is required at location "{self.history}"')
         else:
             value = self.params.pop(key, default)
 
@@ -296,15 +294,8 @@ class Params(MutableMapping):
         Performs the functionality associated with dict.get(key) but also checks for returned
         dicts and returns a Params object in their place with an updated history.
         """
-        if default is self.DEFAULT:
-            try:
-                value = self.params.get(key)
-            except KeyError:
-                raise ConfigurationError(
-                    'key "{}" is required at location "{}"'.format(key, self.history)
-                )
-        else:
-            value = self.params.get(key, default)
+        default = None if default is self.DEFAULT else default
+        value = self.params.get(key, default)
         return self._check_is_dict(key, value)
 
     def pop_choice(
@@ -451,7 +442,7 @@ class Params(MutableMapping):
     def _check_is_dict(self, new_history, value):
         if isinstance(value, dict):
             new_history = self.history + new_history + "."
-            return Params(value, history=new_history,)
+            return Params(value, history=new_history)
         if isinstance(value, list):
             value = [self._check_is_dict(f"{new_history}.{i}", v) for i, v in enumerate(value)]
         return value

--- a/allennlp/data/dataset_readers/text_classification_json.py
+++ b/allennlp/data/dataset_readers/text_classification_json.py
@@ -68,7 +68,7 @@ class TextClassificationJsonReader(DatasetReader):
                     continue
                 items = json.loads(line)
                 text = items["text"]
-                label = items.get("label", None)
+                label = items.get("label")
                 if label is not None:
                     if self._skip_label_indexing:
                         try:

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -63,7 +63,7 @@ class Archive(NamedTuple):
 
         """
         modules_dict = {path: module for path, module in self.model.named_modules()}
-        module = modules_dict.get(path, None)
+        module = modules_dict.get(path)
 
         if not module:
             raise ConfigurationError(
@@ -89,7 +89,7 @@ _WEIGHTS_NAME = "weights.th"
 
 
 def archive_model(
-    serialization_dir: str, weights: str = _DEFAULT_WEIGHTS, archive_path: str = None,
+    serialization_dir: str, weights: str = _DEFAULT_WEIGHTS, archive_path: str = None
 ) -> None:
     """
     Archive the model weights, its training configuration, and its vocabulary to `model.tar.gz`.

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -263,7 +263,7 @@ class Model(torch.nn.Module, Registrable):
         vocab_choice = vocab_params.pop_choice("type", Vocabulary.list_available(), True)
         vocab_class, _ = Vocabulary.resolve_class_name(vocab_choice)
         vocab = vocab_class.from_files(
-            vocab_dir, vocab_params.get("padding_token", None), vocab_params.get("oov_token", None)
+            vocab_dir, vocab_params.get("padding_token"), vocab_params.get("oov_token")
         )
 
         model_params = config.get("model")
@@ -360,7 +360,7 @@ class Model(torch.nn.Module, Registrable):
         embedding_sources_mapping = embedding_sources_mapping or {}
         for model_path, module in self.named_modules():
             if hasattr(module, "extend_vocab"):
-                pretrained_file = embedding_sources_mapping.get(model_path, None)
+                pretrained_file = embedding_sources_mapping.get(model_path)
                 module.extend_vocab(
                     self.vocab, extension_pretrained_file=pretrained_file, model_path=model_path
                 )

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -280,7 +280,7 @@ def create_serialization_dir(
             )
             fail = True
         for key in flat_params.keys():
-            if flat_params.get(key, None) != flat_loaded.get(key, None):
+            if flat_params.get(key) != flat_loaded.get(key):
                 logger.error(
                     f"Value for '{key}' in training configuration does not match that the value in "
                     f"the serialization directory we're recovering from: "


### PR DESCRIPTION
Remove the `, None)` part when calling `.get(..., None)` in a dictionary or `Params`.

It improves readability and it's the default value.