### PR TITLE
add missing param `threshold_mode`

### DIFF
--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -118,6 +118,7 @@ class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetr
             factor=factor,
             patience=patience,
             verbose=verbose,
+            threshold_mode=threshold_mode, 
             threshold=threshold,
             cooldown=cooldown,
             min_lr=min_lr,

--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -118,7 +118,7 @@ class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetr
             factor=factor,
             patience=patience,
             verbose=verbose,
-            threshold_mode=threshold_mode, 
+            threshold_mode=threshold_mode,
             threshold=threshold,
             cooldown=cooldown,
             min_lr=min_lr,


### PR DESCRIPTION
It's probably a bug.
I see `threshold_mode` as a param of `__init__` of `ReduceOnPlateauLearningRateScheduler`, but it misses in the initializer of `torch.optim.lr_scheduler.ReduceLROnPlateau`.
I found this problem in my experiment, by observing exceptional learning rate decay, and further found that the `threshold_mode` of `ReduceOnPlateauLearningRateScheduler.lr_scheduler` is always equal to "rel", even I had set `threshold_mode = 'abs'`.  
If this is not intended, then it's probably an oversight.