### PR TITLE
Simplify pull request workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -101,7 +101,7 @@ jobs:
         EXCLUDE_ALLENNLP_IN_SETUP: "true"
       run: |
         git clone https://github.com/allenai/allennlp-models.git
-        cd allennlp-models && pip install -e . && pip install -r dev-requirements.txt
+        cd allennlp-models && pip install --upgrade -e . -r dev-requirements.txt
 
     - name: Run models tests
       run: |
@@ -190,7 +190,7 @@ jobs:
   # Builds Docker image from the core distribution files and uploads to Docker Hub.
   docker:
     name: Docker
-    needs: [build_package, test_package]
+    needs: [build_package]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
@@ -240,7 +240,7 @@ jobs:
   # allennlp-docs repo.
   docs:
     name: Docs
-    needs: [build_package, test_package]
+    needs: [build_package, test_package, docker]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,8 +34,7 @@ jobs:
     - name: Install requirements
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install -e .
-        pip install --upgrade -r dev-requirements.txt
+        pip install --upgrade -e . -r dev-requirements.txt
 
     - name: Debug info
       run: |
@@ -91,8 +90,7 @@ jobs:
     - name: Install requirements
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install -e .
-        pip install --upgrade -r dev-requirements.txt
+        pip install --upgrade -e . -r dev-requirements.txt
 
     - name: Debug info
       run: |
@@ -142,8 +140,7 @@ jobs:
     - name: Install requirements
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install -e .
-        pip install --upgrade -r dev-requirements.txt
+        pip install --upgrade -e . -r dev-requirements.txt
 
     - name: Build core package
       run: |
@@ -273,8 +270,7 @@ jobs:
     - name: Install requirements
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install -e .
-        pip install --upgrade -r dev-requirements.txt
+        pip install --upgrade -e . -r dev-requirements.txt
 
     - name: Debug info
       run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,10 +1,7 @@
-name: CI
+name: Master
 
 on:
   # TODO: add nightly schedule.
-  pull_request:
-    branches:
-    - master
   push:
     branches:
     - master

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -116,7 +116,6 @@ jobs:
   build_package:
     name: Build Package
     needs: [check_core, check_models]
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -157,7 +156,6 @@ jobs:
   test_package:
     name: Test Package
     needs: [build_package]
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -191,7 +189,6 @@ jobs:
   docker:
     name: Docker
     needs: [build_package]
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
@@ -241,7 +238,6 @@ jobs:
   docs:
     name: Docs
     needs: [build_package, test_package, docker]
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,8 +31,7 @@ jobs:
     - name: Install requirements
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install -e .
-        pip install --upgrade -r dev-requirements.txt
+        pip install --upgrade -e . -r dev-requirements.txt
 
     - name: Debug info
       run: |
@@ -88,8 +87,7 @@ jobs:
     - name: Install requirements
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install -e .
-        pip install --upgrade -r dev-requirements.txt
+        pip install --upgrade -e . -r dev-requirements.txt
 
     - name: Debug info
       run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,112 @@
+name: PR
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  check_core:
+    name: Check Core
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.6', '3.7']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}
+
+    - uses: actions/cache@v1
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ runner.os }}-pydeps-${{ matrix.python }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pydeps-${{ matrix.python }}
+
+    - name: Install requirements
+      run: |
+        pip install --upgrade pip setuptools wheel
+        pip install -e .
+        pip install --upgrade -r dev-requirements.txt
+
+    - name: Debug info
+      run: |
+        pip freeze
+
+    - name: Lint
+      run: |
+        make lint
+
+    - name: Type check
+      run: |
+        make typecheck
+
+    - name: Run tests
+      run: |
+        make test-with-cov
+
+    - name: Upload coverage to Codecov
+      if: matrix.python == '3.7'
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        # Ignore codecov failures as the codecov server is not
+        # very reliable but we don't want to report a failure
+        # in the github UI just because the coverage report failed to
+        # be published.
+        # This will also fail for forked repositories since the secret token won't
+        # be available.
+        codecov -t $CODECOV_TOKEN || echo "codecov upload failed"
+
+  check_models:
+    name: Check Models
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.6', '3.7']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}
+
+    - uses: actions/cache@v1
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ runner.os }}-pydeps-${{ matrix.python }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pydeps-${{ matrix.python }}
+
+    - name: Install requirements
+      run: |
+        pip install --upgrade pip setuptools wheel
+        pip install -e .
+        pip install --upgrade -r dev-requirements.txt
+
+    - name: Debug info
+      run: |
+        pip freeze
+
+    - name: Pull and install models repo
+      env:
+        EXCLUDE_ALLENNLP_IN_SETUP: "true"
+      run: |
+        git clone https://github.com/allenai/allennlp-models.git
+        cd allennlp-models && pip install -e . && pip install -r dev-requirements.txt
+
+    - name: Run models tests
+      run: |
+        cd allennlp-models && make test
+
+    - name: Clean up
+      run: |
+        # Don't want this in the cache since the other workflow uses same cache.
+        pip uninstall --yes allennlp_models

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -98,7 +98,7 @@ jobs:
         EXCLUDE_ALLENNLP_IN_SETUP: "true"
       run: |
         git clone https://github.com/allenai/allennlp-models.git
-        cd allennlp-models && pip install -e . && pip install -r dev-requirements.txt
+        cd allennlp-models && pip install --upgrade -e . -r dev-requirements.txt
 
     - name: Run models tests
       run: |


### PR DESCRIPTION
This separates the workflow that is ran on pull requests from the one that is ran on master commits and releases.

The benefit of this is that **only the relevant jobs will show up on pull requests** instead of all jobs (most of which are skipped). The downside is that two of the jobs need to be duplicated across the workflows.

I definitely don't like duplicated configs, but I also don't like having so many jobs showing up on pull requests. I imagine that would be a source of confusion for contributors.

Also @bryant1410 this covers the `pip install -e . -r dev-requirements.txt` optimization you pointed out.