### PR TITLE
Fix repo check for nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     # Only run this action on "allenai/allennlp", and not forks.
-    if: github.actor == 'repo-owner'
+    if: github.repository == 'allenai/allennlp'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The check was checking if the owner of the repo was equal to the string "repo-owner". Also, switched to checking the full repo name instead of just the owner being allenai for clarity. I tested it on my fork, not really any other way to test github actions that I'm aware of other than pushing it and seeing what happens.

Fixes #3931 