### PR TITLE
Make character tokenizer in token character indexer configurable.

### DIFF
--- a/allennlp/data/token_indexers/token_characters_indexer.py
+++ b/allennlp/data/token_indexers/token_characters_indexer.py
@@ -8,6 +8,7 @@ import torch
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.util import pad_sequence_to_length
 from allennlp.data.token_indexers.token_indexer import TokenIndexer, IndexedTokenList
+from allennlp.data.tokenizers import Tokenizer
 from allennlp.data.tokenizers.character_tokenizer import CharacterTokenizer
 from allennlp.data.tokenizers.token import Token
 from allennlp.data.vocabulary import Vocabulary
@@ -44,7 +45,7 @@ class TokenCharactersIndexer(TokenIndexer):
     def __init__(
         self,
         namespace: str = "token_characters",
-        character_tokenizer: CharacterTokenizer = CharacterTokenizer(),
+        character_tokenizer: Tokenizer = CharacterTokenizer(),
         start_tokens: List[str] = None,
         end_tokens: List[str] = None,
         min_padding_length: int = 0,


### PR DESCRIPTION
In the current form of TokenCharactersIndexer it is impossible to modify it's character_tokenizer to own, custom implementation as shown in the script below.
It ends with ```allennlp.common.checks.ConfigurationError: Extra parameters passed to CharacterTokenizer: {'type': 'custom_character'}```.

I believe that this not desired design so I have changed the type (however I kept default value).
```python
import json

from allennlp.common import Params
from allennlp.data import Tokenizer, TokenIndexer
from allennlp.data.tokenizers import CharacterTokenizer


@Tokenizer.register("custom_character")
class CustomCharacterTokenizer(CharacterTokenizer):
    pass


char_token_indexer = TokenIndexer.from_params(Params(json.loads("""
{
    "type": "characters",
    "character_tokenizer": {
        "type": "custom_character",
        "start_tokens": ["__START__"],
        "end_tokens": ["__END__"],
        "lowercase_characters": false
    }
}
""")))
```