### PR TITLE
Fix amp initialize issues in Model._load

### DIFF
--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -284,7 +284,7 @@ class Model(torch.nn.Module, Registrable):
         remove_pretrained_embedding_params(model_params)
         model = Model.from_params(vocab=vocab, params=model_params)
 
-        # If the model was trained with amp and amp is available, we should re-intialize it with
+        # If the model was trained with amp and amp is available, we should re-initialize it with
         # the opt_level that was used. If the model was trained with amp but amp is not availble, log a warning
         # so this doesn't pass silently.
         if opt_level is not None:
@@ -296,7 +296,7 @@ class Model(torch.nn.Module, Registrable):
                     )
                 )
             else:
-                model = amp.intialize(model, opt_level=opt_level)
+                model = amp.initialize(model, opt_level=opt_level)
 
         # If vocab+embedding extension was done, the model initialized from from_params
         # and one defined by state dict in weights_file might not have same embedding shapes.

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -75,7 +75,7 @@ class Embedding(TokenEmbedder):
         construct it in the original training. We store vocab_namespace used during the original
         training as an attribute, so that it can be retrieved during fine-tuning.
     pretrained_file : `str`, (optional, default=None)
-        Path to a file of word vectors to intialize the embedding matrix. It can be the
+        Path to a file of word vectors to initialize the embedding matrix. It can be the
         path to a local file or a URL of a (cached) remote file. Two formats are supported:
             * hdf5 file - containing an embedding matrix in the form of a torch.Tensor;
             * text file - an utf-8 encoded text file with space separated fields.


### PR DESCRIPTION
There were to issues in my last PR that threw errors when loading a model trained with amp:

-  a misspelling of the `amp.initialize` method in my last PR (#3992). This caused an error when trying to load a model trained with `amp` (I also found the word initialize misspelled in a docstring so I fixed that as well).
- the code that moves the loaded model to GPU was moved to before the call to `amp.initialize`, otherwise, it will throw an error.