### PR TITLE
Sorting keys api

### DIFF
--- a/allennlp/data/fields/adjacency_field.py
+++ b/allennlp/data/fields/adjacency_field.py
@@ -143,3 +143,6 @@ class AdjacencyField(Field[torch.Tensor]):
             f"\t\twith indices:\n {formatted_indices}\n"
             f"\t\tand labels:\n {formatted_labels} \t\tin namespace: '{self._label_namespace}'."
         )
+
+    def __len__(self):
+        return len(self.sequence_field)

--- a/allennlp/data/fields/array_field.py
+++ b/allennlp/data/fields/array_field.py
@@ -58,3 +58,6 @@ class ArrayField(Field[numpy.ndarray]):
 
     def __str__(self) -> str:
         return f"ArrayField with shape: {self.array.shape} and dtype: {self.dtype}."
+
+    def __len__(self):
+        return self.array.shape[0]

--- a/allennlp/data/fields/field.py
+++ b/allennlp/data/fields/field.py
@@ -117,3 +117,7 @@ class Field(Generic[DataArray]):
         if isinstance(self, other.__class__):
             return self.__dict__ == other.__dict__
         return NotImplemented
+
+
+    def __len__(self):
+        raise NotImplementedError

--- a/allennlp/data/fields/field.py
+++ b/allennlp/data/fields/field.py
@@ -118,6 +118,5 @@ class Field(Generic[DataArray]):
             return self.__dict__ == other.__dict__
         return NotImplemented
 
-
     def __len__(self):
         raise NotImplementedError

--- a/allennlp/data/fields/index_field.py
+++ b/allennlp/data/fields/index_field.py
@@ -60,3 +60,6 @@ class IndexField(Field[torch.Tensor]):
         if isinstance(other, int):
             return self.sequence_index == other
         return super().__eq__(other)
+
+    def __len__(self):
+        return 1

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -105,3 +105,6 @@ class LabelField(Field[torch.Tensor]):
 
     def __str__(self) -> str:
         return f"LabelField with label: {self.label} in namespace: '{self._label_namespace}'.'"
+
+    def __len__(self):
+        return 1

--- a/allennlp/data/fields/multilabel_field.py
+++ b/allennlp/data/fields/multilabel_field.py
@@ -136,3 +136,6 @@ class MultiLabelField(Field[torch.Tensor]):
         return (
             f"MultiLabelField with labels: {self.labels} in namespace: '{self._label_namespace}'.'"
         )
+
+    def __len__(self):
+        return 1

--- a/allennlp/data/fields/namespace_swapping_field.py
+++ b/allennlp/data/fields/namespace_swapping_field.py
@@ -48,3 +48,6 @@ class NamespaceSwappingField(Field[torch.Tensor]):
     @overrides
     def empty_field(self) -> "NamespaceSwappingField":
         return NamespaceSwappingField([], self._target_namespace)
+
+    def __len__(self):
+        return len(self._source_tokens)

--- a/allennlp/data/fields/span_field.py
+++ b/allennlp/data/fields/span_field.py
@@ -68,3 +68,6 @@ class SpanField(Field[torch.Tensor]):
         if isinstance(other, tuple) and len(other) == 2:
             return other == (self.span_start, self.span_end)
         return super().__eq__(other)
+
+    def __len__(self):
+        return 2

--- a/allennlp/tests/common/params_test.py
+++ b/allennlp/tests/common/params_test.py
@@ -38,14 +38,14 @@ class TestParams(AllenNlpTestCase):
         overrides = (
             '{ "train_data_path": "FOO", "model": { "type": "BAR" },'
             '"model.text_field_embedder.tokens.type": "BAZ",'
-            '"data_loader.batch_sampler.sorting_keys.0.0": "question"}'
+            '"data_loader.batch_sampler.sorting_keys.0": "question"}'
         )
         params = Params.from_file(filename, overrides)
 
         assert "dataset_reader" in params
         assert "trainer" in params
         assert params["train_data_path"] == "FOO"
-        assert params["data_loader"]["batch_sampler"]["sorting_keys"][0][0] == "question"
+        assert params["data_loader"]["batch_sampler"]["sorting_keys"][0] == "question"
 
         model_params = params.pop("model")
         assert model_params.pop("type") == "BAR"

--- a/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
+++ b/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
@@ -88,9 +88,7 @@ class TestBucketSampler(SamplerTest):
     def test_create_batches_groups_correctly(self):
 
         dataset = AllennlpDataset(self.instances, vocab=self.vocab)
-        sampler = BucketBatchSampler(
-            dataset, batch_size=2, padding_noise=0, sorting_keys=["text"]
-        )
+        sampler = BucketBatchSampler(dataset, batch_size=2, padding_noise=0, sorting_keys=["text"])
 
         grouped_instances = []
         for indices in sampler:
@@ -166,11 +164,7 @@ class TestBucketSampler(SamplerTest):
     def test_drop_last_works(self):
         dataset = AllennlpDataset(self.instances, vocab=self.vocab)
         sampler = BucketBatchSampler(
-            dataset,
-            batch_size=2,
-            padding_noise=0,
-            sorting_keys=["text"],
-            drop_last=True,
+            dataset, batch_size=2, padding_noise=0, sorting_keys=["text"], drop_last=True,
         )
         # We use a custom collate_fn for testing, which doesn't actually create tensors,
         # just the allennlp Batches.
@@ -186,9 +180,7 @@ class TestBucketSampler(SamplerTest):
 
     def test_batch_count(self):
         dataset = AllennlpDataset(self.instances, vocab=self.vocab)
-        sampler = BucketBatchSampler(
-            dataset, batch_size=2, padding_noise=0, sorting_keys=["text"]
-        )
+        sampler = BucketBatchSampler(dataset, batch_size=2, padding_noise=0, sorting_keys=["text"])
         # We use a custom collate_fn for testing, which doesn't actually create tensors,
         # just the allennlp Batches.
         dataloader = DataLoader(dataset, batch_sampler=sampler, collate_fn=lambda x: Batch(x))
@@ -198,11 +190,7 @@ class TestBucketSampler(SamplerTest):
     def test_batch_count_with_drop_last(self):
         dataset = AllennlpDataset(self.instances, vocab=self.vocab)
         sampler = BucketBatchSampler(
-            dataset,
-            batch_size=2,
-            padding_noise=0,
-            sorting_keys=["text"],
-            drop_last=True,
+            dataset, batch_size=2, padding_noise=0, sorting_keys=["text"], drop_last=True,
         )
         # We use a custom collate_fn for testing, which doesn't actually create tensors,
         # just the allennlp Batches.

--- a/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
+++ b/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
@@ -89,7 +89,7 @@ class TestBucketSampler(SamplerTest):
 
         dataset = AllennlpDataset(self.instances, vocab=self.vocab)
         sampler = BucketBatchSampler(
-            dataset, batch_size=2, padding_noise=0, sorting_keys=[("text", "tokens___tokens")]
+            dataset, batch_size=2, padding_noise=0, sorting_keys=["text"]
         )
 
         grouped_instances = []
@@ -133,13 +133,13 @@ class TestBucketSampler(SamplerTest):
         )
         assert sampler.sorting_keys is None
         sampler._guess_sorting_keys(instances)
-        assert sampler.sorting_keys == [("passage", "tokens___tokens")]
+        assert sampler.sorting_keys == ["passage"]
 
     def test_from_params(self):
         dataset = AllennlpDataset(self.instances, self.vocab)
         params = Params({})
 
-        sorting_keys = [("s1", "nt"), ("s2", "nt2")]
+        sorting_keys = ["s1", "s2"]
         params["sorting_keys"] = sorting_keys
         params["batch_size"] = 32
         sampler = BucketBatchSampler.from_params(params=params, data_source=dataset)
@@ -169,7 +169,7 @@ class TestBucketSampler(SamplerTest):
             dataset,
             batch_size=2,
             padding_noise=0,
-            sorting_keys=[("text", "tokens___tokens")],
+            sorting_keys=["text"],
             drop_last=True,
         )
         # We use a custom collate_fn for testing, which doesn't actually create tensors,
@@ -187,7 +187,7 @@ class TestBucketSampler(SamplerTest):
     def test_batch_count(self):
         dataset = AllennlpDataset(self.instances, vocab=self.vocab)
         sampler = BucketBatchSampler(
-            dataset, batch_size=2, padding_noise=0, sorting_keys=[("text", "tokens___tokens")]
+            dataset, batch_size=2, padding_noise=0, sorting_keys=["text"]
         )
         # We use a custom collate_fn for testing, which doesn't actually create tensors,
         # just the allennlp Batches.
@@ -201,7 +201,7 @@ class TestBucketSampler(SamplerTest):
             dataset,
             batch_size=2,
             padding_noise=0,
-            sorting_keys=[("text", "tokens___tokens")],
+            sorting_keys=["text"],
             drop_last=True,
         )
         # We use a custom collate_fn for testing, which doesn't actually create tensors,

--- a/allennlp/tests/fixtures/coref/coref_bert_lstm_small.jsonnet
+++ b/allennlp/tests/fixtures/coref/coref_bert_lstm_small.jsonnet
@@ -78,7 +78,7 @@ local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
   "data_loader": {
       "batch_sampler": {
           "type": "bucket",
-          "sorting_keys": [["text", "tokens___token_ids"]],
+          "sorting_keys": ["text"],
           "batch_size": 1,
           "padding_noise": 0.0
       }

--- a/allennlp/tests/fixtures/simple_tagger/experiment.json
+++ b/allennlp/tests/fixtures/simple_tagger/experiment.json
@@ -25,7 +25,7 @@
   "data_loader": {
       "batch_sampler": {
         "type": "bucket",
-        "sorting_keys": [["tokens", "tokens___tokens"]],
+        "sorting_keys": ["tokens"],
         "padding_noise": 0.0,
         "batch_size" : 80
     }

--- a/docs/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt1.md
+++ b/docs/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt1.md
@@ -462,7 +462,7 @@ were to split strings into words and represent words as single ids under the nam
   "validation_data_path": "https://allennlp.s3.amazonaws.com/datasets/academic-papers-example/dev.jsonl",
   "iterator": {
     "type": "bucket",
-    "sorting_keys": [["abstract", "num_tokens"], ["title", "num_tokens"]],
+    "sorting_keys": ["abstract", "title"],
     "batch_size": 64
   },
   "trainer": {

--- a/training_config/coref_bert_lstm.jsonnet
+++ b/training_config/coref_bert_lstm.jsonnet
@@ -76,7 +76,7 @@ local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
   "data_loader": {
     "batch_sampler": {
       "type": "bucket",
-      "sorting_keys": [["text", "tokens___token_ids"]],
+      "sorting_keys": ["text"],
       "padding_noise": 0.0,
       "batch_size": 1
     }

--- a/training_config/coref_spanbert_large.jsonnet
+++ b/training_config/coref_spanbert_large.jsonnet
@@ -90,7 +90,7 @@ local span_pair_embedding_dim = 3 * span_embedding_dim + feature_size;
       "type": "bucket",
       # Explicitly specifying sorting keys since the guessing heuristic could get it wrong
       # as we a span field.
-      "sorting_keys": [["text", "tokens___token_ids"]],
+      "sorting_keys": ["text"],
       "batch_size": 1
     }
   },

--- a/training_config/stanford_sentiment_treebank_roberta.jsonnet
+++ b/training_config/stanford_sentiment_treebank_roberta.jsonnet
@@ -50,7 +50,7 @@ local cls_is_last_token = false;
   "data_loader": {
     "batch_sampler": {
       "type": "bucket",
-      "sorting_keys": [["tokens", "tokens___token_ids"]],
+      "sorting_keys": ["tokens"],
       "batch_size" : 32
     }
   },

--- a/tutorials/tagger/exercise.jsonnet
+++ b/tutorials/tagger/exercise.jsonnet
@@ -49,7 +49,7 @@ local learning_rate = 0.1;
     "iterator": {
         "type": "bucket",
         "batch_size": batch_size,
-        "sorting_keys": [["sentence", "num_tokens"]]
+        "sorting_keys": ["sentence"]
     },
     "trainer": {
         "num_epochs": num_epochs,

--- a/tutorials/tagger/experiment.jsonnet
+++ b/tutorials/tagger/experiment.jsonnet
@@ -34,7 +34,7 @@ local learning_rate = 0.1;
     "iterator": {
         "type": "bucket",
         "batch_size": batch_size,
-        "sorting_keys": [["sentence", "num_tokens"]]
+        "sorting_keys": ["sentence"]
     },
     "trainer": {
         "num_epochs": num_epochs,


### PR DESCRIPTION
Fixes #3664 

Radical idea for sorting instances - we don't call `get_padding_lengths` at all.
Instead, we just specify what fields we want to sort by, and implement `__len__` for all fields.

I'm pretty sure this has zero downsides, and many upsides:

1. Bucketing now no-longer requires the instances to be indexed, which is a potentially expensive operation.

2. Configs are simpler, because you just pass the name of the field you want to sort by.

3. There are cases for which `len(field)` doesn't correspond directly to what will be padded - e.g wordpiece tokenizers may cause this to be slightly different. We should be willing to gamble that sentence length and wordpieced sentence length are highly correlated in the general case, and so bucketing like this is actually fine.

The only edge case I can think of is listfields of textfields, but it's unclear to me how "efficient" you can be even if you bucket things perfectly in that case. 
