### PR TITLE
update GPU checks CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   gpu_checks:
     name: GPU Checks
+    if: github.repository == 'allenai/allennlp'  # self-hosted runner only available on main repo
     runs-on: [self-hosted, GPU]
 
     steps:


### PR DESCRIPTION
Adds a condition to only run GPU checks on main repo and PRs to main repo so that the workflows will work for forks that have GitHub Actions enabled.