### PR TITLE
Fix the nightly build version number

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: Nightly Release
 on:
   # This is 11am in Seattle time.
   schedule:
-    - cron:  '0 19 * * *'
+    - cron: '0 19 * * *'
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
     - name: Set Version
       # This is somewhat bizarre, but you can't set env variables to bash commands in the action workflow -
       # So we have to use this odd way of exporting a variable instead.
-      run: echo ::set-env name=ALLENNLP_VERSION_SUFFIX::-dev$(date -u +%Y%m%d)+$(git rev-parse --short "$GITHUB_SHA")
+      run: echo ::set-env name=ALLENNLP_VERSION_SUFFIX::.dev$(date -u +%Y%m%d)
     - name: Build Package
       run: |
         echo "Building packages for dev release $ALLENNLP_VERSION_SUFFIX"


### PR DESCRIPTION
**TL;DR:** the nightly build GH action is failing because PyPI doesn't accept the suffix "+commit-sha". This patch fixes it.

<details>
 <summary>Longer explanation</summary>

If you do `python setup.py check` with the nightly build version with the `ALLENNLP_VERSION_SUFFIX` used in the file, it's gonna say it's correct. If you check it with the [2nd regex in PEP 440 Appendix B](https://www.python.org/dev/peps/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions), it will also be fine. However, if you check it with the first one, you'll see it's not gonna be "canonical". There it says:


> As noted earlier in the _Public version identifiers_ section, published version identifiers SHOULD use the canonical format.

Versions that have a `+something` are called in [PEP 440 "local versions"](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers). It says:

> Local version identifiers SHOULD NOT be used when publishing upstream projects to a public index server, but MAY be used to identify private builds created directly from the project source. Local version identifiers SHOULD be used by downstream projects when releasing a version that is API compatible with the version of the upstream project identified by the public version identifier, but contains additional changes (such as bug fixes). As the Python Package Index is intended solely for indexing and hosting upstream projects, it MUST NOT allow the use of local version identifiers.

Also, [TF uploads nightlies like the ones here but without that suffix](https://pypi.org/project/tf-nightly/#history), so that will work.
</details>

If keeping one commit per day then there won't be any problems with this change. Btw, to have in mind, I saw once a package called [versioneer](https://pypi.org/project/versioneer/) that helps you with this stuff.

Also, the "-" is converted to "." by setuptools. So I changed to reflect what it really is.