### PR TITLE
Separate linting from formatting in CI, always run all steps of workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -62,15 +62,23 @@ jobs:
       run: |
         pip freeze
 
+    - name: Format
+      if: always()
+      run: |
+        make format
+
     - name: Lint
+      if: always()
       run: |
         make lint
 
     - name: Type check
+      if: always()
       run: |
         make typecheck
 
     - name: Run tests
+      if: always()
       run: |
         make test-with-cov
 
@@ -233,6 +241,10 @@ jobs:
     - name: Install core package
       run: |
         pip install $(ls dist/*.whl)
+
+    - name: Pip freeze
+      run: |
+        pip freeze
 
     - name: Test install
       run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,19 +49,28 @@ jobs:
       run: |
         pip freeze
 
+    - name: Format
+      if: always()
+      run: |
+        make format
+
     - name: Lint
+      if: always()
       run: |
         make lint
 
     - name: Type check
+      if: always()
       run: |
         make typecheck
 
     - name: Run tests
+      if: always()
       run: |
         make test-with-cov
 
     - name: Ensure docs can build
+      if: always()
       run: |
         make build-docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@ Once you open a pull request, our [continuous build system](https://github.com/a
 You can run all of these checks locally using the following `make` commands:
 
 * `make test`: Runs [`pytest`](https://docs.pytest.org/en/latest/) on all unit tests.
-* `make lint`: Runs [`flake8`](http://flake8.pycqa.org/) to check code style and [`black`](https://black.readthedocs.io) to check code formatting.
+* `make format`: Runs [`black`](https://black.readthedocs.io) to check code formatting.
+* `make lint`: Runs [`flake8`](http://flake8.pycqa.org/) to lint the code.
 * `make typecheck`: Runs [`mypy`](http://mypy-lang.org/) to typecheck the code.
 * `make build-docs`: Ensures the docs can be generated successfully.
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ version :
 .PHONY : lint
 lint :
 	flake8 ./scripts $(SRC)
+
+.PHONY : format
+format :
 	black --check ./scripts $(SRC)
 
 .PHONY : typecheck


### PR DESCRIPTION
I think it's more clear if we separate flake8 linting from black formatting into two separate steps of the CI workflow. This also ensures all steps of the "Check Core" workflow run even if one fails.