### PR TITLE
Add a more informative exception when there's no GPU available.

### DIFF
--- a/allennlp/common/checks.py
+++ b/allennlp/common/checks.py
@@ -115,7 +115,7 @@ def check_for_gpu(device_id: Union[int, List[int]]):
             #
             torch_gpu_error = ""
             try:
-                cuda.current_device()
+                cuda._check_driver()
             except Exception as e:
                 torch_gpu_error = "\n{0}".format(e)
 


### PR DESCRIPTION
I'm not sure this is coded up particularly well, but I wanted to put a PR together to clearly demonstrate what we need.  Our present exception is rather vague, whereas PyTorch will give a clear an informative error.  I spent a few hours yesterday tracking down a problem when the PyTorch exception would have clearly explained the root problem immediately.

`cuda.current_device()` will throw an exception if CUDA is not available.  For example:

1.  On a system with an incompatible driver.

```
The NVIDIA driver on your system is too old (found version 10010).
Please update your GPU driver by downloading and installing a new
version from the URL: http://www.nvidia.com/Download/index.aspx
Alternatively, go to: https://pytorch.org to install
a PyTorch version that has been compiled with your version
of the CUDA driver.
```

2.  On a system where torch isn't compiled for GPU.  This is real output form `allennlp` on this branch.  Note the last line.

```
echo '{"passage": "The Matrix is a 1999 science fiction action film written and directed by The Wachowskis, starring Keanu Reeves, Laurence Fishburne, Carrie-Anne Moss, Hugo Weaving, and Joe Pantoliano.", "question": "Who stars in The Matrix?"}' | \
                                              allennlp predict --cuda-device 0 https://storage.googleapis.com/allennlp-public-models/bidaf-elmo-model-2020.03.19.tar.gz -
2020-05-12 10:20:06,745 - INFO - transformers.file_utils - PyTorch version 1.4.0 available.
Traceback (most recent call last):
  File "/Users/michael/miniconda3/envs/allennlp/bin/allennlp", line 11, in <module>
    load_entry_point('allennlp', 'console_scripts', 'allennlp')()
  File "/Users/michael/hack/allenai/allennlp/allennlp/__main__.py", line 19, in run
    main(prog="allennlp")
  File "/Users/michael/hack/allenai/allennlp/allennlp/commands/__init__.py", line 92, in main
    args.func(args)
  File "/Users/michael/hack/allenai/allennlp/allennlp/commands/predict.py", line 240, in _predict
    predictor = _get_predictor(args)
  File "/Users/michael/hack/allenai/allennlp/allennlp/commands/predict.py", line 136, in _get_predictor
    check_for_gpu(args.cuda_device)
  File "/Users/michael/hack/allenai/allennlp/allennlp/common/checks.py", line 125, in check_for_gpu
    " 'trainer.cuda_device=-1' in the json config file." + torch_gpu_error
allennlp.common.checks.ConfigurationError: Experiment specified a GPU but none is available; if you want to run on CPU use the override 'trainer.cuda_device=-1' in the json config file.
Torch not compiled with CUDA enabled
```

I'm all for a different solution so long as we can retain the PyTorch exception too!