### PR TITLE
Ensure docs can build in PR workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,6 +46,10 @@ jobs:
       run: |
         make test-with-cov
 
+    - name: Ensure docs can build
+      run: |
+        make build-docs
+
     - name: Upload coverage to Codecov
       if: matrix.python == '3.7'
       env:


### PR DESCRIPTION
This will also help verify that dev dependency upgrades don't break the doc building process: https://github.com/allenai/allennlp/pull/4174