### PR TITLE
Fix trainer tests when Apex installed

### DIFF
--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -43,7 +43,7 @@ class TrainerTestBase(AllenNlpTestCase):
                 "text_field_embedder": {
                     "token_embedders": {"tokens": {"type": "embedding", "embedding_dim": 5}}
                 },
-                "encoder": {"type": "lstm", "input_size": 5, "hidden_size": 7, "num_layers": 2,},
+                "encoder": {"type": "lstm", "input_size": 5, "hidden_size": 7, "num_layers": 2},
             }
         )
         self.model = SimpleTagger.from_params(vocab=self.vocab, params=self.model_params)


### PR DESCRIPTION
Hey ya'll,

So I ran into a bunch of issues running the trainer tests after installing Apex. After debugging, I realized this was because the trainer test that uses Apex modifies the model itself, and so every non-Apex test that ran after the Apex test would be using the modified model, which would cause them to fail.

So this PR just refactors the trainer tests so that the Apex test runs with it's own model, vocab, data, etc.