### PR TITLE
Remove the edit link from the docs.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,6 @@ theme:
 
 
 repo_name: allenai/allennlp
-repo_url: https://github.com/allenai/allennlp
 # TODO(markn): Consider adding GA here, if we care about it.
 
 nav:

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -39,6 +39,7 @@ def render_file(relative_src_path: str, src_file: str, to_file: str, modifier="+
             mathy_pydoc_main()
 
     print(f"Built docs for {src_file}: {to_file}")
+    print()
 
 
 def build_docs_for_file(relative_path: str, file_name: str, docs_dir: str) -> Dict[str, str]:

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -3,7 +3,7 @@ set -e
 
 cp README.md docs/README.md
 # Alter the relative path of the README image for the docs.
-sed -i '1s/docs/./' docs/README.md
+gsed -i '1s/docs/./' docs/README.md
 cp LICENSE docs/LICENSE.md
 cp ROADMAP.md docs/ROADMAP.md
 cp CONTRIBUTING.md docs/CONTRIBUTING.md

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -3,7 +3,7 @@ set -e
 
 cp README.md docs/README.md
 # Alter the relative path of the README image for the docs.
-gsed -i '1s/docs/./' docs/README.md
+sed -i '1s/docs/./' docs/README.md
 cp LICENSE docs/LICENSE.md
 cp ROADMAP.md docs/ROADMAP.md
 cp CONTRIBUTING.md docs/CONTRIBUTING.md


### PR DESCRIPTION
https://github.com/allenai/allennlp/pull/3916 didn't fix https://github.com/allenai/allennlp/issues/3914 because a default value is set when `repo_url` is set.  See https://www.mkdocs.org/user-guide/configuration/.

> On a few known hosts (specifically GitHub, Bitbucket and GitLab), the edit_uri is derived from the 'repo_url' and does not need to be set manually. Simply defining a repo_url will automatically populate the edit_uri configs setting.