### PR TITLE
Revert "Fixes contiguous whitespaces causing coref model to produce bad results"

### DIFF
--- a/allennlp/predictors/coref.py
+++ b/allennlp/predictors/coref.py
@@ -199,12 +199,6 @@ class CorefPredictor(Predictor):
         """
         document = json_dict["document"]
         spacy_document = self._spacy(document)
-        # Spacy preserves whitespaces if there are multiple contiguous ones, see
-        # https://github.com/explosion/spaCy/issues/1707
-        # But we don't want those because they are not in the training data, so we remove them.
-        sentences = [
-            [token.text for token in sentence if not token.is_space]
-            for sentence in spacy_document.sents
-        ]
+        sentences = [[token.text for token in sentence] for sentence in spacy_document.sents]
         instance = self._dataset_reader.text_to_instance(sentences)
         return instance


### PR DESCRIPTION
Reverts allenai/allennlp#3786. This was fixed more fundamentally in #3808 . So we are rolling this back to be able to discover similar underlying bugs in the future.