### PR TITLE
clean up dependencies

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -146,8 +146,6 @@ jobs:
       run: |
         git clone https://github.com/allenai/allennlp-models.git
         cd allennlp-models
-        # TODO: remove this line.
-        git checkout conllu
         pip install --upgrade --upgrade-strategy eager -e . -r dev-requirements.txt
 
     - name: Run models tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -146,6 +146,8 @@ jobs:
       run: |
         git clone https://github.com/allenai/allennlp-models.git
         cd allennlp-models
+        # TODO: remove this line.
+        git checkout conllu
         pip install --upgrade --upgrade-strategy eager -e . -r dev-requirements.txt
 
     - name: Run models tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nightly builds no longer run on forks.
 - Distributed training now automatically figures out which worker should see which instances
 - A race condition bug in distributed training caused from saving the vocab to file from the master process while other processing might be reading those files.
+- Unused dependencies in `setup.py` removed.
 
 ### Added
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,11 +19,14 @@ codecov
 # Optional dependencies, which we install for testing purposes.
 matplotlib>=2.2.3
 
-# Required to run sanic tests
-aiohttp
-
 # Required for automatic mixed precision (AMP) training
 git+https://github.com/NVIDIA/apex.git@master
+
+# For mocking HTTP requests/responses.
+responses>=0.7
+
+# For running tests that aren't 100% reliable.
+flaky
 
 #### DOC-RELATED PACKAGES ####
 

--- a/setup.py
+++ b/setup.py
@@ -21,15 +21,6 @@ VERSION = {}
 with open("allennlp/version.py", "r") as version_file:
     exec(version_file.read(), VERSION)
 
-# make pytest-runner a conditional requirement,
-# per: https://github.com/pytest-dev/pytest-runner#considerations
-needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
-pytest_runner = ["pytest-runner"] if needs_pytest else []
-
-setup_requirements = [
-    # add other setup requirements as necessary
-] + pytest_runner
-
 setup(
     name="allennlp",
     version=VERSION["VERSION"],
@@ -66,18 +57,11 @@ setup(
         "scikit-learn",
         "scipy",
         "pytest",
-        "flaky",
-        "responses>=0.7",
-        "conllu==2.3.2",
         "transformers>=2.9,<2.10",
         "jsonpickle",
-        "semantic_version",
         "dataclasses;python_version<'3.7'",
     ],
     entry_points={"console_scripts": ["allennlp=allennlp.__main__:run"]},
-    setup_requires=setup_requirements,
-    # For running via `python setup.py test`.
-    tests_require=["pytest", "flaky", "responses>=0.7", "semantic_version"],
     include_package_data=True,
     python_requires=">=3.6.1",
     zip_safe=False,


### PR DESCRIPTION
- Removes `conllu` dependency (see https://github.com/allenai/allennlp-models/pull/61)
- Removes `semantic_version` dependency (we don't use this at all anymore)
- Removes the `tests_requires` and `setup_requries` section of `setup.py`, since we don't use the `python setup.py test` command. Also see the deprecation notice of `pytest-runner` for why we shouldn't be using this: https://github.com/pytest-dev/pytest-runner#deprecation-notice.
- Moves a few other requirements in the `install_requires` section of `setup.py` to `dev-requirements.txt`, since they are only imported in our `tests/`.
- Removes `aiohttp` from `dev-requirements.txt` since it isn't used anywhere.