### PR TITLE
Fix some external url formatting.

### DIFF
--- a/allennlp/data/dataset_readers/text_classification_json.py
+++ b/allennlp/data/dataset_readers/text_classification_json.py
@@ -25,6 +25,8 @@ class TextClassificationJsonReader(DatasetReader):
 
     Registered as a `DatasetReader` with name "text_classification_json".
 
+    [0]: https://www.cs.cmu.edu/~hovy/papers/16HLT-hierarchical-attention-networks.pdf
+
     # Parameters
 
     token_indexers : `Dict[str, TokenIndexer]`, optional
@@ -35,8 +37,8 @@ class TextClassificationJsonReader(DatasetReader):
         Tokenizer to use to split the input text into words or other kinds of tokens.
     segment_sentences : `bool`, optional (default = `False`)
         If True, we will first segment the text into sentences using SpaCy and then tokenize words.
-        Necessary for some models that require pre-segmentation of sentences, like the Hierarchical
-        Attention Network (https://www.cs.cmu.edu/~hovy/papers/16HLT-hierarchical-attention-networks.pdf).
+        Necessary for some models that require pre-segmentation of sentences, like [the Hierarchical
+        Attention Network][0].
     max_sequence_length : `int`, optional (default = `None`)
         If specified, will truncate tokens to specified maximum length.
     skip_label_indexing : `bool`, optional (default = `False`)

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -58,7 +58,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
     [0]: https://github.com/huggingface/transformers/blob/155c782a2ccd103cf63ad48a2becd7c76a7d2115/transformers/tokenization_utils.py#L691
 
     Argument descriptions are from [0].
-    """
+    """  # noqa: E501
 
     def __init__(
         self,

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -55,8 +55,9 @@ class PretrainedTransformerTokenizer(Tokenizer):
     tokenizer_kwargs: 'Dict[str, Any]'
         Dictionary with additional arguments for `AutoTokenizer.from_pretrained`.
 
-    Argument descriptions are from
-    https://github.com/huggingface/transformers/blob/155c782a2ccd103cf63ad48a2becd7c76a7d2115/transformers/tokenization_utils.py#L691
+    [0]: https://github.com/huggingface/transformers/blob/155c782a2ccd103cf63ad48a2becd7c76a7d2115/transformers/tokenization_utils.py#L691
+
+    Argument descriptions are from [0].
     """
 
     def __init__(

--- a/allennlp/modules/elmo_lstm.py
+++ b/allennlp/modules/elmo_lstm.py
@@ -33,6 +33,8 @@ class ElmoLstm(_EncoderBase):
     This is non-standard, but can be thought of as having an "end of sentence" state, which is
     carried across different sentences.
 
+    [0]: https://arxiv.org/abs/1512.05287
+
     # Parameters
 
     input_size : `int`, required
@@ -47,8 +49,7 @@ class ElmoLstm(_EncoderBase):
         If True, compute gradient of ELMo parameters for fine tuning.
     recurrent_dropout_probability : `float`, optional (default = 0.0)
         The dropout probability to be used in a dropout scheme as stated in
-        [A Theoretically Grounded Application of Dropout in Recurrent Neural Networks]
-        (https://arxiv.org/abs/1512.05287).
+        [A Theoretically Grounded Application of Dropout in Recurrent Neural Networks][0].
     state_projection_clip_value : `float`, optional, (default = None)
         The magnitude with which to clip the hidden_state after projecting it.
     memory_cell_clip_value : `float`, optional, (default = None)

--- a/allennlp/modules/input_variational_dropout.py
+++ b/allennlp/modules/input_variational_dropout.py
@@ -3,8 +3,8 @@ import torch
 
 class InputVariationalDropout(torch.nn.Dropout):
     """
-    Apply the dropout technique in Gal and Ghahramani, "Dropout as a Bayesian Approximation:
-    Representing Model Uncertainty in Deep Learning" (https://arxiv.org/abs/1506.02142) to a
+    Apply the dropout technique in Gal and Ghahramani, [Dropout as a Bayesian Approximation:
+    Representing Model Uncertainty in Deep Learning](https://arxiv.org/abs/1506.02142) to a
     3D tensor.
 
     This module accepts a 3D tensor of shape `(batch_size, num_timesteps, embedding_dim)`

--- a/allennlp/modules/lstm_cell_with_projection.py
+++ b/allennlp/modules/lstm_cell_with_projection.py
@@ -18,6 +18,8 @@ class LstmCellWithProjection(torch.nn.Module):
     it cannot make use of CUDNN optimizations for stacked RNNs due to and
     variational dropout and the custom nature of the cell state.
 
+    [0]: https://arxiv.org/abs/1512.05287
+
     # Parameters
 
     input_size : `int`, required.
@@ -32,7 +34,7 @@ class LstmCellWithProjection(torch.nn.Module):
     recurrent_dropout_probability : `float`, optional (default = 0.0)
         The dropout probability to be used in a dropout scheme as stated in
         [A Theoretically Grounded Application of Dropout in Recurrent Neural Networks]
-        (https://arxiv.org/abs/1512.05287). Implementation wise, this simply
+        [0]. Implementation wise, this simply
         applies a fixed dropout mask per sequence to the recurrent connection of the
         LSTM.
     state_projection_clip_value : `float`, optional, (default = None)

--- a/allennlp/modules/stacked_alternating_lstm.py
+++ b/allennlp/modules/stacked_alternating_lstm.py
@@ -18,7 +18,7 @@ class StackedAlternatingLstm(torch.nn.Module):
     the sequence and going backwards. This implementation is based on the
     description in [Deep Semantic Role Labelling - What works and what's next][0].
 
-    [0]: https://homes.cs.washington.edu/~luheng/files/acl2017_hllz.pdf
+    [0]: https://www.aclweb.org/anthology/P17-1044.pdf
     [1]: https://arxiv.org/abs/1512.05287
 
     # Parameters

--- a/allennlp/modules/stacked_alternating_lstm.py
+++ b/allennlp/modules/stacked_alternating_lstm.py
@@ -16,8 +16,10 @@ class StackedAlternatingLstm(torch.nn.Module):
     """
     A stacked LSTM with LSTM layers which alternate between going forwards over
     the sequence and going backwards. This implementation is based on the
-    description in [Deep Semantic Role Labelling - What works and what's next]
-    (https://homes.cs.washington.edu/~luheng/files/acl2017_hllz.pdf).
+    description in [Deep Semantic Role Labelling - What works and what's next][0].
+
+    [0]: https://homes.cs.washington.edu/~luheng/files/acl2017_hllz.pdf
+    [1]: https://arxiv.org/abs/1512.05287
 
     # Parameters
 
@@ -29,8 +31,7 @@ class StackedAlternatingLstm(torch.nn.Module):
         The number of stacked LSTMs to use.
     recurrent_dropout_probability : `float`, optional (default = 0.0)
         The dropout probability to be used in a dropout scheme as stated in
-        [A Theoretically Grounded Application of Dropout in Recurrent Neural Networks]
-        (https://arxiv.org/abs/1512.05287).
+        [A Theoretically Grounded Application of Dropout in Recurrent Neural Networks][1].
     use_input_projection_bias : `bool`, optional (default = True)
         Whether or not to use a bias on the input projection layer. This is mainly here
         for backwards compatibility reasons and will be removed (and set to False)

--- a/allennlp/modules/stacked_bidirectional_lstm.py
+++ b/allennlp/modules/stacked_bidirectional_lstm.py
@@ -18,6 +18,8 @@ class StackedBidirectionalLstm(torch.nn.Module):
     from the last layer of the LSTM. Note that this will be slower, as it
     doesn't use CUDNN.
 
+    [0]: https://arxiv.org/abs/1512.05287
+
     # Parameters
 
     input_size : `int`, required
@@ -29,11 +31,11 @@ class StackedBidirectionalLstm(torch.nn.Module):
     recurrent_dropout_probability : `float`, optional (default = 0.0)
         The recurrent dropout probability to be used in a dropout scheme as
         stated in [A Theoretically Grounded Application of Dropout in Recurrent
-        Neural Networks](https://arxiv.org/abs/1512.05287).
+        Neural Networks][0].
     layer_dropout_probability : `float`, optional (default = 0.0)
         The layer wise dropout probability to be used in a dropout scheme as
         stated in [A Theoretically Grounded Application of Dropout in Recurrent
-        Neural Networks](https://arxiv.org/abs/1512.05287).
+        Neural Networks][0].
     use_highway : `bool`, optional (default = True)
         Whether or not to use highway connections between layers. This effectively involves
         reparameterising the normal output of an LSTM as::

--- a/allennlp/nn/beam_search.py
+++ b/allennlp/nn/beam_search.py
@@ -14,6 +14,8 @@ class BeamSearch:
     """
     Implements the beam search algorithm for decoding the most likely sequences.
 
+    [0]: https://arxiv.org/abs/1702.01806
+
     # Parameters
 
     end_index : `int`
@@ -28,7 +30,7 @@ class BeamSearch:
         If not given, this just defaults to `beam_size`. Setting this parameter
         to a number smaller than `beam_size` may give better results, as it can introduce
         more diversity into the search. See [Beam Search Strategies for Neural Machine Translation.
-        Freitag and Al-Onaizan, 2017](https://arxiv.org/abs/1702.01806).
+        Freitag and Al-Onaizan, 2017][0].
     """
 
     def __init__(

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -1511,8 +1511,7 @@ def add_positional_features(
 
     """
     Implements the frequency-based positional encoding described
-    in [Attention is all you Need]
-    (https://www.semanticscholar.org/paper/Attention-Is-All-You-Need-Vaswani-Shazeer/0737da0767d77606169cbf4187b83e1ab62f6077).
+    in [Attention is All you Need][0].
 
     Adds sinusoids of different frequencies to a `Tensor`. A sinusoid of a
     different frequency and phase is added to each dimension of the input `Tensor`.
@@ -1522,6 +1521,8 @@ def add_positional_features(
     (min_timescale, max_timescale). For each timescale, the two sinusoidal
     signals sin(timestep / timescale) and cos(timestep / timescale) are
     generated and concatenated along the hidden_dim dimension.
+
+    [0]: https://www.semanticscholar.org/paper/Attention-Is-All-You-Need-Vaswani-Shazeer/0737da0767d77606169cbf4187b83e1ab62f6077
 
     # Parameters
 

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -154,6 +154,9 @@ class GradientDescentTrainer(Trainer):
     largely match the arguments to `__init__`, and we don't repeat their docstrings in
     `from_partial_objects`.
 
+    [0]: https://tinyurl.com/y5mv44fw
+    [1]: https://nvidia.github.io/apex/amp.html#opt-levels-and-properties
+
     # Parameters
 
     model : `Model`, required.
@@ -235,12 +238,12 @@ class GradientDescentTrainer(Trainer):
         The number of `Trainer` workers participating in the distributed training.
     num_gradient_accumulation_steps : `int`, optional, (default = 1)
         Gradients are accumulated for the given number of steps before doing an optimizer step. This can
-        be useful to accommodate batches that are larger than the RAM size. Refer Thomas Wolf's
-        [post](https://tinyurl.com/y5mv44fw) for details on Gradient Accumulation.
+        be useful to accommodate batches that are larger than the RAM size. Refer [Thomas Wolf's
+        post][0] for details on Gradient Accumulation.
     opt_level : `str`, optional, (default = `None`)
         Each opt_level establishes a set of properties that govern Amp’s implementation of pure or mixed
         precision training. Must be a choice of `"O0"`, `"O1"`, `"O2"`, or `"O3"`.
-        See the Apex [documentation](https://nvidia.github.io/apex/amp.html#opt-levels-and-properties) for
+        See [the Apex documentation][1] for
         more details. If `None`, Amp is not used. Defaults to `None`.
     """
 


### PR DESCRIPTION
Addresses some parts of #3630.

External urls in parameters sections are not rendering correctly (i.e. http://docs.allennlp.org/master/api/modules/stacked_alternating_lstm/). I have used reference style links (https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links) to avoid that.

Also fixed some broken links in "regular" places.