### PR TITLE
Remove embedding from params

### DIFF
--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -101,7 +101,9 @@ class CoreferenceResolver(Model):
 
         # 10 possible distance buckets.
         self._num_distance_buckets = 10
-        self._distance_embedding = Embedding(self._num_distance_buckets, feature_size)
+        self._distance_embedding = Embedding(
+            embedding_dim=feature_size, num_embeddings=self._num_distance_buckets
+        )
 
         self._max_span_width = max_span_width
         self._spans_per_word = spans_per_word

--- a/allennlp/models/encoder_decoders/copynet_seq2seq.py
+++ b/allennlp/models/encoder_decoders/copynet_seq2seq.py
@@ -129,7 +129,9 @@ class CopyNetSeq2Seq(Model):
         # the weights for the selective read are simply the predicted probabilities
         # corresponding to each token in the source sentence that matches the target
         # token from the previous timestep.
-        self._target_embedder = Embedding(target_vocab_size, target_embedding_dim)
+        self._target_embedder = Embedding(
+            num_embeddings=target_vocab_size, embedding_dim=target_embedding_dim
+        )
         self._attention = attention
         self._input_projection_layer = Linear(
             target_embedding_dim + self.encoder_output_dim * 2, self.decoder_input_dim

--- a/allennlp/models/encoder_decoders/simple_seq2seq.py
+++ b/allennlp/models/encoder_decoders/simple_seq2seq.py
@@ -135,7 +135,9 @@ class SimpleSeq2Seq(Model):
 
         # Dense embedding of vocab words in the target space.
         target_embedding_dim = target_embedding_dim or source_embedder.get_output_dim()
-        self._target_embedder = Embedding(num_classes, target_embedding_dim)
+        self._target_embedder = Embedding(
+            num_embeddings=num_classes, embedding_dim=target_embedding_dim
+        )
 
         # Decoder output dim needs to be the same as the encoder output dim since we initialize the
         # hidden state of the decoder with the final hidden state of the encoder.

--- a/allennlp/models/semantic_role_labeler.py
+++ b/allennlp/models/semantic_role_labeler.py
@@ -86,7 +86,9 @@ class SemanticRoleLabeler(Model):
 
         self.encoder = encoder
         # There are exactly 2 binary features for the verb predicate embedding.
-        self.binary_feature_embedding = Embedding(2, binary_feature_dim)
+        self.binary_feature_embedding = Embedding(
+            num_embeddings=2, embedding_dim=binary_feature_dim
+        )
         self.tag_projection_layer = TimeDistributed(
             Linear(self.encoder.get_output_dim(), self.num_classes)
         )

--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -665,8 +665,8 @@ class _ElmoBiLm(torch.nn.Module):
         self._bos_embedding = full_embedding[0, :]
         self._eos_embedding = full_embedding[1, :]
         self._word_embedding = Embedding(  # type: ignore
-            vocab_size,
-            embedding_dim,
+            num_embeddings=vocab_size,
+            embedding_dim=embedding_dim,
             weight=embedding.data,
             trainable=self._requires_grad,
             padding_index=0,

--- a/allennlp/modules/sampled_softmax_loss.py
+++ b/allennlp/modules/sampled_softmax_loss.py
@@ -96,9 +96,13 @@ class SampledSoftmaxLoss(torch.nn.Module):
         # Glorit init (std=(1.0 / sqrt(fan_in))
         if sparse:
             # create our own sparse embedding
-            self.softmax_w = torch.nn.Embedding(num_words, embedding_dim, sparse=True)
+            self.softmax_w = torch.nn.Embedding(
+                num_embeddings=num_words, embedding_dim=embedding_dim, sparse=True
+            )
             self.softmax_w.weight.data.normal_(mean=0.0, std=1.0 / np.sqrt(embedding_dim))
-            self.softmax_b = torch.nn.Embedding(num_words, 1, sparse=True)
+            self.softmax_b = torch.nn.Embedding(
+                num_embeddings=num_words, embedding_dim=1, sparse=True
+            )
             self.softmax_b.weight.data.fill_(0.0)
         else:
             # just create tensors to use as the embeddings

--- a/allennlp/modules/span_extractors/bidirectional_endpoint_span_extractor.py
+++ b/allennlp/modules/span_extractors/bidirectional_endpoint_span_extractor.py
@@ -89,7 +89,9 @@ class BidirectionalEndpointSpanExtractor(SpanExtractor):
                 "is bidirectional (and hence divisible by 2)."
             )
         if num_width_embeddings is not None and span_width_embedding_dim is not None:
-            self._span_width_embedding = Embedding(num_width_embeddings, span_width_embedding_dim)
+            self._span_width_embedding = Embedding(
+                num_embeddings=num_width_embeddings, embedding_dim=span_width_embedding_dim
+            )
         elif num_width_embeddings is not None or span_width_embedding_dim is not None:
             raise ConfigurationError(
                 "To use a span width embedding representation, you must"

--- a/allennlp/modules/span_extractors/endpoint_span_extractor.py
+++ b/allennlp/modules/span_extractors/endpoint_span_extractor.py
@@ -69,7 +69,9 @@ class EndpointSpanExtractor(SpanExtractor):
             self._start_sentinel = Parameter(torch.randn([1, 1, int(input_dim)]))
 
         if num_width_embeddings is not None and span_width_embedding_dim is not None:
-            self._span_width_embedding = Embedding(num_width_embeddings, span_width_embedding_dim)
+            self._span_width_embedding = Embedding(
+                num_embeddings=num_width_embeddings, embedding_dim=span_width_embedding_dim
+            )
         elif num_width_embeddings is not None or span_width_embedding_dim is not None:
             raise ConfigurationError(
                 "To use a span width embedding representation, you must"

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -12,7 +12,7 @@ import torch
 from overrides import overrides
 from torch.nn.functional import embedding
 
-from allennlp.common import Tqdm, Registrable
+from allennlp.common import Tqdm
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.file_utils import cached_path, get_file_extension, is_url_or_existing_file
 from allennlp.data import Vocabulary

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -27,7 +27,7 @@ with warnings.catch_warnings():
 logger = logging.getLogger(__name__)
 
 
-@TokenEmbedder.register("embedding", constructor="from_vocab_or_file")
+@TokenEmbedder.register("embedding")
 class Embedding(TokenEmbedder, Registrable):
     """
     A more featureful embedding module than the default in Pytorch.  Adds the ability to:
@@ -90,8 +90,8 @@ class Embedding(TokenEmbedder, Registrable):
 
     def __init__(
         self,
-        num_embeddings: int,
         embedding_dim: int,
+        num_embeddings: int = None,
         projection_dim: int = None,
         weight: torch.FloatTensor = None,
         padding_index: int = None,
@@ -100,11 +100,24 @@ class Embedding(TokenEmbedder, Registrable):
         norm_type: float = 2.0,
         scale_grad_by_freq: bool = False,
         sparse: bool = False,
-        vocab_namespace: str = None,
+        vocab_namespace: str = "tokens",
         pretrained_file: str = None,
         vocabulary: Vocabulary = None,
     ) -> None:
         super().__init__()
+
+        if num_embeddings is None and vocabulary is None:
+            raise ConfigurationError(
+                "Embedding must be constructed with either num_embeddings or a vocabulary."
+            )
+
+        if num_embeddings is None:
+            num_embeddings = vocabulary.get_vocab_size(vocab_namespace)
+        else:
+            # If num_embeddings is present, set default namespace to None so that extend_vocab
+            # call doesn't misinterpret that some namespace was originally used.
+            vocab_namespace = None
+
         self.num_embeddings = num_embeddings
         self.padding_index = padding_index
         self.max_norm = max_norm
@@ -300,58 +313,8 @@ class Embedding(TokenEmbedder, Registrable):
         extended_weight = torch.cat([self.weight.data, extra_weight.to(device)], dim=0)
         self.weight = torch.nn.Parameter(extended_weight, requires_grad=self.weight.requires_grad)
 
-    @classmethod
-    def from_vocab_or_file(
-        cls,
-        vocab: Vocabulary,
-        embedding_dim: int,
-        num_embeddings: int = None,
-        vocab_namespace: str = "tokens",
-        pretrained_file: str = None,
-        projection_dim: int = None,
-        trainable: bool = True,
-        padding_index: int = None,
-        max_norm: float = None,
-        norm_type: float = 2.0,
-        scale_grad_by_freq: bool = False,
-        sparse: bool = False,
-    ) -> "Embedding":
-        """
-        Similar to `__init__`, but has one additional function on top of what's there: if
-        `num_embeddings` is not given, it checks the vocabulary for how many embeddings to
-        construct.
 
-        We need the vocabulary here to know how many items we need to embed, and we look for a
-        `vocab_namespace` key in the parameter dictionary to know which vocabulary to use.  If
-        you know beforehand exactly how many embeddings you need, or aren't using a vocabulary
-        mapping for the things getting embedded here, then you can pass in the `num_embeddings`
-        key directly, and the vocabulary will be ignored.
-        """
-
-        if num_embeddings is None:
-            num_embeddings = vocab.get_vocab_size(vocab_namespace)
-        else:
-            # If num_embeddings is present, set default namespace to None so that extend_vocab
-            # call doesn't misinterpret that some namespace was originally used.
-            vocab_namespace = None
-
-        return cls(
-            num_embeddings=num_embeddings,
-            embedding_dim=embedding_dim,
-            projection_dim=projection_dim,
-            padding_index=padding_index,
-            trainable=trainable,
-            max_norm=max_norm,
-            norm_type=norm_type,
-            scale_grad_by_freq=scale_grad_by_freq,
-            sparse=sparse,
-            vocab_namespace=vocab_namespace,
-            pretrained_file=pretrained_file,
-            vocabulary=vocab,
-        )
-
-
-Embedding.register("embedding", constructor="from_vocab_or_file")(Embedding)
+Embedding.register("embedding")(Embedding)
 
 
 def _read_pretrained_embeddings_file(

--- a/allennlp/tests/common/registrable_test.py
+++ b/allennlp/tests/common/registrable_test.py
@@ -90,7 +90,7 @@ class TestRegistrable(AllenNlpTestCase):
         assert Regularizer.by_name("l2").__name__ == "L2Regularizer"
 
     def test_registry_has_builtin_token_embedders(self):
-        assert TokenEmbedder.by_name("embedding").__name__ == "from_vocab_or_file"
+        assert TokenEmbedder.by_name("embedding").__name__ == "Embedding"
         assert TokenEmbedder.by_name("character_encoding").__name__ == "TokenCharactersEncoder"
 
     def test_registry_has_builtin_text_field_embedders(self):

--- a/allennlp/tests/modules/seq2seq_decoders/auto_regressive_seq_decoder_test.py
+++ b/allennlp/tests/modules/seq2seq_decoders/auto_regressive_seq_decoder_test.py
@@ -79,12 +79,20 @@ class TestAutoRegressiveSeqDecoder(AllenNlpTestCase):
         vocab, decoder_net = create_vocab_and_decoder_net(decoder_inout_dim)
 
         AutoRegressiveSeqDecoder(
-            vocab, decoder_net, 10, Embedding(vocab.get_vocab_size(), decoder_inout_dim)
+            vocab,
+            decoder_net,
+            10,
+            Embedding(num_embeddings=vocab.get_vocab_size(), embedding_dim=decoder_inout_dim),
         )
 
         with pytest.raises(ConfigurationError):
             AutoRegressiveSeqDecoder(
-                vocab, decoder_net, 10, Embedding(vocab.get_vocab_size(), decoder_inout_dim + 1)
+                vocab,
+                decoder_net,
+                10,
+                Embedding(
+                    num_embeddings=vocab.get_vocab_size(), embedding_dim=decoder_inout_dim + 1
+                ),
             )
 
     def test_auto_regressive_seq_decoder_forward(self):
@@ -92,7 +100,10 @@ class TestAutoRegressiveSeqDecoder(AllenNlpTestCase):
         vocab, decoder_net = create_vocab_and_decoder_net(decoder_inout_dim)
 
         auto_regressive_seq_decoder = AutoRegressiveSeqDecoder(
-            vocab, decoder_net, 10, Embedding(vocab.get_vocab_size(), decoder_inout_dim)
+            vocab,
+            decoder_net,
+            10,
+            Embedding(num_embeddings=vocab.get_vocab_size(), embedding_dim=decoder_inout_dim),
         )
 
         encoded_state = torch.rand(batch_size, time_steps, decoder_inout_dim)
@@ -112,7 +123,10 @@ class TestAutoRegressiveSeqDecoder(AllenNlpTestCase):
         vocab, decoder_net = create_vocab_and_decoder_net(decoder_inout_dim)
 
         auto_regressive_seq_decoder = AutoRegressiveSeqDecoder(
-            vocab, decoder_net, 10, Embedding(vocab.get_vocab_size(), decoder_inout_dim)
+            vocab,
+            decoder_net,
+            10,
+            Embedding(num_embeddings=vocab.get_vocab_size(), embedding_dim=decoder_inout_dim),
         )
 
         predictions = torch.tensor([[3, 2, 5, 0, 0], [2, 2, 3, 5, 0]])
@@ -126,7 +140,10 @@ class TestAutoRegressiveSeqDecoder(AllenNlpTestCase):
         vocab, decoder_net = create_vocab_and_decoder_net(decoder_inout_dim)
 
         auto_regressive_seq_decoder = AutoRegressiveSeqDecoder(
-            vocab, decoder_net, 10, Embedding(vocab.get_vocab_size(), decoder_inout_dim)
+            vocab,
+            decoder_net,
+            10,
+            Embedding(num_embeddings=vocab.get_vocab_size(), embedding_dim=decoder_inout_dim),
         )
 
         predictions = torch.tensor([[3, 2, 5, 0, 0], [2, 2, 3, 5, 0]])
@@ -150,7 +167,7 @@ class TestAutoRegressiveSeqDecoder(AllenNlpTestCase):
             vocab,
             decoder_net,
             10,
-            Embedding(vocab.get_vocab_size(), decoder_inout_dim),
+            Embedding(num_embeddings=vocab.get_vocab_size(), embedding_dim=decoder_inout_dim),
             tensor_based_metric=BLEU(),
             token_based_metric=DummyMetric(),
         ).eval()

--- a/allennlp/tests/modules/token_embedders/embedding_test.py
+++ b/allennlp/tests/modules/token_embedders/embedding_test.py
@@ -49,7 +49,7 @@ class TestEmbedding(AllenNlpTestCase):
                 "projection_dim": 20,
             }
         )
-        embedding_layer = Embedding.from_vocab_or_file(vocab, **params.as_dict(quiet=True))
+        embedding_layer = Embedding.from_params(params, vocabulary=vocab)
         input_tensor = torch.LongTensor([[3, 2, 1, 0]])
         embedded = embedding_layer(input_tensor).data.numpy()
         assert embedded.shape == (1, 4, 20)
@@ -69,7 +69,7 @@ class TestEmbedding(AllenNlpTestCase):
             embeddings_file.write("word 1.0 2.3 -1.0\n".encode("utf-8"))
             embeddings_file.write(f"{unicode_space} 3.4 3.3 5.0\n".encode("utf-8"))
         params = Params({"pretrained_file": embeddings_filename, "embedding_dim": 3})
-        embedding_layer = Embedding.from_vocab_or_file(vocab, **params.as_dict(quiet=True))
+        embedding_layer = Embedding.from_params(params, vocabulary=vocab)
         word_vector = embedding_layer.weight.data[vocab.get_token_index("word")]
         assert numpy.allclose(word_vector.numpy(), numpy.array([1.0, 2.3, -1.0]))
         word_vector = embedding_layer.weight.data[vocab.get_token_index(unicode_space)]
@@ -85,7 +85,7 @@ class TestEmbedding(AllenNlpTestCase):
         with gzip.open(embeddings_filename, "wb") as embeddings_file:
             embeddings_file.write("word 1.0 2.3 -1.0\n".encode("utf-8"))
         params = Params({"pretrained_file": embeddings_filename, "embedding_dim": 3})
-        embedding_layer = Embedding.from_vocab_or_file(vocab, **params.as_dict(quiet=True))
+        embedding_layer = Embedding.from_params(params, vocabulary=vocab)
         word_vector = embedding_layer.weight.data[vocab.get_token_index("word2")]
         assert not numpy.allclose(word_vector.numpy(), numpy.array([0.0, 0.0, 0.0]))
 
@@ -99,7 +99,7 @@ class TestEmbedding(AllenNlpTestCase):
             _ = fout.create_dataset("embedding", embeddings.shape, dtype="float32", data=embeddings)
 
         params = Params({"pretrained_file": embeddings_filename, "embedding_dim": 5})
-        embedding_layer = Embedding.from_vocab_or_file(vocab, **params.as_dict(quiet=True))
+        embedding_layer = Embedding.from_params(params, vocabulary=vocab)
         assert numpy.allclose(embedding_layer.weight.data.numpy(), embeddings)
 
     def test_read_hdf5_raises_on_invalid_shape(self):
@@ -112,7 +112,7 @@ class TestEmbedding(AllenNlpTestCase):
 
         params = Params({"pretrained_file": embeddings_filename, "embedding_dim": 5})
         with pytest.raises(ConfigurationError):
-            _ = Embedding.from_vocab_or_file(vocab, **params.as_dict(quiet=True))
+            _ = Embedding.from_params(params, vocabulary=vocab)
 
     def test_read_embedding_file_inside_archive(self):
         token2vec = {
@@ -138,15 +138,13 @@ class TestEmbedding(AllenNlpTestCase):
             "providing a uri of the type: "
             "\\(path_or_url_to_archive\\)#path_inside_archive\\.",
         ):
-            Embedding.from_vocab_or_file(vocab, **params.as_dict(quiet=True))
+            Embedding.from_params(params, vocabulary=vocab)
 
         for ext in [".zip", ".tar.gz"]:
             archive_path = str(self.FIXTURES_ROOT / "embeddings/multi-file-archive") + ext
             file_uri = format_embeddings_file_uri(archive_path, "folder/fake_embeddings.5d.txt")
             params = Params({"pretrained_file": file_uri, "embedding_dim": 5})
-            embeddings = Embedding.from_vocab_or_file(
-                vocab, **params.as_dict(quiet=True)
-            ).weight.data
+            embeddings = Embedding.from_params(params, vocabulary=vocab).weight.data
             for tok, vec in token2vec.items():
                 i = vocab.get_token_index(tok)
                 assert torch.equal(embeddings[i], vec), "Problem with format " + archive_path
@@ -219,7 +217,7 @@ class TestEmbedding(AllenNlpTestCase):
         vocab.add_token_to_namespace("word1", "tokens_a")
         vocab.add_token_to_namespace("word2", "tokens_a")
         embedding_params = Params({"vocab_namespace": "tokens_a", "embedding_dim": 10})
-        embedder = Embedding.from_vocab_or_file(vocab, **embedding_params.as_dict(quiet=True))
+        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
         original_weight = embedder.weight
 
         assert original_weight.shape[0] == 4
@@ -238,7 +236,7 @@ class TestEmbedding(AllenNlpTestCase):
         vocab.add_token_to_namespace("word1")
         vocab.add_token_to_namespace("word2")
         embedding_params = Params({"vocab_namespace": "tokens", "embedding_dim": 10})
-        embedder = Embedding.from_vocab_or_file(vocab, **embedding_params.as_dict(quiet=True))
+        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
         original_weight = embedder.weight
 
         assert original_weight.shape[0] == 4
@@ -257,7 +255,7 @@ class TestEmbedding(AllenNlpTestCase):
         vocab.add_token_to_namespace("word1", "tokens_a")
         vocab.add_token_to_namespace("word2", "tokens_a")
         embedding_params = Params({"vocab_namespace": "tokens_a", "embedding_dim": 10})
-        embedder = Embedding.from_vocab_or_file(vocab, **embedding_params.as_dict(quiet=True))
+        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
 
         # Previous models won't have _vocab_namespace attribute. Force it to be None
         embedder._vocab_namespace = None
@@ -293,7 +291,7 @@ class TestEmbedding(AllenNlpTestCase):
                 "pretrained_file": embeddings_filename,
             }
         )
-        embedder = Embedding.from_vocab_or_file(vocab, **embedding_params.as_dict(quiet=True))
+        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
 
         # Change weight to simulate embedding training
         embedder.weight.data += 1
@@ -323,7 +321,7 @@ class TestEmbedding(AllenNlpTestCase):
         # Case1: When vocab is already in sync with embeddings it should be a no-op.
         vocab = Vocabulary({"tokens": {"word1": 1, "word2": 1}})
         embedding_params = Params({"vocab_namespace": "tokens", "embedding_dim": 10})
-        embedder = Embedding.from_vocab_or_file(vocab, **embedding_params.as_dict(quiet=True))
+        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
         original_weight = embedder.weight
         embedder.extend_vocab(vocab, "tokens")
         assert torch.all(embedder.weight == original_weight)
@@ -334,7 +332,7 @@ class TestEmbedding(AllenNlpTestCase):
         vocab.add_token_to_namespace("word1", "tokens")
         vocab.add_token_to_namespace("word2", "tokens")
         embedding_params = Params({"vocab_namespace": "tokens", "embedding_dim": 10})
-        embedder = Embedding.from_vocab_or_file(vocab, **embedding_params.as_dict(quiet=True))
+        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
         # Previous models won't have _vocab_namespace attribute. Force it to be None
         embedder._vocab_namespace = None
         embedder.weight = torch.nn.Parameter(embedder.weight[:1, :])
@@ -347,7 +345,7 @@ class TestEmbedding(AllenNlpTestCase):
         # it should raise configuration error.
         vocab = Vocabulary({"tokens": {"word1": 1, "word2": 1}})
         embedding_params = Params({"vocab_namespace": "tokens", "embedding_dim": 10})
-        embedder = Embedding.from_vocab_or_file(vocab, **embedding_params.as_dict(quiet=True))
+        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
         with pytest.raises(ConfigurationError):
             embedder.extend_vocab(Vocabulary(), "tokens")
 
@@ -365,7 +363,10 @@ class TestEmbedding(AllenNlpTestCase):
 
         num_embeddings = vocab.get_vocab_size()
         embedding_layer = Embedding(
-            num_embeddings, embedding_dim=3, pretrained_file=embeddings_filename, vocabulary=vocab
+            embedding_dim=3,
+            num_embeddings=num_embeddings,
+            pretrained_file=embeddings_filename,
+            vocabulary=vocab,
         )
         word_vector = embedding_layer.weight.data[vocab.get_token_index("word")]
         assert numpy.allclose(word_vector.numpy(), numpy.array([1.0, 2.3, -1.0]))

--- a/allennlp/tests/modules/token_embedders/embedding_test.py
+++ b/allennlp/tests/modules/token_embedders/embedding_test.py
@@ -49,7 +49,7 @@ class TestEmbedding(AllenNlpTestCase):
                 "projection_dim": 20,
             }
         )
-        embedding_layer = Embedding.from_params(params, vocabulary=vocab)
+        embedding_layer = Embedding.from_params(params, vocab=vocab)
         input_tensor = torch.LongTensor([[3, 2, 1, 0]])
         embedded = embedding_layer(input_tensor).data.numpy()
         assert embedded.shape == (1, 4, 20)
@@ -69,7 +69,7 @@ class TestEmbedding(AllenNlpTestCase):
             embeddings_file.write("word 1.0 2.3 -1.0\n".encode("utf-8"))
             embeddings_file.write(f"{unicode_space} 3.4 3.3 5.0\n".encode("utf-8"))
         params = Params({"pretrained_file": embeddings_filename, "embedding_dim": 3})
-        embedding_layer = Embedding.from_params(params, vocabulary=vocab)
+        embedding_layer = Embedding.from_params(params, vocab=vocab)
         word_vector = embedding_layer.weight.data[vocab.get_token_index("word")]
         assert numpy.allclose(word_vector.numpy(), numpy.array([1.0, 2.3, -1.0]))
         word_vector = embedding_layer.weight.data[vocab.get_token_index(unicode_space)]
@@ -85,7 +85,7 @@ class TestEmbedding(AllenNlpTestCase):
         with gzip.open(embeddings_filename, "wb") as embeddings_file:
             embeddings_file.write("word 1.0 2.3 -1.0\n".encode("utf-8"))
         params = Params({"pretrained_file": embeddings_filename, "embedding_dim": 3})
-        embedding_layer = Embedding.from_params(params, vocabulary=vocab)
+        embedding_layer = Embedding.from_params(params, vocab=vocab)
         word_vector = embedding_layer.weight.data[vocab.get_token_index("word2")]
         assert not numpy.allclose(word_vector.numpy(), numpy.array([0.0, 0.0, 0.0]))
 
@@ -99,7 +99,7 @@ class TestEmbedding(AllenNlpTestCase):
             _ = fout.create_dataset("embedding", embeddings.shape, dtype="float32", data=embeddings)
 
         params = Params({"pretrained_file": embeddings_filename, "embedding_dim": 5})
-        embedding_layer = Embedding.from_params(params, vocabulary=vocab)
+        embedding_layer = Embedding.from_params(params, vocab=vocab)
         assert numpy.allclose(embedding_layer.weight.data.numpy(), embeddings)
 
     def test_read_hdf5_raises_on_invalid_shape(self):
@@ -112,7 +112,7 @@ class TestEmbedding(AllenNlpTestCase):
 
         params = Params({"pretrained_file": embeddings_filename, "embedding_dim": 5})
         with pytest.raises(ConfigurationError):
-            _ = Embedding.from_params(params, vocabulary=vocab)
+            _ = Embedding.from_params(params, vocab=vocab)
 
     def test_read_embedding_file_inside_archive(self):
         token2vec = {
@@ -138,13 +138,13 @@ class TestEmbedding(AllenNlpTestCase):
             "providing a uri of the type: "
             "\\(path_or_url_to_archive\\)#path_inside_archive\\.",
         ):
-            Embedding.from_params(params, vocabulary=vocab)
+            Embedding.from_params(params, vocab=vocab)
 
         for ext in [".zip", ".tar.gz"]:
             archive_path = str(self.FIXTURES_ROOT / "embeddings/multi-file-archive") + ext
             file_uri = format_embeddings_file_uri(archive_path, "folder/fake_embeddings.5d.txt")
             params = Params({"pretrained_file": file_uri, "embedding_dim": 5})
-            embeddings = Embedding.from_params(params, vocabulary=vocab).weight.data
+            embeddings = Embedding.from_params(params, vocab=vocab).weight.data
             for tok, vec in token2vec.items():
                 i = vocab.get_token_index(tok)
                 assert torch.equal(embeddings[i], vec), "Problem with format " + archive_path
@@ -217,7 +217,7 @@ class TestEmbedding(AllenNlpTestCase):
         vocab.add_token_to_namespace("word1", "tokens_a")
         vocab.add_token_to_namespace("word2", "tokens_a")
         embedding_params = Params({"vocab_namespace": "tokens_a", "embedding_dim": 10})
-        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
+        embedder = Embedding.from_params(embedding_params, vocab=vocab)
         original_weight = embedder.weight
 
         assert original_weight.shape[0] == 4
@@ -236,7 +236,7 @@ class TestEmbedding(AllenNlpTestCase):
         vocab.add_token_to_namespace("word1")
         vocab.add_token_to_namespace("word2")
         embedding_params = Params({"vocab_namespace": "tokens", "embedding_dim": 10})
-        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
+        embedder = Embedding.from_params(embedding_params, vocab=vocab)
         original_weight = embedder.weight
 
         assert original_weight.shape[0] == 4
@@ -255,7 +255,7 @@ class TestEmbedding(AllenNlpTestCase):
         vocab.add_token_to_namespace("word1", "tokens_a")
         vocab.add_token_to_namespace("word2", "tokens_a")
         embedding_params = Params({"vocab_namespace": "tokens_a", "embedding_dim": 10})
-        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
+        embedder = Embedding.from_params(embedding_params, vocab=vocab)
 
         # Previous models won't have _vocab_namespace attribute. Force it to be None
         embedder._vocab_namespace = None
@@ -291,7 +291,7 @@ class TestEmbedding(AllenNlpTestCase):
                 "pretrained_file": embeddings_filename,
             }
         )
-        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
+        embedder = Embedding.from_params(embedding_params, vocab=vocab)
 
         # Change weight to simulate embedding training
         embedder.weight.data += 1
@@ -321,7 +321,7 @@ class TestEmbedding(AllenNlpTestCase):
         # Case1: When vocab is already in sync with embeddings it should be a no-op.
         vocab = Vocabulary({"tokens": {"word1": 1, "word2": 1}})
         embedding_params = Params({"vocab_namespace": "tokens", "embedding_dim": 10})
-        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
+        embedder = Embedding.from_params(embedding_params, vocab=vocab)
         original_weight = embedder.weight
         embedder.extend_vocab(vocab, "tokens")
         assert torch.all(embedder.weight == original_weight)
@@ -332,7 +332,7 @@ class TestEmbedding(AllenNlpTestCase):
         vocab.add_token_to_namespace("word1", "tokens")
         vocab.add_token_to_namespace("word2", "tokens")
         embedding_params = Params({"vocab_namespace": "tokens", "embedding_dim": 10})
-        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
+        embedder = Embedding.from_params(embedding_params, vocab=vocab)
         # Previous models won't have _vocab_namespace attribute. Force it to be None
         embedder._vocab_namespace = None
         embedder.weight = torch.nn.Parameter(embedder.weight[:1, :])
@@ -345,7 +345,7 @@ class TestEmbedding(AllenNlpTestCase):
         # it should raise configuration error.
         vocab = Vocabulary({"tokens": {"word1": 1, "word2": 1}})
         embedding_params = Params({"vocab_namespace": "tokens", "embedding_dim": 10})
-        embedder = Embedding.from_params(embedding_params, vocabulary=vocab)
+        embedder = Embedding.from_params(embedding_params, vocab=vocab)
         with pytest.raises(ConfigurationError):
             embedder.extend_vocab(Vocabulary(), "tokens")
 
@@ -366,7 +366,7 @@ class TestEmbedding(AllenNlpTestCase):
             embedding_dim=3,
             num_embeddings=num_embeddings,
             pretrained_file=embeddings_filename,
-            vocabulary=vocab,
+            vocab=vocab,
         )
         word_vector = embedding_layer.weight.data[vocab.get_token_index("word")]
         assert numpy.allclose(word_vector.numpy(), numpy.array([1.0, 2.3, -1.0]))


### PR DESCRIPTION
Following up on #3763.  Turns out the problem was just a mismatch between expected names.  The model was passing something called `vocab`, and the argument name in your original commit was `vocabulary`.  It's a bit magical to find this error, and unfortunate that we don't have better error handling here, but I'm not sure how to make this better.  The good news is that it's not magical if you're not using config files, and this change makes it easier to do that.