### PR TITLE
[WIP] Add a pytorch lightning trainer

### DIFF
--- a/allennlp/tests/commands/train_test.py
+++ b/allennlp/tests/commands/train_test.py
@@ -9,6 +9,7 @@ from typing import Iterable
 import pytest
 import torch
 
+from allennlp.commands import train
 from allennlp.commands.train import Train, train_model, train_model_from_args, TrainModel
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
@@ -82,6 +83,26 @@ class TestTrain(AllenNlpTestCase):
                 force=True,
                 recover=True,
             )
+
+    def test_train_model_with_lightning(self):
+        params = lambda: Params(
+            {
+                "model": {
+                    "type": "simple_tagger",
+                    "text_field_embedder": {
+                        "token_embedders": {"tokens": {"type": "embedding", "embedding_dim": 5}}
+                    },
+                    "encoder": {"type": "lstm", "input_size": 5, "hidden_size": 7, "num_layers": 2},
+                },
+                "dataset_reader": {"type": "sequence_tagging"},
+                "train_data_path": SEQUENCE_TAGGING_DATA_PATH,
+                "validation_data_path": SEQUENCE_TAGGING_DATA_PATH,
+                "data_loader": {"batch_size": 2},
+                "trainer": {"num_epochs": 2, "optimizer": "adam"},
+            }
+        )
+
+        train.train_with_lightning(params())
 
     @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Need multiple GPUs.")
     def test_train_model_distributed(self):


### PR DESCRIPTION
I'm still noodling around, but in about 20 minutes I was able to get a simple test passing.  This needs a lot of work to actually be usable, but the proof of concept is here, it doesn't look like it's very much work, or very much code that we'd have to maintain.

I only used `Params` here because that's what the test I was copying did.  Still to do:
- [ ] Completely remove the `Params` bit out of the code that's added here, and just make a `TrainWithLightning` object that takes concrete objects as arguments (that we can construct `FromParams` if anyone wants to use that pipeline).  This probably also requires a `Registrable` `AllenNlpLightningModule` that can be subclassed for different configuration.
- [ ] Make sure this actually trains a real model, and serializes stuff how we want (we almost certainly want to create our typical model archive, for example, though I'm not sure what pytorch lightning does by default)
- [ ] Add whatever other bells and whistles people might want (not really sure what's necessary here; if anyone reading this uses or wants to use pytorch lightning, let me know what features should definitely be supported)

Bottom line: this is definitely possible, and should be very easy to support.  I don't know exactly what that support should look like, as I have no experience with this other trainer.  If you have specific requests, comment below.  I also will be out of town for a week and likely won't be working on this for a little bit, so if anyone is super eager and wants to try fleshing this out, let me know.