### PR TITLE
Add wordpiece_mask to default to bool tensor

### DIFF
--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -185,7 +185,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
             if key == "type_ids":
                 padding_value = 0
                 mktensor = torch.LongTensor
-            elif key == "mask":
+            elif key == "mask" or key == "wordpiece_mask":
                 padding_value = False
                 mktensor = torch.BoolTensor
             elif len(val) > 0 and isinstance(val[0], bool):


### PR DESCRIPTION
The `pretrained_transformer_mismatched` has a mask called `wordpiece_mask`, but calls into `pretrained_transformer.as_padded_tensor_dict` which doesn't properly default to `BoolTensor` for this mask. I'm not certain this is the right fix, but I ran into this with a `ListField[TextField]` getting padded with empty `TextField`s, and this fixes it for me so thought I would offer a PR.