### PR TITLE
Remove some unused imports

### DIFF
--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -18,20 +18,15 @@ The available Seq2Seq encoders are
 - `"feedforward"` : allennlp.modules.feedforward_encoder.FeedforwardEncoder
 """
 
-from typing import Type
-import logging
-
-import torch
-
-from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
-from allennlp.modules.augmented_lstm import AugmentedLstm
 from allennlp.modules.seq2seq_encoders.bidirectional_language_model_transformer import (
     BidirectionalLanguageModelTransformer,
 )
 from allennlp.modules.seq2seq_encoders.compose_encoder import ComposeEncoder
+from allennlp.modules.seq2seq_encoders.feedforward_encoder import FeedForwardEncoder
 from allennlp.modules.seq2seq_encoders.gated_cnn_encoder import GatedCnnEncoder
 from allennlp.modules.seq2seq_encoders.intra_sentence_attention import IntraSentenceAttentionEncoder
+from allennlp.modules.seq2seq_encoders.multi_head_self_attention import MultiHeadSelfAttention
+from allennlp.modules.seq2seq_encoders.pass_through_encoder import PassThroughEncoder
 from allennlp.modules.seq2seq_encoders.pytorch_seq2seq_wrapper import (
     AugmentedLstmSeq2SeqEncoder,
     GruSeq2SeqEncoder,
@@ -41,11 +36,6 @@ from allennlp.modules.seq2seq_encoders.pytorch_seq2seq_wrapper import (
     StackedAlternatingLstmSeq2SeqEncoder,
     StackedBidirectionalLstmSeq2SeqEncoder,
 )
-from allennlp.modules.seq2seq_encoders.seq2seq_encoder import Seq2SeqEncoder
-from allennlp.modules.stacked_alternating_lstm import StackedAlternatingLstm
-from allennlp.modules.stacked_bidirectional_lstm import StackedBidirectionalLstm
-from allennlp.modules.seq2seq_encoders.stacked_self_attention import StackedSelfAttentionEncoder
-from allennlp.modules.seq2seq_encoders.multi_head_self_attention import MultiHeadSelfAttention
-from allennlp.modules.seq2seq_encoders.pass_through_encoder import PassThroughEncoder
-from allennlp.modules.seq2seq_encoders.feedforward_encoder import FeedForwardEncoder
 from allennlp.modules.seq2seq_encoders.qanet_encoder import QaNetEncoder
+from allennlp.modules.seq2seq_encoders.seq2seq_encoder import Seq2SeqEncoder
+from allennlp.modules.seq2seq_encoders.stacked_self_attention import StackedSelfAttentionEncoder

--- a/allennlp/modules/seq2vec_encoders/__init__.py
+++ b/allennlp/modules/seq2vec_encoders/__init__.py
@@ -15,17 +15,11 @@ The available Seq2Vec encoders are
 * `"stacked_bidirectional_lstm"` allennlp.modules.stacked_bidirectional_lstm.StackedBidirectionalLstm
 """
 
-from typing import Type
-
-import torch
-
-from allennlp.common import Params
-from allennlp.common.checks import ConfigurationError
+from allennlp.modules.seq2vec_encoders.bert_pooler import BertPooler
+from allennlp.modules.seq2vec_encoders.boe_encoder import BagOfEmbeddingsEncoder
 from allennlp.modules.seq2vec_encoders.cls_pooler import ClsPooler
 from allennlp.modules.seq2vec_encoders.cnn_encoder import CnnEncoder
 from allennlp.modules.seq2vec_encoders.cnn_highway_encoder import CnnHighwayEncoder
-from allennlp.modules.seq2vec_encoders.bert_pooler import BertPooler
-from allennlp.modules.seq2vec_encoders.boe_encoder import BagOfEmbeddingsEncoder
 from allennlp.modules.seq2vec_encoders.pytorch_seq2vec_wrapper import (
     AugmentedLstmSeq2VecEncoder,
     GruSeq2VecEncoder,
@@ -36,6 +30,3 @@ from allennlp.modules.seq2vec_encoders.pytorch_seq2vec_wrapper import (
     StackedBidirectionalLstmSeq2VecEncoder,
 )
 from allennlp.modules.seq2vec_encoders.seq2vec_encoder import Seq2VecEncoder
-from allennlp.modules.augmented_lstm import AugmentedLstm
-from allennlp.modules.stacked_alternating_lstm import StackedAlternatingLstm
-from allennlp.modules.stacked_bidirectional_lstm import StackedBidirectionalLstm


### PR DESCRIPTION
These __init__ files shouldn't offer these imports if they don't use them, they should just offer whatever is inside their folders.