### PR TITLE
Speed up docs generation.

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1,3 +1,7 @@
+from mathy_pydoc.__main__ import main
+from contextlib import redirect_stdout
+import sys
+import io
 from typing import Dict
 import os
 from pathlib import Path
@@ -15,7 +19,6 @@ exclude_files = [
     "__main__.py",
 ]
 
-
 def render_file(relative_src_path: str, src_file: str, to_file: str, modifier="++") -> None:
     """
     Shells out to pydocmd, which creates a .md file from the docstrings of python functions and classes in
@@ -31,10 +34,13 @@ def render_file(relative_src_path: str, src_file: str, to_file: str, modifier="+
     else:
         namespace = f"allennlp.{relative_src_namespace}.{src_base}{modifier}"
 
-    args = ["mathy_pydoc", namespace]
-    call_result = check_output(args, env=os.environ).decode("utf-8")
+    sys.argv = ["x", namespace]
+    output = io.StringIO()
+    with redirect_stdout(output):
+        main()
+
     with open(to_file, "w") as f:
-        f.write(call_result)
+        f.write(output.getvalue())
 
     print(f"Built docs for {src_file}: {to_file}")
 

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -34,7 +34,7 @@ def render_file(relative_src_path: str, src_file: str, to_file: str, modifier="+
     else:
         namespace = f"allennlp.{relative_src_namespace}.{src_base}{modifier}"
 
-    sys.argv = ["x", namespace]
+    sys.argv = ["mathy_pydoc", namespace]
     output = io.StringIO()
     with redirect_stdout(output):
         main()

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1,4 +1,4 @@
-from mathy_pydoc.__main__ import main
+from mathy_pydoc.__main__ import main as mathy_pydoc_main
 from contextlib import redirect_stdout
 import sys
 import io
@@ -35,12 +35,9 @@ def render_file(relative_src_path: str, src_file: str, to_file: str, modifier="+
         namespace = f"allennlp.{relative_src_namespace}.{src_base}{modifier}"
 
     sys.argv = ["mathy_pydoc", namespace]
-    output = io.StringIO()
-    with redirect_stdout(output):
-        main()
-
     with open(to_file, "w") as f:
-        f.write(output.getvalue())
+        with redirect_stdout(f):
+            mathy_pydoc_main()
 
     print(f"Built docs for {src_file}: {to_file}")
 

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -19,6 +19,7 @@ exclude_files = [
     "__main__.py",
 ]
 
+
 def render_file(relative_src_path: str, src_file: str, to_file: str, modifier="++") -> None:
     """
     Shells out to pydocmd, which creates a .md file from the docstrings of python functions and classes in

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1,11 +1,9 @@
 from mathy_pydoc.__main__ import main as mathy_pydoc_main
 from contextlib import redirect_stdout
 import sys
-import io
 from typing import Dict
 import os
 from pathlib import Path
-from subprocess import check_output
 
 from ruamel.yaml import YAML
 


### PR DESCRIPTION
Related to https://github.com/allenai/allennlp/issues/3917

This speeds up docs generation from 1165s (20 minutes) to 6s for a 194x speedup.  The code has some gnarly workarounds for the fact that the code in `mathy_pydoc` is not very modular (the main method reads from the args directly and writes directly to stdout).