### PR TITLE
ensure all API docs rebuilt when script changes, and always build from scratch in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ serve-docs : $(MD_DOCS_CONF) $(MD_DOCS) $(MD_DOCS_EXTRAS)
 
 .PHONY : build-all-api-docs
 build-all-api-docs : $(MD_DOCS_SRC) scripts/py2md.py
-	@$(MD_DOCS_CMD) $(subst /,.,$(subst .py,,$(MD_DOCS_SRC))) -c 8 -o $(MD_DOCS)
+	@$(MD_DOCS_CMD) $(subst /,.,$(subst .py,,$(MD_DOCS_SRC))) -o $(MD_DOCS)
 
 .PHONY : update-docs
 update-docs : $(MD_DOCS) $(MD_DOCS_EXTRAS)

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ build-docs : $(MD_DOCS_CONF) $(MD_DOCS) $(MD_DOCS_EXTRAS)
 serve-docs : $(MD_DOCS_CONF) $(MD_DOCS) $(MD_DOCS_EXTRAS)
 	mkdocs serve --dirtyreload
 
+.PHONY : build-all-api-docs
+build-all-api-docs : $(MD_DOCS_SRC) scripts/py2md.py
+	$(MD_DOCS_CMD) $(subst /,.,$(subst .py,,$(MD_DOCS_SRC))) --out $(MD_DOCS)
+
 .PHONY : update-docs
 update-docs : $(MD_DOCS) $(MD_DOCS_EXTRAS)
 
@@ -47,7 +51,7 @@ $(MD_DOCS_CONF) : $(MD_DOCS_CONF_SRC) $(MD_DOCS)
 
 $(MD_DOCS_API_ROOT)%.md : $(SRC)/%.py scripts/py2md.py
 	mkdir -p $(shell dirname $@)
-	$(MD_DOCS_CMD) $(subst /,.,$(subst .py,,$<)) > $@
+	$(MD_DOCS_CMD) $(subst /,.,$(subst .py,,$<)) --out $@
 
 .PHONY : clean
 clean :

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ serve-docs : $(MD_DOCS_CONF) $(MD_DOCS) $(MD_DOCS_EXTRAS)
 
 .PHONY : build-all-api-docs
 build-all-api-docs : $(MD_DOCS_SRC) scripts/py2md.py
-	$(MD_DOCS_CMD) $(subst /,.,$(subst .py,,$(MD_DOCS_SRC))) --out $(MD_DOCS)
+	@$(MD_DOCS_CMD) $(subst /,.,$(subst .py,,$(MD_DOCS_SRC))) -c 8 -o $(MD_DOCS)
 
 .PHONY : update-docs
 update-docs : $(MD_DOCS) $(MD_DOCS_EXTRAS)

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ $(MD_DOCS_ROOT)%.md : %.md
 $(MD_DOCS_CONF) : $(MD_DOCS_CONF_SRC) $(MD_DOCS)
 	python scripts/build_docs_config.py $@ $(MD_DOCS_CONF_SRC) $(MD_DOCS_ROOT) $(MD_DOCS_API_ROOT)
 
-$(MD_DOCS_API_ROOT)%.md : $(SRC)/%.py
+$(MD_DOCS_API_ROOT)%.md : $(SRC)/%.py scripts/py2md.py
 	mkdir -p $(shell dirname $@)
 	$(MD_DOCS_CMD) $(subst /,.,$(subst .py,,$<)) > $@
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -33,7 +33,9 @@ git+https://github.com/NVIDIA/apex.git@master
 # YAML manipulation
 ruamel.yaml
 
+# Generating markdown files from Python modules.
 git+https://github.com/NiklasRosenstein/pydoc-markdown.git@b469839ceb598df3d7e7126b81bff88dfd1343e3
+
 markdown-include==0.5.1
 # Package for the material theme for mkdocs
 mkdocs-material==5.1.0

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -3,4 +3,5 @@
 set -Eeuo pipefail
 
 make clean
-make build-docs --jobs 16
+make build-all-api-docs
+make build-docs

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -2,4 +2,5 @@
 
 set -Eeuo pipefail
 
+make clean
 make build-docs --jobs 16


### PR DESCRIPTION
A few things:
- tweaks the Makefile to make sure all of the API docs are re-built whenever the `scripts/py2md.py` file changes.
- runs `make clean` before `make build-docs` in `scripts/build-docs.sh` to ensure the docs are built from scratch in CI.
- avoids shelling out to Python multiple times when building docs from scratch. Several orders of magnitude faster now.