### PR TITLE
Use training metrics if validation data is not provided

### DIFF
--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -712,6 +712,10 @@ class Trainer(TrainerBase):
                     os.path.join(self._serialization_dir, f"metrics_epoch_{epoch}.json"), metrics
                 )
 
+            # If we do not have a validation data, use the training metrics.
+            if self._validation_data_loader is None:
+                this_epoch_val_metric = metrics["training_" + self._validation_metric]
+
             # The Scheduler API is agnostic to whether your schedule requires a validation metric -
             # if it doesn't, the validation metric passed here is ignored.
             if self._learning_rate_scheduler:


### PR DESCRIPTION
I have an ultra-small dataset that I cannot have the luxury of having a validation dataset. 

A training using only the loss is enough to archive good results on this dataset. However, now the Allennlp do not allow to use a learning_rate_scheduler without a validation dataset.

I could pass the training dataset as the validation during the training, but in this way I have a useless slowdown because you have to double check the training dataset.

In the proposed PR, without the validation_data_loader, we utilize the training metrics to the learning date scheduler.
