### PR TITLE
Add sanitize_wordpiece for ALBERT

### DIFF
--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -631,11 +631,13 @@ def is_distributed() -> bool:
 
 def sanitize_wordpiece(wordpiece: str) -> str:
     """
-    Sanitizes wordpieces from BERT or RoBERTa tokenizers.
+    Sanitizes wordpieces from BERT, RoBERTa or ALBERT tokenizers.
     """
     if wordpiece.startswith("##"):
         return wordpiece[2:]
     elif wordpiece.startswith("Ġ"):
+        return wordpiece[1:]
+    elif wordpiece.startswith("▁"):
         return wordpiece[1:]
     else:
         return wordpiece


### PR DESCRIPTION
ALBERT uses "▁" to denote the start of a wordpiece in their vocabulary. Adding this has enabled the support for ALBERT models when using `PretrainedTransformerTokenizer`.