### PR TITLE
test out github actions for automated nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly Release
 
 on:
   schedule:
-    - cron:  '0 9 * * *'
+    - cron:  '0 11 * * *'
 
 jobs:
   build:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,31 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron:  '0 9 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install requirements
+      run: |
+        pip install -r dev-requirements.txt
+    - name: Build Package
+      env: 
+        ALLENNLP_VERSION: $(git rev-parse --short "$GITHUB_SHA")
+      run: |
+        python setup.py bdist_wheel sdist
+    - name: Test Packages
+      run: |
+        pip install $(ls dist/*.whl)
+        allennlp test-install
+    - name: Deploy
+      run: |
+        twine upload -u ${{ secrets.PYPI_NIGHTLY_USERNAME }} -p ${{ secrets.PYPI_NIGHTLY_PASSWORD }} dist/*
+        rm -rf dist/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
         pip install -r dev-requirements.txt
     - name: Build Package
       env:
-        ALLENNLP_REVISION: $(git rev-parse --short "$GITHUB_SHA")
+        ALLENNLP_REVISION: dev.$(git rev-parse --short "$GITHUB_SHA")
       run: |
         python setup.py bdist_wheel sdist
     - name: Test Packages
@@ -26,6 +26,7 @@ jobs:
         pip install $(ls dist/*.whl)
         allennlp test-install
     - name: Check diff from 24hr ago
+      if: success()
       run: scripts/24hr_diff.sh
     - name: Deploy
       if: success()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,15 +17,18 @@ jobs:
       run: |
         pip install -r dev-requirements.txt
     - name: Build Package
-      env: 
-        ALLENNLP_VERSION: $(git rev-parse --short "$GITHUB_SHA")
+      env:
+        ALLENNLP_REVISION: $(git rev-parse --short "$GITHUB_SHA")
       run: |
         python setup.py bdist_wheel sdist
     - name: Test Packages
       run: |
         pip install $(ls dist/*.whl)
         allennlp test-install
+    - name: Check diff from 24hr ago
+      run: scripts/24hr_diff.sh
     - name: Deploy
+      if: success()
       run: |
         twine upload -u ${{ secrets.PYPI_NIGHTLY_USERNAME }} -p ${{ secrets.PYPI_NIGHTLY_PASSWORD }} dist/*
         rm -rf dist/

--- a/allennlp/tests/commands/find_learning_rate_test.py
+++ b/allennlp/tests/commands/find_learning_rate_test.py
@@ -21,7 +21,7 @@ from allennlp.training.util import datasets_from_params
 
 def is_matplotlib_installed():
     try:
-        import matplotlib
+        import matplotlib  # noqa: F401 - Matplotlib is optional.
     except:  # noqa: E722. Any exception means we don't have a working matplotlib.
         return False
     return True

--- a/allennlp/version.py
+++ b/allennlp/version.py
@@ -5,7 +5,7 @@ _MINOR = "9"
 
 # We check the environment for the revision here, because it
 # enables us to set it to a git sha when doing automated nightly releases.
-_REVISION = os.environ.get("ALLENNLP_REVISION", None) or "1-unreleased"
+_REVISION = os.environ.get("ALLENNLP_REVISION", "1-unreleased")
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
 VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)

--- a/allennlp/version.py
+++ b/allennlp/version.py
@@ -5,7 +5,7 @@ _MINOR = "9"
 
 # We check the environment for the revision here, because it
 # enables us to set it to a git sha when doing automated nightly releases.
-_REVISION = os.environ.get("ALLENNLP_REVISON", None) or "1-unreleased"
+_REVISION = os.environ.get("ALLENNLP_REVISION", None) or "1-unreleased"
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
 VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)

--- a/allennlp/version.py
+++ b/allennlp/version.py
@@ -1,6 +1,11 @@
+import os
+
 _MAJOR = "0"
 _MINOR = "9"
-_REVISION = "1-unreleased"
+
+# We check the environment for the revision here, because it
+# enables us to set it to a git sha when doing automated nightly releases.
+_REVISION = os.environ("ALLENNLP_REVISON", None) or "1-unreleased"
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
 VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)

--- a/allennlp/version.py
+++ b/allennlp/version.py
@@ -5,7 +5,7 @@ _MINOR = "9"
 
 # We check the environment for the revision here, because it
 # enables us to set it to a git sha when doing automated nightly releases.
-_REVISION = os.environ("ALLENNLP_REVISON", None) or "1-unreleased"
+_REVISION = os.environ.get("ALLENNLP_REVISON", None) or "1-unreleased"
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
 VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)

--- a/scripts/24hr_diff.sh
+++ b/scripts/24hr_diff.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# A small script which checks if there have been any commits in the past 24 hours.
+
+if [[ $(git whatchanged --since 'one day ago') ]]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
This actually turned out to be not so hard, but it requires a couple of changes:


1. I need to change `allennlp/version.py` to look for an environment variable when setting the version, so I can change it to `MAJOR.MINOR.GITSHA` for the nightly versions

2. It requires adding our release details for pypi to github secrets


I didn't use TC for this because I thought it might be helpful to be able to generalise this across all of the allennlp* packages eventually, and it's easier for outside maintainers to see what is happening. 

I'll need to merge this before I actually know whether it works or not, but equally the nightly releases are a good place to test this functionality before we try using it for our proper releases. LMK what you think.


For our proper releases, we can configure these to run when new github tags matching a regex are pushed, which would be really nice - we just update the version in a PR, check the tests in TC run, and then push a tag once we've verified that. Then the whole packaging, testing and release step happens automatically.

