### PR TITLE
Add env variable for log level configuration

### DIFF
--- a/allennlp/__main__.py
+++ b/allennlp/__main__.py
@@ -6,7 +6,8 @@ import sys
 if os.environ.get("ALLENNLP_DEBUG"):
     LEVEL = logging.DEBUG
 else:
-    LEVEL = logging.INFO
+    level_name = os.environ.get("ALLENNLP_LOG_LEVEL")
+    LEVEL = logging._nameToLevel.get(level_name, logging.INFO)
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir))))
 logging.basicConfig(format="%(asctime)s - %(levelname)s - %(name)s - %(message)s", level=LEVEL)

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -330,7 +330,8 @@ def prepare_global_logging(
     if os.environ.get("ALLENNLP_DEBUG"):
         LEVEL = logging.DEBUG
     else:
-        LEVEL = logging.INFO
+        level_name = os.environ.get("ALLENNLP_LOG_LEVEL")
+        LEVEL = logging._nameToLevel.get(level_name, logging.INFO)
 
     if rank == 0:
         # stdout/stderr handlers are added only for the


### PR DESCRIPTION
Added ``ALLENNLP_LOG_LEVEL`` as suggested in #3391 with backward compatibility.

Warning - using private python dict to map from str to log level (I can move it if needed).