### PR TITLE
Fix logging

### DIFF
--- a/allennlp/commands/elmo.py
+++ b/allennlp/commands/elmo.py
@@ -76,7 +76,8 @@ from overrides import overrides
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.tqdm import Tqdm
-from allennlp.common.util import lazy_groups_of, prepare_global_logging
+from allennlp.common.logging import prepare_global_logging
+from allennlp.common.util import lazy_groups_of
 from allennlp.data.token_indexers.elmo_indexer import ELMoTokenCharactersIndexer
 from allennlp.modules.elmo import _ElmoBiLm, batch_to_ids
 from allennlp.nn.util import remove_sentence_boundaries

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -49,6 +49,7 @@ from overrides import overrides
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common import Params, Registrable, Lazy
 from allennlp.common.checks import check_for_gpu, ConfigurationError
+from allennlp.common.logging import prepare_global_logging
 from allennlp.common import util as common_util
 from allennlp.common.plugins import import_plugins
 from allennlp.data import DatasetReader, Vocabulary
@@ -393,7 +394,7 @@ def _train_worker(
     best_model : `Optional[Model]`
         The model with the best epoch weights or `None` if in distributed training or in dry run.
     """
-    common_util.prepare_global_logging(
+    prepare_global_logging(
         serialization_dir, file_friendly_logging, rank=process_rank, world_size=world_size
     )
     common_util.prepare_environment(params)

--- a/allennlp/common/logging.py
+++ b/allennlp/common/logging.py
@@ -1,8 +1,11 @@
-"""
-A custom 'logging.Logger' that has additional {warning,debug,etc.}_once() methods
-which allow for logged methods to be logged only once.
-"""
 import logging
+from logging import Filter
+import os
+import sys
+from typing import Optional
+
+from allennlp.common.tee import TeeHandler
+from allennlp.common.tqdm import Tqdm
 
 
 class AllenNlpLogger(logging.Logger):
@@ -42,3 +45,108 @@ class AllenNlpLogger(logging.Logger):
 
 
 logging.setLoggerClass(AllenNlpLogger)
+
+
+class ErrorFilter(Filter):
+    """
+    Filters out everything that is at the ERROR level or higher. This is meant to be used
+    with a stdout handler when a stderr handler is also configured. That way ERROR
+    messages aren't duplicated.
+    """
+
+    def filter(self, record):
+        return record.levelno < logging.ERROR
+
+
+class WorkerLogFilter(Filter):
+    def __init__(self, rank=-1):
+        super().__init__()
+        self._rank = rank
+
+    def filter(self, record):
+        if self._rank != -1:
+            record.msg = f"Rank {self._rank} | {record.msg}"
+        return True
+
+
+def prepare_global_logging(
+    serialization_dir: str, file_friendly_logging: bool, rank: int = 0, world_size: int = 1
+) -> None:
+    # If we don't have a terminal as stdout,
+    # force tqdm to be nicer.
+    if not sys.stdout.isatty():
+        file_friendly_logging = True
+
+    Tqdm.set_slower_interval(file_friendly_logging)
+
+    stdout_file: str
+    stderr_file: str
+    worker_filter: Optional[WorkerLogFilter] = None
+    if world_size == 1:
+        # This case is not distributed training and hence will stick to the older
+        # log file names
+        stdout_file = os.path.join(serialization_dir, "stdout.log")
+        stderr_file = os.path.join(serialization_dir, "stderr.log")
+    else:
+        # Create log files with worker ids
+        stdout_file = os.path.join(serialization_dir, f"stdout_worker{rank}.log")
+        stderr_file = os.path.join(serialization_dir, f"stderr_worker{rank}.log")
+
+        # This adds the worker's rank to messages being logged to files.
+        # This will help when combining multiple worker log files using `less` command.
+        worker_filter = WorkerLogFilter(rank)
+
+    # Patch stdout/err.
+    stdout_patch = TeeHandler(
+        stdout_file,
+        sys.stdout,
+        file_friendly_terminal_output=file_friendly_logging,
+        silent=rank != 0,  # don't print to terminal from non-master workers.
+    )
+    sys.stdout = stdout_patch  # type: ignore
+    stderr_patch = TeeHandler(
+        stderr_file,
+        sys.stderr,
+        file_friendly_terminal_output=file_friendly_logging,
+        silent=rank != 0,  # don't print to terminal from non-master workers.
+    )
+    sys.stderr = stderr_patch  # type: ignore
+
+    # Handlers for stdout/err logging
+    output_handler = logging.StreamHandler(sys.stdout)
+    error_handler = logging.StreamHandler(sys.stderr)
+
+    if worker_filter is not None:
+        output_handler.addFilter(worker_filter)
+        error_handler.addFilter(worker_filter)
+
+    root_logger = logging.getLogger()
+
+    # Remove the already set stream handler in root logger.
+    # Not doing this will result in duplicate log messages
+    # printed in the console
+    if len(root_logger.handlers) > 0:
+        for handler in root_logger.handlers:
+            root_logger.removeHandler(handler)
+
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
+    output_handler.setFormatter(formatter)
+    error_handler.setFormatter(formatter)
+
+    if os.environ.get("ALLENNLP_DEBUG"):
+        LEVEL = logging.DEBUG
+    else:
+        level_name = os.environ.get("ALLENNLP_LOG_LEVEL")
+        LEVEL = logging._nameToLevel.get(level_name, logging.INFO)
+
+    output_handler.setLevel(LEVEL)
+    error_handler.setLevel(logging.ERROR)
+
+    # filter out everything at the ERROR or higher level for output stream
+    # so that error messages don't appear twice in the logs.
+    output_handler.addFilter(ErrorFilter())
+
+    root_logger.addHandler(output_handler)
+    root_logger.addHandler(error_handler)
+
+    root_logger.setLevel(LEVEL)

--- a/allennlp/common/tee.py
+++ b/allennlp/common/tee.py
@@ -1,0 +1,69 @@
+from typing import TextIO
+import os
+
+
+def replace_cr_with_newline(message: str) -> str:
+    """
+    TQDM and requests use carriage returns to get the training line to update for each batch
+    without adding more lines to the terminal output. Displaying those in a file won't work
+    correctly, so we'll just make sure that each batch shows up on its one line.
+    """
+    if "\r" in message:
+        message = message.replace("\r", "")
+        if not message or message[-1] != "\n":
+            message += "\n"
+    return message
+
+
+class TeeHandler:
+    """
+    This class behaves similar to the `tee` command-line utility by writing messages
+    to both a terminal and a file.
+
+    It's meant to be used like this to patch sys.stdout and sys.stderr.
+
+    # Examples
+
+    ```python
+    sys.stdout = TeeHandler("stdout.log", sys.stdout)
+    sys.stderr = TeeHandler("stdout.log", sys.stderr)
+    ```
+    """
+
+    def __init__(
+        self,
+        filename: str,
+        terminal: TextIO,
+        file_friendly_terminal_output: bool = False,
+        silent: bool = False,
+    ) -> None:
+        self.terminal = terminal
+        self.file_friendly_terminal_output = file_friendly_terminal_output
+        self.silent = silent
+        parent_directory = os.path.dirname(filename)
+        os.makedirs(parent_directory, exist_ok=True)
+        self.log = open(filename, "a")
+
+    def write(self, message):
+        cleaned = replace_cr_with_newline(message)
+
+        if not self.silent:
+            if self.file_friendly_terminal_output:
+                self.terminal.write(cleaned)
+            else:
+                self.terminal.write(message)
+
+        self.log.write(cleaned)
+
+    def flush(self):
+        self.terminal.flush()
+        self.log.flush()
+
+    def isatty(self):
+        # Mirror the API of sys.stdout so that we can
+        # check for the presence of a terminal easily.
+        return not self.file_friendly_terminal_output
+
+    def cleanup(self) -> TextIO:
+        self.log.close()
+        return self.terminal

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -264,6 +264,17 @@ class FileFriendlyLogFilter(Filter):
         return True
 
 
+class ErrorFilter(Filter):
+    """
+    Filters out everything that is at the ERROR level or higher. This is meant to be used
+    with a stdout handler when a stderr handler is also configured. That way ERROR
+    messages aren't duplicated.
+    """
+
+    def filter(self, record):
+        return record.levelno < logging.ERROR
+
+
 class WorkerLogFilter(Filter):
     def __init__(self, rank=-1):
         super().__init__()
@@ -342,6 +353,10 @@ def prepare_global_logging(
 
         output_stream_log_handler.setLevel(LEVEL)
         error_stream_log_handler.setLevel(logging.ERROR)
+
+        # filter out everything at the ERROR or higher level for stdout stream
+        # so that error messages don't appear twice in the terminal output.
+        output_stream_log_handler.addFilter(ErrorFilter())
 
         if file_friendly_logging:
             output_stream_log_handler.addFilter(file_friendly_log_filter)

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 from contextlib import contextmanager
 from itertools import islice, zip_longest
-from logging import Filter
 from pathlib import Path
 from typing import (
     Any,
@@ -36,8 +35,6 @@ from spacy.language import Language as SpacyModelType
 
 from allennlp.common.checks import log_pytorch_version_info
 from allennlp.common.params import Params
-from allennlp.common.tee import TeeHandler
-from allennlp.common.tqdm import Tqdm
 
 try:
     import resource
@@ -248,111 +245,6 @@ def prepare_environment(params: Params):
             torch.cuda.manual_seed_all(torch_seed)
 
     log_pytorch_version_info()
-
-
-class ErrorFilter(Filter):
-    """
-    Filters out everything that is at the ERROR level or higher. This is meant to be used
-    with a stdout handler when a stderr handler is also configured. That way ERROR
-    messages aren't duplicated.
-    """
-
-    def filter(self, record):
-        return record.levelno < logging.ERROR
-
-
-class WorkerLogFilter(Filter):
-    def __init__(self, rank=-1):
-        super().__init__()
-        self._rank = rank
-
-    def filter(self, record):
-        if self._rank != -1:
-            record.msg = f"Rank {self._rank} | {record.msg}"
-        return True
-
-
-def prepare_global_logging(
-    serialization_dir: str, file_friendly_logging: bool, rank: int = 0, world_size: int = 1
-) -> None:
-    # If we don't have a terminal as stdout,
-    # force tqdm to be nicer.
-    if not sys.stdout.isatty():
-        file_friendly_logging = True
-
-    Tqdm.set_slower_interval(file_friendly_logging)
-
-    stdout_file: str
-    stderr_file: str
-    worker_filter: Optional[WorkerLogFilter] = None
-    if world_size == 1:
-        # This case is not distributed training and hence will stick to the older
-        # log file names
-        stdout_file = os.path.join(serialization_dir, "stdout.log")
-        stderr_file = os.path.join(serialization_dir, "stderr.log")
-    else:
-        # Create log files with worker ids
-        stdout_file = os.path.join(serialization_dir, f"stdout_worker{rank}.log")
-        stderr_file = os.path.join(serialization_dir, f"stderr_worker{rank}.log")
-
-        # This adds the worker's rank to messages being logged to files.
-        # This will help when combining multiple worker log files using `less` command.
-        worker_filter = WorkerLogFilter(rank)
-
-    # Patch stdout/err.
-    stdout_patch = TeeHandler(
-        stdout_file,
-        sys.stdout,
-        file_friendly_terminal_output=file_friendly_logging,
-        silent=rank != 0,  # don't print to terminal from non-master workers.
-    )
-    sys.stdout = stdout_patch  # type: ignore
-    stderr_patch = TeeHandler(
-        stderr_file,
-        sys.stderr,
-        file_friendly_terminal_output=file_friendly_logging,
-        silent=rank != 0,  # don't print to terminal from non-master workers.
-    )
-    sys.stderr = stderr_patch  # type: ignore
-
-    # Handlers for stdout/err logging
-    output_handler = logging.StreamHandler(sys.stdout)
-    error_handler = logging.StreamHandler(sys.stderr)
-
-    if worker_filter is not None:
-        output_handler.addFilter(worker_filter)
-        error_handler.addFilter(worker_filter)
-
-    root_logger = logging.getLogger()
-
-    # Remove the already set stream handler in root logger.
-    # Not doing this will result in duplicate log messages
-    # printed in the console
-    if len(root_logger.handlers) > 0:
-        for handler in root_logger.handlers:
-            root_logger.removeHandler(handler)
-
-    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s")
-    output_handler.setFormatter(formatter)
-    error_handler.setFormatter(formatter)
-
-    if os.environ.get("ALLENNLP_DEBUG"):
-        LEVEL = logging.DEBUG
-    else:
-        level_name = os.environ.get("ALLENNLP_LOG_LEVEL")
-        LEVEL = logging._nameToLevel.get(level_name, logging.INFO)
-
-    output_handler.setLevel(LEVEL)
-    error_handler.setLevel(logging.ERROR)
-
-    # filter out everything at the ERROR or higher level for output stream
-    # so that error messages don't appear twice in the logs.
-    output_handler.addFilter(ErrorFilter())
-
-    root_logger.addHandler(output_handler)
-    root_logger.addHandler(error_handler)
-
-    root_logger.setLevel(LEVEL)
 
 
 LOADED_SPACY_MODELS: Dict[Tuple[str, bool, bool, bool], SpacyModelType] = {}


### PR DESCRIPTION
Closes #3785 and also ensures tqdm logged to file.

The solution just patches `sys.stdout` and `sys.stderr` with our own `TeeHandler` class.

@OyvindTafjord pinging you so you can give this a review as well

## Example output

**With `--file-friendly-logging`**

![image](https://user-images.githubusercontent.com/8812459/80546629-09f86080-896b-11ea-9fdb-e8f6887bbd25.png)

**Without `--file-friendly-logging`**

![image](https://user-images.githubusercontent.com/8812459/80546692-32805a80-896b-11ea-830a-73eb25c400e5.png)

And in both cases the `stderr.log` looks like this:

![image](https://user-images.githubusercontent.com/8812459/80546781-6b203400-896b-11ea-84a1-44912dcbf28e.png)

## Downsides

- Relies on patching `sys.stdout` and `sys.stderr`. This is scary.
- The tqdm progress bars are not as pretty. Compare the output above to the status bars before this PR:

![image](https://user-images.githubusercontent.com/8812459/80547027-04e7e100-896c-11ea-964a-6b96d7b6db53.png)

We can partially fix this by setting `ascii=False` when initializing the Tqdm instance. With that, it looks like this:

![image](https://user-images.githubusercontent.com/8812459/80547487-301f0000-896d-11ea-995f-8ea8a4c5b641.png)

But it's still not as pretty because it doesn't take up the entire terminal width.