### PR TITLE
add missing param 'eps' in `ReduceOnPlateauLearningRateScheduler`

### DIFF
--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -122,5 +122,6 @@ class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetr
             threshold=threshold,
             cooldown=cooldown,
             min_lr=min_lr,
+            eps=eps,
         )
         super().__init__(lr_scheduler)


### PR DESCRIPTION
(retry)
Just now, I found the `eps` is also missed in the initialization of `ReduceOnPlateauLearningRateScheduler.lr_scheduler`. 
Now, I think all the parameters here are being used.  