### PR TITLE
Document when parameters do not need an entry in a config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Additional CI checks to ensure docstrings are consistently formatted.
 - Ability to train on CPU with multiple processes by setting `cuda_devices` to a list of negative integers in your training config. For example: `"distributed": {"cuda_devices": [-1, -1]}`. This is mainly to make it easier to test and debug distributed training code..
+- Documentation for when parameters don't need config file entries.
 
 ### Changed
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -415,9 +415,7 @@ def _train_worker(
         )
 
     train_loop = TrainModel.from_params(
-        params=params,
-        serialization_dir=serialization_dir,
-        local_rank=process_rank,
+        params=params, serialization_dir=serialization_dir, local_rank=process_rank,
     )
 
     if dry_run:
@@ -517,7 +515,6 @@ class TrainModel(Registrable):
         cls,
         serialization_dir: str,
         local_rank: int,
-        batch_weight_key: str,
         dataset_reader: DatasetReader,
         train_data_path: str,
         model: Lazy[Model],
@@ -530,6 +527,7 @@ class TrainModel(Registrable):
         validation_data_loader: Lazy[DataLoader] = None,
         test_data_path: str = None,
         evaluate_on_test: bool = False,
+        batch_weight_key: str = "",
     ) -> "TrainModel":
         """
         This method is intended for use with our `FromParams` logic, to construct a `TrainModel`

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -180,7 +180,6 @@ def train_model(
     force: bool = False,
     node_rank: int = 0,
     include_package: List[str] = None,
-    batch_weight_key: str = "",
     dry_run: bool = False,
 ) -> Optional[Model]:
     """
@@ -206,8 +205,6 @@ def train_model(
         Rank of the current node in distributed training
     include_package : `List[str]`, optional
         In distributed mode, extra packages mentioned will be imported in trainer workers.
-    batch_weight_key : `str`, optional (default=`""`)
-        If non-empty, name of metric used to weight the loss on a per-batch basis.
     dry_run : `bool`, optional (default=`False`)
         Do not train a model, but create a vocabulary, show dataset statistics and other training
         information.
@@ -230,7 +227,6 @@ def train_model(
             serialization_dir=serialization_dir,
             file_friendly_logging=file_friendly_logging,
             include_package=include_package,
-            batch_weight_key=batch_weight_key,
             dry_run=dry_run,
         )
         if not dry_run:
@@ -289,7 +285,6 @@ def train_model(
                 serialization_dir,
                 file_friendly_logging,
                 include_package,
-                batch_weight_key,
                 dry_run,
                 node_rank,
                 master_addr,
@@ -313,7 +308,6 @@ def _train_worker(
     serialization_dir: str,
     file_friendly_logging: bool = False,
     include_package: List[str] = None,
-    batch_weight_key: str = "",
     dry_run: bool = False,
     node_rank: int = 0,
     master_addr: str = "127.0.0.1",
@@ -341,8 +335,6 @@ def _train_worker(
         In distributed mode, since this function would have been spawned as a separate process,
         the extra imports need to be done again. NOTE: This does not have any effect in single
         GPU training.
-    batch_weight_key : `str`, optional (default=`""`)
-        If non-empty, name of metric used to weight the loss on a per-batch basis.
     dry_run : `bool`, optional (default=`False`)
         Do not train a model, but create a vocabulary, show dataset statistics and other training
         information.
@@ -426,7 +418,6 @@ def _train_worker(
         params=params,
         serialization_dir=serialization_dir,
         local_rank=process_rank,
-        batch_weight_key=batch_weight_key,
     )
 
     if dry_run:
@@ -562,10 +553,14 @@ class TrainModel(Registrable):
         # Parameters
         serialization_dir: `str`
             The directory where logs and model archives will be saved.
+
+            In a typical AllenNLP configuration file, this parameter does not get an entry as a
+            top-level key, it gets passed in separately.
         local_rank: `int`
             The process index that is initialized using the GPU device id.
-        batch_weight_key: `str`
-            The name of metric used to weight the loss on a per-batch basis.
+
+            In a typical AllenNLP configuration file, this parameter does not get an entry as a
+            top-level key, it gets passed in separately.
         dataset_reader: `DatasetReader`
             The `DatasetReader` that will be used for training and (by default) for validation.
         train_data_path: `str`
@@ -603,6 +598,9 @@ class TrainModel(Registrable):
             If given, we will evaluate the final model on this data at the end of training.  Note
             that we do not recommend using this for actual test data in every-day experimentation;
             you should only very rarely evaluate your model on actual test data.
+        batch_weight_key: `str`, optional (default=`""`)
+            The name of metric used to weight the loss on a per-batch basis.  This is only used
+            during evaluation on final test data, if you've specified `evaluate_on_test=True`.
         """
 
         datasets = training_util.read_all_datasets(

--- a/allennlp/data/dataloader.py
+++ b/allennlp/data/dataloader.py
@@ -41,6 +41,9 @@ class DataLoader(Registrable, data.DataLoader):
     of batches after which an epoch ends.  If this is `None`, then an epoch is set to be one full pass
     through your data.  You might use this if you have a very large dataset and want more frequent
     checkpoints and evaluations on validation data, for instance.
+
+    In a typical AllenNLP configuration file, the `dataset` parameter does not get an entry under
+    the "data_loader", it gets constructed separately.
     """
 
     def __init__(

--- a/allennlp/data/samplers/bucket_batch_sampler.py
+++ b/allennlp/data/samplers/bucket_batch_sampler.py
@@ -33,6 +33,8 @@ class BucketBatchSampler(BatchSampler):
     data_source: `data.Dataset`, required
         The pytorch `Dataset` of allennlp Instances to bucket.
 
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "batch_sampler", it gets constructed separately.
     batch_size : `int`, required
         The size of each batch of instances yielded when calling the dataloader.
 

--- a/allennlp/data/samplers/samplers.py
+++ b/allennlp/data/samplers/samplers.py
@@ -41,6 +41,9 @@ class SequentialSampler(data.SequentialSampler, Sampler):
     [SequentialSampler](https://pytorch.org/docs/stable/data.html#torch.utils.data.SequentialSampler).
 
     Registered as a `Sampler` with name "sequential".
+
+    In a typical AllenNLP configuration file, `data_source` parameter does not get an entry under
+    the "sampler", it gets constructed separately.
     """
 
     def __init__(self, data_source: data.Dataset):
@@ -60,6 +63,9 @@ class RandomSampler(data.RandomSampler, Sampler):
     # Parameters
     data_source: `Dataset`, required
         The dataset to sample from.
+
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "sampler", it gets constructed separately.
     replacement : `bool`, optional (default = `False`)
         Samples are drawn with replacement if `True`.
     num_samples: `int` (default = `len(dataset)`)

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -275,6 +275,9 @@ class Vocabulary(Registrable):
         We count all of the vocabulary items in the instances, then pass those counts
         and the other parameters, to :func:`__init__`.  See that method for a description
         of what the other parameters do.
+
+        The `instances` parameter does not get an entry in a typical AllenNLP configuration file,
+        but the other parameters do (if you want non-default parameters).
         """
         logger.info("Fitting token dictionary from dataset.")
         padding_token = padding_token if padding_token is not None else DEFAULT_PADDING_TOKEN
@@ -358,6 +361,10 @@ class Vocabulary(Registrable):
     ) -> "Vocabulary":
         """
         Extends an already generated vocabulary using a collection of instances.
+
+        The `instances` parameter does not get an entry in a typical AllenNLP configuration file,
+        but the other parameters do (if you want non-default parameters).  See `__init__` for a
+        description of what the other parameters mean.
         """
         vocab = cls.from_files(directory, padding_token, oov_token)
         logger.info("Fitting token dictionary from dataset.")

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -62,6 +62,10 @@ class Model(torch.nn.Module, Registrable):
         when constructing embedding matrices or output classifiers (as the vocabulary holds the
         number of classes in your output, also), and translating model output into human-readable
         form.
+
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "model", it gets specified as a top-level parameter, then is passed in to the model
+        separately.
     regularizer: `RegularizerApplicator`, optional
         If given, the `Trainer` will use this to regularize model parameters.
     """

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -82,6 +82,10 @@ class Embedding(TokenEmbedder):
     vocab : `Vocabulary`, optional (default = `None`)
         Used to construct an embedding from a pretrained file.
 
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "embedding", it gets specified as a top-level parameter, then is passed in to this module
+        separately.
+
     # Returns
 
     An Embedding module.

--- a/allennlp/training/checkpointer.py
+++ b/allennlp/training/checkpointer.py
@@ -29,6 +29,9 @@ class Checkpointer(Registrable):
     num_serialized_models_to_keep : `int`, optional (default=`2`)
         Number of previous model checkpoints to retain.  Default is to keep 2 checkpoints.
         A value of None or -1 means all checkpoints will be kept.
+
+        In a typical AllenNLP configuration file, this argument does not get an entry under the
+        "checkpointer", it gets passed in separately.
     keep_serialized_model_every_num_seconds : `int`, optional (default=`None`)
         If num_serialized_models_to_keep is not None, then occasionally it's useful to
         save models at a given interval in addition to the last num_serialized_models_to_keep.

--- a/allennlp/training/learning_rate_schedulers/cosine.py
+++ b/allennlp/training/learning_rate_schedulers/cosine.py
@@ -23,6 +23,7 @@ class CosineWithRestarts(LearningRateScheduler):
     # Parameters
 
     optimizer : `torch.optim.Optimizer`
+        This argument does not get an entry in a configuration file for the object.
     t_initial : `int`
         The number of iterations (epochs) within the first cycle.
     t_mul : `float`, optional (default=`1`)

--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -53,7 +53,8 @@ class _PyTorchLearningRateSchedulerWithMetricsWrapper(_PyTorchLearningRateSchedu
 @LearningRateScheduler.register("step")
 class StepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
-    Registered as a `LearningRateScheduler` with name "step".
+    Registered as a `LearningRateScheduler` with name "step".  The "optimizer" argument does not get
+    an entry in a configuration file for the object.
     """
 
     def __init__(
@@ -68,7 +69,8 @@ class StepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
 @LearningRateScheduler.register("multi_step")
 class MultiStepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
-    Registered as a `LearningRateScheduler` with name "multi_step".
+    Registered as a `LearningRateScheduler` with name "multi_step".  The "optimizer" argument does
+    not get an entry in a configuration file for the object.
     """
 
     def __init__(
@@ -83,7 +85,8 @@ class MultiStepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
 @LearningRateScheduler.register("exponential")
 class ExponentialLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
-    Registered as a `LearningRateScheduler` with name "exponential".
+    Registered as a `LearningRateScheduler` with name "exponential".  The "optimizer" argument does
+    not get an entry in a configuration file for the object.
     """
 
     def __init__(self, optimizer: Optimizer, gamma: float = 0.1, last_epoch: int = -1) -> None:
@@ -96,7 +99,8 @@ class ExponentialLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
 @LearningRateScheduler.register("reduce_on_plateau")
 class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetricsWrapper):
     """
-    Registered as a `LearningRateScheduler` with name "reduce_on_plateau".
+    Registered as a `LearningRateScheduler` with name "reduce_on_plateau".  The "optimizer" argument
+    does not get an entry in a configuration file for the object.
     """
 
     def __init__(

--- a/allennlp/training/learning_rate_schedulers/noam.py
+++ b/allennlp/training/learning_rate_schedulers/noam.py
@@ -16,6 +16,8 @@ class NoamLR(LearningRateScheduler):
 
     # Parameters
 
+    optimizer : `torch.optim.Optimizer`
+        This argument does not get an entry in a configuration file for the object.
     model_size : `int`, required.
         The hidden size parameter which dominates the number of parameters in your model.
     warmup_steps : `int`, required.

--- a/allennlp/training/learning_rate_schedulers/slanted_triangular.py
+++ b/allennlp/training/learning_rate_schedulers/slanted_triangular.py
@@ -29,6 +29,8 @@ class SlantedTriangular(LearningRateScheduler):
 
     # Parameters
 
+    optimizer : `torch.optim.Optimizer`
+        This argument does not get an entry in a configuration file for the object.
     num_epochs : `int`, required.
         The total number of epochs for which the model should be trained.
     num_steps_per_epoch : `int`, required.

--- a/allennlp/training/momentum_schedulers/inverted_triangular.py
+++ b/allennlp/training/momentum_schedulers/inverted_triangular.py
@@ -14,7 +14,8 @@ class InvertedTriangular(MomentumScheduler):
     are still more epochs left over to train, the momentum will stay flat at the original
     value.
 
-    Registered as a `MomentumScheduler` with name "inverted_triangular".
+    Registered as a `MomentumScheduler` with name "inverted_triangular".  The "optimizer" argument
+    does not get an entry in a configuration file for the object.
     """
 
     def __init__(

--- a/allennlp/training/moving_average.py
+++ b/allennlp/training/moving_average.py
@@ -53,6 +53,9 @@ class ExponentialMovingAverage(MovingAverage):
 
     parameters : `Iterable[Tuple[str, Parameter]]`, required
         The parameters whose averages we'll be tracking.
+
+        In a typical AllenNLP configuration file, this argument does not get an entry under the
+        "moving_average", it gets passed in separately.
     decay : `float`, optional (default = `0.9999`)
         The decay rate that will be used if `num_updates` is not passed
         (and that will be used as an upper bound if `num_updates` is passed).

--- a/allennlp/training/no_op_trainer.py
+++ b/allennlp/training/no_op_trainer.py
@@ -17,6 +17,9 @@ class NoOpTrainer(Trainer):
         """
         A trivial trainer to assist in making model archives for models that do not actually
         require training. For instance, a majority class baseline.
+
+        In a typical AllenNLP configuration file, neither the `serialization_dir` nor the `model`
+        arguments would need an entry.
         """
 
         super().__init__(serialization_dir, cuda_device=-1)

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -142,6 +142,12 @@ class Optimizer(Registrable):
     you use a different name, your code will crash.  Nothing will technically crash if you use a
     name other than `parameter_groups` for your second argument, it will just be annoyingly
     inconsistent.
+
+    Most subclasses of `Optimizer` take both a `model_parameters` and a `parameter_groups`
+    constructor argument.  The `model_parameters` argument does not get an entry in a typical
+    AllenNLP configuration file, but the `parameter_groups` argument does (if you want a non-default
+    value).  See the documentation for the `make_parameter_groups` function for more information on
+    how the `parameter_groups` argument should be specified.
     """
 
     default_implementation = "adam"

--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -23,6 +23,9 @@ class TensorboardWriter(FromParams):
 
     serialization_dir : `str`, optional (default = `None`)
         If provided, this is where the Tensorboard logs will be written.
+
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "tensorboard_writer", it gets passed in separately.
     summary_interval : `int`, optional (default = `100`)
         Most statistics will be written out only every this many batches.
     histogram_interval : `int`, optional (default = `None`)

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -168,12 +168,18 @@ class GradientDescentTrainer(Trainer):
         on the correct device. (If you are using our `train` command this will be
         handled for you.)
 
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "trainer", it gets constructed separately.
+
     optimizer : `torch.nn.Optimizer`, required.
         An instance of a Pytorch Optimizer, instantiated with the parameters of the
         model to be optimized.
 
     data_loader : `DataLoader`, required.
         A pytorch `DataLoader` containing your `Dataset`, yielding padded indexed batches.
+
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "trainer", it gets constructed separately.
 
     patience : `Optional[int] > 0`, optional (default=`None`)
         Number of epochs to be patient before early stopping: the training is stopped
@@ -190,12 +196,18 @@ class GradientDescentTrainer(Trainer):
         A `DataLoader` to use for the validation set.  If `None`, then
         use the training `DataLoader` with the validation data.
 
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "trainer", it gets constructed separately.
+
     num_epochs : `int`, optional (default = `20`)
         Number of training epochs.
 
     serialization_dir : `str`, optional (default=`None`)
         Path to directory for saving and loading model files. Models will not be saved if
         this parameter is not passed.
+
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "trainer", it gets constructed separately.
 
     checkpointer : `Checkpointer`, optional (default=`None`)
         A `Checkpointer` is responsible for periodically saving model weights.  If none is given
@@ -250,12 +262,22 @@ class GradientDescentTrainer(Trainer):
         If set, PyTorch's `DistributedDataParallel` is used to train the model in multiple GPUs. This also
         requires `world_size` to be greater than 1.
 
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "trainer", it gets constructed separately (you need a top-level "distributed" key, next to
+        the "trainer" entry, that specifies a list of "cuda_devices").
+
     local_rank : `int`, optional, (default = `0`)
         This is the unique identifier of the `Trainer` in a distributed process group. The GPU device id is
         used as the rank.
 
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "trainer", it gets constructed separately.
+
     world_size : `int`, (default = `1`)
         The number of `Trainer` workers participating in the distributed training.
+
+        In a typical AllenNLP configuration file, this parameter does not get an entry under the
+        "trainer", it gets constructed separately.
 
     num_gradient_accumulation_steps : `int`, optional, (default = `1`)
         Gradients are accumulated for the given number of steps before doing an optimizer step. This can


### PR DESCRIPTION
The point of `FromParams` is to have a config file's keys exactly match constructor parameters.  There are a few cases where that isn't actually true, because we construct an object separately and pass it in, removing the need to specify that constructor argument in a config file.  In writing about how config files work for the allennlp course, I realized that this was a pretty big piece of magic that needed explanation and documentation.  This PR adds documentation for that behavior.

I additionally noticed that there was a `batch_weight_key` in `commands.train` that could be simplified quite a bit, so I simplified it.