### PR TITLE
add missing dependencies for build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,7 @@ jobs:
       env:
         ALLENNLP_VERSION_SUFFIX: -dev$(date -u +%Y%m%d)+$(git rev-parse --short "$GITHUB_SHA")
       run: |
+        echo "Building packages for dev release $ALLENNLP_VERSION_SUFFIX"
         python setup.py bdist_wheel sdist
     - name: Test Packages
       run: |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -42,3 +42,5 @@ mkdocs-material==4.6.2
 
 # Pypi uploads
 twine>=1.11.0
+setuptools
+wheel


### PR DESCRIPTION
Turns out that you need the `wheel` package installed to build wheels, which we never knew because we did our builds in non-automated python environments 🤷‍♂ 