### PR TITLE
Fix trainer tests in GPU

### DIFF
--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -122,12 +122,11 @@ class TestTrainer(AllenNlpTestCase):
         self.model.cuda()
 
         with pytest.raises(ConfigurationError):
-            Trainer(
-                self.model, self.optimizer, self.data_loader, num_epochs=2, cuda_device=[0, 1],
-            )
+            Trainer(self.model, self.optimizer, self.data_loader, num_epochs=2, cuda_device=[0, 1])
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device registered.")
     @pytest.mark.skipif(amp is None, reason="Apex is not installed.")
+    @pytest.mark.spawn
     def test_trainer_can_run_amp(self):
 
         self.model.cuda()


### PR DESCRIPTION
Fix https://github.com/allenai/allennlp/pull/3866#issuecomment-593707746. This should fix the GPU tests in master.

The problem is that amp can change PyTorch's state. Then, after running an amp test, the rest of the tests that run along get affected. I used `pytest.mark.spawn` so the amp test runs in its own subprocess, not affecting the main one. I copied the idea from PyTorchLightning/pytorch-lightning#661.

Apex's amp does a lot of monkey patching, and as far as I understand, there's only one flag that affects PyTorch itself (as opposed to just affecting the models and optimizers, that I don't consider a secondary effect), which is `patch_torch_functions` (or when `opt_level==O1`). It wraps a lot of PyTorch functions based on several criteria, leaving the patches there. And it makes some things stop working, such as PyTorch with CPU, or some unsupported operations (and also amp is enabled even if you don't want).

Do we wanna do something else about it? These are some problematic scenarios:

* Train some model with amp and then in the same program execution train something else without it.
* Unlikely but possible: wanting to train to things in parallel, one with amp and another one without it.

Another related problem: doing more than one amp training in one program will call `amp.initialize` more than once, which isn't supposed to be done.

I think that the least we can do is to warn the user that this can happen and to run the trainer in its own subprocess if they want to avoid any of these problems.

We can also undo the amp stateful effect. AFAIK, it can be undone by checking if the variable `apex.amp.amp_DECORATOR_HANDLE` isn't `None`, calling `_deactivate` and setting `_is_active` to False. This will solve calling trainers with different amp options sequentially but not in parallel.

Any thought?