### PR TITLE
Allow specifying max_sentences in coref readers

### DIFF
--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -44,6 +44,8 @@ class ConllCorefReader(DatasetReader):
         wordpieces. If this is set to `False` (default), the user is expected to use
         `PretrainedTransformerMismatchedIndexer` and `PretrainedTransformerMismatchedEmbedder`,
         and the modeling will be on the word-level.
+    max_sentences: int, optional (default = None)
+        The maximum number of sentences in each document to keep. By default keeps all sentences.
     """
 
     def __init__(
@@ -51,12 +53,14 @@ class ConllCorefReader(DatasetReader):
         max_span_width: int,
         token_indexers: Dict[str, TokenIndexer] = None,
         wordpiece_modeling_tokenizer: Optional[PretrainedTransformerTokenizer] = None,
+        max_sentences: int = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self._max_span_width = max_span_width
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._wordpiece_modeling_tokenizer = wordpiece_modeling_tokenizer
+        self._max_sentences = max_sentences
 
     @overrides
     def _read(self, file_path: str):
@@ -91,4 +95,5 @@ class ConllCorefReader(DatasetReader):
             self._max_span_width,
             gold_clusters,
             self._wordpiece_modeling_tokenizer,
+            self._max_sentences
         )

--- a/allennlp/data/dataset_readers/coreference_resolution/conll.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/conll.py
@@ -95,5 +95,5 @@ class ConllCorefReader(DatasetReader):
             self._max_span_width,
             gold_clusters,
             self._wordpiece_modeling_tokenizer,
-            self._max_sentences
+            self._max_sentences,
         )

--- a/allennlp/data/dataset_readers/coreference_resolution/preco.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/preco.py
@@ -41,6 +41,8 @@ class PrecoReader(DatasetReader):
         wordpieces. If this is set to `False` (default), the user is expected to use
         `PretrainedTransformerMismatchedIndexer` and `PretrainedTransformerMismatchedEmbedder`,
         and the modeling will be on the word-level.
+    max_sentences: int, optional (default = None)
+        The maximum number of sentences in each document to keep. By default keeps all sentences.
     """
 
     def __init__(
@@ -48,12 +50,14 @@ class PrecoReader(DatasetReader):
         max_span_width: int,
         token_indexers: Dict[str, TokenIndexer] = None,
         wordpiece_modeling_tokenizer: Optional[PretrainedTransformerTokenizer] = None,
+        max_sentences: int = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self._max_span_width = max_span_width
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._wordpiece_modeling_tokenizer = wordpiece_modeling_tokenizer
+        self._max_sentences = max_sentences
 
     @overrides
     def _read(self, file_path: str):
@@ -93,4 +97,5 @@ class PrecoReader(DatasetReader):
             self._max_span_width,
             gold_clusters,  # type: ignore
             self._wordpiece_modeling_tokenizer,
+            self._max_sentences,
         )

--- a/allennlp/data/dataset_readers/coreference_resolution/util.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/util.py
@@ -29,11 +29,23 @@ def make_coref_instance(
 
     sentences : `List[List[str]]`, required.
         A list of lists representing the tokenised words and sentences in the document.
+    token_indexers : `Dict[str, TokenIndexer]`
+        This is used to index the words in the document.  See :class:`TokenIndexer`.
+    max_span_width : `int`, required.
+        The maximum width of candidate spans to consider.
     gold_clusters : `Optional[List[List[Tuple[int, int]]]]`, optional (default = None)
         A list of all clusters in the document, represented as word spans with absolute indices
         in the entire document. Each cluster contains some number of spans, which can be nested
         and overlap. If there are exact matches between clusters, they will be resolved
         using `_canonicalize_clusters`.
+    wordpiece_modeling_tokenizer: `PretrainedTransformerTokenizer`, optional (default = None)
+        If not None, this dataset reader does subword tokenization using the supplied tokenizer
+        and distribute the labels to the resulting wordpieces. All the modeling will be based on
+        wordpieces. If this is set to `False` (default), the user is expected to use
+        `PretrainedTransformerMismatchedIndexer` and `PretrainedTransformerMismatchedEmbedder`,
+        and the modeling will be on the word-level.
+    max_sentences: int, optional (default = None)
+        The maximum number of sentences in each document to keep. By default keeps all sentences.
 
     # Returns
 

--- a/allennlp/data/dataset_readers/coreference_resolution/util.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/util.py
@@ -68,9 +68,7 @@ def make_coref_instance(
                 for mention in cluster:
                     start, end = mention
                     if first_token_offset <= start <= end <= last_token_offset:
-                        new_cluster.append(
-                            (start - first_token_offset, end - first_token_offset)
-                        )
+                        new_cluster.append((start - first_token_offset, end - first_token_offset))
                 if new_cluster:
                     new_gold_clusters.append(new_cluster)
 

--- a/allennlp/data/dataset_readers/coreference_resolution/util.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/util.py
@@ -1,4 +1,3 @@
-import random
 from typing import Any, Dict, List, Optional, Tuple, Set
 
 from allennlp.data.fields import (

--- a/allennlp/data/dataset_readers/coreference_resolution/util.py
+++ b/allennlp/data/dataset_readers/coreference_resolution/util.py
@@ -62,25 +62,17 @@ def make_coref_instance(
                 with respect to the `spans `ListField`.
     """
     if max_sentences is not None and len(sentences) > max_sentences:
-        first_sentence = random.randint(0, len(sentences) - max_sentences)
-        last_sentence = first_sentence + max_sentences - 1  # inclusive
-        first_token_offset = sum(len(sentence) for sentence in sentences[:first_sentence])
-        last_token_offset = (
-            first_token_offset
-            + sum(len(sentence) for sentence in sentences[first_sentence : last_sentence + 1])
-            - 1
-        )  # inclusive
+        sentences = sentences[:max_sentences]
+        total_length = sum(len(sentence) for sentence in sentences)
 
-        sentences = sentences[first_sentence : last_sentence + 1]
         if gold_clusters is not None:
             new_gold_clusters = []
 
             for cluster in gold_clusters:
                 new_cluster = []
                 for mention in cluster:
-                    start, end = mention
-                    if first_token_offset <= start <= end <= last_token_offset:
-                        new_cluster.append((start - first_token_offset, end - first_token_offset))
+                    if mention[1] < total_length:
+                        new_cluster.append(mention)
                 if new_cluster:
                     new_gold_clusters.append(new_cluster)
 

--- a/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
@@ -288,3 +288,23 @@ class TestCorefReader:
         # candidate spans are less than what we specified
         assert all(self.span_width >= len(x) > 0 for x in candidate_mentions)
         return candidate_mentions
+
+    def test_max_sentences(self):
+        conll_reader = ConllCorefReader(max_span_width=self.span_width)
+        instances = ensure_list(
+            conll_reader.read(str(AllenNlpTestCase.FIXTURES_ROOT / "coref" / "coref.gold_conll"))
+        )
+
+        limited_conll_reader = ConllCorefReader(max_span_width=self.span_width, max_sentences=2)
+        limited_instances = ensure_list(
+            limited_conll_reader.read(str(AllenNlpTestCase.FIXTURES_ROOT / "coref" / "coref.gold_conll"))
+        )
+
+        assert len(limited_instances) == len(instances) == 4
+
+        # Some are truncated, some short ones are not
+        length_of = lambda instance: len(instance.fields["text"].tokens)
+        assert length_of(limited_instances[0]) < length_of(instances[0])
+        assert length_of(limited_instances[1]) == length_of(instances[1])
+        assert length_of(limited_instances[2]) < length_of(instances[2])
+        assert length_of(limited_instances[3]) == length_of(instances[3])

--- a/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
@@ -316,9 +316,9 @@ class TestCorefReader:
         # Truncation happened
         assert len(limited_docs[0]) < len(docs[0])
         assert len(limited_docs[2]) < len(docs[2])
-        assert 'Disney' in text_of(docs[0]) and 'Disney' not in text_of(limited_docs[0])
-        assert 'tourism' in text_of(docs[2]) and 'tourism' not in text_of(limited_docs[2])
+        assert "Disney" in text_of(docs[0]) and "Disney" not in text_of(limited_docs[0])
+        assert "tourism" in text_of(docs[2]) and "tourism" not in text_of(limited_docs[2])
 
         # Truncated tokens are the prefixes
-        assert limited_docs[0] == docs[0][:len(limited_docs[0])]
-        assert limited_docs[2] == docs[2][:len(limited_docs[2])]
+        assert limited_docs[0] == docs[0][: len(limited_docs[0])]
+        assert limited_docs[2] == docs[2][: len(limited_docs[2])]

--- a/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
@@ -304,9 +304,21 @@ class TestCorefReader:
 
         assert len(limited_instances) == len(instances) == 4
 
-        # Some are truncated, some short ones are not
-        length_of = lambda instance: len(instance.fields["text"].tokens)
-        assert length_of(limited_instances[0]) < length_of(instances[0])
-        assert length_of(limited_instances[1]) == length_of(instances[1])
-        assert length_of(limited_instances[2]) < length_of(instances[2])
-        assert length_of(limited_instances[3]) == length_of(instances[3])
+        tokens_of = lambda instance: instance.fields["text"].tokens
+        text_of = lambda tokens: [token.text for token in tokens]
+        docs = [tokens_of(instance) for instance in instances]
+        limited_docs = [tokens_of(instance) for instance in limited_instances]
+
+        # Short ones; not truncated
+        assert limited_docs[1] == docs[1]
+        assert limited_docs[3] == docs[3]
+
+        # Truncation happened
+        assert len(limited_docs[0]) < len(docs[0])
+        assert len(limited_docs[2]) < len(docs[2])
+        assert 'Disney' in text_of(docs[0]) and 'Disney' not in text_of(limited_docs[0])
+        assert 'tourism' in text_of(docs[2]) and 'tourism' not in text_of(limited_docs[2])
+
+        # Truncated tokens are the prefixes
+        assert limited_docs[0] == docs[0][:len(limited_docs[0])]
+        assert limited_docs[2] == docs[2][:len(limited_docs[2])]

--- a/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/coreference/coref_reader_test.py
@@ -297,7 +297,9 @@ class TestCorefReader:
 
         limited_conll_reader = ConllCorefReader(max_span_width=self.span_width, max_sentences=2)
         limited_instances = ensure_list(
-            limited_conll_reader.read(str(AllenNlpTestCase.FIXTURES_ROOT / "coref" / "coref.gold_conll"))
+            limited_conll_reader.read(
+                str(AllenNlpTestCase.FIXTURES_ROOT / "coref" / "coref.gold_conll")
+            )
         )
 
         assert len(limited_instances) == len(instances) == 4


### PR DESCRIPTION
Sometimes the documents are very long which creates memory issues when using large models and large representations. This option allows sampling a subset of sentences for each document. It should be used during training only.