### PR TITLE
ensure only one process initializes its model at a time to avoid race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A bug where `TextField`s could not be duplicated since some tokenizers cannot be deep-copied.
   See https://github.com/allenai/allennlp/issues/4270.
+- A race condition that could occur in the distributed training scenario when the model
+  relies on files that need to be downloaded.
 
 ### Added
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -628,8 +628,8 @@ class TrainModel(Registrable):
 
         if common_util.is_distributed():
             # In the distributed scenario we have to be careful to avoid potential
-            # that could occur when initializing the model if the model relies
-            # on any files that need to be downloaded. Therefor we ensure
+            # race conditions that could occur when initializing the model if the model
+            # relies on any files that need to be downloaded. Therefor we ensure
             # only one process is initializing its model at a time using the lock.
             lock.acquire()
             model_ = model.construct(vocab=vocabulary_)


### PR DESCRIPTION
This should make distributed training more robust at least until we can improve our caching mechanism with lock files.