### PR TITLE
Fix special values overflow/underflow for amp

### DIFF
--- a/allennlp/models/biattentive_classification_network.py
+++ b/allennlp/models/biattentive_classification_network.py
@@ -278,11 +278,11 @@ class BiattentiveClassificationNetwork(Model):
 
         # Simple Pooling layers
         max_masked_integrated_encodings = util.replace_masked_values(
-            integrated_encodings, text_mask.unsqueeze(2), -1e4
+            integrated_encodings, text_mask.unsqueeze(2), util.min_value_of_dtype(integrated_encodings.dtype)
         )
         max_pool = torch.max(max_masked_integrated_encodings, 1)[0]
         min_masked_integrated_encodings = util.replace_masked_values(
-            integrated_encodings, text_mask.unsqueeze(2), +1e4
+            integrated_encodings, text_mask.unsqueeze(2), util.max_value_of_dtype(integrated_encodings.dtype)
         )
         min_pool = torch.min(min_masked_integrated_encodings, 1)[0]
         mean_pool = torch.sum(integrated_encodings, 1) / torch.sum(text_mask, 1, keepdim=True)

--- a/allennlp/models/biattentive_classification_network.py
+++ b/allennlp/models/biattentive_classification_network.py
@@ -278,11 +278,15 @@ class BiattentiveClassificationNetwork(Model):
 
         # Simple Pooling layers
         max_masked_integrated_encodings = util.replace_masked_values(
-            integrated_encodings, text_mask.unsqueeze(2), util.min_value_of_dtype(integrated_encodings.dtype)
+            integrated_encodings,
+            text_mask.unsqueeze(2),
+            util.min_value_of_dtype(integrated_encodings.dtype),
         )
         max_pool = torch.max(max_masked_integrated_encodings, 1)[0]
         min_masked_integrated_encodings = util.replace_masked_values(
-            integrated_encodings, text_mask.unsqueeze(2), util.max_value_of_dtype(integrated_encodings.dtype)
+            integrated_encodings,
+            text_mask.unsqueeze(2),
+            util.max_value_of_dtype(integrated_encodings.dtype),
         )
         min_pool = torch.min(min_masked_integrated_encodings, 1)[0]
         mean_pool = torch.sum(integrated_encodings, 1) / torch.sum(text_mask, 1, keepdim=True)

--- a/allennlp/models/biattentive_classification_network.py
+++ b/allennlp/models/biattentive_classification_network.py
@@ -278,11 +278,11 @@ class BiattentiveClassificationNetwork(Model):
 
         # Simple Pooling layers
         max_masked_integrated_encodings = util.replace_masked_values(
-            integrated_encodings, text_mask.unsqueeze(2), -1e7
+            integrated_encodings, text_mask.unsqueeze(2), -1e4
         )
         max_pool = torch.max(max_masked_integrated_encodings, 1)[0]
         min_masked_integrated_encodings = util.replace_masked_values(
-            integrated_encodings, text_mask.unsqueeze(2), +1e7
+            integrated_encodings, text_mask.unsqueeze(2), +1e4
         )
         min_pool = torch.min(min_masked_integrated_encodings, 1)[0]
         mean_pool = torch.sum(integrated_encodings, 1) / torch.sum(text_mask, 1, keepdim=True)

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -859,7 +859,7 @@ class CoreferenceResolver(Model):
         ).squeeze(-1)
         antecedent_scores += top_partial_coreference_scores
         antecedent_scores = util.replace_masked_values(
-            antecedent_scores, top_antecedent_mask, -1e4
+            antecedent_scores, top_antecedent_mask, util.min_value_of_dtype(antecedent_scores.dtype)
         )
 
         # Shape: (batch_size, num_spans_to_keep, 1)

--- a/allennlp/models/coreference_resolution/coref.py
+++ b/allennlp/models/coreference_resolution/coref.py
@@ -859,7 +859,7 @@ class CoreferenceResolver(Model):
         ).squeeze(-1)
         antecedent_scores += top_partial_coreference_scores
         antecedent_scores = util.replace_masked_values(
-            antecedent_scores, top_antecedent_mask, -1e20
+            antecedent_scores, top_antecedent_mask, -1e4
         )
 
         # Shape: (batch_size, num_spans_to_keep, 1)

--- a/allennlp/models/encoder_decoders/copynet_seq2seq.py
+++ b/allennlp/models/encoder_decoders/copynet_seq2seq.py
@@ -417,7 +417,7 @@ class CopyNetSeq2Seq(Model):
         # to create `selective_weights`, which are used in the next timestep to create
         # a selective read state.
         # shape: (batch_size, trimmed_source_length)
-        copy_log_probs = log_probs[:, target_size:] + (target_to_source.to(log_probs.dtype) + util.tiny_value_of_dtype(log_probs.dtype)).log()
+        copy_log_probs = log_probs[:, target_size:] + (target_to_source.to(log_probs.dtype) + util.eps_value_of_dtype(log_probs.dtype)).log()
         # Since `log_probs[:, target_size]` gives us the raw copy log probabilities,
         # we use a non-log softmax to get the normalized non-log copy probabilities.
         selective_weights = util.masked_softmax(log_probs[:, target_size:], target_to_source)
@@ -426,7 +426,7 @@ class CopyNetSeq2Seq(Model):
         # matching tokens in the source sentence.
         # shape: (batch_size, 1)
         gen_mask = (target_tokens != self._oov_index) | (target_to_source.sum(-1) == 0)
-        log_gen_mask = (gen_mask + util.tiny_value_of_dtype(log_probs.dtype)).log().unsqueeze(-1)
+        log_gen_mask = (gen_mask + util.eps_value_of_dtype(log_probs.dtype)).log().unsqueeze(-1)
         # Now we get the generation score for the gold target token.
         # shape: (batch_size, 1)
         generation_log_probs = log_probs.gather(1, target_tokens.unsqueeze(1)) + log_gen_mask
@@ -680,7 +680,7 @@ class CopyNetSeq2Seq(Model):
             # to the OOV token.
             copy_log_probs_to_add_mask = source_to_target_slice != self._oov_index
             copy_log_probs_to_add = (
-                copy_log_probs_slice + (copy_log_probs_to_add_mask + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)).log()
+                copy_log_probs_slice + (copy_log_probs_to_add_mask + util.eps_value_of_dtype(copy_log_probs_slice.dtype)).log()
             )
             # shape: (batch_size, 1)
             copy_log_probs_to_add = copy_log_probs_to_add.unsqueeze(-1)
@@ -706,7 +706,7 @@ class CopyNetSeq2Seq(Model):
                 )
                 # shape: (group_size, trimmed_source_length - i)
                 future_copy_log_probs = (
-                    copy_log_probs[:, (i + 1) :] + (source_future_occurences + util.tiny_value_of_dtype(copy_log_probs.dtype)).log()
+                    copy_log_probs[:, (i + 1) :] + (source_future_occurences + util.eps_value_of_dtype(copy_log_probs.dtype)).log()
                 )
                 # shape: (group_size, 1 + trimmed_source_length - i)
                 combined = torch.cat(
@@ -722,13 +722,13 @@ class CopyNetSeq2Seq(Model):
                 ].unsqueeze(-1)
                 # shape: (group_size,)
                 duplicate_mask = source_previous_occurences.sum(dim=-1) == 0
-                copy_log_probs_slice = copy_log_probs_slice + (duplicate_mask + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)).log()
+                copy_log_probs_slice = copy_log_probs_slice + (duplicate_mask + util.eps_value_of_dtype(copy_log_probs_slice.dtype)).log()
 
             # Finally, we zero-out copy scores that we added to the generation scores
             # above so that we don't double-count them.
             # shape: (group_size,)
             left_over_copy_log_probs = (
-                copy_log_probs_slice + (~copy_log_probs_to_add_mask + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)).log()
+                copy_log_probs_slice + (~copy_log_probs_to_add_mask + util.eps_value_of_dtype(copy_log_probs_slice.dtype)).log()
             )
             modified_log_probs_list.append(left_over_copy_log_probs.unsqueeze(-1))
         modified_log_probs_list.insert(0, generation_log_probs)

--- a/allennlp/models/encoder_decoders/copynet_seq2seq.py
+++ b/allennlp/models/encoder_decoders/copynet_seq2seq.py
@@ -420,7 +420,7 @@ class CopyNetSeq2Seq(Model):
         copy_log_probs = (
             log_probs[:, target_size:]
             + (
-                target_to_source.to(log_probs.dtype) + util.eps_value_of_dtype(log_probs.dtype)
+                target_to_source.to(log_probs.dtype) + util.tiny_value_of_dtype(log_probs.dtype)
             ).log()
         )
         # Since `log_probs[:, target_size]` gives us the raw copy log probabilities,
@@ -431,7 +431,7 @@ class CopyNetSeq2Seq(Model):
         # matching tokens in the source sentence.
         # shape: (batch_size, 1)
         gen_mask = (target_tokens != self._oov_index) | (target_to_source.sum(-1) == 0)
-        log_gen_mask = (gen_mask + util.eps_value_of_dtype(log_probs.dtype)).log().unsqueeze(-1)
+        log_gen_mask = (gen_mask + util.tiny_value_of_dtype(log_probs.dtype)).log().unsqueeze(-1)
         # Now we get the generation score for the gold target token.
         # shape: (batch_size, 1)
         generation_log_probs = log_probs.gather(1, target_tokens.unsqueeze(1)) + log_gen_mask
@@ -688,7 +688,7 @@ class CopyNetSeq2Seq(Model):
             copy_log_probs_to_add = (
                 copy_log_probs_slice
                 + (
-                    copy_log_probs_to_add_mask + util.eps_value_of_dtype(copy_log_probs_slice.dtype)
+                    copy_log_probs_to_add_mask + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)
                 ).log()
             )
             # shape: (batch_size, 1)
@@ -717,7 +717,7 @@ class CopyNetSeq2Seq(Model):
                 future_copy_log_probs = (
                     copy_log_probs[:, (i + 1) :]
                     + (
-                        source_future_occurences + util.eps_value_of_dtype(copy_log_probs.dtype)
+                        source_future_occurences + util.tiny_value_of_dtype(copy_log_probs.dtype)
                     ).log()
                 )
                 # shape: (group_size, 1 + trimmed_source_length - i)
@@ -736,7 +736,7 @@ class CopyNetSeq2Seq(Model):
                 duplicate_mask = source_previous_occurences.sum(dim=-1) == 0
                 copy_log_probs_slice = (
                     copy_log_probs_slice
-                    + (duplicate_mask + util.eps_value_of_dtype(copy_log_probs_slice.dtype)).log()
+                    + (duplicate_mask + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)).log()
                 )
 
             # Finally, we zero-out copy scores that we added to the generation scores
@@ -746,7 +746,7 @@ class CopyNetSeq2Seq(Model):
                 copy_log_probs_slice
                 + (
                     ~copy_log_probs_to_add_mask
-                    + util.eps_value_of_dtype(copy_log_probs_slice.dtype)
+                    + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)
                 ).log()
             )
             modified_log_probs_list.append(left_over_copy_log_probs.unsqueeze(-1))

--- a/allennlp/models/encoder_decoders/copynet_seq2seq.py
+++ b/allennlp/models/encoder_decoders/copynet_seq2seq.py
@@ -688,7 +688,8 @@ class CopyNetSeq2Seq(Model):
             copy_log_probs_to_add = (
                 copy_log_probs_slice
                 + (
-                    copy_log_probs_to_add_mask + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)
+                    copy_log_probs_to_add_mask
+                    + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)
                 ).log()
             )
             # shape: (batch_size, 1)

--- a/allennlp/models/encoder_decoders/copynet_seq2seq.py
+++ b/allennlp/models/encoder_decoders/copynet_seq2seq.py
@@ -547,7 +547,7 @@ class CopyNetSeq2Seq(Model):
         # Initialize the copy scores to zero.
         state["copy_log_probs"] = (
             state["decoder_hidden"].new_zeros((batch_size, trimmed_source_length))
-            + util.min_value_of_dtype(state["decoder_hidden"].dtype)
+            + util.tiny_value_of_dtype(state["decoder_hidden"].dtype)
         ).log()
         # shape: (batch_size,)
         start_predictions = state["source_mask"].new_full(

--- a/allennlp/models/encoder_decoders/copynet_seq2seq.py
+++ b/allennlp/models/encoder_decoders/copynet_seq2seq.py
@@ -417,7 +417,7 @@ class CopyNetSeq2Seq(Model):
         # to create `selective_weights`, which are used in the next timestep to create
         # a selective read state.
         # shape: (batch_size, trimmed_source_length)
-        copy_log_probs = log_probs[:, target_size:] + (target_to_source.float() + 1e-45).log()
+        copy_log_probs = log_probs[:, target_size:] + (target_to_source.to(log_probs.dtype) + util.tiny_value_of_dtype(log_probs.dtype)).log()
         # Since `log_probs[:, target_size]` gives us the raw copy log probabilities,
         # we use a non-log softmax to get the normalized non-log copy probabilities.
         selective_weights = util.masked_softmax(log_probs[:, target_size:], target_to_source)
@@ -426,7 +426,7 @@ class CopyNetSeq2Seq(Model):
         # matching tokens in the source sentence.
         # shape: (batch_size, 1)
         gen_mask = (target_tokens != self._oov_index) | (target_to_source.sum(-1) == 0)
-        log_gen_mask = (gen_mask + 1e-45).log().unsqueeze(-1)
+        log_gen_mask = (gen_mask + util.tiny_value_of_dtype(log_probs.dtype)).log().unsqueeze(-1)
         # Now we get the generation score for the gold target token.
         # shape: (batch_size, 1)
         generation_log_probs = log_probs.gather(1, target_tokens.unsqueeze(1)) + log_gen_mask
@@ -541,7 +541,7 @@ class CopyNetSeq2Seq(Model):
         trimmed_source_length = source_length - 2
         # Initialize the copy scores to zero.
         state["copy_log_probs"] = (
-            state["decoder_hidden"].new_zeros((batch_size, trimmed_source_length)) + 1e-45
+            state["decoder_hidden"].new_zeros((batch_size, trimmed_source_length)) + util.min_value_of_dtype(state["decoder_hidden"].dtype)
         ).log()
         # shape: (batch_size,)
         start_predictions = state["source_mask"].new_full(
@@ -680,7 +680,7 @@ class CopyNetSeq2Seq(Model):
             # to the OOV token.
             copy_log_probs_to_add_mask = source_to_target_slice != self._oov_index
             copy_log_probs_to_add = (
-                copy_log_probs_slice + (copy_log_probs_to_add_mask + 1e-45).log()
+                copy_log_probs_slice + (copy_log_probs_to_add_mask + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)).log()
             )
             # shape: (batch_size, 1)
             copy_log_probs_to_add = copy_log_probs_to_add.unsqueeze(-1)
@@ -703,10 +703,10 @@ class CopyNetSeq2Seq(Model):
                 # shape: (group_size, trimmed_source_length - i)
                 source_future_occurences = (
                     source_token_ids[:, (i + 1) :] == source_token_ids[:, i].unsqueeze(-1)
-                ).float()  # noqa
+                )
                 # shape: (group_size, trimmed_source_length - i)
                 future_copy_log_probs = (
-                    copy_log_probs[:, (i + 1) :] + (source_future_occurences + 1e-45).log()
+                    copy_log_probs[:, (i + 1) :] + (source_future_occurences + util.tiny_value_of_dtype(copy_log_probs.dtype)).log()
                 )
                 # shape: (group_size, 1 + trimmed_source_length - i)
                 combined = torch.cat(
@@ -722,13 +722,13 @@ class CopyNetSeq2Seq(Model):
                 ].unsqueeze(-1)
                 # shape: (group_size,)
                 duplicate_mask = source_previous_occurences.sum(dim=-1) == 0
-                copy_log_probs_slice = copy_log_probs_slice + (duplicate_mask + 1e-45).log()
+                copy_log_probs_slice = copy_log_probs_slice + (duplicate_mask + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)).log()
 
             # Finally, we zero-out copy scores that we added to the generation scores
             # above so that we don't double-count them.
             # shape: (group_size,)
             left_over_copy_log_probs = (
-                copy_log_probs_slice + (~copy_log_probs_to_add_mask + 1e-45).log()
+                copy_log_probs_slice + (~copy_log_probs_to_add_mask + util.tiny_value_of_dtype(copy_log_probs_slice.dtype)).log()
             )
             modified_log_probs_list.append(left_over_copy_log_probs.unsqueeze(-1))
         modified_log_probs_list.insert(0, generation_log_probs)

--- a/allennlp/models/esim.py
+++ b/allennlp/models/esim.py
@@ -205,8 +205,8 @@ class ESIM(Model):
 
         # The pooling layer -- max and avg pooling.
         # (batch_size, model_dim)
-        v_a_max, _ = masked_max(v_ai, premise_mask.unsqueeze(-1), 1)
-        v_b_max, _ = masked_max(v_bi, hypothesis_mask.unsqueeze(-1), 1)
+        v_a_max = masked_max(v_ai, premise_mask.unsqueeze(-1), 1)
+        v_b_max = masked_max(v_bi, hypothesis_mask.unsqueeze(-1), 1)
 
         v_a_avg = torch.sum(v_ai * premise_mask.unsqueeze(-1), dim=1) / torch.sum(
             premise_mask, 1, keepdim=True

--- a/allennlp/models/esim.py
+++ b/allennlp/models/esim.py
@@ -205,8 +205,8 @@ class ESIM(Model):
 
         # The pooling layer -- max and avg pooling.
         # (batch_size, model_dim)
-        v_a_max = masked_max(v_ai, premise_mask.unsqueeze(-1), 1)
-        v_b_max = masked_max(v_bi, hypothesis_mask.unsqueeze(-1), 1)
+        v_a_max = masked_max(v_ai, premise_mask.unsqueeze(-1), dim=1)
+        v_b_max = masked_max(v_bi, hypothesis_mask.unsqueeze(-1), dim=1)
 
         v_a_avg = torch.sum(v_ai * premise_mask.unsqueeze(-1), dim=1) / torch.sum(
             premise_mask, 1, keepdim=True

--- a/allennlp/models/esim.py
+++ b/allennlp/models/esim.py
@@ -205,8 +205,8 @@ class ESIM(Model):
 
         # The pooling layer -- max and avg pooling.
         # (batch_size, model_dim)
-        v_a_max, _ = replace_masked_values(v_ai, premise_mask.unsqueeze(-1), -1e7).max(dim=1)
-        v_b_max, _ = replace_masked_values(v_bi, hypothesis_mask.unsqueeze(-1), -1e7).max(dim=1)
+        v_a_max, _ = replace_masked_values(v_ai, premise_mask.unsqueeze(-1), -1e4).max(dim=1)
+        v_b_max, _ = replace_masked_values(v_bi, hypothesis_mask.unsqueeze(-1), -1e4).max(dim=1)
 
         v_a_avg = torch.sum(v_ai * premise_mask.unsqueeze(-1), dim=1) / torch.sum(
             premise_mask, 1, keepdim=True

--- a/allennlp/models/esim.py
+++ b/allennlp/models/esim.py
@@ -13,7 +13,7 @@ from allennlp.nn.util import (
     get_text_field_mask,
     masked_softmax,
     weighted_sum,
-    replace_masked_values,
+    masked_max,
 )
 from allennlp.training.metrics import CategoricalAccuracy
 
@@ -205,8 +205,8 @@ class ESIM(Model):
 
         # The pooling layer -- max and avg pooling.
         # (batch_size, model_dim)
-        v_a_max, _ = replace_masked_values(v_ai, premise_mask.unsqueeze(-1), -1e4).max(dim=1)
-        v_b_max, _ = replace_masked_values(v_bi, hypothesis_mask.unsqueeze(-1), -1e4).max(dim=1)
+        v_a_max, _ = masked_max(v_ai, premise_mask.unsqueeze(-1), 1)
+        v_b_max, _ = masked_max(v_bi, hypothesis_mask.unsqueeze(-1), 1)
 
         v_a_avg = torch.sum(v_ai * premise_mask.unsqueeze(-1), dim=1) / torch.sum(
             premise_mask, 1, keepdim=True

--- a/allennlp/models/graph_parser.py
+++ b/allennlp/models/graph_parser.py
@@ -14,6 +14,7 @@ from allennlp.modules.matrix_attention.bilinear_matrix_attention import Bilinear
 from allennlp.modules import FeedForward
 from allennlp.models.model import Model
 from allennlp.nn import InitializerApplicator, Activation
+from allennlp.nn.util import min_value_of_dtype
 from allennlp.nn.util import get_text_field_mask
 from allennlp.nn.util import get_lengths_from_binary_sequence_mask
 from allennlp.training.metrics import F1Measure
@@ -193,8 +194,7 @@ class GraphParser(Model):
         # Switch to (batch_size, sequence_length, sequence_length, num_tags)
         arc_tag_logits = arc_tag_logits.permute(0, 2, 3, 1).contiguous()
 
-        minus_inf = -1e8
-        minus_mask = ~mask * minus_inf
+        minus_mask = ~mask * min_value_of_dtype(arc_scores.dtype)
         arc_scores = arc_scores + minus_mask.unsqueeze(2) + minus_mask.unsqueeze(1)
 
         arc_probs, arc_tag_probs = self._greedy_decode(arc_scores, arc_tag_logits, mask)

--- a/allennlp/models/graph_parser.py
+++ b/allennlp/models/graph_parser.py
@@ -194,7 +194,8 @@ class GraphParser(Model):
         # Switch to (batch_size, sequence_length, sequence_length, num_tags)
         arc_tag_logits = arc_tag_logits.permute(0, 2, 3, 1).contiguous()
 
-        minus_mask = ~mask * min_value_of_dtype(arc_scores.dtype)
+        # Since we'll be doing some additions, using the min value will cause underflow
+        minus_mask = ~mask * min_value_of_dtype(arc_scores.dtype) / 10
         arc_scores = arc_scores + minus_mask.unsqueeze(2) + minus_mask.unsqueeze(1)
 
         arc_probs, arc_tag_probs = self._greedy_decode(arc_scores, arc_tag_logits, mask)

--- a/allennlp/modules/attention/cosine_attention.py
+++ b/allennlp/modules/attention/cosine_attention.py
@@ -13,9 +13,9 @@ class CosineAttention(Attention):
     @overrides
     def _forward_internal(self, vector: torch.Tensor, matrix: torch.Tensor) -> torch.Tensor:
         a_norm = vector / (
-            vector.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(vector.dtype)
+            vector.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(vector.dtype)
         )
         b_norm = matrix / (
-            matrix.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix.dtype)
+            matrix.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(matrix.dtype)
         )
         return torch.bmm(a_norm.unsqueeze(dim=1), b_norm.transpose(-1, -2)).squeeze(1)

--- a/allennlp/modules/attention/cosine_attention.py
+++ b/allennlp/modules/attention/cosine_attention.py
@@ -12,6 +12,6 @@ class CosineAttention(Attention):
 
     @overrides
     def _forward_internal(self, vector: torch.Tensor, matrix: torch.Tensor) -> torch.Tensor:
-        a_norm = vector / (vector.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(vector.dtype))
-        b_norm = matrix / (matrix.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(matrix.dtype))
+        a_norm = vector / (vector.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(vector.dtype))
+        b_norm = matrix / (matrix.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix.dtype))
         return torch.bmm(a_norm.unsqueeze(dim=1), b_norm.transpose(-1, -2)).squeeze(1)

--- a/allennlp/modules/attention/cosine_attention.py
+++ b/allennlp/modules/attention/cosine_attention.py
@@ -1,6 +1,7 @@
 import torch
 from overrides import overrides
 from allennlp.modules.attention.attention import Attention
+from allennlp.nn import util
 
 
 @Attention.register("cosine")
@@ -11,6 +12,6 @@ class CosineAttention(Attention):
 
     @overrides
     def _forward_internal(self, vector: torch.Tensor, matrix: torch.Tensor) -> torch.Tensor:
-        a_norm = vector / (vector.norm(p=2, dim=-1, keepdim=True) + 1e-13)
-        b_norm = matrix / (matrix.norm(p=2, dim=-1, keepdim=True) + 1e-13)
+        a_norm = vector / (vector.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(vector.dtype))
+        b_norm = matrix / (matrix.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(matrix.dtype))
         return torch.bmm(a_norm.unsqueeze(dim=1), b_norm.transpose(-1, -2)).squeeze(1)

--- a/allennlp/modules/attention/cosine_attention.py
+++ b/allennlp/modules/attention/cosine_attention.py
@@ -12,6 +12,10 @@ class CosineAttention(Attention):
 
     @overrides
     def _forward_internal(self, vector: torch.Tensor, matrix: torch.Tensor) -> torch.Tensor:
-        a_norm = vector / (vector.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(vector.dtype))
-        b_norm = matrix / (matrix.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix.dtype))
+        a_norm = vector / (
+            vector.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(vector.dtype)
+        )
+        b_norm = matrix / (
+            matrix.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix.dtype)
+        )
         return torch.bmm(a_norm.unsqueeze(dim=1), b_norm.transpose(-1, -2)).squeeze(1)

--- a/allennlp/modules/bimpm_matching.py
+++ b/allennlp/modules/bimpm_matching.py
@@ -15,7 +15,7 @@ from allennlp.nn.util import (
     masked_max,
     masked_mean,
     masked_softmax,
-    eps_value_of_dtype,
+    tiny_value_of_dtype,
 )
 
 
@@ -98,7 +98,7 @@ def multi_perspective_match_pairwise(
     norm_value = vector1_norm * vector2_norm.transpose(2, 3)
 
     # (batch, seq_len1, seq_len2, num_perspectives)
-    return (mul_result / norm_value.clamp(min=eps_value_of_dtype(norm_value.dtype))).permute(
+    return (mul_result / norm_value.clamp(min=tiny_value_of_dtype(norm_value.dtype))).permute(
         0, 2, 3, 1
     )
 

--- a/allennlp/modules/bimpm_matching.py
+++ b/allennlp/modules/bimpm_matching.py
@@ -15,7 +15,7 @@ from allennlp.nn.util import (
     masked_max,
     masked_mean,
     masked_softmax,
-    tiny_value_of_dtype
+    eps_value_of_dtype
 )
 
 
@@ -98,7 +98,7 @@ def multi_perspective_match_pairwise(
     norm_value = vector1_norm * vector2_norm.transpose(2, 3)
 
     # (batch, seq_len1, seq_len2, num_perspectives)
-    return (mul_result / norm_value.clamp(min=tiny_value_of_dtype(norm_value.dtype))).permute(0, 2, 3, 1)
+    return (mul_result / norm_value.clamp(min=eps_value_of_dtype(norm_value.dtype))).permute(0, 2, 3, 1)
 
 
 class BiMpmMatching(nn.Module, FromParams):

--- a/allennlp/modules/bimpm_matching.py
+++ b/allennlp/modules/bimpm_matching.py
@@ -15,7 +15,7 @@ from allennlp.nn.util import (
     masked_max,
     masked_mean,
     masked_softmax,
-    eps_value_of_dtype
+    eps_value_of_dtype,
 )
 
 
@@ -98,7 +98,9 @@ def multi_perspective_match_pairwise(
     norm_value = vector1_norm * vector2_norm.transpose(2, 3)
 
     # (batch, seq_len1, seq_len2, num_perspectives)
-    return (mul_result / norm_value.clamp(min=eps_value_of_dtype(norm_value.dtype))).permute(0, 2, 3, 1)
+    return (mul_result / norm_value.clamp(min=eps_value_of_dtype(norm_value.dtype))).permute(
+        0, 2, 3, 1
+    )
 
 
 class BiMpmMatching(nn.Module, FromParams):

--- a/allennlp/modules/bimpm_matching.py
+++ b/allennlp/modules/bimpm_matching.py
@@ -256,10 +256,10 @@ class BiMpmMatching(nn.Module, FromParams):
         cosine_sim = F.cosine_similarity(context_1.unsqueeze(-2), context_2.unsqueeze(-3), dim=3)
 
         # (batch, seq_len*, 1)
-        cosine_max_1 = masked_max(cosine_sim, mask_2.unsqueeze(-2), dim=2, keepdim=True)
+        cosine_max_1 = masked_max(cosine_sim, mask_2.unsqueeze(-2), min_val=-1e4, dim=2, keepdim=True)
         cosine_mean_1 = masked_mean(cosine_sim, mask_2.unsqueeze(-2), dim=2, keepdim=True)
         cosine_max_2 = masked_max(
-            cosine_sim.permute(0, 2, 1), mask_1.unsqueeze(-2), dim=2, keepdim=True
+            cosine_sim.permute(0, 2, 1), mask_1.unsqueeze(-2), min_val=-1e4, dim=2, keepdim=True
         )
         cosine_mean_2 = masked_mean(
             cosine_sim.permute(0, 2, 1), mask_1.unsqueeze(-2), dim=2, keepdim=True
@@ -312,13 +312,13 @@ class BiMpmMatching(nn.Module, FromParams):
 
             # (batch, seq_len*, num_perspectives)
             matching_vector_1_max = masked_max(
-                matching_vector_max, mask_2.unsqueeze(-2).unsqueeze(-1), dim=2
+                matching_vector_max, mask_2.unsqueeze(-2).unsqueeze(-1), min_val=-1e4, dim=2
             )
             matching_vector_1_mean = masked_mean(
                 matching_vector_max, mask_2.unsqueeze(-2).unsqueeze(-1), dim=2
             )
             matching_vector_2_max = masked_max(
-                matching_vector_max.permute(0, 2, 1, 3), mask_1.unsqueeze(-2).unsqueeze(-1), dim=2
+                matching_vector_max.permute(0, 2, 1, 3), mask_1.unsqueeze(-2).unsqueeze(-1), min_val=-1e4, dim=2
             )
             matching_vector_2_mean = masked_mean(
                 matching_vector_max.permute(0, 2, 1, 3), mask_1.unsqueeze(-2).unsqueeze(-1), dim=2
@@ -362,9 +362,9 @@ class BiMpmMatching(nn.Module, FromParams):
         # corresponding attentive vector.
         if self.with_max_attentive_match:
             # (batch, seq_len*, hidden_dim)
-            att_max_2 = masked_max(att_2, mask_2.unsqueeze(-2).unsqueeze(-1), dim=2)
+            att_max_2 = masked_max(att_2, mask_2.unsqueeze(-2).unsqueeze(-1), min_val=-1e4, dim=2)
             att_max_1 = masked_max(
-                att_1.permute(0, 2, 1, 3), mask_1.unsqueeze(-2).unsqueeze(-1), dim=2
+                att_1.permute(0, 2, 1, 3), mask_1.unsqueeze(-2).unsqueeze(-1), min_val=-1e4, dim=2
             )
 
             # (batch, seq_len*, num_perspectives)

--- a/allennlp/modules/layer_norm.py
+++ b/allennlp/modules/layer_norm.py
@@ -32,4 +32,6 @@ class LayerNorm(torch.nn.Module):
     def forward(self, tensor: torch.Tensor):
         mean = tensor.mean(-1, keepdim=True)
         std = tensor.std(-1, unbiased=False, keepdim=True)
-        return self.gamma * (tensor - mean) / (std + util.tiny_value_of_dtype(std.dtype)) + self.beta
+        return (
+            self.gamma * (tensor - mean) / (std + util.tiny_value_of_dtype(std.dtype)) + self.beta
+        )

--- a/allennlp/modules/layer_norm.py
+++ b/allennlp/modules/layer_norm.py
@@ -32,4 +32,4 @@ class LayerNorm(torch.nn.Module):
     def forward(self, tensor: torch.Tensor):
         mean = tensor.mean(-1, keepdim=True)
         std = tensor.std(-1, unbiased=False, keepdim=True)
-        return self.gamma * (tensor - mean) / (std + util.eps_value_of_dtype(std.dtype)) + self.beta
+        return self.gamma * (tensor - mean) / (std + util.tiny_value_of_dtype(std.dtype)) + self.beta

--- a/allennlp/modules/layer_norm.py
+++ b/allennlp/modules/layer_norm.py
@@ -32,4 +32,4 @@ class LayerNorm(torch.nn.Module):
     def forward(self, tensor: torch.Tensor):
         mean = tensor.mean(-1, keepdim=True)
         std = tensor.std(-1, unbiased=False, keepdim=True)
-        return self.gamma * (tensor - mean) / (std + util.tiny_value_of_dtype(std.dtype)) + self.beta
+        return self.gamma * (tensor - mean) / (std + util.eps_value_of_dtype(std.dtype)) + self.beta

--- a/allennlp/modules/layer_norm.py
+++ b/allennlp/modules/layer_norm.py
@@ -1,5 +1,7 @@
 import torch
 
+from allennlp.nn import util
+
 
 class LayerNorm(torch.nn.Module):
 
@@ -16,22 +18,18 @@ class LayerNorm(torch.nn.Module):
 
     dimension : `int`, required.
         The dimension of the layer output to normalize.
-    eps : `float`, optional, (default = 1e-6)
-        An epsilon to prevent dividing by zero in the case
-        the layer has zero variance.
 
     # Returns
 
     The normalized layer output.
     """  # noqa
 
-    def __init__(self, dimension: int, eps: float = 1e-6) -> None:
+    def __init__(self, dimension: int) -> None:
         super().__init__()
         self.gamma = torch.nn.Parameter(torch.ones(dimension))
         self.beta = torch.nn.Parameter(torch.zeros(dimension))
-        self.eps = eps
 
     def forward(self, tensor: torch.Tensor):
         mean = tensor.mean(-1, keepdim=True)
         std = tensor.std(-1, unbiased=False, keepdim=True)
-        return self.gamma * (tensor - mean) / (std + self.eps) + self.beta
+        return self.gamma * (tensor - mean) / (std + util.tiny_value_of_dtype(std.dtype)) + self.beta

--- a/allennlp/modules/masked_layer_norm.py
+++ b/allennlp/modules/masked_layer_norm.py
@@ -1,5 +1,7 @@
 import torch
 
+from allennlp.nn import util
+
 
 class MaskedLayerNorm(torch.nn.Module):
     """
@@ -8,12 +10,11 @@ class MaskedLayerNorm(torch.nn.Module):
     Note, however, that unlike LayerNorm this norm includes a batch component.
     """
 
-    def __init__(self, size: int, gamma0: float = 0.1, eps: float = 1e-6) -> None:
+    def __init__(self, size: int, gamma0: float = 0.1) -> None:
         super().__init__()
         self.gamma = torch.nn.Parameter(torch.ones(1, 1, size) * gamma0)
         self.beta = torch.nn.Parameter(torch.zeros(1, 1, size))
         self.size = size
-        self.eps = eps
 
     def forward(self, tensor: torch.Tensor, mask: torch.BoolTensor) -> torch.Tensor:
 
@@ -21,5 +22,5 @@ class MaskedLayerNorm(torch.nn.Module):
         num_elements = broadcast_mask.sum() * self.size
         mean = (tensor * broadcast_mask).sum() / num_elements
         masked_centered = (tensor - mean) * broadcast_mask
-        std = torch.sqrt((masked_centered * masked_centered).sum() / num_elements + self.eps)
-        return self.gamma * (tensor - mean) / (std + self.eps) + self.beta
+        std = torch.sqrt((masked_centered * masked_centered).sum() / num_elements + util.tiny_value_of_dtype(tensor.dtype))
+        return self.gamma * (tensor - mean) / (std + util.tiny_value_of_dtype(tensor.dtype)) + self.beta

--- a/allennlp/modules/masked_layer_norm.py
+++ b/allennlp/modules/masked_layer_norm.py
@@ -24,8 +24,8 @@ class MaskedLayerNorm(torch.nn.Module):
         masked_centered = (tensor - mean) * broadcast_mask
         std = torch.sqrt(
             (masked_centered * masked_centered).sum() / num_elements
-            + util.eps_value_of_dtype(tensor.dtype)
+            + util.tiny_value_of_dtype(tensor.dtype)
         )
         return (
-            self.gamma * (tensor - mean) / (std + util.eps_value_of_dtype(tensor.dtype)) + self.beta
+            self.gamma * (tensor - mean) / (std + util.tiny_value_of_dtype(tensor.dtype)) + self.beta
         )

--- a/allennlp/modules/masked_layer_norm.py
+++ b/allennlp/modules/masked_layer_norm.py
@@ -27,5 +27,6 @@ class MaskedLayerNorm(torch.nn.Module):
             + util.tiny_value_of_dtype(tensor.dtype)
         )
         return (
-            self.gamma * (tensor - mean) / (std + util.tiny_value_of_dtype(tensor.dtype)) + self.beta
+            self.gamma * (tensor - mean) / (std + util.tiny_value_of_dtype(tensor.dtype))
+            + self.beta
         )

--- a/allennlp/modules/masked_layer_norm.py
+++ b/allennlp/modules/masked_layer_norm.py
@@ -22,5 +22,5 @@ class MaskedLayerNorm(torch.nn.Module):
         num_elements = broadcast_mask.sum() * self.size
         mean = (tensor * broadcast_mask).sum() / num_elements
         masked_centered = (tensor - mean) * broadcast_mask
-        std = torch.sqrt((masked_centered * masked_centered).sum() / num_elements + util.tiny_value_of_dtype(tensor.dtype))
-        return self.gamma * (tensor - mean) / (std + util.tiny_value_of_dtype(tensor.dtype)) + self.beta
+        std = torch.sqrt((masked_centered * masked_centered).sum() / num_elements + util.eps_value_of_dtype(tensor.dtype))
+        return self.gamma * (tensor - mean) / (std + util.eps_value_of_dtype(tensor.dtype)) + self.beta

--- a/allennlp/modules/masked_layer_norm.py
+++ b/allennlp/modules/masked_layer_norm.py
@@ -22,5 +22,10 @@ class MaskedLayerNorm(torch.nn.Module):
         num_elements = broadcast_mask.sum() * self.size
         mean = (tensor * broadcast_mask).sum() / num_elements
         masked_centered = (tensor - mean) * broadcast_mask
-        std = torch.sqrt((masked_centered * masked_centered).sum() / num_elements + util.eps_value_of_dtype(tensor.dtype))
-        return self.gamma * (tensor - mean) / (std + util.eps_value_of_dtype(tensor.dtype)) + self.beta
+        std = torch.sqrt(
+            (masked_centered * masked_centered).sum() / num_elements
+            + util.eps_value_of_dtype(tensor.dtype)
+        )
+        return (
+            self.gamma * (tensor - mean) / (std + util.eps_value_of_dtype(tensor.dtype)) + self.beta
+        )

--- a/allennlp/modules/matrix_attention/cosine_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/cosine_matrix_attention.py
@@ -15,9 +15,9 @@ class CosineMatrixAttention(MatrixAttention):
     @overrides
     def forward(self, matrix_1: torch.Tensor, matrix_2: torch.Tensor) -> torch.Tensor:
         a_norm = matrix_1 / (
-            matrix_1.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix_1.dtype)
+            matrix_1.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(matrix_1.dtype)
         )
         b_norm = matrix_2 / (
-            matrix_2.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix_2.dtype)
+            matrix_2.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(matrix_2.dtype)
         )
         return torch.bmm(a_norm, b_norm.transpose(-1, -2))

--- a/allennlp/modules/matrix_attention/cosine_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/cosine_matrix_attention.py
@@ -2,6 +2,7 @@ import torch
 from overrides import overrides
 
 from allennlp.modules.matrix_attention.matrix_attention import MatrixAttention
+from allennlp.nn import util
 
 
 @MatrixAttention.register("cosine")
@@ -13,6 +14,6 @@ class CosineMatrixAttention(MatrixAttention):
 
     @overrides
     def forward(self, matrix_1: torch.Tensor, matrix_2: torch.Tensor) -> torch.Tensor:
-        a_norm = matrix_1 / (matrix_1.norm(p=2, dim=-1, keepdim=True) + 1e-13)
-        b_norm = matrix_2 / (matrix_2.norm(p=2, dim=-1, keepdim=True) + 1e-13)
+        a_norm = matrix_1 / (matrix_1.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(matrix_1.dtype))
+        b_norm = matrix_2 / (matrix_2.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(matrix_2.dtype))
         return torch.bmm(a_norm, b_norm.transpose(-1, -2))

--- a/allennlp/modules/matrix_attention/cosine_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/cosine_matrix_attention.py
@@ -14,6 +14,10 @@ class CosineMatrixAttention(MatrixAttention):
 
     @overrides
     def forward(self, matrix_1: torch.Tensor, matrix_2: torch.Tensor) -> torch.Tensor:
-        a_norm = matrix_1 / (matrix_1.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix_1.dtype))
-        b_norm = matrix_2 / (matrix_2.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix_2.dtype))
+        a_norm = matrix_1 / (
+            matrix_1.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix_1.dtype)
+        )
+        b_norm = matrix_2 / (
+            matrix_2.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix_2.dtype)
+        )
         return torch.bmm(a_norm, b_norm.transpose(-1, -2))

--- a/allennlp/modules/matrix_attention/cosine_matrix_attention.py
+++ b/allennlp/modules/matrix_attention/cosine_matrix_attention.py
@@ -14,6 +14,6 @@ class CosineMatrixAttention(MatrixAttention):
 
     @overrides
     def forward(self, matrix_1: torch.Tensor, matrix_2: torch.Tensor) -> torch.Tensor:
-        a_norm = matrix_1 / (matrix_1.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(matrix_1.dtype))
-        b_norm = matrix_2 / (matrix_2.norm(p=2, dim=-1, keepdim=True) + util.tiny_value_of_dtype(matrix_2.dtype))
+        a_norm = matrix_1 / (matrix_1.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix_1.dtype))
+        b_norm = matrix_2 / (matrix_2.norm(p=2, dim=-1, keepdim=True) + util.eps_value_of_dtype(matrix_2.dtype))
         return torch.bmm(a_norm, b_norm.transpose(-1, -2))

--- a/allennlp/modules/sampled_softmax_loss.py
+++ b/allennlp/modules/sampled_softmax_loss.py
@@ -209,7 +209,7 @@ class SampledSoftmaxLoss(torch.nn.Module):
             (true_w * embeddings).sum(dim=1)
             + true_b
             - torch.log(
-                target_expected_count + util.eps_value_of_dtype(target_expected_count.dtype)
+                target_expected_count + util.tiny_value_of_dtype(target_expected_count.dtype)
             )
         )
         # [batch_size, n_samples]
@@ -217,7 +217,7 @@ class SampledSoftmaxLoss(torch.nn.Module):
             torch.matmul(embeddings, sampled_w.t())
             + sampled_b
             - torch.log(
-                sampled_expected_count + util.eps_value_of_dtype(sampled_expected_count.dtype)
+                sampled_expected_count + util.tiny_value_of_dtype(sampled_expected_count.dtype)
             )
         )
 

--- a/allennlp/modules/sampled_softmax_loss.py
+++ b/allennlp/modules/sampled_softmax_loss.py
@@ -6,6 +6,7 @@ import numpy as np
 import torch
 
 from allennlp.common.checks import ConfigurationError
+from allennlp.nn import util
 
 
 def _choice(num_words: int, num_samples: int) -> Tuple[np.ndarray, int]:
@@ -205,13 +206,13 @@ class SampledSoftmaxLoss(torch.nn.Module):
         # compute the logits and remove log expected counts
         # [batch_size, ]
         true_logits = (
-            (true_w * embeddings).sum(dim=1) + true_b - torch.log(target_expected_count + 1e-7)
+            (true_w * embeddings).sum(dim=1) + true_b - torch.log(target_expected_count + util.tiny_value_of_dtype(target_expected_count.dtype))
         )
         # [batch_size, n_samples]
         sampled_logits = (
             torch.matmul(embeddings, sampled_w.t())
             + sampled_b
-            - torch.log(sampled_expected_count + 1e-7)
+            - torch.log(sampled_expected_count + util.tiny_value_of_dtype(sampled_expected_count.dtype))
         )
 
         # remove true labels -- we will take

--- a/allennlp/modules/sampled_softmax_loss.py
+++ b/allennlp/modules/sampled_softmax_loss.py
@@ -206,13 +206,19 @@ class SampledSoftmaxLoss(torch.nn.Module):
         # compute the logits and remove log expected counts
         # [batch_size, ]
         true_logits = (
-            (true_w * embeddings).sum(dim=1) + true_b - torch.log(target_expected_count + util.eps_value_of_dtype(target_expected_count.dtype))
+            (true_w * embeddings).sum(dim=1)
+            + true_b
+            - torch.log(
+                target_expected_count + util.eps_value_of_dtype(target_expected_count.dtype)
+            )
         )
         # [batch_size, n_samples]
         sampled_logits = (
             torch.matmul(embeddings, sampled_w.t())
             + sampled_b
-            - torch.log(sampled_expected_count + util.eps_value_of_dtype(sampled_expected_count.dtype))
+            - torch.log(
+                sampled_expected_count + util.eps_value_of_dtype(sampled_expected_count.dtype)
+            )
         )
 
         # remove true labels -- we will take

--- a/allennlp/modules/sampled_softmax_loss.py
+++ b/allennlp/modules/sampled_softmax_loss.py
@@ -206,13 +206,13 @@ class SampledSoftmaxLoss(torch.nn.Module):
         # compute the logits and remove log expected counts
         # [batch_size, ]
         true_logits = (
-            (true_w * embeddings).sum(dim=1) + true_b - torch.log(target_expected_count + util.tiny_value_of_dtype(target_expected_count.dtype))
+            (true_w * embeddings).sum(dim=1) + true_b - torch.log(target_expected_count + util.eps_value_of_dtype(target_expected_count.dtype))
         )
         # [batch_size, n_samples]
         sampled_logits = (
             torch.matmul(embeddings, sampled_w.t())
             + sampled_b
-            - torch.log(sampled_expected_count + util.tiny_value_of_dtype(sampled_expected_count.dtype))
+            - torch.log(sampled_expected_count + util.eps_value_of_dtype(sampled_expected_count.dtype))
         )
 
         # remove true labels -- we will take

--- a/allennlp/modules/scalar_mix.py
+++ b/allennlp/modules/scalar_mix.py
@@ -4,6 +4,7 @@ import torch
 from torch.nn import ParameterList, Parameter
 
 from allennlp.common.checks import ConfigurationError
+from allennlp.nn import util
 
 
 class ScalarMix(torch.nn.Module):
@@ -68,7 +69,7 @@ class ScalarMix(torch.nn.Module):
             variance = (
                 torch.sum(((tensor_masked - mean) * broadcast_mask) ** 2) / num_elements_not_masked
             )
-            return (tensor - mean) / torch.sqrt(variance + 1e-12)
+            return (tensor - mean) / torch.sqrt(variance + util.tiny_value_of_dtype(variance.dtype))
 
         normed_weights = torch.nn.functional.softmax(
             torch.cat([parameter for parameter in self.scalar_parameters]), dim=0

--- a/allennlp/modules/scalar_mix.py
+++ b/allennlp/modules/scalar_mix.py
@@ -69,7 +69,7 @@ class ScalarMix(torch.nn.Module):
             variance = (
                 torch.sum(((tensor_masked - mean) * broadcast_mask) ** 2) / num_elements_not_masked
             )
-            return (tensor - mean) / torch.sqrt(variance + util.eps_value_of_dtype(variance.dtype))
+            return (tensor - mean) / torch.sqrt(variance + util.tiny_value_of_dtype(variance.dtype))
 
         normed_weights = torch.nn.functional.softmax(
             torch.cat([parameter for parameter in self.scalar_parameters]), dim=0

--- a/allennlp/modules/scalar_mix.py
+++ b/allennlp/modules/scalar_mix.py
@@ -69,7 +69,7 @@ class ScalarMix(torch.nn.Module):
             variance = (
                 torch.sum(((tensor_masked - mean) * broadcast_mask) ** 2) / num_elements_not_masked
             )
-            return (tensor - mean) / torch.sqrt(variance + util.tiny_value_of_dtype(variance.dtype))
+            return (tensor - mean) / torch.sqrt(variance + util.eps_value_of_dtype(variance.dtype))
 
         normed_weights = torch.nn.functional.softmax(
             torch.cat([parameter for parameter in self.scalar_parameters]), dim=0

--- a/allennlp/modules/seq2seq_encoders/bidirectional_language_model_transformer.py
+++ b/allennlp/modules/seq2seq_encoders/bidirectional_language_model_transformer.py
@@ -33,7 +33,7 @@ def attention(
     d_k = query.size(-1)
     scores = torch.matmul(query, key.transpose(-2, -1)) / math.sqrt(d_k)
     if mask is not None:
-        scores = scores.masked_fill(~mask, -1e4)
+        scores = scores.masked_fill(~mask, util.min_value_of_dtype(scores.dtype))
     p_attn = F.softmax(scores, dim=-1)
     if dropout is not None:
         p_attn = dropout(p_attn)

--- a/allennlp/modules/seq2seq_encoders/bidirectional_language_model_transformer.py
+++ b/allennlp/modules/seq2seq_encoders/bidirectional_language_model_transformer.py
@@ -33,7 +33,7 @@ def attention(
     d_k = query.size(-1)
     scores = torch.matmul(query, key.transpose(-2, -1)) / math.sqrt(d_k)
     if mask is not None:
-        scores = scores.masked_fill(~mask, -1e9)
+        scores = scores.masked_fill(~mask, -1e4)
     p_attn = F.softmax(scores, dim=-1)
     if dropout is not None:
         p_attn = dropout(p_attn)

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -244,7 +244,7 @@ def masked_softmax(
     mask: torch.BoolTensor,
     dim: int = -1,
     memory_efficient: bool = False,
-    mask_fill_value: float = -1e32,
+    mask_fill_value: float = -1e4,
 ) -> torch.Tensor:
     """
     `torch.nn.functional.softmax(vector)` does not work if some elements of `vector` should be
@@ -1786,8 +1786,8 @@ def masked_topk(
     k = k.reshape(-1)
 
     # Make sure that we don't select any masked items by setting their scores to be very
-    # negative.  These are logits, typically, so -1e20 should be plenty negative.
-    input_ = replace_masked_values(input_, mask, -1e20)
+    # negative.  These are logits, typically, so -1e4 should be plenty negative.
+    input_ = replace_masked_values(input_, mask, -1e4)
 
     # Shape: (batch_size, max_k)
     _, top_indices = input_.topk(max_k, 1)

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -1846,10 +1846,16 @@ def max_value_of_dtype(dtype: torch.dtype):
 
 def tiny_value_of_dtype(dtype: torch.dtype):
     """
-    Returns the smallest representatble value of a given PyTorch data type such that
-    `1.0 + eps != 1.0`.
+    Returns a moderately tiny value for a given PyTorch data type that is used to avoid numerical
+    issues such as division by zero.
+    This is different from `info_value_of_dtype(dtype).tiny` because it causes some NaN bugs.
     Only supports floating point dtypes.
     """
     if not dtype.is_floating_point:
         raise TypeError("Only supports floating point dtypes.")
-    return info_value_of_dtype(dtype).tiny
+    if dtype == torch.float or torch.double:
+        return 1e-13
+    elif dtype == torch.half:
+        return 1e-4
+    else:
+        raise TypeError("Does not support dtype " + str(dtype))

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -270,7 +270,9 @@ def masked_softmax(
             # To limit numerical errors from large vector elements outside the mask, we zero these out.
             result = torch.nn.functional.softmax(vector * mask, dim=dim)
             result = result * mask
-            result = result / (result.sum(dim=dim, keepdim=True) + tiny_value_of_dtype(result.dtype))
+            result = result / (
+                result.sum(dim=dim, keepdim=True) + tiny_value_of_dtype(result.dtype)
+            )
         else:
             masked_vector = vector.masked_fill(~mask, min_value_of_dtype(vector.dtype))
             result = torch.nn.functional.softmax(masked_vector, dim=dim)

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -240,10 +240,7 @@ def get_dropout_mask(dropout_probability: float, tensor_for_masking: torch.Tenso
 
 
 def masked_softmax(
-    vector: torch.Tensor,
-    mask: torch.BoolTensor,
-    dim: int = -1,
-    memory_efficient: bool = False,
+    vector: torch.Tensor, mask: torch.BoolTensor, dim: int = -1, memory_efficient: bool = False,
 ) -> torch.Tensor:
     """
     `torch.nn.functional.softmax(vector)` does not work if some elements of `vector` should be
@@ -312,10 +309,7 @@ def masked_log_softmax(vector: torch.Tensor, mask: torch.BoolTensor, dim: int = 
 
 
 def masked_max(
-    vector: torch.Tensor,
-    mask: torch.BoolTensor,
-    dim: int,
-    keepdim: bool = False,
+    vector: torch.Tensor, mask: torch.BoolTensor, dim: int, keepdim: bool = False,
 ) -> torch.Tensor:
     """
     To calculate max along certain dimensions on masked values
@@ -826,14 +820,22 @@ def sequence_cross_entropy_with_logits(
 
     if average == "batch":
         # shape : (batch_size,)
-        per_batch_loss = negative_log_likelihood.sum(non_batch_dims) / (weights_batch_sum + eps_value_of_dtype(negative_log_likelihood.dtype))
-        num_non_empty_sequences = (weights_batch_sum > 0).sum() + eps_value_of_dtype(negative_log_likelihood.dtype)
+        per_batch_loss = negative_log_likelihood.sum(non_batch_dims) / (
+            weights_batch_sum + eps_value_of_dtype(negative_log_likelihood.dtype)
+        )
+        num_non_empty_sequences = (weights_batch_sum > 0).sum() + eps_value_of_dtype(
+            negative_log_likelihood.dtype
+        )
         return per_batch_loss.sum() / num_non_empty_sequences
     elif average == "token":
-        return negative_log_likelihood.sum() / (weights_batch_sum.sum() + eps_value_of_dtype(negative_log_likelihood.dtype))
+        return negative_log_likelihood.sum() / (
+            weights_batch_sum.sum() + eps_value_of_dtype(negative_log_likelihood.dtype)
+        )
     else:
         # shape : (batch_size,)
-        per_batch_loss = negative_log_likelihood.sum(non_batch_dims) / (weights_batch_sum + eps_value_of_dtype(negative_log_likelihood.dtype))
+        per_batch_loss = negative_log_likelihood.sum(non_batch_dims) / (
+            weights_batch_sum + eps_value_of_dtype(negative_log_likelihood.dtype)
+        )
         return per_batch_loss
 
 

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -270,7 +270,7 @@ def masked_softmax(
             # To limit numerical errors from large vector elements outside the mask, we zero these out.
             result = torch.nn.functional.softmax(vector * mask, dim=dim)
             result = result * mask
-            result = result / (result.sum(dim=dim, keepdim=True) + tiny_value_of_dtype(result.dtype))
+            result = result / (result.sum(dim=dim, keepdim=True) + 1e-13)
         else:
             masked_vector = vector.masked_fill(~mask, min_value_of_dtype(vector.dtype))
             result = torch.nn.functional.softmax(masked_vector, dim=dim)

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -270,7 +270,7 @@ def masked_softmax(
             # To limit numerical errors from large vector elements outside the mask, we zero these out.
             result = torch.nn.functional.softmax(vector * mask, dim=dim)
             result = result * mask
-            result = result / (result.sum(dim=dim, keepdim=True) + eps_value_of_dtype(result.dtype))
+            result = result / (result.sum(dim=dim, keepdim=True) + tiny_value_of_dtype(result.dtype))
         else:
             masked_vector = vector.masked_fill(~mask, min_value_of_dtype(vector.dtype))
             result = torch.nn.functional.softmax(masked_vector, dim=dim)
@@ -304,7 +304,7 @@ def masked_log_softmax(vector: torch.Tensor, mask: torch.BoolTensor, dim: int = 
         # vector + mask.log() is an easy way to zero out masked elements in logspace, but it
         # results in nans when the whole vector is masked.  We need a very small value instead of a
         # zero in the mask for these cases.
-        vector = vector + (mask + eps_value_of_dtype(vector.dtype)).log()
+        vector = vector + (mask + tiny_value_of_dtype(vector.dtype)).log()
     return torch.nn.functional.log_softmax(vector, dim=dim)
 
 
@@ -359,7 +359,7 @@ def masked_mean(
 
     value_sum = torch.sum(replaced_vector, dim=dim, keepdim=keepdim)
     value_count = torch.sum(mask, dim=dim, keepdim=keepdim)
-    return value_sum / value_count.float().clamp(min=eps_value_of_dtype(torch.float))
+    return value_sum / value_count.float().clamp(min=tiny_value_of_dtype(torch.float))
 
 
 def masked_flip(padded_sequence: torch.Tensor, sequence_lengths: List[int]) -> torch.Tensor:
@@ -821,20 +821,20 @@ def sequence_cross_entropy_with_logits(
     if average == "batch":
         # shape : (batch_size,)
         per_batch_loss = negative_log_likelihood.sum(non_batch_dims) / (
-            weights_batch_sum + eps_value_of_dtype(negative_log_likelihood.dtype)
+            weights_batch_sum + tiny_value_of_dtype(negative_log_likelihood.dtype)
         )
-        num_non_empty_sequences = (weights_batch_sum > 0).sum() + eps_value_of_dtype(
+        num_non_empty_sequences = (weights_batch_sum > 0).sum() + tiny_value_of_dtype(
             negative_log_likelihood.dtype
         )
         return per_batch_loss.sum() / num_non_empty_sequences
     elif average == "token":
         return negative_log_likelihood.sum() / (
-            weights_batch_sum.sum() + eps_value_of_dtype(negative_log_likelihood.dtype)
+            weights_batch_sum.sum() + tiny_value_of_dtype(negative_log_likelihood.dtype)
         )
     else:
         # shape : (batch_size,)
         per_batch_loss = negative_log_likelihood.sum(non_batch_dims) / (
-            weights_batch_sum + eps_value_of_dtype(negative_log_likelihood.dtype)
+            weights_batch_sum + tiny_value_of_dtype(negative_log_likelihood.dtype)
         )
         return per_batch_loss
 
@@ -1844,7 +1844,7 @@ def max_value_of_dtype(dtype: torch.dtype):
     return info_value_of_dtype(dtype).max
 
 
-def eps_value_of_dtype(dtype: torch.dtype):
+def tiny_value_of_dtype(dtype: torch.dtype):
     """
     Returns the smallest representatble value of a given PyTorch data type such that
     `1.0 + eps != 1.0`.
@@ -1852,4 +1852,4 @@ def eps_value_of_dtype(dtype: torch.dtype):
     """
     if not dtype.is_floating_point:
         raise TypeError("Only supports floating point dtypes.")
-    return info_value_of_dtype(dtype).eps
+    return info_value_of_dtype(dtype).tiny

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -244,7 +244,6 @@ def masked_softmax(
     mask: torch.BoolTensor,
     dim: int = -1,
     memory_efficient: bool = False,
-    mask_fill_value: float = -1e4,
 ) -> torch.Tensor:
     """
     `torch.nn.functional.softmax(vector)` does not work if some elements of `vector` should be
@@ -274,9 +273,9 @@ def masked_softmax(
             # To limit numerical errors from large vector elements outside the mask, we zero these out.
             result = torch.nn.functional.softmax(vector * mask, dim=dim)
             result = result * mask
-            result = result / (result.sum(dim=dim, keepdim=True) + 1e-13)
+            result = result / (result.sum(dim=dim, keepdim=True) + tiny_value_of_dtype(result.dtype))
         else:
-            masked_vector = vector.masked_fill(~mask, mask_fill_value)
+            masked_vector = vector.masked_fill(~mask, min_value_of_dtype(vector.dtype))
             result = torch.nn.functional.softmax(masked_vector, dim=dim)
     return result
 
@@ -307,10 +306,8 @@ def masked_log_softmax(vector: torch.Tensor, mask: torch.BoolTensor, dim: int = 
             mask = mask.unsqueeze(1)
         # vector + mask.log() is an easy way to zero out masked elements in logspace, but it
         # results in nans when the whole vector is masked.  We need a very small value instead of a
-        # zero in the mask for these cases.  log(1 + 1e-45) is still basically 0, so we can safely
-        # just add 1e-45 before calling mask.log().  We use 1e-45 because 1e-46 is so small it
-        # becomes 0 - this is just the smallest value we can actually use.
-        vector = vector + (mask + 1e-45).log()
+        # zero in the mask for these cases.
+        vector = vector + (mask + tiny_value_of_dtype(vector.dtype)).log()
     return torch.nn.functional.log_softmax(vector, dim=dim)
 
 
@@ -319,7 +316,6 @@ def masked_max(
     mask: torch.BoolTensor,
     dim: int,
     keepdim: bool = False,
-    min_val: float = -1e7,
 ) -> torch.Tensor:
     """
     To calculate max along certain dimensions on masked values
@@ -334,20 +330,18 @@ def masked_max(
         The dimension to calculate max
     keepdim : `bool`
         Whether to keep dimension
-    min_val : `float`
-        The minimal value for paddings
 
     # Returns
 
     A `torch.Tensor` of including the maximum values.
     """
-    replaced_vector = vector.masked_fill(~mask, min_val)
+    replaced_vector = vector.masked_fill(~mask, min_value_of_dtype(vector.dtype))
     max_value, _ = replaced_vector.max(dim=dim, keepdim=keepdim)
     return max_value
 
 
 def masked_mean(
-    vector: torch.Tensor, mask: torch.BoolTensor, dim: int, keepdim: bool = False, eps: float = 1e-8
+    vector: torch.Tensor, mask: torch.BoolTensor, dim: int, keepdim: bool = False
 ) -> torch.Tensor:
     """
     To calculate mean along certain dimensions on masked values
@@ -362,8 +356,6 @@ def masked_mean(
         The dimension to calculate mean
     keepdim : `bool`
         Whether to keep dimension
-    eps : `float`
-        A small value to avoid zero division problem.
 
     # Returns
 
@@ -373,7 +365,7 @@ def masked_mean(
 
     value_sum = torch.sum(replaced_vector, dim=dim, keepdim=keepdim)
     value_count = torch.sum(mask, dim=dim, keepdim=keepdim)
-    return value_sum / value_count.float().clamp(min=eps)
+    return value_sum / value_count.float().clamp(min=tiny_value_of_dtype(torch.float))
 
 
 def masked_flip(padded_sequence: torch.Tensor, sequence_lengths: List[int]) -> torch.Tensor:
@@ -757,7 +749,7 @@ def sequence_cross_entropy_with_logits(
         raise ValueError("Got average f{average}, expected one of None, 'token', or 'batch'")
 
     # make sure weights are float
-    weights = weights.float()
+    weights = weights.to(logits.dtype)
     # sum all dim except batch
     non_batch_dims = tuple(range(1, len(weights.shape)))
     # shape : (batch_size,)
@@ -834,14 +826,14 @@ def sequence_cross_entropy_with_logits(
 
     if average == "batch":
         # shape : (batch_size,)
-        per_batch_loss = negative_log_likelihood.sum(non_batch_dims) / (weights_batch_sum + 1e-13)
-        num_non_empty_sequences = (weights_batch_sum > 0).float().sum() + 1e-13
+        per_batch_loss = negative_log_likelihood.sum(non_batch_dims) / (weights_batch_sum + tiny_value_of_dtype(negative_log_likelihood.dtype))
+        num_non_empty_sequences = (weights_batch_sum > 0).sum() + tiny_value_of_dtype(negative_log_likelihood.dtype)
         return per_batch_loss.sum() / num_non_empty_sequences
     elif average == "token":
-        return negative_log_likelihood.sum() / (weights_batch_sum.sum() + 1e-13)
+        return negative_log_likelihood.sum() / (weights_batch_sum.sum() + tiny_value_of_dtype(negative_log_likelihood.dtype))
     else:
         # shape : (batch_size,)
-        per_batch_loss = negative_log_likelihood.sum(non_batch_dims) / (weights_batch_sum + 1e-13)
+        per_batch_loss = negative_log_likelihood.sum(non_batch_dims) / (weights_batch_sum + tiny_value_of_dtype(negative_log_likelihood.dtype))
         return per_batch_loss
 
 
@@ -1786,8 +1778,8 @@ def masked_topk(
     k = k.reshape(-1)
 
     # Make sure that we don't select any masked items by setting their scores to be very
-    # negative.  These are logits, typically, so -1e4 should be plenty negative.
-    input_ = replace_masked_values(input_, mask, -1e4)
+    # negative.
+    input_ = replace_masked_values(input_, mask, min_value_of_dtype(input_.dtype))
 
     # Shape: (batch_size, max_k)
     _, top_indices = input_.topk(max_k, 1)
@@ -1822,3 +1814,39 @@ def masked_topk(
         top_mask.reshape(*permuted_size).permute(*reverse_permutation),
         top_indices.reshape(*permuted_size).permute(*reverse_permutation),
     )
+
+
+def info_value_of_dtype(dtype: torch.dtype):
+    """
+    Returns the `finfo` or `iinfo` object of a given PyTorch data type. Does not allow torch.bool.
+    """
+    if dtype == torch.bool:
+        raise TypeError("Does not support torch.bool")
+    elif dtype.is_floating_point:
+        return torch.finfo(dtype)
+    else:
+        return torch.iinfo(dtype)
+
+
+def min_value_of_dtype(dtype: torch.dtype):
+    """
+    Returns the minimum value of a given PyTorch data type. Does not allow torch.bool.
+    """
+    return info_value_of_dtype(dtype).min
+
+
+def max_value_of_dtype(dtype: torch.dtype):
+    """
+    Returns the maximum value of a given PyTorch data type. Does not allow torch.bool.
+    """
+    return info_value_of_dtype(dtype).max
+
+
+def tiny_value_of_dtype(dtype: torch.dtype):
+    """
+    Returns the smallest representatble value of a given PyTorch data type.
+    Only supports floating point dtypes.
+    """
+    if not dtype.is_floating_point:
+        raise TypeError("Only supports floating point dtypes.")
+    return info_value_of_dtype(dtype).tiny

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -270,7 +270,7 @@ def masked_softmax(
             # To limit numerical errors from large vector elements outside the mask, we zero these out.
             result = torch.nn.functional.softmax(vector * mask, dim=dim)
             result = result * mask
-            result = result / (result.sum(dim=dim, keepdim=True) + 1e-13)
+            result = result / (result.sum(dim=dim, keepdim=True) + tiny_value_of_dtype(result.dtype))
         else:
             masked_vector = vector.masked_fill(~mask, min_value_of_dtype(vector.dtype))
             result = torch.nn.functional.softmax(masked_vector, dim=dim)

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -1853,7 +1853,7 @@ def tiny_value_of_dtype(dtype: torch.dtype):
     """
     if not dtype.is_floating_point:
         raise TypeError("Only supports floating point dtypes.")
-    if dtype == torch.float or torch.double:
+    if dtype == torch.float or dtype == torch.double:
         return 1e-13
     elif dtype == torch.half:
         return 1e-4

--- a/allennlp/tests/modules/masked_layer_norm_test.py
+++ b/allennlp/tests/modules/masked_layer_norm_test.py
@@ -21,8 +21,8 @@ class TestMaskedLayerNorm(AllenNlpTestCase):
         mean = (x_n * np.expand_dims(mask_n, axis=-1)).sum() / N
         std = np.sqrt(
             (((x_n - mean) * np.expand_dims(mask_n, axis=-1)) ** 2).sum() / N
-            + util.eps_value_of_dtype(torch.float)
+            + util.tiny_value_of_dtype(torch.float)
         )
-        expected = 0.2 * (x_n - mean) / (std + util.eps_value_of_dtype(torch.float))
+        expected = 0.2 * (x_n - mean) / (std + util.tiny_value_of_dtype(torch.float))
 
         assert np.allclose(normed_x.data.numpy(), expected)

--- a/allennlp/tests/modules/masked_layer_norm_test.py
+++ b/allennlp/tests/modules/masked_layer_norm_test.py
@@ -19,7 +19,10 @@ class TestMaskedLayerNorm(AllenNlpTestCase):
 
         N = 7 * 5
         mean = (x_n * np.expand_dims(mask_n, axis=-1)).sum() / N
-        std = np.sqrt((((x_n - mean) * np.expand_dims(mask_n, axis=-1)) ** 2).sum() / N + util.eps_value_of_dtype(torch.float))
+        std = np.sqrt(
+            (((x_n - mean) * np.expand_dims(mask_n, axis=-1)) ** 2).sum() / N
+            + util.eps_value_of_dtype(torch.float)
+        )
         expected = 0.2 * (x_n - mean) / (std + util.eps_value_of_dtype(torch.float))
 
         assert np.allclose(normed_x.data.numpy(), expected)

--- a/allennlp/tests/modules/masked_layer_norm_test.py
+++ b/allennlp/tests/modules/masked_layer_norm_test.py
@@ -3,6 +3,7 @@ import torch
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.modules.masked_layer_norm import MaskedLayerNorm
+from allennlp.nn import util
 
 
 class TestMaskedLayerNorm(AllenNlpTestCase):
@@ -18,7 +19,7 @@ class TestMaskedLayerNorm(AllenNlpTestCase):
 
         N = 7 * 5
         mean = (x_n * np.expand_dims(mask_n, axis=-1)).sum() / N
-        std = np.sqrt((((x_n - mean) * np.expand_dims(mask_n, axis=-1)) ** 2).sum() / N + 1e-6)
-        expected = 0.2 * (x_n - mean) / (std + 1e-6)
+        std = np.sqrt((((x_n - mean) * np.expand_dims(mask_n, axis=-1)) ** 2).sum() / N + util.tiny_value_of_dtype(torch.float))
+        expected = 0.2 * (x_n - mean) / (std + util.tiny_value_of_dtype(torch.float))
 
         assert np.allclose(normed_x.data.numpy(), expected)

--- a/allennlp/tests/modules/masked_layer_norm_test.py
+++ b/allennlp/tests/modules/masked_layer_norm_test.py
@@ -19,7 +19,7 @@ class TestMaskedLayerNorm(AllenNlpTestCase):
 
         N = 7 * 5
         mean = (x_n * np.expand_dims(mask_n, axis=-1)).sum() / N
-        std = np.sqrt((((x_n - mean) * np.expand_dims(mask_n, axis=-1)) ** 2).sum() / N + util.tiny_value_of_dtype(torch.float))
-        expected = 0.2 * (x_n - mean) / (std + util.tiny_value_of_dtype(torch.float))
+        std = np.sqrt((((x_n - mean) * np.expand_dims(mask_n, axis=-1)) ** 2).sum() / N + util.eps_value_of_dtype(torch.float))
+        expected = 0.2 * (x_n - mean) / (std + util.eps_value_of_dtype(torch.float))
 
         assert np.allclose(normed_x.data.numpy(), expected)

--- a/allennlp/tests/modules/scalar_mix_test.py
+++ b/allennlp/tests/modules/scalar_mix_test.py
@@ -6,6 +6,7 @@ import numpy
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.common.checks import ConfigurationError
 from allennlp.modules import ScalarMix
+from allennlp.nn import util
 
 
 class TestScalarMix(AllenNlpTestCase):
@@ -59,7 +60,7 @@ class TestScalarMix(AllenNlpTestCase):
         for k in range(3):
             mean = numpy.mean(tensors[k].data.numpy()[numpy_mask == 1])
             std = numpy.std(tensors[k].data.numpy()[numpy_mask == 1])
-            normed_tensor = (tensors[k].data.numpy() - mean) / (std + 1e-12)
+            normed_tensor = (tensors[k].data.numpy() - mean) / (std + util.tiny_value_of_dtype(torch.float))
             expected_result += normed_tensor * normed_weights[k]
         expected_result *= 0.5
 

--- a/allennlp/tests/modules/scalar_mix_test.py
+++ b/allennlp/tests/modules/scalar_mix_test.py
@@ -60,7 +60,7 @@ class TestScalarMix(AllenNlpTestCase):
         for k in range(3):
             mean = numpy.mean(tensors[k].data.numpy()[numpy_mask == 1])
             std = numpy.std(tensors[k].data.numpy()[numpy_mask == 1])
-            normed_tensor = (tensors[k].data.numpy() - mean) / (std + util.tiny_value_of_dtype(torch.float))
+            normed_tensor = (tensors[k].data.numpy() - mean) / (std + util.eps_value_of_dtype(torch.float))
             expected_result += normed_tensor * normed_weights[k]
         expected_result *= 0.5
 

--- a/allennlp/tests/modules/scalar_mix_test.py
+++ b/allennlp/tests/modules/scalar_mix_test.py
@@ -60,7 +60,9 @@ class TestScalarMix(AllenNlpTestCase):
         for k in range(3):
             mean = numpy.mean(tensors[k].data.numpy()[numpy_mask == 1])
             std = numpy.std(tensors[k].data.numpy()[numpy_mask == 1])
-            normed_tensor = (tensors[k].data.numpy() - mean) / (std + util.eps_value_of_dtype(torch.float))
+            normed_tensor = (tensors[k].data.numpy() - mean) / (
+                std + util.eps_value_of_dtype(torch.float)
+            )
             expected_result += normed_tensor * normed_weights[k]
         expected_result *= 0.5
 

--- a/allennlp/tests/modules/scalar_mix_test.py
+++ b/allennlp/tests/modules/scalar_mix_test.py
@@ -61,7 +61,7 @@ class TestScalarMix(AllenNlpTestCase):
             mean = numpy.mean(tensors[k].data.numpy()[numpy_mask == 1])
             std = numpy.std(tensors[k].data.numpy()[numpy_mask == 1])
             normed_tensor = (tensors[k].data.numpy() - mean) / (
-                std + util.eps_value_of_dtype(torch.float)
+                std + util.tiny_value_of_dtype(torch.float)
             )
             expected_result += normed_tensor * normed_weights[k]
         expected_result *= 0.5

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -1626,10 +1626,10 @@ class TestNnUtil(AllenNlpTestCase):
 
         assert util.min_value_of_dtype(torch.half) == -65504.0
         assert util.max_value_of_dtype(torch.half) == 65504.0
-        assert util.tiny_value_of_dtype(torch.half) == 6.103515625e-05
+        assert util.eps_value_of_dtype(torch.half) == 6.103515625e-05
         assert util.min_value_of_dtype(torch.float) == -3.4028234663852886e38
         assert util.max_value_of_dtype(torch.float) == 3.4028234663852886e+38
-        assert util.tiny_value_of_dtype(torch.float) == 1.1754943508222875e-38
+        assert util.eps_value_of_dtype(torch.float) == 1.1754943508222875e-38
 
         assert util.min_value_of_dtype(torch.uint8) == 0
         assert util.max_value_of_dtype(torch.uint8) == 255

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -1619,3 +1619,19 @@ class TestNnUtil(AllenNlpTestCase):
         assert util.tensors_equal([torch.tensor([1])], [torch.tensor([1])])
         assert not util.tensors_equal([torch.tensor([1])], [torch.tensor([2])])
         assert util.tensors_equal({"key": torch.tensor([1])}, {"key": torch.tensor([1])})
+
+    def test_info_value_of_dtype(self):
+        with pytest.raises(TypeError):
+            util.info_value_of_dtype(torch.bool)
+
+        assert util.min_value_of_dtype(torch.half) == -65504.0
+        assert util.max_value_of_dtype(torch.half) == 65504.0
+        assert util.tiny_value_of_dtype(torch.half) == 6.103515625e-05
+        assert util.min_value_of_dtype(torch.float) == -3.4028234663852886e38
+        assert util.max_value_of_dtype(torch.float) == 3.4028234663852886e+38
+        assert util.tiny_value_of_dtype(torch.float) == 1.1754943508222875e-38
+
+        assert util.min_value_of_dtype(torch.uint8) == 0
+        assert util.max_value_of_dtype(torch.uint8) == 255
+        assert util.min_value_of_dtype(torch.long) == -9223372036854775808
+        assert util.max_value_of_dtype(torch.long) == 9223372036854775807

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -1626,10 +1626,10 @@ class TestNnUtil(AllenNlpTestCase):
 
         assert util.min_value_of_dtype(torch.half) == -65504.0
         assert util.max_value_of_dtype(torch.half) == 65504.0
-        assert util.eps_value_of_dtype(torch.half) == 6.103515625e-05
+        assert util.tiny_value_of_dtype(torch.half) == 6.103515625e-05
         assert util.min_value_of_dtype(torch.float) == -3.4028234663852886e38
         assert util.max_value_of_dtype(torch.float) == 3.4028234663852886e38
-        assert util.eps_value_of_dtype(torch.float) == 1.1754943508222875e-38
+        assert util.tiny_value_of_dtype(torch.float) == 1.1754943508222875e-38
 
         assert util.min_value_of_dtype(torch.uint8) == 0
         assert util.max_value_of_dtype(torch.uint8) == 255

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -1626,10 +1626,10 @@ class TestNnUtil(AllenNlpTestCase):
 
         assert util.min_value_of_dtype(torch.half) == -65504.0
         assert util.max_value_of_dtype(torch.half) == 65504.0
-        assert util.tiny_value_of_dtype(torch.half) == 6.103515625e-05
+        assert util.tiny_value_of_dtype(torch.half) == 1e-4
         assert util.min_value_of_dtype(torch.float) == -3.4028234663852886e38
         assert util.max_value_of_dtype(torch.float) == 3.4028234663852886e38
-        assert util.tiny_value_of_dtype(torch.float) == 1.1754943508222875e-38
+        assert util.tiny_value_of_dtype(torch.float) == 1e-13
 
         assert util.min_value_of_dtype(torch.uint8) == 0
         assert util.max_value_of_dtype(torch.uint8) == 255

--- a/allennlp/tests/nn/util_test.py
+++ b/allennlp/tests/nn/util_test.py
@@ -1628,7 +1628,7 @@ class TestNnUtil(AllenNlpTestCase):
         assert util.max_value_of_dtype(torch.half) == 65504.0
         assert util.eps_value_of_dtype(torch.half) == 6.103515625e-05
         assert util.min_value_of_dtype(torch.float) == -3.4028234663852886e38
-        assert util.max_value_of_dtype(torch.float) == 3.4028234663852886e+38
+        assert util.max_value_of_dtype(torch.float) == 3.4028234663852886e38
         assert util.eps_value_of_dtype(torch.float) == 1.1754943508222875e-38
 
         assert util.min_value_of_dtype(torch.uint8) == 0

--- a/allennlp/training/callbacks/log_to_tensorboard.py
+++ b/allennlp/training/callbacks/log_to_tensorboard.py
@@ -95,7 +95,8 @@ class LogToTensorboard(Callback):
                 update_norm = torch.norm(self.param_updates[name].view(-1))
                 param_norm = torch.norm(param.view(-1)).cpu()
                 self.tensorboard.add_train_scalar(
-                    "gradient_update/" + name, update_norm / (param_norm + nn_util.eps_value_of_dtype(param_norm.dtype))
+                    "gradient_update/" + name,
+                    update_norm / (param_norm + nn_util.eps_value_of_dtype(param_norm.dtype)),
                 )
             self.param_updates.clear()
             self.tensorboard.log_histograms(trainer.model, self.histogram_parameters)

--- a/allennlp/training/callbacks/log_to_tensorboard.py
+++ b/allennlp/training/callbacks/log_to_tensorboard.py
@@ -5,6 +5,7 @@ import logging
 import torch
 
 from allennlp.common.params import Params
+from allennlp.nn import util as nn_util
 from allennlp.training import util as training_util
 from allennlp.training.callbacks.callback import Callback, handle_event
 from allennlp.training.callbacks.events import Events
@@ -94,7 +95,7 @@ class LogToTensorboard(Callback):
                 update_norm = torch.norm(self.param_updates[name].view(-1))
                 param_norm = torch.norm(param.view(-1)).cpu()
                 self.tensorboard.add_train_scalar(
-                    "gradient_update/" + name, update_norm / (param_norm + 1e-7)
+                    "gradient_update/" + name, update_norm / (param_norm + nn_util.tiny_value_of_dtype(param_norm.dtype))
                 )
             self.param_updates.clear()
             self.tensorboard.log_histograms(trainer.model, self.histogram_parameters)

--- a/allennlp/training/callbacks/log_to_tensorboard.py
+++ b/allennlp/training/callbacks/log_to_tensorboard.py
@@ -96,7 +96,7 @@ class LogToTensorboard(Callback):
                 param_norm = torch.norm(param.view(-1)).cpu()
                 self.tensorboard.add_train_scalar(
                     "gradient_update/" + name,
-                    update_norm / (param_norm + nn_util.eps_value_of_dtype(param_norm.dtype)),
+                    update_norm / (param_norm + nn_util.tiny_value_of_dtype(param_norm.dtype)),
                 )
             self.param_updates.clear()
             self.tensorboard.log_histograms(trainer.model, self.histogram_parameters)

--- a/allennlp/training/callbacks/log_to_tensorboard.py
+++ b/allennlp/training/callbacks/log_to_tensorboard.py
@@ -95,7 +95,7 @@ class LogToTensorboard(Callback):
                 update_norm = torch.norm(self.param_updates[name].view(-1))
                 param_norm = torch.norm(param.view(-1)).cpu()
                 self.tensorboard.add_train_scalar(
-                    "gradient_update/" + name, update_norm / (param_norm + nn_util.tiny_value_of_dtype(param_norm.dtype))
+                    "gradient_update/" + name, update_norm / (param_norm + nn_util.eps_value_of_dtype(param_norm.dtype))
                 )
             self.param_updates.clear()
             self.tensorboard.log_histograms(trainer.model, self.histogram_parameters)

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -452,7 +452,7 @@ class Trainer(TrainerBase):
                     update_norm = torch.norm(param_updates[name].view(-1))
                     param_norm = torch.norm(param.view(-1)).cpu()
                     self._tensorboard.add_train_scalar(
-                        "gradient_update/" + name, update_norm / (param_norm + 1e-7)
+                        "gradient_update/" + name, update_norm / (param_norm + nn_util.tiny_value_of_dtype(param_norm.dtype))
                     )
             else:
                 self.optimizer.step()

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -453,7 +453,7 @@ class Trainer(TrainerBase):
                     param_norm = torch.norm(param.view(-1)).cpu()
                     self._tensorboard.add_train_scalar(
                         "gradient_update/" + name,
-                        update_norm / (param_norm + nn_util.eps_value_of_dtype(param_norm.dtype)),
+                        update_norm / (param_norm + nn_util.tiny_value_of_dtype(param_norm.dtype)),
                     )
             else:
                 self.optimizer.step()

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -452,7 +452,8 @@ class Trainer(TrainerBase):
                     update_norm = torch.norm(param_updates[name].view(-1))
                     param_norm = torch.norm(param.view(-1)).cpu()
                     self._tensorboard.add_train_scalar(
-                        "gradient_update/" + name, update_norm / (param_norm + nn_util.eps_value_of_dtype(param_norm.dtype))
+                        "gradient_update/" + name,
+                        update_norm / (param_norm + nn_util.eps_value_of_dtype(param_norm.dtype)),
                     )
             else:
                 self.optimizer.step()

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -452,7 +452,7 @@ class Trainer(TrainerBase):
                     update_norm = torch.norm(param_updates[name].view(-1))
                     param_norm = torch.norm(param.view(-1)).cpu()
                     self._tensorboard.add_train_scalar(
-                        "gradient_update/" + name, update_norm / (param_norm + nn_util.tiny_value_of_dtype(param_norm.dtype))
+                        "gradient_update/" + name, update_norm / (param_norm + nn_util.eps_value_of_dtype(param_norm.dtype))
                     )
             else:
                 self.optimizer.step()

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -66,7 +66,7 @@ def sparse_clip_norm(parameters, max_norm, norm_type=2) -> float:
                 param_norm = p.grad.data.norm(norm_type)
             total_norm += param_norm ** norm_type
         total_norm = total_norm ** (1.0 / norm_type)
-    clip_coef = max_norm / (total_norm + 1e-6)
+    clip_coef = max_norm / (total_norm + nn_util.tiny_value_of_dtype(total_norm.dtype))
     if clip_coef < 1:
         for p in parameters:
             if p.grad.is_sparse:

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -66,7 +66,7 @@ def sparse_clip_norm(parameters, max_norm, norm_type=2) -> float:
                 param_norm = p.grad.data.norm(norm_type)
             total_norm += param_norm ** norm_type
         total_norm = total_norm ** (1.0 / norm_type)
-    clip_coef = max_norm / (total_norm + nn_util.eps_value_of_dtype(total_norm.dtype))
+    clip_coef = max_norm / (total_norm + nn_util.tiny_value_of_dtype(total_norm.dtype))
     if clip_coef < 1:
         for p in parameters:
             if p.grad.is_sparse:

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -66,7 +66,7 @@ def sparse_clip_norm(parameters, max_norm, norm_type=2) -> float:
                 param_norm = p.grad.data.norm(norm_type)
             total_norm += param_norm ** norm_type
         total_norm = total_norm ** (1.0 / norm_type)
-    clip_coef = max_norm / (total_norm + nn_util.tiny_value_of_dtype(total_norm.dtype))
+    clip_coef = max_norm / (total_norm + nn_util.eps_value_of_dtype(total_norm.dtype))
     if clip_coef < 1:
         for p in parameters:
             if p.grad.is_sparse:


### PR DESCRIPTION
We currently use a lot of extremely positive/negative/tiny for special values in masked operations. However these cause overflow/underflow with AMP. So this PR changes them to unified constants depending on the dtype.