### PR TITLE
Exclude .DS_Store files from the Pip package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ recursive-include allennlp *
 recursive-include scripts *
 recursive-include training_config *.json
 recursive-include tutorials *
-recursive-exclude * __pycache__
+global-exclude .DS_Store
+global-exclude __pycache__


### PR DESCRIPTION
I found one in the latest stable version.

Btw, "scripts", "training_config" and "tutorials" aren't being part of the packaging. Should those be removed as well?