### PR TITLE
Fix mistake on tutorial

### DIFF
--- a/tutorials/tagger/experiment.jsonnet
+++ b/tutorials/tagger/experiment.jsonnet
@@ -34,7 +34,7 @@ local learning_rate = 0.1;
     "iterator": {
         "type": "bucket",
         "batch_size": batch_size,
-        "sorting_keys": ["sentence"]
+        "sorting_keys": [["sentence", "num_tokens"]]
     },
     "trainer": {
         "num_epochs": num_epochs,


### PR DESCRIPTION
Fix `ValueError: too many values to unpack (expected 2)` when trying to run the example on:

https://allennlp.org/tutorials