### PR TITLE
Adds a "duplicate()" method on instances and fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Nothing yet
+
+- A bug where `TextField`s could not be deep-copied since some tokenizers cannot be deep-copied.
+  See https://github.com/allenai/allennlp/issues/4270.
 
 ### Added
+
 - Nothing yet
 
 ### Changed
+
 - Nothing yet
 
 ## [v1.0.0rc5](https://github.com/allenai/allennlp/releases/tag/v1.0.0rc5) - 2020-05-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A bug where `TextField`s could not be deep-copied since some tokenizers cannot be deep-copied.
+- A bug where `TextField`s could not be duplicated since some tokenizers cannot be deep-copied.
   See https://github.com/allenai/allennlp/issues/4270.
 
 ### Added
 
-- Nothing yet
+- A `duplicate()` method on `Instance`s and `Field`s, to be used instead of `copy.deepcopy()`.
 
 ### Changed
 

--- a/allennlp/data/fields/field.py
+++ b/allennlp/data/fields/field.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Dict, Generic, List, TypeVar
 
 import torch
@@ -120,3 +121,6 @@ class Field(Generic[DataArray]):
 
     def __len__(self):
         raise NotImplementedError
+
+    def duplicate(self):
+        return deepcopy(self)

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -155,15 +155,16 @@ class TextField(SequenceField[TextFieldTensors]):
     def __len__(self) -> int:
         return len(self.tokens)
 
-    def __deepcopy__(self, memo):
+    @overrides
+    def duplicate(self):
         """
-        Overrides the behavior of `deepcopy` so that `self._token_indexers` won't
+        Overrides the behavior of `duplicate` so that `self._token_indexers` won't
         actually be deep-copied.
 
         Not only would it be extremely inefficient to deep-copy the token indexers,
         but it also fails in many cases since some tokenizers (like those used in
         the 'transformers' lib) cannot actually be deep-copied.
         """
-        new = TextField(deepcopy(self.tokens, memo), {k: v for k, v in self._token_indexers})
-        new._indexed_tokens = deepcopy(self._indexed_tokens, memo)
+        new = TextField(deepcopy(self.tokens), {k: v for k, v in self._token_indexers.items()})
+        new._indexed_tokens = deepcopy(self._indexed_tokens)
         return new

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -3,6 +3,7 @@ A `TextField` represents a string of text, the kind that you might want to repre
 standard word vectors, or pass through an LSTM.
 """
 from collections import defaultdict
+from copy import deepcopy
 from typing import Dict, List, Optional, Iterator
 import textwrap
 
@@ -153,3 +154,16 @@ class TextField(SequenceField[TextFieldTensors]):
 
     def __len__(self) -> int:
         return len(self.tokens)
+
+    def __deepcopy__(self, memo):
+        """
+        Overrides the behavior of `deepcopy` so that `self._token_indexers` won't
+        actually be deep-copied.
+
+        Not only would it be extremely inefficient to deep-copy the token indexers,
+        but it also fails in many cases since some tokenizers (like those used in
+        the 'transformers' lib) cannot actually be deep-copied.
+        """
+        new = TextField(deepcopy(self.tokens, memo), self._token_indexers)
+        new._indexed_tokens = deepcopy(self._indexed_tokens, memo)
+        return new

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -164,6 +164,6 @@ class TextField(SequenceField[TextFieldTensors]):
         but it also fails in many cases since some tokenizers (like those used in
         the 'transformers' lib) cannot actually be deep-copied.
         """
-        new = TextField(deepcopy(self.tokens, memo), self._token_indexers)
+        new = TextField(deepcopy(self.tokens, memo), {k: v for k, v in self._token_indexers})
         new._indexed_tokens = deepcopy(self._indexed_tokens, memo)
         return new

--- a/allennlp/data/instance.py
+++ b/allennlp/data/instance.py
@@ -104,3 +104,8 @@ class Instance(Mapping[str, Field]):
         return " ".join(
             [base_string] + [f"\t {name}: {field} \n" for name, field in self.fields.items()]
         )
+
+    def duplicate(self) -> "Instance":
+        new = Instance({k: field.duplicate() for k, field in self.fields.items()})
+        new.indexed = self.indexed
+        return new

--- a/allennlp/predictors/sentence_tagger.py
+++ b/allennlp/predictors/sentence_tagger.py
@@ -1,5 +1,4 @@
 from typing import List, Dict
-from copy import deepcopy
 
 from overrides import overrides
 import numpy
@@ -105,7 +104,7 @@ class SentenceTaggerPredictor(Predictor):
         # Creates a new instance for each contiguous tag
         instances = []
         for labels in predicted_spans:
-            new_instance = deepcopy(instance)
+            new_instance = instance.duplicate()
             text_field: TextField = instance["tokens"]  # type: ignore
             new_instance.add_field(
                 "tags", SequenceLabelField(labels, text_field), self._model.vocab

--- a/allennlp/predictors/text_classifier.py
+++ b/allennlp/predictors/text_classifier.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import List, Dict
 
 from overrides import overrides
@@ -42,7 +41,7 @@ class TextClassifierPredictor(Predictor):
     def predictions_to_labeled_instances(
         self, instance: Instance, outputs: Dict[str, numpy.ndarray]
     ) -> List[Instance]:
-        new_instance = deepcopy(instance)
+        new_instance = instance.duplicate()
         label = numpy.argmax(outputs["probs"])
         new_instance.add_field("label", LabelField(int(label), skip_indexing=True))
         return [new_instance]

--- a/tests/data/instance_test.py
+++ b/tests/data/instance_test.py
@@ -1,6 +1,7 @@
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Instance
 from allennlp.data.fields import TextField, LabelField
+from allennlp.data.token_indexers import PretrainedTransformerIndexer
 from allennlp.data.tokenizers import Token
 
 
@@ -20,3 +21,22 @@ class TestInstance(AllenNlpTestCase):
         values = [v for k, v in instance.items()]
         assert words_field in values
         assert label_field in values
+
+    def test_duplicate(self):
+        # Verify the `duplicate()` method works with a `PretrainedTransformerIndexer` in
+        # a `TextField`. See https://github.com/allenai/allennlp/issues/4270.
+        instance = Instance(
+            {
+                "words": TextField(
+                    [Token("hello")], {"tokens": PretrainedTransformerIndexer("bert-base-uncased")}
+                )
+            }
+        )
+
+        other = instance.duplicate()
+        assert other == instance
+
+        # Adding new fields to the original instance should not effect the duplicate.
+        instance.add_field("labels", LabelField("some_label"))
+        assert "labels" not in other.fields
+        assert other != instance  # sanity check on the '__eq__' method.


### PR DESCRIPTION
Closes https://github.com/allenai/allennlp/issues/4270.

This new method should be used in place of `copy.deepcopy()`. It can be overridden on certain fields to avoid making deep copies of certain attributes when deep copying is unnecessary or not possible.

---

Note: I was lazy and haven't added tests yet, but I'll do so before merging if ya'll agree with this approach.