### PR TITLE
ensure intra_word_tokenize raises an exception when token cannot be split into wordpieces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ be imported successfully, and prints out some other useful information such as t
 and the number of GPU devices available.
 - All of the tests moved from `allennlp/tests` to `tests` at the root level, and
 `allennlp/tests/fixtures` moved to `test_fixtures` at the root level. The PyPI source and wheel distributions will no longer include tests and fixtures.
+- `PretrainedTransformerTokenizer.intra_word_tokenize` will raise an exception now when a token can't be split into wordpieces.
 
 ## [v1.0.0rc4](https://github.com/allenai/allennlp/releases/tag/v1.0.0rc4) - 2019-05-14
 

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -336,7 +336,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
     def _intra_word_tokenize(
         self, string_tokens: List[str]
-    ) -> Tuple[List[Token], List[Optional[Tuple[int, int]]]]:
+    ) -> Tuple[List[Token], List[Tuple[int, int]]]:
         tokens: List[Token] = []
         offsets: List[Optional[Tuple[int, int]]] = []
         for token_string in string_tokens:
@@ -357,21 +357,18 @@ class PretrainedTransformerTokenizer(Tokenizer):
                     for wp_id, wp_text in zip(wp_ids, self.tokenizer.convert_ids_to_tokens(wp_ids))
                 )
             else:
-                offsets.append(None)
+                raise ValueError(f"token '{token_string}' cannot be split into wordpieces")
         return tokens, offsets
 
     @staticmethod
     def _increment_offsets(
         offsets: Iterable[Optional[Tuple[int, int]]], increment: int
-    ) -> List[Optional[Tuple[int, int]]]:
-        return [
-            None if offset is None else (offset[0] + increment, offset[1] + increment)
-            for offset in offsets
-        ]
+    ) -> List[Tuple[int, int]]:
+        return [(offset[0] + increment, offset[1] + increment) for offset in offsets]
 
     def intra_word_tokenize(
         self, string_tokens: List[str]
-    ) -> Tuple[List[Token], List[Optional[Tuple[int, int]]]]:
+    ) -> Tuple[List[Token], List[Tuple[int, int]]]:
         """
         Tokenizes each word into wordpieces separately and returns the wordpiece IDs.
         Also calculates offsets such that tokens[offsets[i][0]:offsets[i][1] + 1]

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -338,7 +338,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         self, string_tokens: List[str]
     ) -> Tuple[List[Token], List[Tuple[int, int]]]:
         tokens: List[Token] = []
-        offsets: List[Optional[Tuple[int, int]]] = []
+        offsets: List[Tuple[int, int]] = []
         for token_string in string_tokens:
             wordpieces = self.tokenizer.encode_plus(
                 token_string,
@@ -362,7 +362,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
     @staticmethod
     def _increment_offsets(
-        offsets: Iterable[Optional[Tuple[int, int]]], increment: int
+        offsets: Iterable[Tuple[int, int]], increment: int
     ) -> List[Tuple[int, int]]:
         return [(offset[0] + increment, offset[1] + increment) for offset in offsets]
 

--- a/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -1,5 +1,7 @@
 from typing import Iterable, List
 
+import pytest
+
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Token
@@ -222,27 +224,12 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
         assert offsets_a == expected_offsets_a
         assert offsets_b == expected_offsets_b
 
-    def test_intra_word_tokenize_whitespaces(self):
+    def test_intra_word_tokenize_whitespaces_raises(self):
         tokenizer = PretrainedTransformerTokenizer("bert-base-cased")
 
         sentence = ["A,", " ", "[MASK]", "AllenNLP", "\u007f", "sentence."]
-        expected_tokens = [
-            "[CLS]",
-            "A",
-            ",",
-            "[MASK]",
-            "Allen",
-            "##NL",
-            "##P",
-            "sentence",
-            ".",
-            "[SEP]",
-        ]
-        expected_offsets = [(1, 2), None, (3, 3), (4, 6), None, (7, 8)]
-        tokens, offsets = tokenizer.intra_word_tokenize(sentence)
-        tokens = [t.text for t in tokens]
-        assert tokens == expected_tokens
-        assert offsets == expected_offsets
+        with pytest.raises(ValueError):
+            tokenizer.intra_word_tokenize(sentence)
 
     def test_special_tokens_added(self):
         def get_token_ids(tokens: Iterable[Token]) -> List[int]:


### PR DESCRIPTION
Closes https://github.com/allenai/allennlp/issues/4281.

I think when `intra_word_tokenize` cannot split a token into wordpieces we should raise an exception instead of just using `None` for the offsets. Especially considering there are several other downstream functions that depend on the offsets not being `None`. For example,
- https://github.com/allenai/allennlp/blob/master/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py#L96
- https://github.com/allenai/allennlp-models/blob/master/allennlp_models/coref/util.py#L105