### PR TITLE
Enable AMP with Apex

### DIFF
--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -121,14 +121,20 @@ class TestTrainer(AllenNlpTestCase):
             Trainer(
                 self.model, self.optimizer, self.data_loader, num_epochs=2, cuda_device=[0, 1],
             )
-    
+
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device registered.")
     @pytest.mark.skipif(importlib.util.find_spec("apex") is None, reason="Apex is not installed.")
     def test_trainer_can_run_amp(self):
         from apex import amp
+
         self.model.cuda()
         trainer = Trainer(
-            self.model, self.optimizer, self.data_loader, num_epochs=2, cuda_device=0, opt_level="O1"
+            self.model,
+            self.optimizer,
+            self.data_loader,
+            num_epochs=2,
+            cuda_device=0,
+            opt_level="O1",
         )
         metrics = trainer.train()
         assert "peak_cpu_memory_MB" in metrics

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -125,7 +125,6 @@ class TestTrainer(AllenNlpTestCase):
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device registered.")
     @pytest.mark.skipif(importlib.util.find_spec("apex") is None, reason="Apex is not installed.")
     def test_trainer_can_run_amp(self):
-        from apex import amp
 
         self.model.cuda()
         trainer = Trainer(

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -1,5 +1,6 @@
 import copy
 import glob
+import importlib
 import json
 import os
 import re

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -188,6 +188,11 @@ class Trainer(TrainerBase):
             Gradients are accumulated for the given number of steps before doing an optimizer step. This can
             be useful to accommodate batches that are larger than the RAM size. Refer Thomas Wolf's
             [post](https://tinyurl.com/y5mv44fw) for details on Gradient Accumulation.
+        opt_level : `str`, optional, (default = `None`)
+            Each opt_level establishes a set of properties that govern Amp’s implementation of pure or mixed
+            precision training. Must be a choice of `"O0"`, `"O1"`, `"O2"`, or `"O3"`.
+            See the Apex [documentation](https://nvidia.github.io/apex/amp.html#opt-levels-and-properties) for
+            more details. If `None`, Amp is not used. Defaults to `None`.
         """
         super().__init__(serialization_dir, cuda_device, distributed, local_rank, world_size)
 

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -282,11 +282,15 @@ class Trainer(TrainerBase):
         if self._opt_level is not None:
             if amp is not None:
                 raise ConfigurationError(
-                    ("Apex not installed but opt_level was provided. Please install NVIDIA's Apex to enable"
-                     " automatic mixed precision (AMP) training. See: https://github.com/NVIDIA/apex.")
+                    (
+                        "Apex not installed but opt_level was provided. Please install NVIDIA's Apex to enable"
+                        " automatic mixed precision (AMP) training. See: https://github.com/NVIDIA/apex."
+                    )
                 )
 
-            self.model, self.optimizer = amp.initialize(self.model, self.optimizer, opt_level=self._opt_level)
+            self.model, self.optimizer = amp.initialize(
+                self.model, self.optimizer, opt_level=self._opt_level
+            )
 
         # Using `DistributedDataParallel`(ddp) brings in a quirk wrt AllenNLP's `Model` interface and its
         # usage. A `Model` object is wrapped by `ddp`, but assigning the wrapped model to `self.model`
@@ -309,7 +313,9 @@ class Trainer(TrainerBase):
         if self._grad_norm:
             if self._opt_level is not None:
                 # See: https://nvidia.github.io/apex/advanced.html#gradient-clipping
-                parameters_to_clip = [p for p in amp.master_params(self.optimizer) if p.grad is not None]
+                parameters_to_clip = [
+                    p for p in amp.master_params(self.optimizer) if p.grad is not None
+                ]
             else:
                 parameters_to_clip = [p for p in self.model.parameters() if p.grad is not None]
             return training_util.sparse_clip_norm(parameters_to_clip, self._grad_norm)

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -7,6 +7,7 @@ import time
 import traceback
 from typing import Dict, List, Optional, Tuple, Union, Any
 
+from apex import amp
 import torch
 import torch.distributed as dist
 import torch.optim.lr_scheduler
@@ -31,8 +32,6 @@ from allennlp.training.moving_average import MovingAverage
 from allennlp.training.optimizers import Optimizer
 from allennlp.training.tensorboard_writer import TensorboardWriter
 from allennlp.training.trainer_base import TrainerBase
-
-from apex import amp
 
 logger = logging.getLogger(__name__)
 

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -280,7 +280,7 @@ class Trainer(TrainerBase):
         # Enable automatic mixed precision training with NVIDIA Apex.
         self._opt_level = opt_level
         if self._opt_level is not None:
-            if amp is not None:
+            if amp is None:
                 raise ConfigurationError(
                     (
                         "Apex not installed but opt_level was provided. Please install NVIDIA's Apex to enable"

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -7,7 +7,10 @@ import time
 import traceback
 from typing import Dict, List, Optional, Tuple, Union, Any
 
-from apex import amp
+try:
+    from apex import amp
+except ImportError:
+    amp = None
 import torch
 import torch.distributed as dist
 import torch.optim.lr_scheduler
@@ -277,6 +280,12 @@ class Trainer(TrainerBase):
         # Enable automatic mixed precision training with NVIDIA Apex.
         self._opt_level = opt_level
         if self._opt_level is not None:
+            if amp is not None:
+                raise ConfigurationError(
+                    ("Apex not installed but opt_level was provided. Please install NVIDIA's Apex to enable"
+                     " automatic mixed precision (AMP) training. See: https://github.com/NVIDIA/apex.")
+                )
+
             self.model, self.optimizer = amp.initialize(self.model, self.optimizer, opt_level=self._opt_level)
 
         # Using `DistributedDataParallel`(ddp) brings in a quirk wrt AllenNLP's `Model` interface and its

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -25,6 +25,9 @@ matplotlib>=2.2.3
 # Required to run sanic tests
 aiohttp
 
+# Required for automatic mixed precision (AMP) training
+git+https://github.com/NVIDIA/apex.git@master
+
 #### DOC-RELATED PACKAGES ####
 
 # YAML manipulation


### PR DESCRIPTION
# Overview

This PR enables automatic mixed precision training with NVIDIA's [Apex](https://nvidia.github.io/apex/index.html) which has been much discussed in #2149 and is one of the action items on the [roadmap](https://github.com/allenai/allennlp/blob/master/ROADMAP.md).

The modifications were very straightforward. Here is the high-level:

1. Add argument `opt_level` to `Trainer`. This coincides with the [opt levels of Apex](https://nvidia.github.io/apex/amp.html#opt-levels).
2. In the constructor of `Trainer`, if `opt_level is not None`, wrap `self.model` and `self.optimizer` with `amp.initialize`.
3. `rescale_gradients` needs to be modified slightly when using Apex. See [here](https://nvidia.github.io/apex/advanced.html#gradient-clipping) for more info.
4. In `_train_epoch`, `if opt_level is not None`, call `loss.backward()` in the `amp.scale_loss` context manager.

I got all of this straight from the [Apex docs](https://nvidia.github.io/apex/index.html).

## Benchmark

I tested it on [my model](https://github.com/JohnGiorgi/t2t) and found a ~40% speedup in time per epoch during training. It also allowed me to train with a 40% larger mini-batch. The majority of my models parameters exist in a pre-trained transformer (`distilroberta-base` from [Transformers](https://huggingface.co/transformers/index.html)).

Simple benchmark on a [16GB-V100](https://www.nvidia.com/en-us/data-center/v100/) using a random 1K documents from [wikitext-103](https://blog.einstein.ai/the-wikitext-long-term-dependency-language-modeling-dataset/):

| `opt_level`   |      Batch Size      |  Time per epoch |
|----------|:-------------:|------:|
| `"O0"` |  12* | ~58s |
| `"O1"` |  12 | ~35s |
| `"O1"` |  20* | ~39s |

\*Maximum batch size that fits in memory at this `opt_level`.

Obviously, mileage will vary but this gives a flavour of the magnitude of speedup you can get with Apex.

## Things I need help with

- The way I have written this, there will be an `ImportError` if the user does not have `amp` installed. This is probably not what we want.
- I just shoehorned in the required modification to `rescale_gradients`. There is likely a cleaner way to do this.