### PR TITLE
Remove dataset.py

### DIFF
--- a/allennlp/data/dataset.py
+++ b/allennlp/data/dataset.py
@@ -1,2 +1,0 @@
-# Import for backward compatability.
-from allennlp.data.batch import Batch  # noqa: F401


### PR DESCRIPTION
It was deprecated a long time ago, and now with `AllenNlpDataset` existing, it's misleading.  It should be removed before 1.0.