### PR TITLE
pads in a more pythonic way which is significantly faster.

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -180,6 +180,8 @@ def pad_sequence_to_length(
         padded_sequence = sequence[-desired_length:]
     # Continues to pad with default_value() until we reach the desired length.
     pad_length = desired_length - len(padded_sequence)
+    # This just creates the default value once, so if it's a list, and if it gets mutated
+    # later, it could cause subtle bugs. But the risk there is low, and this is much faster.
     values_to_pad = [default_value()] * pad_length
     if padding_on_right:
         padded_sequence = padded_sequence + values_to_pad

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -179,11 +179,12 @@ def pad_sequence_to_length(
     else:
         padded_sequence = sequence[-desired_length:]
     # Continues to pad with default_value() until we reach the desired length.
-    for _ in range(desired_length - len(padded_sequence)):
-        if padding_on_right:
-            padded_sequence.append(default_value())
-        else:
-            padded_sequence.insert(0, default_value())
+    pad_length = desired_length - len(padded_sequence)
+    values_to_pad = [default_value()] * pad_length
+    if padding_on_right:
+        padded_sequence = padded_sequence + values_to_pad
+    else:
+        padded_sequence = values_to_pad + padded_sequence
     return padded_sequence
 
 


### PR DESCRIPTION
This commit does the padding in a more pythonic way which significantly improves the speed.

A preliminary benchmark on my own dataset and model:
The original version:
![image](https://user-images.githubusercontent.com/1304505/76833387-34cca080-6866-11ea-9dfd-dd8334a90b07.png)

new version:
![image](https://user-images.githubusercontent.com/1304505/76833489-66de0280-6866-11ea-8b0d-38c556e70dc1.png)

The second column is the call count. The third is the execution time and the percentage. The forth is the execution time of `pad_sequence_to_length` excluding the functions it calls 

I think the difference is mainly due to that doing  lots of insertion and append is expensive.