### PR TITLE
Decouple generator and filepath to fix pickle bug

### DIFF
--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -41,7 +41,7 @@ class _LazyInstances(IterableDataset):
 
     def __init__(
         self,
-        instance_generator: Callable[[], Iterable[Instance]],
+        instance_generator: Callable[[str], Iterable[Instance]],
         file_path: str,
         cache_file: str = None,
         deserialize: Callable[[str], Instance] = None,

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -42,6 +42,7 @@ class _LazyInstances(IterableDataset):
     def __init__(
         self,
         instance_generator: Callable[[], Iterable[Instance]],
+        file_path: str,
         cache_file: str = None,
         deserialize: Callable[[str], Instance] = None,
         serialize: Callable[[Instance], str] = None,
@@ -49,6 +50,7 @@ class _LazyInstances(IterableDataset):
     ) -> None:
         super().__init__()
         self.instance_generator = instance_generator
+        self.file_path = file_path
         self.cache_file = cache_file
         self.deserialize = deserialize
         self.serialize = serialize
@@ -67,7 +69,7 @@ class _LazyInstances(IterableDataset):
         # Case 2: Need to cache instances
         elif self.cache_file is not None:
             with open(self.cache_file, "w") as data_file:
-                for instance in self.instance_generator():
+                for instance in self.instance_generator(self.file_path):
                     data_file.write(self.serialize(instance))
                     data_file.write("\n")
                     if self.vocab is not None:
@@ -75,7 +77,7 @@ class _LazyInstances(IterableDataset):
                     yield instance
         # Case 3: No cache
         else:
-            instances = self.instance_generator()
+            instances = self.instance_generator(self.file_path)
             if isinstance(instances, list):
                 raise ConfigurationError(
                     "For a lazy dataset reader, _read() must return a generator"
@@ -176,7 +178,8 @@ class DatasetReader(Registrable):
 
         if lazy:
             instances: Iterable[Instance] = _LazyInstances(
-                lambda: self._read(file_path),
+                self._read,
+                file_path,
                 cache_file,
                 self.deserialize_instance,
                 self.serialize_instance,


### PR DESCRIPTION
# Overview

This PR addresses #3924 by decoupling the `instance_generator` argument to `_LazyInstances` into two arguments: `instance_generator` and `file_path`. Intead of passing a `lambda: self._read(file_path),` to `_LazyInstances` in `DatasetReader`, we now pass `self._read` and `file_path`, and `_LazyInstances` just calls: `self._read(filepath)`.

I tested that this fixes #3924 by training in distributed mode with a lazy dataset reader.

Thanks to @matt-gardner for the solution.

## Closes

Closes #3924.