### PR TITLE
Clean up the command to create a commit list.

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -38,16 +38,10 @@ Then you can copy and paste the commands below without worrying about mistyping 
     ```
 
 4. Find the tag you just pushed [on GitHub](https://github.com/allenai/allennlp/tags) and
-click edit. Now copy over the latest section from the `CHANGELOG.md`. And finally, add a section called "Commits" with the output from this:
+click edit. Now copy over the latest section from the `CHANGELOG.md`. And finally, add a section called "Commits" with the output a command like the following:
 
     ```bash
-    git log `git describe --always --tags --abbrev=0 HEAD^^`..HEAD^ --oneline
-    ```
-
-    Or, if you're using fish,
-
-    ```fish
-    git log (git describe --always --tags --abbrev=0 HEAD^^)..HEAD^ --oneline
+    git log v0.9.0..v1.0.0rc4 --oneline
     ```
 
     On a Mac, for example, you can just pipe the above command into `pbcopy`.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -44,6 +44,11 @@ click edit. Now copy over the latest section from the `CHANGELOG.md`. And finall
     OLD_TAG=$(git describe --always --tags --abbrev=0 $TAG^)
     git log $OLD_TAG..$TAG --oneline
     ```
+    
+    ```fish
+    set -x OLD_TAG $(git describe --always --tags --abbrev=0 $TAG^)
+    git log $OLD_TAG..$TAG --oneline
+    ```
 
     On a Mac, for example, you can just pipe the above command into `pbcopy`.
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -46,7 +46,7 @@ click edit. Now copy over the latest section from the `CHANGELOG.md`. And finall
     ```
     
     ```fish
-    set -x OLD_TAG $(git describe --always --tags --abbrev=0 $TAG^)
+    set -x OLD_TAG (git describe --always --tags --abbrev=0 $TAG^)
     git log $OLD_TAG..$TAG --oneline
     ```
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -38,7 +38,7 @@ Then you can copy and paste the commands below without worrying about mistyping 
     ```
 
 4. Find the tag you just pushed [on GitHub](https://github.com/allenai/allennlp/tags) and
-click edit. Now copy over the latest section from the `CHANGELOG.md`. And finally, add a section called "Commits" with the output a command like the following:
+click edit. Now copy over the latest section from the `CHANGELOG.md`. And finally, add a section called "Commits" with the output of a command like the following:
 
     ```bash
     OLD_TAG=$(git describe --always --tags --abbrev=0 $TAG^)

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -41,7 +41,8 @@ Then you can copy and paste the commands below without worrying about mistyping 
 click edit. Now copy over the latest section from the `CHANGELOG.md`. And finally, add a section called "Commits" with the output a command like the following:
 
     ```bash
-    git log v0.9.0..v1.0.0rc4 --oneline
+    OLD_TAG=$(git describe --always --tags --abbrev=0 $TAG^)
+    git log $OLD_TAG..$TAG --oneline
     ```
 
     On a Mac, for example, you can just pipe the above command into `pbcopy`.


### PR DESCRIPTION
I'm not really sure what the previous command does.  It seems easier if we simplify the syntax to specify the version range.  I think it will make it less likely to make a mistake.