### PR TITLE
Shuffle batches in bucket sampler

### DIFF
--- a/allennlp/data/samplers/bucket_batch_sampler.py
+++ b/allennlp/data/samplers/bucket_batch_sampler.py
@@ -101,11 +101,15 @@ class BucketBatchSampler(BatchSampler):
     def __iter__(self) -> Iterable[List[int]]:
 
         indices = self._argsort_by_padding(self.data_source)
+        batches = []
         for group in lazy_groups_of(indices, self.batch_size):
             batch_indices = list(group)
             if self.drop_last and len(batch_indices) < self.batch_size:
                 continue
-            yield batch_indices
+            batches.append(batch_indices)
+        random.shuffle(batches)
+        for batch in batches:
+            yield batch
 
     def _guess_sorting_keys(self, instances: Iterable[Instance], num_instances: int = 10) -> None:
         """

--- a/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
+++ b/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
@@ -92,11 +92,15 @@ class TestBucketSampler(SamplerTest):
         grouped_instances = []
         for indices in sampler:
             grouped_instances.append([self.instances[idx] for idx in indices])
-        assert grouped_instances == [
+        expected_groups = [
             [self.instances[4], self.instances[2]],
             [self.instances[0], self.instances[1]],
             [self.instances[3]],
         ]
+        for group in grouped_instances:
+            if group in expected_groups:
+                expected_groups.remove(group)
+        assert expected_groups == []
 
     def test_guess_sorting_key_picks_the_longest_key(self):
         dataset = AllennlpDataset(self.instances, vocab=self.vocab)

--- a/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
+++ b/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
@@ -98,10 +98,8 @@ class TestBucketSampler(SamplerTest):
             [self.instances[3]],
         ]
         for group in grouped_instances:
-            if group in expected_groups:
-                expected_groups.remove(group)
-            else:
-                assert False
+            assert group in expected_groups
+            expected_groups.remove(group)
         assert expected_groups == []
 
     def test_guess_sorting_key_picks_the_longest_key(self):

--- a/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
+++ b/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
@@ -100,6 +100,8 @@ class TestBucketSampler(SamplerTest):
         for group in grouped_instances:
             if group in expected_groups:
                 expected_groups.remove(group)
+            else:
+                assert False
         assert expected_groups == []
 
     def test_guess_sorting_key_picks_the_longest_key(self):


### PR DESCRIPTION
In writing a chapter for the allennlp course, I trained a model and discovered that the batches were not shuffled when using the `BucketBatchSampler`, so the model was seeing shortest instances first, then longer instances.  This isn't great from a learning standpoint.  This PR fixes that issue.