### PR TITLE
Remove unnecessary epoch param in Scheduler.step()

### DIFF
--- a/allennlp/tests/training/learning_rate_schedulers/cosine_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers/cosine_test.py
@@ -124,8 +124,8 @@ class CosineWithRestartsTest(AllenNlpTestCase):
                 optimizer=optimizer, params=Params(params)
             )
             lrs = [optimizer.param_groups[0]["lr"]]
-            for epoch in range(epochs):
-                scheduler.step(epoch)
+            for _ in range(epochs):
+                scheduler.step()
                 lrs.append(optimizer.param_groups[0]["lr"])
 
             for it, lr in lr_checks:
@@ -163,7 +163,7 @@ class CosineWithRestartsTest(AllenNlpTestCase):
                     scheduler = init_and_restore_scheduler(optimizer, params, state_dict=state)
 
                 # Take step and record learning rate.
-                scheduler.step(1, epoch)
+                scheduler.step(1)
                 lrs.append(optimizer.param_groups[0]["lr"])
 
                 # Save state again.

--- a/allennlp/tests/training/learning_rate_schedulers/learning_rate_scheduler_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers/learning_rate_scheduler_test.py
@@ -19,7 +19,7 @@ class LearningRateSchedulersTest(AllenNlpTestCase):
                     model_parameters=self.model.named_parameters(), params=Params({"type": "adam"})
                 ),
                 params=Params({"type": "reduce_on_plateau"}),
-            ).step(None, None)
+            ).step(None)
         assert "learning rate scheduler requires a validation metric" in str(context.exception)
 
     def test_reduce_on_plateau_works_when_metrics_exist(self):
@@ -28,7 +28,7 @@ class LearningRateSchedulersTest(AllenNlpTestCase):
                 model_parameters=self.model.named_parameters(), params=Params({"type": "adam"})
             ),
             params=Params({"type": "reduce_on_plateau"}),
-        ).step(10, None)
+        ).step(10)
 
     def test_no_metric_wrapper_can_support_none_for_metrics(self):
         lrs = LearningRateScheduler.from_params(
@@ -38,7 +38,7 @@ class LearningRateSchedulersTest(AllenNlpTestCase):
             params=Params({"type": "step", "step_size": 1}),
         )
         lrs.lr_scheduler.optimizer.step()  # to avoid a pytorch warning
-        lrs.step(None, None)
+        lrs.step(None)
 
     def test_noam_learning_rate_schedule_does_not_crash(self):
         lrs = LearningRateScheduler.from_params(
@@ -47,7 +47,7 @@ class LearningRateSchedulersTest(AllenNlpTestCase):
             ),
             params=Params({"type": "noam", "model_size": 10, "warmup_steps": 2000}),
         )
-        lrs.step(None, None)
+        lrs.step(None)
         lrs.step_batch(None)
 
     def test_exponential_works_properly(self):
@@ -62,12 +62,9 @@ class LearningRateSchedulersTest(AllenNlpTestCase):
         optimizer.step()  # to avoid a pytorch warning
         # Initial learning rate should be unchanged for first epoch.
         assert optimizer.param_groups[0]["lr"] == 1.0
-        # But since the way PyTorch LR schedulers work is a little wonky,
-        # the LR will also be unchanged for the second epoch (epoch id 0).
-        scheduler.step(epoch=0)
-        assert optimizer.param_groups[0]["lr"] == 1.0
-        # Now the learning rate starts to be updated...
-        scheduler.step(epoch=1)
+        scheduler.step()
         assert optimizer.param_groups[0]["lr"] == 0.5
-        scheduler.step(epoch=2)
+        scheduler.step()
         assert optimizer.param_groups[0]["lr"] == 0.5 ** 2
+        scheduler.step()
+        assert optimizer.param_groups[0]["lr"] == 0.5 ** 3

--- a/allennlp/tests/training/learning_rate_schedulers/slanted_triangular_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers/slanted_triangular_test.py
@@ -82,7 +82,7 @@ class SlantedTriangularTest(AllenNlpTestCase):
                 if params.get("gradual_unfreezing") and epoch == 0:
                     assert scheduler.freezing_current
             # step() takes two arguments: validation metric and epoch
-            scheduler.step(None, epoch)
+            scheduler.step(None)
 
         return lrs
 

--- a/allennlp/tests/training/momentum_schedulers/inverted_triangular_test.py
+++ b/allennlp/tests/training/momentum_schedulers/inverted_triangular_test.py
@@ -42,30 +42,32 @@ class InvertedTriangularTest(AllenNlpTestCase):
         assert optimizer.param_groups[0]["momentum"] == self.base_momentum
         # After first epoch, `step` is called, and momentum should be adjusted for
         # the next epoch.
-        scheduler.step(epoch=0)
+        scheduler.step()
         assert isclose(
             optimizer.param_groups[0]["momentum"],
             self.base_momentum - (self.base_momentum - self.base_momentum / 5) * (1 / 6),
         )
         # After second epoch, `step` is called and momentum is updated for 3rd epoch.
-        scheduler.step(epoch=1)
+        scheduler.step()
         assert isclose(
             optimizer.param_groups[0]["momentum"],
             self.base_momentum - (self.base_momentum - self.base_momentum / 5) * (2 / 6),
         )
+        scheduler.last_epoch = 4
         # ... after the 6th epoch (epoch id 5), momentum should be set to `base_momentum / ratio`.
-        scheduler.step(epoch=5)
+        scheduler.step()
         assert isclose(optimizer.param_groups[0]["momentum"], self.base_momentum / 5)
         # Then the momentum stars increasing again.
-        scheduler.step(epoch=6)
+        scheduler.step()
         assert isclose(
             optimizer.param_groups[0]["momentum"],
             self.base_momentum / 5 + (self.base_momentum - self.base_momentum / 5) * (1 / 10),
         )
         # After the 16th epoch (6 + 10) (epoch id 15), momentum should be back to the base level.
-        scheduler.step(epoch=15)
+        scheduler.last_epoch = 14
+        scheduler.step()
         assert isclose(optimizer.param_groups[0]["momentum"], self.base_momentum)
-        scheduler.step(epoch=16)
+        scheduler.step()
         assert isclose(optimizer.param_groups[0]["momentum"], self.base_momentum)
-        scheduler.step(epoch=17)
+        scheduler.step()
         assert isclose(optimizer.param_groups[0]["momentum"], self.base_momentum)

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -23,6 +23,7 @@ from allennlp.data.dataset_readers import SequenceTaggingDatasetReader
 from allennlp.models.model import Model
 from allennlp.models.simple_tagger import SimpleTagger
 from allennlp.training import Trainer
+from allennlp.training.learning_rate_schedulers import CosineWithRestarts
 from allennlp.training.learning_rate_schedulers import ExponentialLearningRateScheduler
 from allennlp.training.momentum_schedulers import MomentumScheduler
 from allennlp.training.moving_average import ExponentialMovingAverage
@@ -431,7 +432,7 @@ class TestTrainer(TrainerTestBase):
         trainer.train()
 
     def test_trainer_can_resume_with_lr_scheduler(self):
-        lr_scheduler = ExponentialLearningRateScheduler(self.optimizer, gamma=0.5)
+        lr_scheduler = CosineWithRestarts(self.optimizer, t_initial=5)
         trainer = Trainer(
             model=self.model,
             optimizer=self.optimizer,
@@ -443,7 +444,7 @@ class TestTrainer(TrainerTestBase):
         )
         trainer.train()
 
-        new_lr_scheduler = ExponentialLearningRateScheduler(self.optimizer, gamma=0.5)
+        new_lr_scheduler = CosineWithRestarts(self.optimizer, t_initial=5)
         new_trainer = Trainer(
             model=self.model,
             optimizer=self.optimizer,
@@ -455,7 +456,7 @@ class TestTrainer(TrainerTestBase):
         )
         epoch = new_trainer._restore_checkpoint()
         assert epoch == 2
-        assert new_trainer._learning_rate_scheduler.lr_scheduler.last_epoch == 1
+        assert new_trainer._learning_rate_scheduler.last_epoch == 1
         new_trainer.train()
 
     def test_trainer_raises_on_model_with_no_loss_key(self):

--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -26,8 +26,8 @@ class _PyTorchLearningRateSchedulerWrapper(LearningRateScheduler):
         return self.lr_scheduler.get_last_lr()
 
     @overrides
-    def step(self, metric: float = None, epoch: int = None) -> None:
-        self.lr_scheduler.step(epoch)
+    def step(self, metric: float = None) -> None:
+        self.lr_scheduler.step()
 
     @overrides
     def state_dict(self) -> Dict[str, Any]:
@@ -40,14 +40,14 @@ class _PyTorchLearningRateSchedulerWrapper(LearningRateScheduler):
 
 class _PyTorchLearningRateSchedulerWithMetricsWrapper(_PyTorchLearningRateSchedulerWrapper):
     @overrides
-    def step(self, metric: float = None, epoch: int = None) -> None:
+    def step(self, metric: float = None) -> None:
         if metric is None:
             raise ConfigurationError(
                 "This learning rate scheduler requires "
                 "a validation metric to compute the schedule and therefore "
                 "must be used with a validation dataset."
             )
-        self.lr_scheduler.step(metric, epoch)
+        self.lr_scheduler.step(metric)
 
 
 @LearningRateScheduler.register("step")

--- a/allennlp/training/learning_rate_schedulers/noam.py
+++ b/allennlp/training/learning_rate_schedulers/noam.py
@@ -36,7 +36,7 @@ class NoamLR(LearningRateScheduler):
         super().__init__(optimizer, last_epoch=last_epoch)
 
     @overrides
-    def step(self, metric: float = None, epoch: int = None) -> None:
+    def step(self, metric: float = None) -> None:
         pass
 
     def step_batch(self, batch_num_total: int = None) -> None:

--- a/allennlp/training/learning_rate_schedulers/slanted_triangular.py
+++ b/allennlp/training/learning_rate_schedulers/slanted_triangular.py
@@ -74,6 +74,7 @@ class SlantedTriangular(LearningRateScheduler):
                 " for gradual unfreezing / discriminative fine-tuning to make sense."
             )
         super().__init__(optimizer, last_epoch)
+        self.step()
         if discriminative_fine_tuning:
             # skip the last param_group if it is has no parameters
             exponent = 0
@@ -88,7 +89,8 @@ class SlantedTriangular(LearningRateScheduler):
         self.step_batch(0)
 
     @overrides
-    def step(self, metric: float = None, epoch: int = None) -> None:
+    def step(self, metric: float = None) -> None:
+        self.last_epoch += 1
         if len(self.batch_num_total_epoch_end) == 0:
             self.batch_num_total_epoch_end.append(0)
         else:
@@ -104,7 +106,7 @@ class SlantedTriangular(LearningRateScheduler):
                 num_layers_to_unfreeze = 1
                 self.is_first_epoch = False
             else:
-                num_layers_to_unfreeze = epoch + 2
+                num_layers_to_unfreeze = self.last_epoch + 2
             if num_layers_to_unfreeze >= len(self.optimizer.param_groups) - 1:
                 logger.info("Gradual unfreezing finished. Training all layers.")
                 self.freezing_current = False

--- a/allennlp/training/scheduler.py
+++ b/allennlp/training/scheduler.py
@@ -46,7 +46,6 @@ class Scheduler:
         self.base_values = [
             group[self._initial_param_group_field] for group in self.optimizer.param_groups
         ]
-        self.step(epoch=last_epoch)
         self.last_epoch = last_epoch
 
     def state_dict(self) -> Dict[str, Any]:
@@ -69,11 +68,8 @@ class Scheduler:
     def get_values(self):
         raise NotImplementedError
 
-    def step(self, metric: float = None, epoch: int = None) -> None:
-        if epoch is None:
-            self.last_epoch += 1  # type: ignore
-        else:
-            self.last_epoch = epoch
+    def step(self, metric: float = None) -> None:
+        self.last_epoch += 1
         self.metric = metric
         for param_group, value in zip(self.optimizer.param_groups, self.get_values()):
             param_group[self.param_group_field] = value

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -716,9 +716,9 @@ class Trainer(TrainerBase):
             # The Scheduler API is agnostic to whether your schedule requires a validation metric -
             # if it doesn't, the validation metric passed here is ignored.
             if self._learning_rate_scheduler:
-                self._learning_rate_scheduler.step(this_epoch_val_metric, epoch)
+                self._learning_rate_scheduler.step(this_epoch_val_metric)
             if self._momentum_scheduler:
-                self._momentum_scheduler.step(this_epoch_val_metric, epoch)
+                self._momentum_scheduler.step(this_epoch_val_metric)
 
             if self._master:
                 self._save_checkpoint(epoch)


### PR DESCRIPTION
closes #3922 

We might also want to consider removing the `batch_num_total` parameter in `Scheduler.step_batch`, as I think that's equally unnecessary.

This does change the behavior of the `ExponentialLearningRateScheduler`, but I believe the change is actually a fix, i.e. it makes this LR scheduler behave how it was intended (the LR will now be updated after the first epoch, whereas before it would only start updating after the second epoch).