### PR TITLE
remove verbose mode of linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ version :
 
 .PHONY : lint
 lint :
-	flake8 -v ./scripts $(SRC)
-	black -v --check ./scripts $(SRC)
+	flake8 ./scripts $(SRC)
+	black --check ./scripts $(SRC)
 
 .PHONY : typecheck
 typecheck :


### PR DESCRIPTION
I feel like with `-v` it takes more effort to figure out what the issue is when one of the linters complains. For example, in [this run](https://github.com/allenai/allennlp/pull/4175/checks?check_run_id=633723168) you have to scroll up throw the output just to find which file black is complaining about.