### PR TITLE
Update documentation of saliency_interpreter.py

### DIFF
--- a/allennlp/interpret/saliency_interpreters/saliency_interpreter.py
+++ b/allennlp/interpret/saliency_interpreters/saliency_interpreter.py
@@ -14,8 +14,7 @@ class SaliencyInterpreter(Registrable):
 
     def saliency_interpret_from_json(self, inputs: JsonDict) -> JsonDict:
         """
-        This function finds a modification to the input text that would change the model's
-        prediction in some desired manner (e.g., an adversarial attack).
+        This function finds saliency values for each input token.
 
         # Parameters
 


### PR DESCRIPTION
The documentation was wrongly copy-pasted from `allennlp/interpret/attackers/attacker.py`.