### PR TITLE
Move Tensorboard logic into TensorboardWriter

### DIFF
--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -125,9 +125,7 @@ class TensorboardWriter(FromParams):
 
             if (self._batches_this_epoch - 1) % self._batch_size_interval == 0:
                 average = self._cumulative_batch_group_size / self._batches_this_epoch
-                logger.info(
-                    f"current batch size: {batch_group_size} mean batch size: {average}"
-                )
+                logger.info(f"current batch size: {batch_group_size} mean batch size: {average}")
                 self.add_train_scalar("current_batch_size", batch_group_size)
                 self.add_train_scalar("mean_batch_size", average)
 
@@ -216,7 +214,9 @@ class TensorboardWriter(FromParams):
         if not self._histogram_parameters:
             # Avoiding calling this every batch.  If we ever use two separate models with a single
             # writer, this is wrong, but I doubt that will ever happen.
-            self._histogram_parameters = set(model.get_parameters_for_histogram_tensorboard_logging())
+            self._histogram_parameters = set(
+                model.get_parameters_for_histogram_tensorboard_logging()
+            )
         for name, param in model.named_parameters():
             if name in self._histogram_parameters:
                 self.add_train_histogram("parameter_histogram/" + name, param)

--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -1,4 +1,4 @@
-from typing import Any, Set, Optional, Callable
+from typing import Any, Callable, Dict, List, Optional, Set
 import logging
 import os
 
@@ -6,6 +6,10 @@ from tensorboardX import SummaryWriter
 import torch
 
 from allennlp.common.from_params import FromParams
+from allennlp.data.dataloader import TensorDict
+from allennlp.nn import util as nn_util
+from allennlp.training.optimizers import Optimizer
+from allennlp.training import util as training_util
 from allennlp.models.model import Model
 
 logger = logging.getLogger(__name__)
@@ -36,6 +40,8 @@ class TensorboardWriter(FromParams):
         slow, so we recommend logging histograms relatively infrequently.
         Note: only Modules that return tensors, tuples of tensors or dicts
         with tensors as values currently support activation logging.
+    batch_size_interval : `int`, optional, (default = `None`)
+        If defined, how often to log the average batch size.
     should_log_parameter_statistics : bool, optional (default = True)
         Whether to log parameter statistics (mean and standard deviation of parameters and
         gradients).
@@ -53,6 +59,7 @@ class TensorboardWriter(FromParams):
         serialization_dir: Optional[str] = None,
         summary_interval: int = 100,
         histogram_interval: int = None,
+        batch_size_interval: Optional[int] = None,
         should_log_parameter_statistics: bool = True,
         should_log_learning_rate: bool = False,
         get_batch_num_total: Callable[[], int] = None,
@@ -71,9 +78,14 @@ class TensorboardWriter(FromParams):
 
         self._summary_interval = summary_interval
         self._histogram_interval = histogram_interval
+        self._batch_size_interval = batch_size_interval
         self._should_log_parameter_statistics = should_log_parameter_statistics
         self._should_log_learning_rate = should_log_learning_rate
         self.get_batch_num_total = get_batch_num_total
+
+        self._cumulative_batch_group_size = 0
+        self._batches_this_epoch = 0
+        self._histogram_parameters: Set[str] = None
 
     @staticmethod
     def _item(value: Any):
@@ -82,6 +94,46 @@ class TensorboardWriter(FromParams):
         else:
             val = value
         return val
+
+    def log_batch(
+        self,
+        model: Model,
+        optimizer: Optimizer,
+        batch_grad_norm: Optional[float],
+        metrics: Dict[str, float],
+        batch_group: List[List[TensorDict]],
+        param_updates: Optional[Dict[str, torch.Tensor]],
+    ) -> None:
+        if self.should_log_this_batch():
+            self.log_parameter_and_gradient_statistics(model, batch_grad_norm)
+            self.log_learning_rates(model, optimizer)
+
+            self.add_train_scalar("loss/loss_train", metrics["loss"])
+            self.log_metrics({"epoch_metrics/" + k: v for k, v in metrics.items()})
+
+        if self.should_log_histograms_this_batch():
+            self.log_histograms(model)
+            self.log_gradient_updates(model, param_updates)
+
+        if self._batch_size_interval:
+            # We're assuming here that `log_batch` will get called every batch, and only every
+            # batch.  This is true with our current usage of this code (version 1.0); if that
+            # assumption becomes wrong, this code will break.
+            batch_group_size = sum(training_util.get_batch_size(batch) for batch in batch_group)
+            self._batches_this_epoch += 1
+            self._cumulative_batch_group_size += batch_group_size
+
+            if (self._batches_this_epoch - 1) % self._batch_size_interval == 0:
+                average = self._cumulative_batch_group_size / self._batches_this_epoch
+                logger.info(
+                    f"current batch size: {batch_group_size} mean batch size: {average}"
+                )
+                self.add_train_scalar("current_batch_size", batch_group_size)
+                self.add_train_scalar("mean_batch_size", average)
+
+    def reset_epoch(self) -> None:
+        self._cumulative_batch_group_size = 0
+        self._batches_this_epoch = 0
 
     def should_log_this_batch(self) -> bool:
         return self.get_batch_num_total() % self._summary_interval == 0
@@ -157,13 +209,26 @@ class TensorboardWriter(FromParams):
                     effective_rate = rate * float(param.requires_grad)
                     self.add_train_scalar("learning_rate/" + names[param], effective_rate)
 
-    def log_histograms(self, model: Model, histogram_parameters: Set[str]) -> None:
+    def log_histograms(self, model: Model) -> None:
         """
         Send histograms of parameters to tensorboard.
         """
+        if not self._histogram_parameters:
+            # Avoiding calling this every batch.  If we ever use two separate models with a single
+            # writer, this is wrong, but I doubt that will ever happen.
+            self._histogram_parameters = set(model.get_parameters_for_histogram_tensorboard_logging())
         for name, param in model.named_parameters():
-            if name in histogram_parameters:
+            if name in self._histogram_parameters:
                 self.add_train_histogram("parameter_histogram/" + name, param)
+
+    def log_gradient_updates(self, model: Model, param_updates: Dict[str, torch.Tensor]) -> None:
+        for name, param in model.named_parameters():
+            update_norm = torch.norm(param_updates[name].view(-1))
+            param_norm = torch.norm(param.view(-1)).cpu()
+            self.add_train_scalar(
+                "gradient_update/" + name,
+                update_norm / (param_norm + nn_util.tiny_value_of_dtype(param_norm.dtype)),
+            )
 
     def log_metrics(
         self,


### PR DESCRIPTION
Just moving things around, to have less logic inside of `Trainer`, and making it easier to customize what happens in tensorboard logging, if you want.

This fixes another part of #3913, specifically all of part 3 up to the "question".  I'm thinking at this point that the answer to the "question" should be to not worry about changing the tensorboard writer at all, but instead add two callbacks: a `BatchCallback`, and an `EpochCallback`, that are given appropriate objects that a person can do whatever they want with.  By default we do nothing.  This adds very little complexity to our code, but gives people a lot of flexibility to customize things.