### PR TITLE
Allow CRF to compute loss just for single span prediction

### DIFF
--- a/allennlp/data/fields/__init__.py
+++ b/allennlp/data/fields/__init__.py
@@ -4,15 +4,16 @@ that ends up as an array in a model.
 """
 
 from allennlp.data.fields.field import Field
-from allennlp.data.fields.array_field import ArrayField
 from allennlp.data.fields.adjacency_field import AdjacencyField
+from allennlp.data.fields.array_field import ArrayField
+from allennlp.data.fields.flag_field import FlagField
 from allennlp.data.fields.index_field import IndexField
 from allennlp.data.fields.label_field import LabelField
-from allennlp.data.fields.multilabel_field import MultiLabelField
 from allennlp.data.fields.list_field import ListField
 from allennlp.data.fields.metadata_field import MetadataField
+from allennlp.data.fields.multilabel_field import MultiLabelField
+from allennlp.data.fields.namespace_swapping_field import NamespaceSwappingField
 from allennlp.data.fields.sequence_field import SequenceField
 from allennlp.data.fields.sequence_label_field import SequenceLabelField
 from allennlp.data.fields.span_field import SpanField
 from allennlp.data.fields.text_field import TextField
-from allennlp.data.fields.namespace_swapping_field import NamespaceSwappingField

--- a/allennlp/data/fields/flag_field.py
+++ b/allennlp/data/fields/flag_field.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List
+
+from overrides import overrides
+
+from allennlp.data.fields.field import Field
+
+
+class FlagField(Field[Any]):
+    """
+    A class representing a flag, which must be constant across all instances in a batch.
+    This will be passed to a `forward` method as a single value of whatever type you pass in.
+
+    This is intended for use with boolean flags, but in principle it should also work with any other
+    type.
+    """
+
+    def __init__(self, flag_value: Any) -> None:
+        self.flag_value = flag_value
+
+    @overrides
+    def get_padding_lengths(self) -> Dict[str, int]:
+        return {}
+
+    @overrides
+    def as_tensor(self, padding_lengths: Dict[str, int]) -> Any:
+        return self.flag_value
+
+    @overrides
+    def empty_field(self):
+        # Because this has to be constant across all instances in a batch, we need to keep the same
+        # value.
+        return FlagField(self.flag_value)
+
+    def __str__(self) -> str:
+        return f"FlagField({self.flag_value})"
+
+    @overrides
+    def batch_tensors(self, tensor_list: List[Any]) -> Any:
+        if len(set(tensor_list)) != 1:
+            raise ValueError(
+                f"Got different values in a FlagField when trying to batch them: {tensor_list}"
+            )
+        return tensor_list[0]

--- a/allennlp/data/fields/flag_field.py
+++ b/allennlp/data/fields/flag_field.py
@@ -9,9 +9,6 @@ class FlagField(Field[Any]):
     """
     A class representing a flag, which must be constant across all instances in a batch.
     This will be passed to a `forward` method as a single value of whatever type you pass in.
-
-    This is intended for use with boolean flags, but in principle it should also work with any other
-    type.
     """
 
     def __init__(self, flag_value: Any) -> None:

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -163,7 +163,8 @@ class CrfTagger(Model):
         tokens: TextFieldTensors,
         tags: torch.LongTensor = None,
         metadata: List[Dict[str, Any]] = None,
-        **kwargs,
+        ignore_loss_on_o_tags: bool = False,
+        **kwargs,  # to allow for a more general dataset reader that passes args we don't need
     ) -> Dict[str, torch.Tensor]:
 
         """
@@ -178,11 +179,15 @@ class CrfTagger(Model):
             sequence.  The dictionary is designed to be passed directly to a `TextFieldEmbedder`,
             which knows how to combine different word representations into a single vector per
             token in your input.
-        tags : `torch.LongTensor`, optional (default = `None`)
+        tags : `torch.LongTensor`, optional (default = None)
             A torch tensor representing the sequence of integer gold class labels of shape
             `(batch_size, num_tokens)`.
         metadata : `List[Dict[str, Any]]`, optional, (default = None)
             metadata containg the original words in the sentence to be tagged under a 'words' key.
+        ignore_loss_on_o_tags : `bool`, optional (default = False)
+            If True, we compute the loss only for actual spans in `tags`, and not on `O` tokens.
+            This is useful for computing gradients of the loss on a _single span_, for
+            interpretation / attacking.
 
         # Returns
 
@@ -223,8 +228,12 @@ class CrfTagger(Model):
             output["top_k_tags"] = best_paths
 
         if tags is not None:
+            if ignore_loss_on_o_tags:
+                crf_mask = mask & (tags != 0)
+            else:
+                crf_mask = mask
             # Add negative log-likelihood as loss
-            log_likelihood = self.crf(logits, tags, mask)
+            log_likelihood = self.crf(logits, tags, crf_mask)
 
             output["loss"] = -log_likelihood
 

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -104,6 +104,9 @@ class CrfTagger(Model):
             output_dim = self.encoder.get_output_dim()
         self.tag_projection_layer = TimeDistributed(Linear(output_dim, self.num_tags))
 
+        # Used when `ignore_loss_on_o_tags` is `True` in `self.forward`.
+        self._o_tag_index = self.vocab.get_token_index("O", namespace=self.label_namespace)
+
         # if  constrain_crf_decoding and calculate_span_f1 are not
         # provided, (i.e., they're None), set them to True
         # if label_encoding is provided and False if it isn't.
@@ -229,7 +232,7 @@ class CrfTagger(Model):
 
         if tags is not None:
             if ignore_loss_on_o_tags:
-                crf_mask = mask & (tags != 0)
+                crf_mask = mask & (tags != self._o_tag_index)
             else:
                 crf_mask = mask
             # Add negative log-likelihood as loss

--- a/allennlp/models/crf_tagger.py
+++ b/allennlp/models/crf_tagger.py
@@ -104,9 +104,6 @@ class CrfTagger(Model):
             output_dim = self.encoder.get_output_dim()
         self.tag_projection_layer = TimeDistributed(Linear(output_dim, self.num_tags))
 
-        # Used when `ignore_loss_on_o_tags` is `True` in `self.forward`.
-        self._o_tag_index = self.vocab.get_token_index("O", namespace=self.label_namespace)
-
         # if  constrain_crf_decoding and calculate_span_f1 are not
         # provided, (i.e., they're None), set them to True
         # if label_encoding is provided and False if it isn't.
@@ -232,7 +229,8 @@ class CrfTagger(Model):
 
         if tags is not None:
             if ignore_loss_on_o_tags:
-                crf_mask = mask & (tags != self._o_tag_index)
+                o_tag_index = self.vocab.get_token_index("O", namespace=self.label_namespace)
+                crf_mask = mask & (tags != o_tag_index)
             else:
                 crf_mask = mask
             # Add negative log-likelihood as loss

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -73,9 +73,6 @@ class SimpleTagger(Model):
             Linear(self.encoder.get_output_dim(), self.num_classes)
         )
 
-        # Used when `ignore_loss_on_o_tags` is `True` in `self.forward`.
-        self._o_tag_index = self.vocab.get_token_index("O", namespace=self.label_namespace)
-
         check_dimensions_match(
             text_field_embedder.get_output_dim(),
             encoder.get_input_dim(),
@@ -163,7 +160,8 @@ class SimpleTagger(Model):
 
         if tags is not None:
             if ignore_loss_on_o_tags:
-                tag_mask = mask & (tags != self._o_tag_index)
+                o_tag_index = self.vocab.get_token_index("O", namespace=self.label_namespace)
+                tag_mask = mask & (tags != o_tag_index)
             else:
                 tag_mask = mask
             loss = sequence_cross_entropy_with_logits(logits, tags, tag_mask)

--- a/allennlp/predictors/sentence_tagger.py
+++ b/allennlp/predictors/sentence_tagger.py
@@ -6,7 +6,7 @@ import numpy
 
 from allennlp.common.util import JsonDict
 from allennlp.data import DatasetReader, Instance
-from allennlp.data.fields import TextField, SequenceLabelField
+from allennlp.data.fields import FlagField, TextField, SequenceLabelField
 from allennlp.data.tokenizers.spacy_tokenizer import SpacyTokenizer
 from allennlp.models import Model
 from allennlp.predictors.predictor import Predictor
@@ -65,6 +65,10 @@ class SentenceTaggerPredictor(Predictor):
 
         Mary  went to Seattle to visit Microsoft Research
         O      O    O    O     O   O     B-Org     L-Org
+
+        We additionally add a flag to these instances to tell the model to only compute loss on
+        non-O tags, so that we get gradients that are specific to the particular span prediction
+        that each instance represents.
         """
         predicted_tags = outputs["tags"]
         predicted_spans = []
@@ -98,7 +102,7 @@ class SentenceTaggerPredictor(Predictor):
             new_instance.add_field(
                 "tags", SequenceLabelField(labels, text_field), self._model.vocab
             )
+            new_instance.add_field("ignore_loss_on_o_tags", FlagField(True))
             instances.append(new_instance)
-        instances.reverse()  # NER tags are in the opposite order as desired for the interpret UI
 
         return instances

--- a/allennlp/tests/data/fields/flag_field_test.py
+++ b/allennlp/tests/data/fields/flag_field_test.py
@@ -1,0 +1,36 @@
+import pytest
+
+from allennlp.common.testing.test_case import AllenNlpTestCase
+from allennlp.data.fields import FlagField
+
+
+class TestFlagField(AllenNlpTestCase):
+    def test_get_padding_lengths_returns_nothing(self):
+        flag_field = FlagField(True)
+        assert flag_field.get_padding_lengths() == {}
+
+    def test_as_tensor_just_returns_value(self):
+        for value in [True, 3.234, "this is a string"]:
+            assert FlagField(value).as_tensor({}) == value
+
+    def test_printing_doesnt_crash(self):
+        flag = FlagField(True)
+        print(flag)
+
+    def test_batch_tensors_returns_single_value(self):
+        value = True
+        fields = [FlagField(value) for _ in range(5)]
+        values = [field.as_tensor({}) for field in fields]
+        batched_value = fields[0].batch_tensors(values)
+        assert batched_value == value
+
+    def test_batch_tensors_crashes_with_non_uniform_values(self):
+        field = FlagField(True)
+        with pytest.raises(ValueError):
+            field.batch_tensors([True, False, True])
+
+        with pytest.raises(ValueError):
+            field.batch_tensors([1, 2, 3, 4])
+
+        with pytest.raises(ValueError):
+            field.batch_tensors(["different", "string", "flags"])


### PR DESCRIPTION
I finally figured out why our NER interpret demo never worked as well as the original implementation that was used when @Eric-Wallace created his video.  Somehow the loss masking code never got checked in, so we were computing the loss for the whole sequence.  As that includes "O" tags that were intentionally changed away from predicted NER tags, the loss for those tags was quite high, and dominated the loss computation, so the result was basically the opposite of what we wanted.

This PR adds the ability to mask the loss computation in our CRF model, so that the loss is only calculated on non-O tags.  In order to set this flag at interpretation time, but not any other time, I added a `FlagField` that batches as a single (in this case boolean) value that gets passed to the model, and I added that field to the instances in the NER predictor.  I verified manually that this gives basically the same result with our current NER model and code as we got in our original paper and video.

This means that only models that accept this flag (`ignore_loss_on_o_tags`) now work with the `SentenceTaggerPredictor` (when doing interpretations; this doesn't affect anything else), but this is actually an improvement, because previously models that didn't use this flag were just silently broken.  Now you'll just crash.