### PR TITLE
Remove occurrences of 'pylint'

### DIFF
--- a/allennlp/modules/seq2seq_encoders/compose_encoder.py
+++ b/allennlp/modules/seq2seq_encoders/compose_encoder.py
@@ -42,11 +42,7 @@ class ComposeEncoder(Seq2SeqEncoder):
             last_enc = enc
 
     @overrides
-    def forward(
-        self,  # pylint: disable=arguments-differ
-        inputs: torch.Tensor,
-        mask: torch.LongTensor = None,
-    ) -> torch.Tensor:
+    def forward(self, inputs: torch.Tensor, mask: torch.LongTensor = None) -> torch.Tensor:
         """
         # Parameters
 

--- a/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
+++ b/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
@@ -1,4 +1,3 @@
-# pylint: disable=no-self-use,invalid-name
 import torch
 import numpy
 from overrides import overrides

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -692,9 +692,9 @@ class TestNnUtil(AllenNlpTestCase):
         # Test Viterbi decoding is equal to greedy decoding with no pairwise potentials.
         sequence_logits = torch.autograd.Variable(torch.rand([5, 9]))
         transition_matrix = torch.zeros([9, 9])
-        # pylint: disable=no-member
+
         indices, _ = util.viterbi_decode(sequence_logits.data, transition_matrix, top_k=5)
-        # pylint: enable=no-member
+
         _, argmax_indices = torch.max(sequence_logits, 1)
         assert indices[0] == argmax_indices.data.squeeze().tolist()
 
@@ -756,14 +756,13 @@ class TestNnUtil(AllenNlpTestCase):
             """
             # Create all possible sequences
             sequences = [[]]  # type: ignore
-            # pylint: disable=consider-using-enumerate
+
             for i in range(len(tag_sequence)):
                 new_sequences = []  # type: ignore
                 for j in range(len(tag_sequence[i])):
                     for sequence in sequences:
                         new_sequences.append(sequence[:] + [j])
                 sequences = new_sequences
-            # pylint: enable=consider-using-enumerate
 
             # Score
             scored_sequences = []  # type: ignore

--- a/allennlp/tests/training/metrics/spearman_correlation_test.py
+++ b/allennlp/tests/training/metrics/spearman_correlation_test.py
@@ -6,8 +6,6 @@ from numpy.testing import assert_allclose
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.training.metrics import SpearmanCorrelation
 
-# pylint: disable=no-self-use
-
 
 def spearman_formula(predictions, labels, mask=None):
     """

--- a/scripts/ai2_internal/resume_daemon.py
+++ b/scripts/ai2_internal/resume_daemon.py
@@ -37,7 +37,7 @@ from logging.handlers import RotatingFileHandler
 from sqlite3 import Connection
 from subprocess import PIPE
 
-logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 formatter = logging.Formatter(
     fmt="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"

--- a/scripts/pylint.sh
+++ b/scripts/pylint.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# Run our linter over the python code.
-echo "you should switch to flake8.py"
-
-./scripts/verify.py --checks flake8


### PR DESCRIPTION
`pylint` isn't used anymore, so I removed references to it.