### PR TITLE
Add coarse-to-fine and second order inference for coref. Also a new coref config

### DIFF
--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -177,7 +177,6 @@ class CoreferenceResolver(Model):
         # Shape: (batch_size, document_length, embedding_size)
         text_embeddings = self._lexical_dropout(self._text_field_embedder(text))
 
-        device = util.get_device_of(spans)
         batch_size = spans.size(0)
         document_length = text_embeddings.size(1)
         num_spans = spans.size(1)

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -317,9 +317,11 @@ class CoreferenceResolver(Model):
         # top_antecedent_offsets: (batch_size, num_spans_to_keep, max_antecedents)
         # top_antecedent_indices: (batch_size, num_spans_to_keep, max_antecedents)
 
+        flat_top_antecedent_indices = util.flatten_and_batch_shift_indices(top_antecedent_indices, num_spans_to_keep)
+
         # Shape: (batch_size, num_spans_to_keep, max_antecedents, embedding_size)
         top_antecedent_embeddings = util.batched_index_select(
-            top_span_embeddings, top_antecedent_indices
+            top_span_embeddings, top_antecedent_indices, flat_top_antecedent_indices
         )
         # Shape: (batch_size, num_spans_to_keep, 1 + max_antecedents)
         coreference_scores = self._compute_coreference_scores(
@@ -345,7 +347,7 @@ class CoreferenceResolver(Model):
 
             # Shape: (batch_size, num_spans_to_keep, max_antecedents, embedding_size)
             top_antecedent_embeddings = util.batched_index_select(
-                top_span_embeddings, top_antecedent_indices
+                top_span_embeddings, top_antecedent_indices, flat_top_antecedent_indices
             )
             # Shape: (batch_size, num_spans_to_keep, 1 + max_antecedents)
             coreference_scores = self._compute_coreference_scores(
@@ -380,7 +382,7 @@ class CoreferenceResolver(Model):
 
             # Shape: (batch_size, num_spans_to_keep, max_antecedents)
             antecedent_labels = util.batched_index_select(
-                pruned_gold_labels, top_antecedent_indices
+                pruned_gold_labels, top_antecedent_indices, flat_top_antecedent_indices
             ).squeeze(-1)
             antecedent_labels = util.replace_masked_values(antecedent_labels, top_antecedent_mask, -100)
 

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -245,7 +245,7 @@ class CoreferenceResolver(Model):
                 num_spans_to_keep, num_spans_to_keep, util.get_device_of(spans)
             )
 
-            # Shape: (batch_size, num_spans_to_keep, num_spans_to_keep)
+            # Shape: (batch_size, num_spans_to_keep, num_spans_to_keep); broadcast op
             partial_antecedent_scores = top_span_mention_scores.unsqueeze(
                 1
             ) + top_span_mention_scores.unsqueeze(2)
@@ -254,11 +254,8 @@ class CoreferenceResolver(Model):
             )
 
             # Shape: (batch_size, num_spans_to_keep, num_spans_to_keep); broadcast op
-            span_pair_mask = top_span_mask.bool().unsqueeze(-1) & valid_antecedent_mask
+            span_pair_mask = top_span_mask.unsqueeze(-1) & valid_antecedent_mask
 
-            ## The corresponding mask for top embeddings: (batch_size, max_num_items_to_keep, max_antecedents)
-            ## The indices of the top-k scoring items into the original embedding:  (batch_size, max_num_items_to_keep, max_antecedents)
-            ## (batch_size, max_num_items_to_keep, max_num_items_to_keep, 1) fast_top_ancedents_scores already included the mention scores.
             # Shape:
             # (batch_size, num_spans_to_keep, max_antecedents) * 3
             (

--- a/allennlp/tests/models/coreference_resolution/coref_test.py
+++ b/allennlp/tests/models/coreference_resolution/coref_test.py
@@ -12,7 +12,14 @@ class CorefTest(ModelTestCase):
         )
 
     def test_coref_model_can_train_save_and_load(self):
-        self.ensure_model_can_train_save_and_load(self.param_file)
+        for coarse_to_fine in (True, False):
+            self._test_coref_model_can_train_save_and_load(coarse_to_fine)
+
+    def _test_coref_model_can_train_save_and_load(self, coarse_to_fine: bool):
+        overrides = '{"model.coarse_to_fine": ' + f"{str(coarse_to_fine).lower()}" + "}"
+        self.ensure_model_can_train_save_and_load(self.param_file, overrides=overrides)
+        self.tearDown()
+        self.setUp()
 
     def test_coref_bert_model_can_train_save_and_load(self):
         self.set_up_model(

--- a/allennlp/tests/models/coreference_resolution/coref_test.py
+++ b/allennlp/tests/models/coreference_resolution/coref_test.py
@@ -13,10 +13,20 @@ class CorefTest(ModelTestCase):
 
     def test_coref_model_can_train_save_and_load(self):
         for coarse_to_fine in (True, False):
-            self._test_coref_model_can_train_save_and_load(coarse_to_fine)
+            for num_coref_layes in (1, 3):
+                self._test_coref_model_can_train_save_and_load(coarse_to_fine, num_coref_layes)
 
-    def _test_coref_model_can_train_save_and_load(self, coarse_to_fine: bool):
-        overrides = '{"model.coarse_to_fine": ' + f"{str(coarse_to_fine).lower()}" + "}"
+    def _test_coref_model_can_train_save_and_load(
+        self, coarse_to_fine: bool = False, num_coref_layes: int = 1
+    ):
+        # fmt: off
+        overrides = (
+            "{"
+            + '"model.coarse_to_fine": ' + f"{str(coarse_to_fine).lower()}" + ","
+            + '"model.num_coref_layers": ' + f"{num_coref_layes}"
+            + "}"
+        )
+        # fmt: on
         self.ensure_model_can_train_save_and_load(self.param_file, overrides=overrides)
         self.tearDown()
         self.setUp()

--- a/allennlp/tests/models/coreference_resolution/coref_test.py
+++ b/allennlp/tests/models/coreference_resolution/coref_test.py
@@ -42,7 +42,7 @@ class CorefTest(ModelTestCase):
                 [3, 2, 1, 0, 0, 0],
                 [4, 3, 2, 1, 0, 0],
             ]
-        )
+        ).unsqueeze(0)
 
         spans = spans.unsqueeze(0)
         antecedent_indices = antecedent_indices

--- a/allennlp/tests/models/coreference_resolution/coref_test.py
+++ b/allennlp/tests/models/coreference_resolution/coref_test.py
@@ -13,17 +13,17 @@ class CorefTest(ModelTestCase):
 
     def test_coref_model_can_train_save_and_load(self):
         for coarse_to_fine in (True, False):
-            for num_coref_layes in (1, 3):
-                self._test_coref_model_can_train_save_and_load(coarse_to_fine, num_coref_layes)
+            for inference_order in (1, 3):
+                self._test_coref_model_can_train_save_and_load(coarse_to_fine, inference_order)
 
     def _test_coref_model_can_train_save_and_load(
-        self, coarse_to_fine: bool = False, num_coref_layes: int = 1
+        self, coarse_to_fine: bool = False, inference_order: int = 1
     ):
         # fmt: off
         overrides = (
             "{"
             + '"model.coarse_to_fine": ' + f"{str(coarse_to_fine).lower()}" + ","
-            + '"model.num_coref_layers": ' + f"{num_coref_layes}"
+            + '"model.inference_order": ' + f"{inference_order}"
             + "}"
         )
         # fmt: on

--- a/allennlp/training/metrics/conll_coref_scores.py
+++ b/allennlp/training/metrics/conll_coref_scores.py
@@ -29,9 +29,8 @@ class ConllCorefScores(Metric):
             (start, end) indices for all spans kept after span pruning in the model.
             Expected shape: (batch_size, num_spans, 2)
         antecedent_indices : `torch.Tensor`
-            For each span, the indices of all allowed antecedents for that span.  This is
-            independent of the batch dimension, as it's just based on order in the document.
-            Expected shape: (num_spans, num_antecedents)
+            For each span, the indices of all allowed antecedents for that span.
+            Expected shape: (batch_size, num_spans, num_antecedents)
         predicted_antecedents : `torch.Tensor`
             For each span, this contains the index (into antecedent_indices) of the most likely
             antecedent for that span.
@@ -52,7 +51,7 @@ class ConllCorefScores(Metric):
         for i, metadata in enumerate(metadata_list):
             gold_clusters, mention_to_gold = self.get_gold_clusters(metadata["clusters"])
             predicted_clusters, mention_to_predicted = self.get_predicted_clusters(
-                top_spans[i], antecedent_indices, predicted_antecedents[i]
+                top_spans[i], antecedent_indices[i], predicted_antecedents[i]
             )
             for scorer in self.scorers:
                 scorer.update(

--- a/training_config/coref_spanbert_large.jsonnet
+++ b/training_config/coref_spanbert_large.jsonnet
@@ -69,6 +69,7 @@ local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
     },
     "initializer": {
       "regexes": [
+        [".*_span_updating_gated_sum.*weight", {"type": "xavier_normal"}],
         [".*linear_layers.*weight", {"type": "xavier_normal"}],
         [".*scorer._module.weight", {"type": "xavier_normal"}],
         ["_distance_embedding.weight", {"type": "xavier_normal"}],
@@ -82,7 +83,7 @@ local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
     "spans_per_word": 0.4,
     "max_antecedents": 50,
     "coarse_to_fine": true,
-    "num_coref_layers": 2
+    "inference_order": 2
   },
   "iterator": {
     "type": "bucket",

--- a/training_config/coref_spanbert_large.jsonnet
+++ b/training_config/coref_spanbert_large.jsonnet
@@ -71,7 +71,7 @@ local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
       "regexes": [
         [".*_span_updating_gated_sum.*weight", {"type": "xavier_normal"}],
         [".*linear_layers.*weight", {"type": "xavier_normal"}],
-        [".*scorer._module.weight", {"type": "xavier_normal"}],
+        [".*scorer.*weight", {"type": "xavier_normal"}],
         ["_distance_embedding.weight", {"type": "xavier_normal"}],
         ["_span_width_embedding.weight", {"type": "xavier_normal"}],
         ["_context_layer._module.weight_ih.*", {"type": "xavier_normal"}],

--- a/training_config/coref_spanbert_large.jsonnet
+++ b/training_config/coref_spanbert_large.jsonnet
@@ -1,0 +1,109 @@
+// Configuration for a coreference resolution model based on:
+//   Lee, Kenton et al. “Higher-order Coreference Resolution with Coarse-to-fine Inference.” NAACL (2018).
+//   + SpanBERT-large
+
+local transformer_model = "SpanBERT/spanbert-large-cased";
+local max_length = 512;
+local feature_size = 20;
+local max_span_width = 30;
+
+local transformer_dim = 1024;  # uniquely determined by transformer_model
+local span_embedding_dim = 3 * transformer_dim + feature_size;
+local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
+
+{
+  "dataset_reader": {
+    "type": "coref",
+    "token_indexers": {
+      "tokens": {
+        "type": "pretrained_transformer_mismatched",
+        "model_name": transformer_model,
+        "max_length": max_length
+      },
+    },
+    "max_span_width": max_span_width,
+    "max_sentences": 110
+  },
+  "validation_dataset_reader": {
+    "type": "coref",
+    "token_indexers": {
+      "tokens": {
+        "type": "pretrained_transformer_mismatched",
+        "model_name": transformer_model,
+        "max_length": max_length
+      },
+    },
+    "max_span_width": max_span_width
+  },
+  "train_data_path": std.extVar("COREF_TRAIN_DATA_PATH"),
+  "validation_data_path": std.extVar("COREF_DEV_DATA_PATH"),
+  "test_data_path": std.extVar("COREF_TEST_DATA_PATH"),
+  "model": {
+    "type": "coref",
+    "text_field_embedder": {
+      "token_embedders": {
+        "tokens": {
+            "type": "pretrained_transformer_mismatched",
+            "model_name": transformer_model,
+            "max_length": max_length
+        }
+      }
+    },
+    "context_layer": {
+        "type": "pass_through",
+        "input_dim": transformer_dim
+    },
+    "mention_feedforward": {
+        "input_dim": span_embedding_dim,
+        "num_layers": 2,
+        "hidden_dims": 1500,
+        "activations": "relu",
+        "dropout": 0.3
+    },
+    "antecedent_feedforward": {
+        "input_dim": span_pair_embedding_dim,
+        "num_layers": 2,
+        "hidden_dims": 1500,
+        "activations": "relu",
+        "dropout": 0.3
+    },
+    "initializer": {
+      "regexes": [
+        [".*linear_layers.*weight", {"type": "xavier_normal"}],
+        [".*scorer._module.weight", {"type": "xavier_normal"}],
+        ["_distance_embedding.weight", {"type": "xavier_normal"}],
+        ["_span_width_embedding.weight", {"type": "xavier_normal"}],
+        ["_context_layer._module.weight_ih.*", {"type": "xavier_normal"}],
+        ["_context_layer._module.weight_hh.*", {"type": "orthogonal"}]
+      ]
+    },
+    "feature_size": feature_size,
+    "max_span_width": max_span_width,
+    "spans_per_word": 0.4,
+    "max_antecedents": 50,
+    "coarse_to_fine": true,
+    "num_coref_layers": 2
+  },
+  "iterator": {
+    "type": "bucket",
+    "sorting_keys": [["text", "tokens___token_ids"]],
+    "batch_size": 1
+  },
+  "trainer": {
+    "num_epochs": 40,
+    "patience" : 7,
+    "cuda_device" : 0,
+    "validation_metric": "+coref_f1",
+    "learning_rate_scheduler": {
+      "type": "slanted_triangular",
+      "cut_frac": 0.06
+    },
+    "optimizer": {
+      "type": "huggingface_adamw",
+      "lr": 3e-4,
+      "parameter_groups": [
+        [[".*transformer.*"], {"lr": 1e-5}]
+      ]
+    }
+  }
+}

--- a/training_config/coref_spanbert_large.jsonnet
+++ b/training_config/coref_spanbert_large.jsonnet
@@ -92,7 +92,7 @@ local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
   },
   "trainer": {
     "num_epochs": 40,
-    "patience" : 7,
+    "patience" : 10,
     "cuda_device" : 0,
     "validation_metric": "+coref_f1",
     "learning_rate_scheduler": {


### PR DESCRIPTION
Based on https://arxiv.org/pdf/1804.05392.pdf. 79.17 dev 78.87 test. URL: https://storage.googleapis.com/allennlp-public-models/coref-spanbert-large-2020.02.27.tar.gz

SpanBERT reports 79.6 on test. According to the e2e-coref paper, speaker and genre metadata, which we aren't using, contributes 1.4 F1. So I assume that's where the difference is coming from.