### PR TITLE
Make special token inference logic more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix bug where `PretrainedTransformerTokenizer` crashed with some transformers (#4267)
 - Make `cached_path` work offline.
 - Tons of docstring inconsistencies resolved.
 - Nightly builds no longer run on forks.

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -132,9 +132,6 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         seen_dummy_a = False
         seen_dummy_b = False
-        print(dummy_output)
-        print(dummy_a)
-        print(dummy_b)
         for token_id, token_type_id in zip(
             dummy_output["input_ids"], dummy_output["token_type_ids"]
         ):

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -85,22 +85,20 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         self._tokenizer_lowercases = self.tokenizer_lowercases(self.tokenizer)
 
-        # Reverse-engineer the tokenizer for two sequences
-        tokenizer_with_special_tokens = AutoTokenizer.from_pretrained(
-            model_name, add_special_tokens=True, **tokenizer_kwargs
-        )
-        dummy_output = tokenizer_with_special_tokens.encode_plus(
-            "1",  # "a" and "b" get tokenized into multiple word pieces, but for now, "1" and "2" do not.
-            "2",
-            add_special_tokens=True,
-            return_token_type_ids=True,
-            return_attention_mask=False,
-        )
-        dummy_a = self.tokenizer.encode("1", add_special_tokens=False)[0]
-        assert dummy_a in dummy_output["input_ids"]
-        dummy_b = self.tokenizer.encode("2", add_special_tokens=False)[0]
-        assert dummy_b in dummy_output["input_ids"]
+        try:
+            self._reverse_engineer_speical_tokens("a", "b", model_name, tokenizer_kwargs)
+        except AssertionError:
+            # For most transformer models, "a" and "b" work just fine as dummy tokens.  For a few,
+            # they don't, and so we use "1" and "2" instead.
+            self._reverse_engineer_speical_tokens("1", "2", model_name, tokenizer_kwargs)
 
+    def _reverse_engineer_speical_tokens(
+        self,
+        token_a: str,
+        token_b: str,
+        model_name: str,
+        tokenizer_kwargs: Optional[Dict[str, Any]],
+    ):
         # storing the special tokens
         self.sequence_pair_start_tokens = []
         self.sequence_pair_mid_tokens = []
@@ -109,8 +107,34 @@ class PretrainedTransformerTokenizer(Tokenizer):
         self.sequence_pair_first_token_type_id = None
         self.sequence_pair_second_token_type_id = None
 
+        # storing the special tokens
+        self.single_sequence_start_tokens = []
+        self.single_sequence_end_tokens = []
+        # storing token type id for the sequence
+        self.single_sequence_token_type_id = None
+
+        # Reverse-engineer the tokenizer for two sequences
+        tokenizer_with_special_tokens = AutoTokenizer.from_pretrained(
+            model_name, add_special_tokens=True, **tokenizer_kwargs
+        )
+        dummy_output = tokenizer_with_special_tokens.encode_plus(
+            token_a,
+            token_b,
+            add_special_tokens=True,
+            return_token_type_ids=True,
+            return_attention_mask=False,
+        )
+        dummy_a = self.tokenizer.encode(token_a, add_special_tokens=False)[0]
+        assert dummy_a in dummy_output["input_ids"]
+        dummy_b = self.tokenizer.encode(token_b, add_special_tokens=False)[0]
+        assert dummy_b in dummy_output["input_ids"]
+        assert dummy_a != dummy_b
+
         seen_dummy_a = False
         seen_dummy_b = False
+        print(dummy_output)
+        print(dummy_a)
+        print(dummy_b)
         for token_id, token_type_id in zip(
             dummy_output["input_ids"], dummy_output["token_type_ids"]
         ):
@@ -156,14 +180,11 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         # Reverse-engineer the tokenizer for one sequence
         dummy_output = tokenizer_with_special_tokens.encode_plus(
-            "1", add_special_tokens=True, return_token_type_ids=True, return_attention_mask=False
+            token_a,
+            add_special_tokens=True,
+            return_token_type_ids=True,
+            return_attention_mask=False,
         )
-
-        # storing the special tokens
-        self.single_sequence_start_tokens = []
-        self.single_sequence_end_tokens = []
-        # storing token type id for the sequence
-        self.single_sequence_token_type_id = None
 
         seen_dummy_a = False
         for token_id, token_type_id in zip(

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -86,13 +86,13 @@ class PretrainedTransformerTokenizer(Tokenizer):
         self._tokenizer_lowercases = self.tokenizer_lowercases(self.tokenizer)
 
         try:
-            self._reverse_engineer_speical_tokens("a", "b", model_name, tokenizer_kwargs)
+            self._reverse_engineer_special_tokens("a", "b", model_name, tokenizer_kwargs)
         except AssertionError:
             # For most transformer models, "a" and "b" work just fine as dummy tokens.  For a few,
             # they don't, and so we use "1" and "2" instead.
-            self._reverse_engineer_speical_tokens("1", "2", model_name, tokenizer_kwargs)
+            self._reverse_engineer_special_tokens("1", "2", model_name, tokenizer_kwargs)
 
-    def _reverse_engineer_speical_tokens(
+    def _reverse_engineer_special_tokens(
         self,
         token_a: str,
         token_b: str,

--- a/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -63,6 +63,34 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
         tokens = [t.text for t in tokenizer.tokenize(sentence)]
         assert tokens == expected_tokens
 
+    def test_splits_reformer_small(self):
+        sentence = "A, [MASK] AllenNLP sentence."
+        expected_tokens = [
+            "▁A",
+            ",",
+            "▁",
+            "<unk>",
+            "M",
+            "A",
+            "S",
+            "K",
+            "<unk>",
+            "▁A",
+            "ll",
+            "en",
+            "N",
+            "L",
+            "P",
+            "▁s",
+            "ent",
+            "en",
+            "ce",
+            ".",
+        ]
+        tokenizer = PretrainedTransformerTokenizer("google/reformer-crime-and-punishment")
+        tokens = [t.text for t in tokenizer.tokenize(sentence)]
+        assert tokens == expected_tokens
+
     def test_token_idx_bert_uncased(self):
         sentence = "A, naïve [MASK] AllenNLP sentence."
         expected_tokens = [


### PR DESCRIPTION
I tried to use a small transformer model in part of the course, and it failed the assertions in the tokenizer (because "1" and "2" were not in the vocabulary, so they were both mapped to the same UNK token).  This PR makes the logic more robust to other transformer models.