### PR TITLE
Add __len__ to FlagField

### DIFF
--- a/allennlp/data/fields/flag_field.py
+++ b/allennlp/data/fields/flag_field.py
@@ -31,6 +31,9 @@ class FlagField(Field[Any]):
     def __str__(self) -> str:
         return f"FlagField({self.flag_value})"
 
+    def __len__(self) -> int:
+        return 1
+
     @overrides
     def batch_tensors(self, tensor_list: List[Any]) -> Any:
         if len(set(tensor_list)) != 1:


### PR DESCRIPTION
I didn't add this method when I first implemented `FlagField`, because I didn't know what it was for and thought it was unnecessary.  Then I looked at the bucket sampler code and realized that we needed this.  I'm a bit unhappy that our CI didn't warn me about an unimplemented abstract method - pylint would have done that.  Oh well.