### PR TITLE
Another missing param `eps` in lr_scheduler

### DIFF
--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -118,6 +118,7 @@ class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetr
             factor=factor,
             patience=patience,
             verbose=verbose,
+            threshold_mode=threshold_mode, 
             threshold=threshold,
             cooldown=cooldown,
             min_lr=min_lr,

--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -122,5 +122,6 @@ class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetr
             threshold=threshold,
             cooldown=cooldown,
             min_lr=min_lr,
+            eps=eps
         )
         super().__init__(lr_scheduler)

--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -122,6 +122,6 @@ class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetr
             threshold=threshold,
             cooldown=cooldown,
             min_lr=min_lr,
-            eps=eps
+            eps=eps,
         )
         super().__init__(lr_scheduler)

--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -118,7 +118,7 @@ class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetr
             factor=factor,
             patience=patience,
             verbose=verbose,
-            threshold_mode=threshold_mode, 
+            threshold_mode=threshold_mode,
             threshold=threshold,
             cooldown=cooldown,
             min_lr=min_lr,


### PR DESCRIPTION
Just now, I found the `eps` is also missed in the initialization of `ReduceOnPlateauLearningRateScheduler.lr_scheduler`. 
Now, I think all the parameters here are being used.  