### PR TITLE
[PROPOSAL] Switch to pytest style test classes, use plain asserts

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -117,7 +117,6 @@ jobs:
       run: |
         git clone https://github.com/allenai/allennlp-models.git
         cd allennlp-models
-        git checkout test-case  # TODO remove this line
         pip install --upgrade --upgrade-strategy eager -e . -r dev-requirements.txt
 
     - name: Run models tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -116,7 +116,9 @@ jobs:
         ALLENNLP_VERSION_OVERRIDE: ""  # Don't replace the core library.
       run: |
         git clone https://github.com/allenai/allennlp-models.git
-        cd allennlp-models && pip install --upgrade --upgrade-strategy eager -e . -r dev-requirements.txt
+        cd allennlp-models
+        git checkout test-case  # TODO remove this line
+        pip install --upgrade --upgrade-strategy eager -e . -r dev-requirements.txt
 
     - name: Run models tests
       run: |

--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -61,7 +61,7 @@ class AllenNlpTestCase:
 
 _available_devices = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 
-multi_device = pytest.mark.parametrize("device", _available_devices)
+multi_device = lambda f: pytest.mark.parametrize("device", _available_devices)(pytest.mark.gpu(f))
 """
 Decorator that provides an argument `device` of type `str` for each available PyTorch device.
 """

--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -3,17 +3,17 @@ import os
 import pathlib
 import shutil
 import tempfile
-from typing import Any, Iterable
-from unittest import TestCase, mock
+from unittest import mock
 
 import torch
+import pytest
 
 from allennlp.common.checks import log_pytorch_version_info
 
 TEST_DIR = tempfile.mkdtemp(prefix="allennlp_tests")
 
 
-class AllenNlpTestCase(TestCase):
+class AllenNlpTestCase:
     """
     A custom subclass of `unittest.TestCase` that disables some of the more verbose AllenNLP
     logging and that creates and destroys a temp directory as a test fixture.
@@ -25,7 +25,7 @@ class AllenNlpTestCase(TestCase):
     TESTS_ROOT = MODULE_ROOT / "tests"
     FIXTURES_ROOT = TESTS_ROOT / "fixtures"
 
-    def setUp(self):
+    def setup_method(self):
         logging.basicConfig(
             format="%(asctime)s - %(levelname)s - %(name)s - %(message)s", level=logging.DEBUG
         )
@@ -54,37 +54,14 @@ class AllenNlpTestCase(TestCase):
         )
         self.mock_cleanup_archive_dir = self.patcher.start()
 
-    def tearDown(self):
+    def teardown_method(self):
         shutil.rmtree(self.TEST_DIR)
         self.patcher.stop()
 
 
-def parametrize(arg_names: Iterable[str], arg_values: Iterable[Iterable[Any]]):
-    """
-    Decorator to create parameterized tests.
-
-    # Parameters
-
-    arg_names : `Iterable[str]`, required.
-        Argument names to pass to the test function.
-    arg_values : `Iterable[Iterable[Any]]`, required.
-        Iterable of values to pass to each of the args.
-        The decorated test will be run for each inner iterable.
-    """
-
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            for arg_value in arg_values:
-                kwargs_extra = {name: value for name, value in zip(arg_names, arg_value)}
-                func(*args, **kwargs, **kwargs_extra)
-
-        return wrapper
-
-    return decorator
-
-
 _available_devices = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
-multi_device = parametrize(("device",), [(device,) for device in _available_devices])
+
+multi_device = pytest.mark.parametrize("device", _available_devices)
 """
 Decorator that provides an argument `device` of type `str` for each available PyTorch device.
 """

--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -61,7 +61,9 @@ class AllenNlpTestCase:
 
 _available_devices = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 
-multi_device = lambda f: pytest.mark.parametrize("device", _available_devices)(pytest.mark.gpu(f))
-"""
-Decorator that provides an argument `device` of type `str` for each available PyTorch device.
-"""
+
+def multi_device(test_method):
+    """
+    Decorator that provides an argument `device` of type `str` for each available PyTorch device.
+    """
+    return pytest.mark.parametrize("device", _available_devices)(pytest.mark.gpu(test_method))

--- a/allennlp/tests/commands/docstring_help_test.py
+++ b/allennlp/tests/commands/docstring_help_test.py
@@ -42,20 +42,16 @@ class TestDocstringHelp(AllenNlpTestCase):
                 subcommand = match.group(2)
                 actual_output = _subcommand_help_output(subcommand)
 
-                self.assertEqual(
-                    expected_output,
-                    actual_output,
+                assert expected_output == actual_output, (
                     f"The documentation for the subcommand usage"
                     f" in the module {module_info.name}"
                     f" does not match the output of running"
                     f" `{str_call_subcommand_help}`."
                     f" Please update the docstring to match the"
-                    f" output.",
+                    f" output."
                 )
             else:
-                self.assertIn(
-                    module_info.name,
-                    [parent_module.__name__ + ".subcommand"],
+                assert module_info.name in [parent_module.__name__ + ".subcommand"], (
                     f"The documentation for the subcommand usage was not found within the docstring of"
                     f" the module {module_info.name}",
                 )

--- a/allennlp/tests/commands/evaluate_test.py
+++ b/allennlp/tests/commands/evaluate_test.py
@@ -4,6 +4,7 @@ from typing import Iterator, List, Dict
 
 import torch
 from flaky import flaky
+import pytest
 
 from allennlp.commands.evaluate import evaluate_from_args, Evaluate, evaluate
 from allennlp.common.testing import AllenNlpTestCase
@@ -32,8 +33,8 @@ class DummyModel(Model):
 
 
 class TestEvaluate(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
 
         self.parser = argparse.ArgumentParser(description="Testing")
         subparsers = self.parser.add_subparsers(title="Commands", metavar="")
@@ -44,7 +45,7 @@ class TestEvaluate(AllenNlpTestCase):
         outputs = [{"loss": torch.Tensor([loss])} for loss in losses]
         data_loader = DummyDataLoader(outputs)
         metrics = evaluate(DummyModel(), data_loader, -1, "")
-        self.assertAlmostEqual(metrics["loss"], 8.0)
+        assert metrics["loss"] == pytest.approx(8.0)
 
     def test_evaluate_calculates_average_loss_with_weights(self):
         losses = [7.0, 9.0, 8.0]
@@ -56,7 +57,7 @@ class TestEvaluate(AllenNlpTestCase):
         ]
         data_loader = DummyDataLoader(outputs)
         metrics = evaluate(DummyModel(), data_loader, -1, "batch_weight")
-        self.assertAlmostEqual(metrics["loss"], (70 + 18 + 12) / 13.5)
+        assert metrics["loss"] == pytest.approx((70 + 18 + 12) / 13.5)
 
     @flaky
     def test_evaluate_from_args(self):

--- a/allennlp/tests/commands/find_learning_rate_test.py
+++ b/allennlp/tests/commands/find_learning_rate_test.py
@@ -29,8 +29,8 @@ def is_matplotlib_installed():
 
 
 class TestFindLearningRate(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.params = lambda: Params(
             {
                 "model": {
@@ -122,12 +122,12 @@ class TestFindLearningRate(AllenNlpTestCase):
             assert args.serialization_dir == "serialization_dir"
 
         # config is required
-        with self.assertRaises(SystemExit) as cm:
+        with pytest.raises(SystemExit) as cm:
             parser.parse_args(["find-lr", "-s", "serialization_dir"])
             assert cm.exception.code == 2  # argparse code for incorrect usage
 
         # serialization dir is required
-        with self.assertRaises(SystemExit) as cm:
+        with pytest.raises(SystemExit) as cm:
             parser.parse_args(["find-lr", "path/to/params"])
             assert cm.exception.code == 2  # argparse code for incorrect usage
 
@@ -154,8 +154,8 @@ class TestFindLearningRate(AllenNlpTestCase):
 
 
 class TestSearchLearningRate(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         params = Params(
             {
                 "model": {

--- a/allennlp/tests/commands/main_test.py
+++ b/allennlp/tests/commands/main_test.py
@@ -23,10 +23,10 @@ class TestMain(AllenNlpTestCase):
             "--silent",
         ]
 
-        with self.assertRaises(SystemExit) as cm:
+        with pytest.raises(SystemExit) as cm:
             main()
 
-        assert cm.exception.code == 2  # argparse code for incorrect usage
+        assert cm.value.code == 2  # argparse code for incorrect usage
 
     def test_subcommand_overrides(self):
         called = False
@@ -134,9 +134,9 @@ class TestMain(AllenNlpTestCase):
         sys.argv = ["allennlp"]
 
         available_plugins = set(discover_plugins())
-        self.assertSetEqual(set(), available_plugins)
+        assert available_plugins == set()
 
         with pushd(plugins_root):
             main()
             subcommands_available = Subcommand.list_available()
-            self.assertIn("d", subcommands_available)
+            assert "d" in subcommands_available

--- a/allennlp/tests/commands/predict_test.py
+++ b/allennlp/tests/commands/predict_test.py
@@ -21,8 +21,8 @@ from allennlp.predictors import Predictor, TextClassifierPredictor
 
 
 class TestPredict(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.classifier_model_path = (
             self.FIXTURES_ROOT / "basic_classifier" / "serialization" / "model.tar.gz"
         )
@@ -215,7 +215,7 @@ class TestPredict(AllenNlpTestCase):
             "--predictor",
             "test-predictor",
         ]
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             main()
 
     def test_base_predictor(self):
@@ -296,10 +296,10 @@ class TestPredict(AllenNlpTestCase):
             "/path/to/archive",
         ]  # executable  # command  # archive, but no input file
 
-        with self.assertRaises(SystemExit) as cm:
+        with pytest.raises(SystemExit) as cm:
             main()
 
-        assert cm.exception.code == 2  # argparse code for incorrect usage
+        assert cm.value.code == 2  # argparse code for incorrect usage
 
     def test_can_specify_predictor(self):
         @Predictor.register("classification-explicit")

--- a/allennlp/tests/commands/print_results_test.py
+++ b/allennlp/tests/commands/print_results_test.py
@@ -11,8 +11,8 @@ from allennlp.common.testing import AllenNlpTestCase
 
 
 class TestPrintResults(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
 
         self.out_dir1 = pathlib.Path(tempfile.mkdtemp(prefix="hi"))
         self.out_dir2 = pathlib.Path(tempfile.mkdtemp(prefix="hi"))

--- a/allennlp/tests/commands/train_test.py
+++ b/allennlp/tests/commands/train_test.py
@@ -402,12 +402,12 @@ class TestTrain(AllenNlpTestCase):
             assert args.serialization_dir == "serialization_dir"
 
         # config is required
-        with self.assertRaises(SystemExit) as cm:
+        with pytest.raises(SystemExit) as cm:
             args = parser.parse_args(["train", "-s", "serialization_dir"])
             assert cm.exception.code == 2  # argparse code for incorrect usage
 
         # serialization dir is required
-        with self.assertRaises(SystemExit) as cm:
+        with pytest.raises(SystemExit) as cm:
             args = parser.parse_args(["train", "path/to/params"])
             assert cm.exception.code == 2  # argparse code for incorrect usage
 
@@ -534,8 +534,8 @@ class TestTrainOnLazyDataset(AllenNlpTestCase):
 
 
 class TestDryRun(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
 
         self.params = Params(
             {

--- a/allennlp/tests/common/file_utils_test.py
+++ b/allennlp/tests/common/file_utils_test.py
@@ -51,8 +51,8 @@ def set_up_glove(url: str, byt: bytes, change_etag_every: int = 1000):
 
 
 class TestFileUtils(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.glove_file = self.FIXTURES_ROOT / "embeddings/glove.6B.100d.sample.txt.gz"
         with open(self.glove_file, "rb") as glove:
             self.glove_bytes = glove.read()

--- a/allennlp/tests/common/logging_test.py
+++ b/allennlp/tests/common/logging_test.py
@@ -7,8 +7,8 @@ from allennlp.common.testing import AllenNlpTestCase
 
 
 class TestLogging(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         logger = logging.getLogger(str(random.random()))
         self.test_log_file = os.path.join(self.TEST_DIR, "test.log")
         logger.addHandler(logging.FileHandler(self.test_log_file))

--- a/allennlp/tests/common/plugins_test.py
+++ b/allennlp/tests/common/plugins_test.py
@@ -11,22 +11,22 @@ from allennlp.common.util import pushd
 
 class TestPlugins(AllenNlpTestCase):
     @overrides
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.plugins_root = self.FIXTURES_ROOT / "plugins"
 
     def test_no_plugins(self):
         available_plugins = set(discover_plugins())
-        self.assertSetEqual(set(), available_plugins)
+        assert available_plugins == set()
 
     def test_file_plugin(self):
         available_plugins = set(discover_plugins())
-        self.assertSetEqual(set(), available_plugins)
+        assert available_plugins == set()
 
         with pushd(self.plugins_root):
             available_plugins = set(discover_plugins())
-            self.assertSetEqual({"d"}, available_plugins)
+            assert available_plugins == {"d"}
 
             import_plugins()
             subcommands_available = Subcommand.list_available()
-            self.assertIn("d", subcommands_available)
+            assert "d" in subcommands_available

--- a/allennlp/tests/common/testing.py
+++ b/allennlp/tests/common/testing.py
@@ -2,18 +2,14 @@ import torch
 
 from allennlp.common.testing import AllenNlpTestCase, multi_device
 
+actual_devices = set()
+
 
 class TestTesting(AllenNlpTestCase):
-    def test_multi_device(self):
-        actual_devices = set()
+    @multi_device
+    def test_multi_device(self, device: str):
+        actual_devices.add(device)
 
-        @multi_device
-        def dummy_func(_self, device: str):
-            # Have `self` as in class test functions.
-            nonlocal actual_devices
-            actual_devices.add(device)
-
-        dummy_func(self)
-
+    def test_devices_accounted_for(self):
         expected_devices = {"cpu", "cuda"} if torch.cuda.is_available() else {"cpu"}
-        self.assertSetEqual(expected_devices, actual_devices)
+        assert expected_devices == actual_devices

--- a/allennlp/tests/data/dataset_readers/dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_reader_test.py
@@ -7,12 +7,13 @@ from allennlp.data.dataset_readers import TextClassificationJsonReader
 from allennlp.data.dataset_readers.dataset_reader import _LazyInstances
 
 
-class TestDatasetReader:
-    cache_directory = str(AllenNlpTestCase.FIXTURES_ROOT / "data_cache" / "with_prefix")
+class TestDatasetReader(AllenNlpTestCase):
+    def setup_method(self):
+        super().setup_method()
+        self.cache_directory = str(AllenNlpTestCase.FIXTURES_ROOT / "data_cache" / "with_prefix")
 
-    @pytest.fixture(autouse=True)
-    def cache_directory_fixture(self):
-        yield self.cache_directory
+    def teardown_method(self):
+        super().teardown_method()
         if os.path.exists(self.cache_directory):
             shutil.rmtree(self.cache_directory)
 

--- a/allennlp/tests/data/dataset_readers/dataset_utils/span_utils_test.py
+++ b/allennlp/tests/data/dataset_readers/dataset_utils/span_utils_test.py
@@ -1,4 +1,5 @@
 from typing import List
+import pytest
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data.dataset_readers.dataset_utils import span_utils
@@ -19,7 +20,7 @@ class SpanUtilsTest(AllenNlpTestCase):
 
         # Check that it raises when we use U- tags for single tokens.
         tag_sequence = ["O", "B-ARG1", "I-ARG1", "O", "B-ARG2", "I-ARG2", "U-ARG1", "U-ARG2"]
-        with self.assertRaises(span_utils.InvalidTagSequence):
+        with pytest.raises(span_utils.InvalidTagSequence):
             spans = span_utils.bio_tags_to_spans(tag_sequence)
 
         # Check that invalid BIO sequences are also handled as spans.
@@ -51,7 +52,7 @@ class SpanUtilsTest(AllenNlpTestCase):
 
         # Check that it raises when we use U- tags for single tokens.
         tag_sequence = ["O", "B", "I", "O", "B", "I", "U", "U"]
-        with self.assertRaises(span_utils.InvalidTagSequence):
+        with pytest.raises(span_utils.InvalidTagSequence):
             spans = span_utils.bio_tags_to_spans(tag_sequence)
 
         # Check that invalid BIO sequences are also handled as spans.
@@ -82,7 +83,7 @@ class SpanUtilsTest(AllenNlpTestCase):
 
         # Check that it raises when we use U- tags for single tokens.
         tag_sequence = ["O", "B", "I", "O", "B", "I", "U", "U"]
-        with self.assertRaises(span_utils.InvalidTagSequence):
+        with pytest.raises(span_utils.InvalidTagSequence):
             spans = span_utils.iob1_tags_to_spans(tag_sequence)
 
         # Check that invalid IOB1 sequences are also handled as spans.
@@ -103,7 +104,7 @@ class SpanUtilsTest(AllenNlpTestCase):
 
         # Check that it raises when we use U- tags for single tokens.
         tag_sequence = ["O", "B-ARG1", "I-ARG1", "O", "B-ARG2", "I-ARG2", "U-ARG1", "U-ARG2"]
-        with self.assertRaises(span_utils.InvalidTagSequence):
+        with pytest.raises(span_utils.InvalidTagSequence):
             spans = span_utils.iob1_tags_to_spans(tag_sequence)
 
         # Check that invalid IOB1 sequences are also handled as spans.
@@ -175,7 +176,7 @@ class SpanUtilsTest(AllenNlpTestCase):
         assert spans == [("PER", (0, 2)), ("PER", (3, 3)), ("LOC", (4, 4))]
 
         tag_sequence = ["B-PER", "I-PER", "O"]
-        with self.assertRaises(span_utils.InvalidTagSequence):
+        with pytest.raises(span_utils.InvalidTagSequence):
             spans = span_utils.bioul_tags_to_spans(tag_sequence)
 
     def test_bioul_tags_to_spans_without_labels(self):
@@ -184,7 +185,7 @@ class SpanUtilsTest(AllenNlpTestCase):
         assert spans == [("", (0, 2)), ("", (3, 3)), ("", (4, 4))]
 
         tag_sequence = ["B", "I", "O"]
-        with self.assertRaises(span_utils.InvalidTagSequence):
+        with pytest.raises(span_utils.InvalidTagSequence):
             spans = span_utils.bioul_tags_to_spans(tag_sequence)
 
     def test_iob1_to_bioul(self):
@@ -202,7 +203,7 @@ class SpanUtilsTest(AllenNlpTestCase):
         assert bioul_sequence == ["U-ORG", "O", "U-MISC", "O", "B-MISC", "I-MISC", "L-MISC"]
 
         # Encoding in IOB format should throw error with incorrect encoding.
-        with self.assertRaises(span_utils.InvalidTagSequence):
+        with pytest.raises(span_utils.InvalidTagSequence):
             tag_sequence = ["O", "I-PER", "B-PER", "I-PER", "I-PER", "B-PER"]
             bioul_sequence = span_utils.to_bioul(tag_sequence, encoding="BIO")
 

--- a/allennlp/tests/data/dataset_readers/lazy_dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/lazy_dataset_reader_test.py
@@ -22,8 +22,8 @@ class LazyDatasetReader(DatasetReader):
 
 
 class TestLazyDatasetReader(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         token_indexer = {"tokens": SingleIdTokenIndexer()}
 
         field1 = TextField([Token(t) for t in ["this", "is", "a", "sentence", "."]], token_indexer)

--- a/allennlp/tests/data/dataset_readers/sharded_dataset_reader_test.py
+++ b/allennlp/tests/data/dataset_readers/sharded_dataset_reader_test.py
@@ -17,8 +17,8 @@ def fingerprint(instance: Instance) -> Tuple[str, ...]:
 
 
 class TestShardedDatasetReader(AllenNlpTestCase):
-    def setUp(self) -> None:
-        super().setUp()
+    def setup_method(self) -> None:
+        super().setup_method()
 
         # use SequenceTaggingDatasetReader as the base reader
         self.base_reader = SequenceTaggingDatasetReader(lazy=True)

--- a/allennlp/tests/data/dataset_test.py
+++ b/allennlp/tests/data/dataset_test.py
@@ -10,7 +10,7 @@ from allennlp.data.token_indexers import SingleIdTokenIndexer
 
 
 class TestDataset(AllenNlpTestCase):
-    def setUp(self):
+    def setup_method(self):
         self.vocab = Vocabulary()
         self.vocab.add_token_to_namespace("this")
         self.vocab.add_token_to_namespace("is")
@@ -19,7 +19,7 @@ class TestDataset(AllenNlpTestCase):
         self.vocab.add_token_to_namespace(".")
         self.token_indexer = {"tokens": SingleIdTokenIndexer()}
         self.instances = self.get_instances()
-        super().setUp()
+        super().setup_method()
 
     def test_instances_must_have_homogeneous_fields(self):
         instance1 = Instance({"tag": (LabelField(1, skip_indexing=True))})

--- a/allennlp/tests/data/fields/adjacency_field_test.py
+++ b/allennlp/tests/data/fields/adjacency_field_test.py
@@ -8,8 +8,8 @@ from allennlp.data import Vocabulary, Token
 
 
 class TestAdjacencyField(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.text = TextField(
             [Token(t) for t in ["here", "is", "a", "sentence", "."]],
             {"words": SingleIdTokenIndexer("words")},

--- a/allennlp/tests/data/fields/index_field_test.py
+++ b/allennlp/tests/data/fields/index_field_test.py
@@ -9,8 +9,8 @@ from allennlp.data.token_indexers import SingleIdTokenIndexer
 
 
 class TestIndexField(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.text = TextField(
             [Token(t) for t in ["here", "is", "a", "sentence", "."]],
             {"words": SingleIdTokenIndexer("words")},

--- a/allennlp/tests/data/fields/list_field_test.py
+++ b/allennlp/tests/data/fields/list_field_test.py
@@ -37,7 +37,7 @@ class DummyModel(Model):
 
 
 class TestListField(AllenNlpTestCase):
-    def setUp(self):
+    def setup_method(self):
         self.vocab = Vocabulary()
         self.vocab.add_token_to_namespace("this", "words")
         self.vocab.add_token_to_namespace("is", "words")
@@ -83,7 +83,7 @@ class TestListField(AllenNlpTestCase):
         non_empty_fields = {"list_tensor": non_empty_list_field}
         self.non_empty_instance = Instance(non_empty_fields)
 
-        super().setUp()
+        super().setup_method()
 
     def test_get_padding_lengths(self):
         list_field = ListField([self.field1, self.field2, self.field3])

--- a/allennlp/tests/data/fields/span_field_test.py
+++ b/allennlp/tests/data/fields/span_field_test.py
@@ -8,8 +8,8 @@ from allennlp.data.token_indexers import SingleIdTokenIndexer
 
 
 class TestSpanField(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.indexers = {"words": SingleIdTokenIndexer("words")}
         self.text = TextField(
             [Token(t) for t in ["here", "is", "a", "sentence", "for", "spans", "."]], self.indexers

--- a/allennlp/tests/data/fields/text_field_test.py
+++ b/allennlp/tests/data/fields/text_field_test.py
@@ -33,7 +33,7 @@ class DictReturningTokenIndexer(TokenIndexer):
 
 
 class TestTextField(AllenNlpTestCase):
-    def setUp(self):
+    def setup_method(self):
         self.vocab = Vocabulary()
         self.vocab.add_token_to_namespace("sentence", namespace="words")
         self.vocab.add_token_to_namespace("A", namespace="words")
@@ -43,7 +43,7 @@ class TestTextField(AllenNlpTestCase):
         self.vocab.add_token_to_namespace("n", namespace="characters")
         self.vocab.add_token_to_namespace("t", namespace="characters")
         self.vocab.add_token_to_namespace("c", namespace="characters")
-        super().setUp()
+        super().setup_method()
 
     def test_field_counts_vocab_items_correctly(self):
         field = TextField(

--- a/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
+++ b/allennlp/tests/data/samplers/bucket_batch_sampler_test.py
@@ -20,8 +20,8 @@ class LazyIterable:
 
 
 class SamplerTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.token_indexers = {"tokens": SingleIdTokenIndexer()}
         self.vocab = Vocabulary()
         self.this_index = self.vocab.add_token_to_namespace("this")

--- a/allennlp/tests/data/tokenizers/letters_digits_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/letters_digits_tokenizer_test.py
@@ -4,8 +4,8 @@ from allennlp.data.tokenizers.token import Token
 
 
 class TestLettersDigitsTokenizer(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.word_tokenizer = LettersDigitsTokenizer()
 
     def test_tokenize_handles_complex_punctuation(self):

--- a/allennlp/tests/data/tokenizers/sentence_splitter_test.py
+++ b/allennlp/tests/data/tokenizers/sentence_splitter_test.py
@@ -3,8 +3,8 @@ from allennlp.data.tokenizers.sentence_splitter import SpacySentenceSplitter
 
 
 class TestSentenceSplitter(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.dep_parse_splitter = SpacySentenceSplitter(rule_based=False)
         self.rule_based_splitter = SpacySentenceSplitter(rule_based=True)
 

--- a/allennlp/tests/data/tokenizers/spacy_tokenizer_test.py
+++ b/allennlp/tests/data/tokenizers/spacy_tokenizer_test.py
@@ -6,8 +6,8 @@ from allennlp.data.tokenizers.spacy_tokenizer import SpacyTokenizer
 
 
 class TestSpacyTokenizer(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.word_tokenizer = SpacyTokenizer()
 
     def test_tokenize_handles_complex_punctuation(self):

--- a/allennlp/tests/data/vocabulary_test.py
+++ b/allennlp/tests/data/vocabulary_test.py
@@ -25,7 +25,7 @@ from allennlp.modules.token_embedders.embedding import format_embeddings_file_ur
 
 
 class TestVocabulary(AllenNlpTestCase):
-    def setUp(self):
+    def setup_method(self):
         token_indexer = SingleIdTokenIndexer("tokens")
         text_field = TextField(
             [Token(t) for t in ["a", "a", "a", "a", "b", "b", "c", "c", "c"]],
@@ -33,7 +33,7 @@ class TestVocabulary(AllenNlpTestCase):
         )
         self.instance = Instance({"text": text_field})
         self.dataset = Batch([self.instance])
-        super().setUp()
+        super().setup_method()
 
     def test_pickling(self):
         vocab = Vocabulary.from_instances(self.dataset)

--- a/allennlp/tests/models/archival_test.py
+++ b/allennlp/tests/models/archival_test.py
@@ -27,8 +27,8 @@ def assert_models_equal(model, model2):
 
 
 class ArchivalTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
 
         self.params = Params(
             {

--- a/allennlp/tests/models/basic_classifier_test.py
+++ b/allennlp/tests/models/basic_classifier_test.py
@@ -4,8 +4,8 @@ from allennlp.common.testing import ModelTestCase
 
 
 class TestBasicClassifier(ModelTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.set_up_model(
             self.FIXTURES_ROOT / "basic_classifier" / "experiment_seq2vec.jsonnet",
             self.FIXTURES_ROOT / "data" / "text_classification_json" / "imdb_corpus.jsonl",

--- a/allennlp/tests/models/simple_tagger_test.py
+++ b/allennlp/tests/models/simple_tagger_test.py
@@ -13,8 +13,8 @@ from allennlp.training import GradientDescentTrainer, Trainer
 
 
 class SimpleTaggerTest(ModelTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.set_up_model(
             self.FIXTURES_ROOT / "simple_tagger" / "experiment.json",
             self.FIXTURES_ROOT / "data" / "sequence_tagging.tsv",
@@ -71,8 +71,8 @@ class SimpleTaggerTest(ModelTestCase):
 
 
 class SimpleTaggerSpanF1Test(ModelTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.set_up_model(
             self.FIXTURES_ROOT / "simple_tagger_with_span_f1" / "experiment.json",
             self.FIXTURES_ROOT / "data" / "conll2003.txt",
@@ -87,8 +87,8 @@ class SimpleTaggerSpanF1Test(ModelTestCase):
 
 
 class SimpleTaggerRegularizationTest(ModelTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         param_file = self.FIXTURES_ROOT / "simple_tagger" / "experiment_with_regularization.json"
         self.set_up_model(param_file, self.FIXTURES_ROOT / "data" / "sequence_tagging.tsv")
         params = Params.from_file(param_file)

--- a/allennlp/tests/models/test_model_test_case.py
+++ b/allennlp/tests/models/test_model_test_case.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 from allennlp.common.testing import ModelTestCase
 
@@ -9,8 +10,8 @@ class ModelWithIncorrectValidationMetricTest(ModelTestCase):
     in `ensure_model_can_train_save_and_load`
     """
 
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.set_up_model(
             self.FIXTURES_ROOT / "simple_tagger" / "model_test_case.jsonnet",
             self.FIXTURES_ROOT / "data" / "sequence_tagging.tsv",
@@ -18,7 +19,7 @@ class ModelWithIncorrectValidationMetricTest(ModelTestCase):
 
     def test_01_test_validation_metric_does_not_exist(self):
         overrides = {"trainer.num_epochs": 2}
-        self.assertRaises(
+        pytest.raises(
             AssertionError,
             self.ensure_model_can_train_save_and_load,
             self.param_file,
@@ -28,7 +29,7 @@ class ModelWithIncorrectValidationMetricTest(ModelTestCase):
         )
 
     def test_02a_test_validation_metric_terminal_value_not_set(self):
-        self.assertRaises(
+        pytest.raises(
             AssertionError,
             self.ensure_model_can_train_save_and_load,
             self.param_file,
@@ -37,7 +38,7 @@ class ModelWithIncorrectValidationMetricTest(ModelTestCase):
         )
 
     def test_02b_test_validation_metric_terminal_value_not_met(self):
-        self.assertRaises(
+        pytest.raises(
             AssertionError,
             self.ensure_model_can_train_save_and_load,
             self.param_file,

--- a/allennlp/tests/modules/augmented_lstm_test.py
+++ b/allennlp/tests/modules/augmented_lstm_test.py
@@ -14,8 +14,8 @@ from allennlp.nn.util import sort_batch_by_length
 
 
 class TestAugmentedLSTM(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         tensor = torch.rand([5, 7, 10])
         tensor[0, 3:, :] = 0
         tensor[1, 4:, :] = 0

--- a/allennlp/tests/modules/conditional_random_field_test.py
+++ b/allennlp/tests/modules/conditional_random_field_test.py
@@ -12,8 +12,8 @@ from allennlp.common.testing import AllenNlpTestCase
 
 
 class TestConditionalRandomField(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.logits = torch.Tensor(
             [
                 [[0, 0, 0.5, 0.5, 0.2], [0, 0, 0.3, 0.3, 0.1], [0, 0, 0.9, 10, 1]],

--- a/allennlp/tests/modules/elmo_test.py
+++ b/allennlp/tests/modules/elmo_test.py
@@ -24,8 +24,8 @@ with warnings.catch_warnings():
 
 
 class ElmoTestCase(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.elmo_fixtures_path = self.FIXTURES_ROOT / "elmo"
         self.options_file = str(self.elmo_fixtures_path / "options.json")
         self.weight_file = str(self.elmo_fixtures_path / "lm_weights.hdf5")
@@ -113,17 +113,15 @@ class TestElmoBiLm(ElmoTestCase):
             lengths = mask.data.numpy().sum(axis=1)
             batch_sentences = [sentences[k][i] for k in range(3)]
             expected_lengths = [len(sentence.split()) for sentence in batch_sentences]
-            self.assertEqual(lengths.tolist(), expected_lengths)
+            assert lengths.tolist() == expected_lengths
 
             # get the expected embeddings and compare!
             expected_top_layer = [expected_lm_embeddings[k][i] for k in range(3)]
             for k in range(3):
-                self.assertTrue(
-                    numpy.allclose(
-                        top_layer_embeddings[k, : lengths[k], :].data.numpy(),
-                        expected_top_layer[k],
-                        atol=1.0e-6,
-                    )
+                assert numpy.allclose(
+                    top_layer_embeddings[k, : lengths[k], :].data.numpy(),
+                    expected_top_layer[k],
+                    atol=1.0e-6,
                 )
 
     def test_elmo_char_cnn_cache_does_not_raise_error_for_uncached_words(self):
@@ -164,8 +162,8 @@ class TestElmoBiLm(ElmoTestCase):
 
 
 class TestElmo(ElmoTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
 
         self.elmo = Elmo(self.options_file, self.weight_file, 2, dropout=0.0)
 

--- a/allennlp/tests/modules/encoder_base_test.py
+++ b/allennlp/tests/modules/encoder_base_test.py
@@ -9,8 +9,8 @@ from allennlp.nn.util import sort_batch_by_length, get_lengths_from_binary_seque
 
 
 class TestEncoderBase(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.lstm = LSTM(
             bidirectional=True, num_layers=3, input_size=3, hidden_size=7, batch_first=True
         )
@@ -267,7 +267,7 @@ class TestEncoderBase(AllenNlpTestCase):
 
         # Check that error is raised if mask has wrong batch size.
         bad_mask = torch.tensor([True, True, False])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.encoder_base.reset_states(bad_mask)
 
         # Check that states are reset to None if no mask is provided.

--- a/allennlp/tests/modules/feedforward_test.py
+++ b/allennlp/tests/modules/feedforward_test.py
@@ -100,4 +100,4 @@ class TestFeedForward(AllenNlpTestCase):
         )
         actual_text_representation = str(feedforward)
 
-        self.assertEqual(actual_text_representation, expected_text_representation)
+        assert actual_text_representation == expected_text_representation

--- a/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
+++ b/allennlp/tests/modules/seq2seq_encoders/compose_encoder_test.py
@@ -1,6 +1,7 @@
 import torch
 import numpy
 from overrides import overrides
+import pytest
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.modules.seq2seq_encoders import ComposeEncoder, FeedForwardEncoder, Seq2SeqEncoder
@@ -40,8 +41,8 @@ def _make_feedforward(input_dim, output_dim):
 
 
 class TestPassThroughEncoder(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.encoder = ComposeEncoder(
             [_make_feedforward(9, 5), _make_feedforward(5, 10), _make_feedforward(10, 3)]
         )
@@ -74,11 +75,11 @@ class TestPassThroughEncoder(AllenNlpTestCase):
         )
 
     def test_empty(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ComposeEncoder([])
 
     def test_mismatched_size(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ComposeEncoder(
                 [
                     MockSeq2SeqEncoder(input_dim=9, output_dim=5),
@@ -87,7 +88,7 @@ class TestPassThroughEncoder(AllenNlpTestCase):
             )
 
     def test_mismatched_bidirectionality(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ComposeEncoder(
                 [
                     MockSeq2SeqEncoder(input_dim=9, output_dim=5),

--- a/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
+++ b/allennlp/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
@@ -9,8 +9,8 @@ from allennlp.common.testing import AllenNlpTestCase
 
 
 class TestBasicTextFieldEmbedder(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.vocab = Vocabulary()
         self.vocab.add_token_to_namespace("1")
         self.vocab.add_token_to_namespace("2")

--- a/allennlp/tests/modules/token_embedders/bag_of_word_counts_token_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/bag_of_word_counts_token_embedder_test.py
@@ -10,8 +10,8 @@ from allennlp.modules.token_embedders import BagOfWordCountsTokenEmbedder
 
 
 class TestBagOfWordCountsTokenEmbedder(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.vocab = Vocabulary()
         self.vocab.add_token_to_namespace("1")
         self.vocab.add_token_to_namespace("2")

--- a/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
+++ b/allennlp/tests/modules/token_embedders/elmo_token_embedder_test.py
@@ -7,8 +7,8 @@ from allennlp.modules.token_embedders import ElmoTokenEmbedder
 
 
 class TestElmoTokenEmbedder(ModelTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.set_up_model(
             self.FIXTURES_ROOT / "elmo" / "config" / "characters_token_embedder.json",
             self.FIXTURES_ROOT / "data" / "conll2003.txt",

--- a/allennlp/tests/modules/token_embedders/token_characters_encoder_test.py
+++ b/allennlp/tests/modules/token_embedders/token_characters_encoder_test.py
@@ -13,8 +13,8 @@ from allennlp.common.testing import AllenNlpTestCase
 
 
 class TestTokenCharactersEncoder(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.vocab = Vocabulary()
         self.vocab.add_token_to_namespace("1", "token_characters")
         self.vocab.add_token_to_namespace("2", "token_characters")

--- a/allennlp/tests/nn/beam_search_test.py
+++ b/allennlp/tests/nn/beam_search_test.py
@@ -44,8 +44,8 @@ def take_step(
 
 
 class BeamSearchTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.end_index = transition_probabilities.size()[0] - 1
         self.beam_search = BeamSearch(self.end_index, max_steps=10, beam_size=3)
 

--- a/allennlp/tests/nn/initializers_test.py
+++ b/allennlp/tests/nn/initializers_test.py
@@ -15,8 +15,8 @@ from allennlp.common.params import Params
 
 
 class TestInitializers(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         logging.getLogger("allennlp.nn.initializers").disabled = False
 
     def tearDown(self):

--- a/allennlp/tests/nn/pretrained_model_initializer_test.py
+++ b/allennlp/tests/nn/pretrained_model_initializer_test.py
@@ -31,8 +31,8 @@ class _Net2(torch.nn.Module):
 
 
 class TestPretrainedModelInitializer(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.net1 = _Net1()
         self.net2 = _Net2()
         self.temp_file = self.TEST_DIR / "weights.th"
@@ -116,7 +116,7 @@ class TestPretrainedModelInitializer(AllenNlpTestCase):
         assert self.net2.linear_1.weight.is_cuda is True
         assert self.net2.linear_1.bias.is_cuda is True
 
-        # We need to manually save the parameters to a file because setUp()
+        # We need to manually save the parameters to a file because setup_method()
         # only does it for the CPU
         temp_file = self.TEST_DIR / "gpu_weights.th"
         torch.save(self.net2.state_dict(), temp_file)
@@ -166,7 +166,7 @@ class TestPretrainedModelInitializer(AllenNlpTestCase):
         assert self.net1.linear_1.weight.is_cuda is True
         assert self.net1.linear_1.bias.is_cuda is True
 
-        # net2's parameters are already saved to CPU from setUp()
+        # net2's parameters are already saved to CPU from setup_method()
         applicator = self._get_applicator("linear_1.*", self.temp_file)
         applicator(self.net1)
 

--- a/allennlp/tests/training/learning_rate_schedulers/cosine_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers/cosine_test.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from typing import Dict, Any
 
 import torch
+import pytest
 
 from allennlp.common import Params
 from allennlp.common.checks import ConfigurationError
@@ -11,8 +12,8 @@ from allennlp.training.optimizers import Optimizer
 
 
 class CosineWithRestartsTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.model = torch.nn.Sequential(torch.nn.Linear(10, 10))
 
         # We use these cases to verify that the scheduler works as expected.
@@ -111,7 +112,7 @@ class CosineWithRestartsTest(AllenNlpTestCase):
         # Learning should be unchanged after initializing scheduler.
         assert optim.param_groups[0]["lr"] == 1.0
 
-        with self.assertRaises(ConfigurationError):
+        with pytest.raises(ConfigurationError):
             # t_initial is required.
             LearningRateScheduler.from_params(optimizer=optim, params=Params({"type": "cosine"}))
 

--- a/allennlp/tests/training/learning_rate_schedulers/learning_rate_scheduler_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers/learning_rate_scheduler_test.py
@@ -1,4 +1,5 @@
 import torch
+import pytest
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.training.optimizers import Optimizer
@@ -8,12 +9,12 @@ from allennlp.common.params import Params
 
 
 class LearningRateSchedulersTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.model = torch.nn.Sequential(torch.nn.Linear(10, 10))
 
     def test_reduce_on_plateau_error_throw_when_no_metrics_exist(self):
-        with self.assertRaises(ConfigurationError) as context:
+        with pytest.raises(ConfigurationError) as context:
             LearningRateScheduler.from_params(
                 optimizer=Optimizer.from_params(
                     model_parameters=self.model.named_parameters(), params=Params({"type": "adam"})

--- a/allennlp/tests/training/learning_rate_schedulers/learning_rate_scheduler_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers/learning_rate_scheduler_test.py
@@ -14,14 +14,15 @@ class LearningRateSchedulersTest(AllenNlpTestCase):
         self.model = torch.nn.Sequential(torch.nn.Linear(10, 10))
 
     def test_reduce_on_plateau_error_throw_when_no_metrics_exist(self):
-        with pytest.raises(ConfigurationError) as context:
+        with pytest.raises(
+            ConfigurationError, match="learning rate scheduler requires a validation metric"
+        ) as context:
             LearningRateScheduler.from_params(
                 optimizer=Optimizer.from_params(
                     model_parameters=self.model.named_parameters(), params=Params({"type": "adam"})
                 ),
                 params=Params({"type": "reduce_on_plateau"}),
             ).step(None)
-            assert "learning rate scheduler requires a validation metric" in str(context.value)
 
     def test_reduce_on_plateau_works_when_metrics_exist(self):
         LearningRateScheduler.from_params(

--- a/allennlp/tests/training/learning_rate_schedulers/learning_rate_scheduler_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers/learning_rate_scheduler_test.py
@@ -21,7 +21,7 @@ class LearningRateSchedulersTest(AllenNlpTestCase):
                 ),
                 params=Params({"type": "reduce_on_plateau"}),
             ).step(None)
-        assert "learning rate scheduler requires a validation metric" in str(context.exception)
+            assert "learning rate scheduler requires a validation metric" in str(context.value)
 
     def test_reduce_on_plateau_works_when_metrics_exist(self):
         LearningRateScheduler.from_params(

--- a/allennlp/tests/training/learning_rate_schedulers/learning_rate_scheduler_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers/learning_rate_scheduler_test.py
@@ -16,7 +16,7 @@ class LearningRateSchedulersTest(AllenNlpTestCase):
     def test_reduce_on_plateau_error_throw_when_no_metrics_exist(self):
         with pytest.raises(
             ConfigurationError, match="learning rate scheduler requires a validation metric"
-        ) as context:
+        ):
             LearningRateScheduler.from_params(
                 optimizer=Optimizer.from_params(
                     model_parameters=self.model.named_parameters(), params=Params({"type": "adam"})

--- a/allennlp/tests/training/learning_rate_schedulers/slanted_triangular_test.py
+++ b/allennlp/tests/training/learning_rate_schedulers/slanted_triangular_test.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from typing import Any, Dict, List, Tuple
 
 import torch
+import pytest
 
 from allennlp.data.dataset_readers.dataset_reader import AllennlpDataset
 from allennlp.common import Lazy, Params
@@ -45,8 +46,8 @@ def is_hat_shaped(learning_rates: List[float]):
 
 
 class SlantedTriangularTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.model = torch.nn.Sequential(
             OrderedDict([("lin1", torch.nn.Linear(10, 10)), ("lin2", torch.nn.Linear(10, 10))])
         )
@@ -181,7 +182,7 @@ class SlantedTriangularTest(AllenNlpTestCase):
         assert optim.param_groups[-2]["lr"] == 1.0 / sched.ratio
         assert optim.param_groups[-3]["lr"] == 0.5 / sched.ratio
 
-        with self.assertRaises(ConfigurationError):
+        with pytest.raises(ConfigurationError):
             # num_epochs and num_steps_per_epoch are required
             LearningRateScheduler.from_params(
                 optimizer=optim, params=Params({"type": "slanted_triangular", "num_epochs": 5})

--- a/allennlp/tests/training/metrics/attachment_scores_test.py
+++ b/allennlp/tests/training/metrics/attachment_scores_test.py
@@ -5,8 +5,8 @@ from allennlp.training.metrics import AttachmentScores
 
 
 class AttachmentScoresTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.scorer = AttachmentScores()
 
         self.predictions = torch.Tensor([[0, 1, 3, 5, 2, 4], [0, 3, 2, 1, 0, 0]])

--- a/allennlp/tests/training/metrics/bleu_test.py
+++ b/allennlp/tests/training/metrics/bleu_test.py
@@ -9,8 +9,8 @@ from allennlp.training.metrics import BLEU
 
 
 class BleuTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.metric = BLEU(ngram_weights=(0.5, 0.5), exclude_indices={0})
 
     @multi_device

--- a/allennlp/tests/training/metrics/boolean_accuracy_test.py
+++ b/allennlp/tests/training/metrics/boolean_accuracy_test.py
@@ -61,4 +61,4 @@ class BooleanAccuracyTest(AllenNlpTestCase):
     @multi_device
     def test_does_not_divide_by_zero_with_no_count(self, device: str):
         accuracy = BooleanAccuracy()
-        self.assertAlmostEqual(accuracy.get_metric(), 0.0)
+        assert accuracy.get_metric() == pytest.approx(0.0)

--- a/allennlp/tests/training/metrics/categorical_accuracy_test.py
+++ b/allennlp/tests/training/metrics/categorical_accuracy_test.py
@@ -142,4 +142,4 @@ class CategoricalAccuracyTest(AllenNlpTestCase):
     @multi_device
     def test_does_not_divide_by_zero_with_no_count(self, device: str):
         accuracy = CategoricalAccuracy()
-        self.assertAlmostEqual(accuracy.get_metric(), 0.0)
+        assert accuracy.get_metric() == pytest.approx(0.0)

--- a/allennlp/tests/training/metrics/evalb_bracketing_scorer_test.py
+++ b/allennlp/tests/training/metrics/evalb_bracketing_scorer_test.py
@@ -5,8 +5,8 @@ from allennlp.training.metrics import EvalbBracketingScorer
 
 
 class EvalbBracketingScorerTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         EvalbBracketingScorer.compile_evalb()
 
     def tearDown(self):

--- a/allennlp/tests/training/metrics/fbeta_measure_test.py
+++ b/allennlp/tests/training/metrics/fbeta_measure_test.py
@@ -3,6 +3,7 @@ from typing import List
 import torch
 from sklearn.metrics import precision_recall_fscore_support
 from torch.testing import assert_allclose
+import pytest
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.testing import AllenNlpTestCase, multi_device
@@ -10,8 +11,8 @@ from allennlp.training.metrics import FBetaMeasure
 
 
 class FBetaMeasureTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         # [0, 1, 1, 1, 3, 1]
         self.predictions = torch.tensor(
             [
@@ -45,19 +46,19 @@ class FBetaMeasureTest(AllenNlpTestCase):
     @multi_device
     def test_config_errors(self, device: str):
         # Bad beta
-        self.assertRaises(ConfigurationError, FBetaMeasure, beta=0.0)
+        pytest.raises(ConfigurationError, FBetaMeasure, beta=0.0)
 
         # Bad average option
-        self.assertRaises(ConfigurationError, FBetaMeasure, average="mega")
+        pytest.raises(ConfigurationError, FBetaMeasure, average="mega")
 
         # Empty input labels
-        self.assertRaises(ConfigurationError, FBetaMeasure, labels=[])
+        pytest.raises(ConfigurationError, FBetaMeasure, labels=[])
 
     @multi_device
     def test_runtime_errors(self, device: str):
         fbeta = FBetaMeasure()
         # Metric was never called.
-        self.assertRaises(RuntimeError, fbeta.get_metric)
+        pytest.raises(RuntimeError, fbeta.get_metric)
 
     @multi_device
     def test_fbeta_multiclass_state(self, device: str):

--- a/allennlp/tests/training/metrics/span_based_f1_measure_test.py
+++ b/allennlp/tests/training/metrics/span_based_f1_measure_test.py
@@ -1,5 +1,6 @@
 import torch
 from torch.testing import assert_allclose
+import pytest
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.params import Params
@@ -9,8 +10,8 @@ from allennlp.training.metrics import SpanBasedF1Measure, Metric
 
 
 class SpanBasedF1Test(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         vocab = Vocabulary()
         vocab.add_token_to_namespace("O", "tags")
         vocab.add_token_to_namespace("B-ARG1", "tags")
@@ -241,9 +242,9 @@ class SpanBasedF1Test(AllenNlpTestCase):
         assert_allclose(metric_dict["precision-overall"], 1.0)
         assert_allclose(metric_dict["f1-measure-overall"], 1.0)
 
-        with self.assertRaises(ConfigurationError):
+        with pytest.raises(ConfigurationError):
             SpanBasedF1Measure(self.vocab, label_encoding="INVALID")
-        with self.assertRaises(ConfigurationError):
+        with pytest.raises(ConfigurationError):
             SpanBasedF1Measure(self.vocab, tags_to_spans_function=mock_tags_to_spans_function)
-        with self.assertRaises(ConfigurationError):
+        with pytest.raises(ConfigurationError):
             SpanBasedF1Measure(self.vocab, label_encoding=None, tags_to_spans_function=None)

--- a/allennlp/tests/training/momentum_schedulers/inverted_triangular_test.py
+++ b/allennlp/tests/training/momentum_schedulers/inverted_triangular_test.py
@@ -8,8 +8,8 @@ from allennlp.training.optimizers import Optimizer
 
 
 class InvertedTriangularTest(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.model = torch.nn.Sequential(torch.nn.Linear(10, 10))
         self.base_momentum = 0.9
 

--- a/allennlp/tests/training/no_op_trainer_test.py
+++ b/allennlp/tests/training/no_op_trainer_test.py
@@ -16,8 +16,8 @@ class ConstantModel(Model):
 
 
 class TestNoOpTrainer(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.instances = SequenceTaggingDatasetReader().read(
             self.FIXTURES_ROOT / "data" / "sequence_tagging.tsv"
         )

--- a/allennlp/tests/training/optimizer_test.py
+++ b/allennlp/tests/training/optimizer_test.py
@@ -9,8 +9,8 @@ from allennlp.training.optimizers import Optimizer
 
 
 class TestOptimizer(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.instances = SequenceTaggingDatasetReader().read(
             self.FIXTURES_ROOT / "data" / "sequence_tagging.tsv"
         )
@@ -68,8 +68,8 @@ class TestOptimizer(AllenNlpTestCase):
 
 
 class TestDenseSparseAdam(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.instances = SequenceTaggingDatasetReader().read(
             self.FIXTURES_ROOT / "data" / "sequence_tagging.tsv"
         )

--- a/allennlp/tests/training/trainer_test.py
+++ b/allennlp/tests/training/trainer_test.py
@@ -41,8 +41,8 @@ from allennlp.data import allennlp_collate
 
 
 class TrainerTestBase(AllenNlpTestCase):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        super().setup_method()
         self.instances = SequenceTaggingDatasetReader().read(
             self.FIXTURES_ROOT / "data" / "sequence_tagging.tsv"
         )
@@ -1022,4 +1022,4 @@ class TestSparseClipGrad(AllenNlpTestCase):
         _ = clip_grad_norm_([embedding.weight], 1.5)
         # Final norm should be 1.5
         grad = embedding.weight.grad.coalesce()
-        self.assertAlmostEqual(grad._values().norm(2.0).item(), 1.5, places=5)
+        assert grad._values().norm(2.0).item() == pytest.approx(1.5, rel=1e-4)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -38,7 +38,7 @@ git+https://github.com/NiklasRosenstein/pydoc-markdown.git@b469839ceb598df3d7e71
 
 markdown-include==0.5.1
 # Package for the material theme for mkdocs
-mkdocs-material==5.1.4
+mkdocs-material==5.1.5
 
 #### PACKAGE-UPLOAD PACKAGES ####
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = allennlp/tests/
+python_classes = Test* *Test
 log_format = %(asctime)s - %(levelname)s - %(name)s - %(message)s
 log_level = DEBUG
 markers =


### PR DESCRIPTION
As far as I can tell, since we're using `pytest` to run tests, there's no benefit of using `unittest.TestCase` as the base class for `AllenNlpTestCase` as opposed to plain [`pytest` style classes](https://docs.pytest.org/en/latest/xunit_setup.html?highlight=setup_class#class-level-setup-teardown).

There is, however, several disadvantages:
1.  [`@pytest.mark.parametrize` does not work with methods on a `unittest.TestCase` class](https://stackoverflow.com/questions/18182251/does-pytest-parametrized-test-work-with-unittest-class-based-tests). Given that parametrizing tests is such a powerful tool, I think this is a major issue.
2. `unittest.TestCase` assertion methods (`self.assertEqual`, `self.assertSetEqual`, etc) are less concise than plain `assert` statements, which are recommended by `pytest`.
3. The `setUp` and `tearDown` methods do not have [PEP-8](https://www.python.org/dev/peps/pep-0008/#method-names-and-instance-variables) compatible names, and it's not clear when these methods are run based on their names. On the other hand, the `pytest` equivalents (`setup_method` and `teardown_method` or `setup_class` and `teardown_class`) have snake-case names that are perfectly clear as to when they run.

---

I know this looks like a huge PR but it's mostly just replacing `unittest` assertion methods with the `pytest` equivalents.