### PR TITLE
fix new linting errors

### DIFF
--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -246,7 +246,7 @@ def find_learning_rate_model(
         linear_steps=linear_steps,
         stopping_factor=stopping_factor,
     )
-    logger.info(f"Finished learning rate search.")
+    logger.info("Finished learning rate search.")
     losses = _smooth(losses, 0.98)
 
     _save_plot(learning_rates, losses, os.path.join(serialization_dir, "lr-losses.png"))

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -23,7 +23,7 @@ except ImportError:
 
     def evaluate_snippet(_filename: str, expr: str, **_kwargs) -> str:
         logger.warning(
-            f"error loading _jsonnet (this is expected on Windows), treating snippet as plain json"
+            "error loading _jsonnet (this is expected on Windows), treating snippet as plain json"
         )
         return expr
 

--- a/allennlp/common/tqdm.py
+++ b/allennlp/common/tqdm.py
@@ -5,7 +5,7 @@ global defaults for certain tqdm parameters.
 
 try:
     SHELL = str(type(get_ipython()))  # type:ignore # noqa: F821
-except:  # noqa: E261
+except:  # noqa: E722
     SHELL = ""
 
 if "zmqshell.ZMQInteractiveShell" in SHELL:

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -119,7 +119,7 @@ def group_by_count(iterable: List[Any], count: int, default_value: Any) -> List[
     This is a short method, but it's complicated and hard to remember as a one-liner, so we just
     make a function out of it.
     """
-    return [list(l) for l in zip_longest(*[iter(iterable)] * count, fillvalue=default_value)]
+    return [list(x) for x in zip_longest(*[iter(iterable)] * count, fillvalue=default_value)]
 
 
 A = TypeVar("A")

--- a/allennlp/data/fields/metadata_field.py
+++ b/allennlp/data/fields/metadata_field.py
@@ -63,4 +63,4 @@ class MetadataField(Field[DataArray], Mapping[str, Any]):
         return tensor_list
 
     def __str__(self) -> str:
-        return f"MetadataField (print field.metadata to see specific information)."
+        return "MetadataField (print field.metadata to see specific information)."

--- a/allennlp/data/instance.py
+++ b/allennlp/data/instance.py
@@ -100,7 +100,7 @@ class Instance(Mapping[str, Field]):
         return tensors
 
     def __str__(self) -> str:
-        base_string = f"Instance with fields:\n"
+        base_string = "Instance with fields:\n"
         return " ".join(
             [base_string] + [f"\t {name}: {field} \n" for name, field in self.fields.items()]
         )

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -115,7 +115,7 @@ def _read_pretrained_tokens(embeddings_file_uri: str) -> List[str]:
                 tokens.append(token)
             else:
                 line_begin = line[:20] + "..." if len(line) > 20 else line
-                logger.warning(f"Skipping line number %d: %s", line_number, line_begin)
+                logger.warning("Skipping line number %d: %s", line_number, line_begin)
     return tokens
 
 
@@ -679,7 +679,7 @@ class Vocabulary(Registrable):
         return False
 
     def __str__(self) -> str:
-        base_string = f"Vocabulary with namespaces:\n"
+        base_string = "Vocabulary with namespaces:\n"
         non_padded_namespaces = f"\tNon Padded Namespaces: {self._non_padded_namespaces}\n"
         namespaces = [
             f"\tNamespace: {name}, Size: {self.get_vocab_size(name)} \n"
@@ -689,7 +689,7 @@ class Vocabulary(Registrable):
 
     def __repr__(self) -> str:
         # This is essentially the same as __str__, but with no newlines
-        base_string = f"Vocabulary with namespaces: "
+        base_string = "Vocabulary with namespaces: "
         namespaces = [
             f"{name}, Size: {self.get_vocab_size(name)} ||" for name in self._index_to_token
         ]

--- a/allennlp/interpret/attackers/utils.py
+++ b/allennlp/interpret/attackers/utils.py
@@ -41,8 +41,8 @@ def instance_has_changed(instance: Instance, fields_to_compare: JsonDict):
     if "clusters" in fields_to_compare:
         # Coref needs a special case here, apparently.  I (mattg) am not sure why the check below
         # doesn't catch this case; TODO: look into this.
-        original_clusters = set(tuple(l) for l in fields_to_compare["clusters"])
-        new_clusters = set(tuple(l) for l in instance["clusters"])  # type: ignore
+        original_clusters = set(tuple(x) for x in fields_to_compare["clusters"])
+        new_clusters = set(tuple(x) for x in instance["clusters"])  # type: ignore
         return original_clusters != new_clusters
     if any(instance[field] != fields_to_compare[field] for field in fields_to_compare):
         return True

--- a/allennlp/tests/modules/feedforward_test.py
+++ b/allennlp/tests/modules/feedforward_test.py
@@ -17,7 +17,7 @@ class TestFeedForward(AllenNlpTestCase):
         assert len(feedforward._activations) == 2
         assert [isinstance(a, torch.nn.ReLU) for a in feedforward._activations]
         assert len(feedforward._linear_layers) == 2
-        assert [l.weight.size(-1) == 3 for l in feedforward._linear_layers]
+        assert [layer.weight.size(-1) == 3 for layer in feedforward._linear_layers]
 
         params = Params(
             {

--- a/scripts/ai2_internal/run_with_beaker.py
+++ b/scripts/ai2_internal/run_with_beaker.py
@@ -60,7 +60,7 @@ def main(param_file: str, args: argparse.Namespace):
         print(f"Building the Docker image ({docker_image})...")
         subprocess.run(f"docker build -t {docker_image} .", shell=True, check=True)
 
-        print(f"Create a Beaker image...")
+        print("Create a Beaker image...")
         image = subprocess.check_output(
             f"beaker image create --quiet {docker_image}", shell=True, universal_newlines=True
         ).strip()

--- a/scripts/py2md.py
+++ b/scripts/py2md.py
@@ -31,7 +31,7 @@ class AllenNlpDocstringProcessor(Struct):
     Use to turn our docstrings into Markdown.
     """
 
-    CROSS_REF_RE = re.compile(f"(:(class|func|mod):`~?([a-zA-Z0-9_.]+)`)")
+    CROSS_REF_RE = re.compile("(:(class|func|mod):`~?([a-zA-Z0-9_.]+)`)")
 
     @override
     def process(self, graph, resolver):
@@ -168,7 +168,7 @@ class AllenNlpRenderer(MarkdownRenderer):
             parts.append(" -> {}".format(func.return_))
         result = "".join(parts)
         if add_method_bar and func.is_method():
-            result = "\n".join(" | " + l for l in result.split("\n"))
+            result = "\n".join(" | " + line for line in result.split("\n"))
         return result
 
     def _format_classdef_signature(self, cls: Class) -> str:


### PR DESCRIPTION
Fixes new linting errors introduced by a new version of flake8. Most of the lints are uncontroversial, such as F541 ("f-string is missing placeholders"). But one that I don't totally agree with is E741 ("ambiguous variable name") - which occurs whenever you use `l` as a variable name - since syntax highlighting (and a good font) usually removes the ambiguity.