### PR TITLE
Use docs.allennlp.org for documentation URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for developing state-of-the-art deep learning models on a wide variety of lingui
 * [Website](https://allennlp.org/)
 * [Tutorial](https://allennlp.org/tutorials)
 * [Forum](https://discourse.allennlp.org)
-* [Documentation](https://allenai.github.io/allennlp-docs/master/master/)
+* [Documentation](https://docs.allennlp.org/master/master/)
 * [Contributing Guidelines](CONTRIBUTING.md)
 * [Pretrained Models](https://github.com/allenai/allennlp-hub/blob/master/allennlp_hub/pretrained/allennlp_pretrained.py)
 * [Continuous Build](http://build.allennlp.org/)

--- a/docs/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt1.md
+++ b/docs/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt1.md
@@ -538,7 +538,7 @@ here is a wrapper around pytorch's built-in LSTMs that make them conform to the 
 API.  All of the parameters except for "type" get passed directly to pytorch code.
 
 The feed-forward network has a configurable depth, width, and activation.  You can look at the
-[documentation](https://allenai.github.io/allennlp-docs/master/api/modules/feedforward/) of
+[documentation](https://docs.allennlp.org/master/api/modules/feedforward/) of
 `FeedForward` for more information on these parameters.
 
 And that's it!  You're now the proud owner of a new `DatasetReader`, `Model`, and means to train

--- a/docs/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt2.md
+++ b/docs/tutorials/getting_started/predicting_paper_venues/predicting_paper_venues_pt2.md
@@ -37,7 +37,7 @@ abstraction that wraps a model and does precisely this.
 Most of the functionality you need for a `Predictor` is already implemented in the base class.
 Usually you only need to implement the `predict_json` function,
 which specifies how to turn a JSON dict of inputs into an AllenNLP
-[`Instance`](https://allenai.github.io/allennlp-docs/master/api/data/instance/).
+[`Instance`](https://docs.allennlp.org/master/api/data/instance/).
 Since we want to return more than an Instance in this function, we use `predict_instance` serialize the Instance to JSON dict.
 And our `DatasetReader` already has a
 [`text_to_instance`](https://github.com/allenai/allennlp-as-a-library-example/blob/master/my_library/dataset_readers/semantic_scholar_papers.py#L68)

--- a/docs/tutorials/getting_started/walk_through_allennlp/configuration.md
+++ b/docs/tutorials/getting_started/walk_through_allennlp/configuration.md
@@ -18,7 +18,7 @@ Most AllenNLP classes inherit from the
 [`Registrable`](https://docs.allennlp.org/master/api/common/registrable/#registrable)
 base class,
 which gives them a named registry for their subclasses. This means that if we had
-a `Model(Registrable)` base class ([we do](https://docs.allennlp.org/master/api/allennlp.models.model.html#allennlp.models.model.Model)),
+a `Model(Registrable)` base class ([we do](http://docs.allennlp.org/master/api/models/model/#model)),
 and we decorated a subclass like
 
 ```python
@@ -130,7 +130,7 @@ If you look at the code for `SequenceTaggingDatasetReader.read()`,
 it turns each sentence into a `TextField`
 of tokens and a `SequenceLabelField` of tags. The latter isn't
 really configurable, but the former wants a dictionary of
-[TokenIndexer](https://docs.allennlp.org/master/api/allennlp.data.token_indexers.html#allennlp.data.token_indexers.token_indexer.TokenIndexer)s
+[TokenIndexer](http://docs.allennlp.org/master/api/data/token_indexers/token_indexer/#tokenindexer)s
 that indicate how to convert the tokens into arrays.
 
 Our configuration specifies two token indexers:

--- a/docs/tutorials/getting_started/walk_through_allennlp/configuration.md
+++ b/docs/tutorials/getting_started/walk_through_allennlp/configuration.md
@@ -15,10 +15,10 @@ each section of the configuration file in detail, explaining what all the parame
 ## A preliminary: Registrable and from_params
 
 Most AllenNLP classes inherit from the
-[`Registrable`](https://allenai.github.io/allennlp-docs/master/api/common/registrable/#registrable)
+[`Registrable`](https://docs.allennlp.org/master/api/common/registrable/#registrable)
 base class,
 which gives them a named registry for their subclasses. This means that if we had
-a `Model(Registrable)` base class ([we do](https://allenai.github.io/allennlp-docs/master/api/allennlp.models.model.html#allennlp.models.model.Model)),
+a `Model(Registrable)` base class ([we do](https://docs.allennlp.org/master/api/allennlp.models.model.html#allennlp.models.model.Model)),
 and we decorated a subclass like
 
 ```python
@@ -35,7 +35,7 @@ Model.by_name("custom")
 
 By convention, all such classes have a `from_params` factory method that
 allows you to instantiate instances from a
-[`Params`](https://allenai.github.io/allennlp-docs/master/api/common/params/#params)
+[`Params`](https://docs.allennlp.org/master/api/common/params/#params)
 object, which is basically a `dict` of parameters
 with some added functionality that we won't get into here.
 
@@ -62,24 +62,24 @@ You can also create your own script that imports your custom classes and then ca
 ## Batches and Instances and Fields
 
 We train and evaluate our models on `Batch`es. A
-[`Batch`](https://allenai.github.io/allennlp-docs/master/api/data/batch/)
+[`Batch`](https://docs.allennlp.org/master/api/data/batch/)
 is a collection of
-[`Instance`](https://allenai.github.io/allennlp-docs/master/api/data/instance/#instance)s.
+[`Instance`](https://docs.allennlp.org/master/api/data/instance/#instance)s.
 In our tagging experiment,
 each dataset is a collection of tagged sentences, and each instance is one of those tagged sentences.
 
 An instance consists of
-[`Field`](https://allenai.github.io/allennlp-docs/master/api/data/fields/field/#field)s,
+[`Field`](https://docs.allennlp.org/master/api/data/fields/field/#field)s,
 each of which represents some part of the instance as arrays suitable for feeding into a model.
 
 In our tagging setup, each instance will contain a
-[`TextField`](https://allenai.github.io/allennlp-docs/master/api/data/fields/text_field/#textfield)
+[`TextField`](https://docs.allennlp.org/master/api/data/fields/text_field/#textfield)
 representing the words/tokens of the sentence and a
-[`SequenceLabelField`](https://allenai.github.io/allennlp-docs/master/api/data/fields/sequence_label_field/#sequencelabelfield)
+[`SequenceLabelField`](https://docs.allennlp.org/master/api/data/fields/sequence_label_field/#sequencelabelfield)
 representing the corresponding part-of-speech tags.
 
 How do we turn a text file full of sentences into `Batches`? With a
-[`DatasetReader`](https://allenai.github.io/allennlp-docs/master/api/data/dataset_readers/dataset_reader/#datasetreader)
+[`DatasetReader`](https://docs.allennlp.org/master/api/data/dataset_readers/dataset_reader/#datasetreader)
 specified by our configuration file.
 
 ## DatasetReaders
@@ -104,7 +104,7 @@ The first section of our configuration file defines the `dataset_reader`:
 
 Here we've specified that we want to use the `DatasetReader` subclass that's registered
 under the name `"sequence_tagging"`. Unsurprisingly, this is the
-[`SequenceTaggingDatasetReader`](https://allenai.github.io/allennlp-docs/master/api/data/dataset_readers/sequence_tagging/#sequencetaggingdatasetreader)
+[`SequenceTaggingDatasetReader`](https://docs.allennlp.org/master/api/data/dataset_readers/sequence_tagging/#sequencetaggingdatasetreader)
 subclass. This reader assumes a text file of newline-separated sentences, where each sentence looks like the following for some "word tag delimiter" `{wtd}` and some "token delimiter" `{td}`.
 
 ```
@@ -130,7 +130,7 @@ If you look at the code for `SequenceTaggingDatasetReader.read()`,
 it turns each sentence into a `TextField`
 of tokens and a `SequenceLabelField` of tags. The latter isn't
 really configurable, but the former wants a dictionary of
-[TokenIndexer](https://allenai.github.io/allennlp-docs/master/api/allennlp.data.token_indexers.html#allennlp.data.token_indexers.token_indexer.TokenIndexer)s
+[TokenIndexer](https://docs.allennlp.org/master/api/allennlp.data.token_indexers.html#allennlp.data.token_indexers.token_indexer.TokenIndexer)s
 that indicate how to convert the tokens into arrays.
 
 Our configuration specifies two token indexers:
@@ -148,13 +148,13 @@ Our configuration specifies two token indexers:
 ```
 
 The first, `"tokens"`, is a
-[`SingleIdTokenIndexer`](https://allenai.github.io/allennlp-docs/master/api/data/token_indexers/single_id_token_indexer/#singleidtokenindexer)
+[`SingleIdTokenIndexer`](https://docs.allennlp.org/master/api/data/token_indexers/single_id_token_indexer/#singleidtokenindexer)
 that just represents each token (word) as a single integer.
 The configuration also specifies that we *lowercase* the tokens before encoding;
 that is, that this token indexer should ignore case.
 
 The second, `"token_characters"`, is a
-[`TokenCharactersIndexer`](https://allenai.github.io/allennlp-docs/master/api/data/token_indexers/token_characters_indexer/#tokencharactersindexer)
+[`TokenCharactersIndexer`](https://docs.allennlp.org/master/api/data/token_indexers/token_characters_indexer/#tokencharactersindexer)
 that represents each token as a list of int-encoded characters.
 
 Notice that this gives us two different encodings for each token.
@@ -185,12 +185,12 @@ The next section configures our model.
 
 This indicates we want to use the `Model` subclass that's registered as `"simple_tagger"`,
 which is the
-[`SimpleTagger`](https://allenai.github.io/allennlp-docs/master/api/models/simple_tagger/#simpletagger) model.
+[`SimpleTagger`](https://docs.allennlp.org/master/api/models/simple_tagger/#simpletagger) model.
 
 If you look at its code, you'll see it consists of a
-[`TextFieldEmbedder`](https://allenai.github.io/allennlp-docs/master/api/modules/text_field_embedders/text_field_embedder/#textfieldembedder)
+[`TextFieldEmbedder`](https://docs.allennlp.org/master/api/modules/text_field_embedders/text_field_embedder/#textfieldembedder)
 that embeds the output of our text fields, a
-[`Seq2SeqEncoder`](https://allenai.github.io/allennlp-docs/master/api/modules/seq2seq_encoders/seq2seq_encoder/#seq2seqencoder)
+[`Seq2SeqEncoder`](https://docs.allennlp.org/master/api/modules/seq2seq_encoders/seq2seq_encoder/#seq2seqencoder)
 that transforms that sequence into an output sequence,
 and a linear layer to convert the output sequences
 into logits representing the probabilities of predicted tags.
@@ -226,22 +226,22 @@ Let's first look at the text field embedder configuration:
 
 You can see that it has an entry for each of the named encodings in our `TextField`.
 Each entry specifies a
-[`TokenEmbedder`](https://allenai.github.io/allennlp-docs/master/api/modules/token_embedders/token_embedder/#tokenembedder)
+[`TokenEmbedder`](https://docs.allennlp.org/master/api/modules/token_embedders/token_embedder/#tokenembedder)
 that indicates how to embed
 the tokens encoded with that name. The `TextFieldEmbedder`'s output is the concatenation
 of these embeddings.
 
 The `"tokens"` input (which consists of integer encodings of the lowercased words in the input)
 gets fed into an
-[`Embedding`](https://allenai.github.io/allennlp-docs/master/api/modules/token_embedders/embedding/#embedding)
+[`Embedding`](https://docs.allennlp.org/master/api/modules/token_embedders/embedding/#embedding)
 module that embeds the vocabulary words in a 50-dimensional space, as specified by the `embedding_dim` parameter.
 
 The `"token_characters"` input (which consists of integer-sequence encodings of the characters in each word)
 gets fed into a
-[`TokenCharactersEncoder`](https://allenai.github.io/allennlp-docs/master/api/modules/token_embedders/token_characters_encoder/#tokencharactersencoder),
+[`TokenCharactersEncoder`](https://docs.allennlp.org/master/api/modules/token_embedders/token_characters_encoder/#tokencharactersencoder),
 which embeds the characters in an 8-dimensional space
 and then applies a
-[`CnnEncoder`](https://allenai.github.io/allennlp-docs/master/api/modules/seq2vec_encoders/cnn_encoder/#cnnencoder)
+[`CnnEncoder`](https://docs.allennlp.org/master/api/modules/seq2vec_encoders/cnn_encoder/#cnnencoder)
 that uses 50 filters and so also produces a 50-dimensional output. You can see that this encoder also uses a 20% dropout during training.
 
 The output of this `TextFieldEmbedder` is a 50-dimensional vector for `"tokens"`
@@ -258,7 +258,7 @@ code.
 
 The output of the `TextFieldEmbedder` is processed by the "stacked encoder",
 which needs to be a
-[`Seq2SeqEncoder`](https://allenai.github.io/allennlp-docs/master/api/modules/seq2seq_encoders/seq2seq_encoder/#seq2seqencoder):
+[`Seq2SeqEncoder`](https://docs.allennlp.org/master/api/modules/seq2seq_encoders/seq2seq_encoder/#seq2seqencoder):
 
 ```js
     "encoder": {
@@ -289,7 +289,7 @@ The rest of the config file is dedicated to the training process.
 ```
 
 We'll iterate over our datasets using a
-[`BasicIterator`](https://allenai.github.io/allennlp-docs/master/api/allennlp.data.iterators.html#allennlp.data.iterators.basic_iterator.BasicIterator)
+[`BasicIterator`](https://docs.allennlp.org/master/api/allennlp.data.iterators.html#allennlp.data.iterators.basic_iterator.BasicIterator)
 that pads our data and processes it in batches of size 32.
 
 

--- a/docs/tutorials/getting_started/walk_through_allennlp/creating_a_model.md
+++ b/docs/tutorials/getting_started/walk_through_allennlp/creating_a_model.md
@@ -3,9 +3,9 @@
 Using the included models is fine, but at some point you'll probably want to implement your own models, which is what this tutorial is for.
 
 Generally speaking, in order to implement a new model, you'll need to implement a
-[`DatasetReader`](https://allenai.github.io/allennlp-docs/master/api/allennlp.data.dataset_readers.html)
+[`DatasetReader`](https://docs.allennlp.org/master/api/allennlp.data.dataset_readers.html)
 subclass to read in your datasets and a
-[`Model`](https://allenai.github.io/allennlp-docs/master/api/allennlp.models.model.html)
+[`Model`](https://docs.allennlp.org/master/api/allennlp.models.model.html)
 subclass corresponding to the model you want to implement.
 (If there's already a `DatasetReader` for the dataset you want to use,
  of course you can reuse that one.)
@@ -25,7 +25,7 @@ on the [CoNLL 2003 dataset](https://www.clips.uantwerpen.be/conll2003/ner/),
 which (due to licensing reasons) you'll have to source for yourself.
 
 The simple tagger gets about 88%
-[span-based F1](https://allenai.github.io/allennlp-docs/master/api/allennlp.training.metrics.html#span-based-f1-measure)
+[span-based F1](https://docs.allennlp.org/master/api/allennlp.training.metrics.html#span-based-f1-measure)
 on the validation dataset. We'd like to do better.
 
 One way to approach this is to add a [Conditional Random Field](https://en.wikipedia.org/wiki/Conditional_random_field)
@@ -47,7 +47,7 @@ For example, our NER data has distinct tags that represent the beginning, middle
 of each entity type. We'd like not to allow a "beginning of a person entity" tag
 to be followed by an "end of location entity tag".
 
-As the CRF is just a component of our model, we'll implement it as a [Module](https://allenai.github.io/allennlp-docs/master/api/allennlp.modules.html).
+As the CRF is just a component of our model, we'll implement it as a [Module](https://docs.allennlp.org/master/api/allennlp.modules.html).
 
 ## Implementing the CRF Module
 

--- a/docs/tutorials/getting_started/walk_through_allennlp/creating_a_model.md
+++ b/docs/tutorials/getting_started/walk_through_allennlp/creating_a_model.md
@@ -10,7 +10,7 @@ subclass corresponding to the model you want to implement.
 (If there's already a `DatasetReader` for the dataset you want to use,
  of course you can reuse that one.)
 In this tutorial we'll also implement a custom PyTorch
-[`Module`](https://pytorch.org/docs/master/nn.html#torch.nn.Module),
+[`Module`](https://docs.allennlp.org/master/api/models/model/#model),
 but you won't need to do that in general.
 
 Our [simple tagger](training_and_evaluating.md) model
@@ -47,7 +47,7 @@ For example, our NER data has distinct tags that represent the beginning, middle
 of each entity type. We'd like not to allow a "beginning of a person entity" tag
 to be followed by an "end of location entity tag".
 
-As the CRF is just a component of our model, we'll implement it as a [Module](https://docs.allennlp.org/master/api/allennlp.modules.html).
+As the CRF is just a component of our model, we'll implement it as a `Module`.
 
 ## Implementing the CRF Module
 

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -6,7 +6,7 @@ Our 2018 EMNLP tutorial is available at https://github.com/allenai/writing-code-
 
 ## Tutorials Have Moved!
 
-Our tutorials now live in the [docs directory](../docs/tutorials). You can view them via our [docs website](https://allenai.github.io/allennlp-docs/master/). This directory now only contains the introductory, interactive tagging tutorial present on our main website, [allennlp.org](https://allennlp.org/).
+Our tutorials now live in the [docs directory](../docs/tutorials). You can view them via our [docs website](https://docs.allennlp.org/master/). This directory now only contains the introductory, interactive tagging tutorial present on our main website, [allennlp.org](https://allennlp.org/).
 
 ## Internal Tutorials
 

--- a/tutorials/tagger/README.md
+++ b/tutorials/tagger/README.md
@@ -59,10 +59,10 @@ Each sentence consists of space-separated word-tag pairs, which are themselves s
 
 Typically to solve a problem like this using AllenNLP, you'll have to implement two classes.
 
-The first is a [`DatasetReader`](https://allenai.github.io/allennlp-docs/master/api/allennlp.data.dataset_readers.html), which contains the logic for reading a file of data
+The first is a [`DatasetReader`](https://docs.allennlp.org/master/api/allennlp.data.dataset_readers.html), which contains the logic for reading a file of data
 and producing a stream of `Instance`s (more about those shortly).
 
-The second is a [`Model`](https://allenai.github.io/allennlp-docs/master/api/allennlp.models.model.html), which is a PyTorch `Module` that takes `Tensor` inputs and produces a dict of `Tensor` outputs (including the training `loss` you want to optimize).
+The second is a [`Model`](https://docs.allennlp.org/master/api/allennlp.models.model.html), which is a PyTorch `Module` that takes `Tensor` inputs and produces a dict of `Tensor` outputs (including the training `loss` you want to optimize).
 
 AllenNLP handles the remaining details such as training, batching, padding, logging, model persistence, and so on.
 AllenNLP also includes many high-level abstractions that will make writing those two classes much easier.

--- a/tutorials/tagger/README.md
+++ b/tutorials/tagger/README.md
@@ -59,10 +59,10 @@ Each sentence consists of space-separated word-tag pairs, which are themselves s
 
 Typically to solve a problem like this using AllenNLP, you'll have to implement two classes.
 
-The first is a [`DatasetReader`](https://docs.allennlp.org/master/api/allennlp.data.dataset_readers.html), which contains the logic for reading a file of data
+The first is a [`DatasetReader`], which contains the logic for reading a file of data
 and producing a stream of `Instance`s (more about those shortly).
 
-The second is a [`Model`](https://docs.allennlp.org/master/api/allennlp.models.model.html), which is a PyTorch `Module` that takes `Tensor` inputs and produces a dict of `Tensor` outputs (including the training `loss` you want to optimize).
+The second is a [`Model`](https://docs.allennlp.org/master/api/models/model/#model), which is a PyTorch `Module` that takes `Tensor` inputs and produces a dict of `Tensor` outputs (including the training `loss` you want to optimize).
 
 AllenNLP handles the remaining details such as training, batching, padding, logging, model persistence, and so on.
 AllenNLP also includes many high-level abstractions that will make writing those two classes much easier.


### PR DESCRIPTION
Switches URLs from `allenai.github.io/allennlp-docs` to `docs.allennlp.org/master`.