### PR TITLE
add lock file within caching mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Nothing yet
+- Similar to our caching mechanism, we introduced a lock file to the vocab to avoid race
+  conditions when saving/loading the vocab from/to the same serialization directory in different processes.
 
 ## [v1.0.0rc5](https://github.com/allenai/allennlp/releases/tag/v1.0.0rc5) - 2020-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A bug where `TextField`s could not be duplicated since some tokenizers cannot be deep-copied.
   See https://github.com/allenai/allennlp/issues/4270.
+- Our caching mechanism had the potential to introduce race conditions if multiple processes
+  were attempting to cache the same file at once. This was fixed by using a lock file tied to each
+  cached file.
 
 ### Added
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -628,12 +628,9 @@ class TrainModel(Registrable):
 
         # Initializing the model can have side effect of expanding the vocabulary.
         # Save the vocab only in the master. In the degenerate non-distributed
-        # case, we're trivially the master. But in the distributed case we need to be careful
-        # to avoid a race condition where we might be writing the vocab from the master
-        # process while another process is reading it. So we use a barrier here
-        # to wait for the other processes to finish reading.
-        if common_util.is_distributed():
-            dist.barrier()
+        # case, we're trivially the master. In the distributed case this is safe
+        # to do without worrying about race conditions since saving and loading
+        # the vocab involves acquiring a file lock.
         if common_util.is_master():
             vocabulary_path = os.path.join(serialization_dir, "vocabulary")
             vocabulary_.save_to_files(vocabulary_path)

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -298,8 +298,8 @@ def get_from_cache(url: str, cache_dir: str = None) -> str:
     # on the call to `lock.acquire()` until the process currently holding the lock
     # releases it.
     logger.info("checking cache for %s at %s", url, cache_path)
-    lock = FileLock(cache_path + ".lock")
-    with lock.acquire():
+    logger.info("waiting to acquire lock on %s", cache_path)
+    with FileLock(cache_path + ".lock"):
         if os.path.exists(cache_path):
             logger.info("cache of %s is up-to-date", url)
         else:

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -17,6 +17,7 @@ from functools import wraps
 import boto3
 import botocore
 from botocore.exceptions import ClientError, EndpointConnectionError
+from filelock import FileLock
 import requests
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError
@@ -288,37 +289,44 @@ def get_from_cache(url: str, cache_dir: str = None) -> str:
 
     filename = url_to_filename(url, etag)
 
-    # get cache path to put the file
+    # Get cache path to put the file.
     cache_path = os.path.join(cache_dir, filename)
 
-    if not os.path.exists(cache_path):
-        # Download to temporary file, then copy to cache dir once finished.
-        # Otherwise you get corrupt cache entries if the download gets interrupted.
-        with tempfile.NamedTemporaryFile() as temp_file:
-            logger.info("%s not found in cache, downloading to %s", url, temp_file.name)
+    # Multiple processes may be trying to cache the same file at once, so we need
+    # to be a little careful to avoid race conditions. We do this using a lock file.
+    # Only one process can own this lock file at a time, and a process will block
+    # on the call to `lock.acquire()` until the process currently holding the lock
+    # releases it.
+    lock = FileLock(cache_path + ".lock")
+    with lock.acquire():
+        if not os.path.exists(cache_path):
+            # Download to temporary file, then copy to cache dir once finished.
+            # Otherwise you get corrupt cache entries if the download gets interrupted.
+            with tempfile.NamedTemporaryFile() as temp_file:
+                logger.info("%s not found in cache, downloading to %s", url, temp_file.name)
 
-            # GET file object
-            if url.startswith("s3://"):
-                _s3_get(url, temp_file)
-            else:
-                _http_get(url, temp_file)
+                # GET file object
+                if url.startswith("s3://"):
+                    _s3_get(url, temp_file)
+                else:
+                    _http_get(url, temp_file)
 
-            # we are copying the file before closing it, so flush to avoid truncation
-            temp_file.flush()
-            # shutil.copyfileobj() starts at the current position, so go to the start
-            temp_file.seek(0)
+                # we are copying the file before closing it, so flush to avoid truncation
+                temp_file.flush()
+                # shutil.copyfileobj() starts at the current position, so go to the start
+                temp_file.seek(0)
 
-            logger.info("copying %s to cache at %s", temp_file.name, cache_path)
-            with open(cache_path, "wb") as cache_file:
-                shutil.copyfileobj(temp_file, cache_file)
+                logger.info("copying %s to cache at %s", temp_file.name, cache_path)
+                with open(cache_path, "wb") as cache_file:
+                    shutil.copyfileobj(temp_file, cache_file)
 
-            logger.info("creating metadata file for %s", cache_path)
-            meta = {"url": url, "etag": etag}
-            meta_path = cache_path + ".json"
-            with open(meta_path, "w") as meta_file:
-                json.dump(meta, meta_file)
+                logger.info("creating metadata file for %s", cache_path)
+                meta = {"url": url, "etag": etag}
+                meta_path = cache_path + ".json"
+                with open(meta_path, "w") as meta_file:
+                    json.dump(meta, meta_file)
 
-            logger.info("removing temp file %s", temp_file.name)
+                logger.info("removing temp file %s", temp_file.name)
 
     return cache_path
 

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -297,9 +297,12 @@ def get_from_cache(url: str, cache_dir: str = None) -> str:
     # Only one process can own this lock file at a time, and a process will block
     # on the call to `lock.acquire()` until the process currently holding the lock
     # releases it.
+    logger.info("checking cache for %s at %s", url, cache_path)
     lock = FileLock(cache_path + ".lock")
     with lock.acquire():
-        if not os.path.exists(cache_path):
+        if os.path.exists(cache_path):
+            logger.info("cache of %s is up-to-date", url)
+        else:
             # Download to temporary file, then copy to cache dir once finished.
             # Otherwise you get corrupt cache entries if the download gets interrupted.
             with tempfile.NamedTemporaryFile() as temp_file:

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "transformers>=2.9,<2.10",
         "jsonpickle",
         "dataclasses;python_version<'3.7'",
-        "filelock",
+        "filelock>=3.0,<3.1",
     ],
     entry_points={"console_scripts": ["allennlp=allennlp.__main__:run"]},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "transformers>=2.9,<2.10",
         "jsonpickle",
         "dataclasses;python_version<'3.7'",
+        "filelock",
     ],
     entry_points={"console_scripts": ["allennlp=allennlp.__main__:run"]},
     include_package_data=True,

--- a/tests/commands/train_test.py
+++ b/tests/commands/train_test.py
@@ -695,7 +695,12 @@ class TestDryRun(AllenNlpTestCase):
         train_model(self.params, self.TEST_DIR, dry_run=True)
 
         vocab_files = os.listdir(vocab_path)
-        assert set(vocab_files) == {"labels.txt", "non_padded_namespaces.txt", "tokens.txt"}
+        assert set(vocab_files) == {
+            ".lock",
+            "labels.txt",
+            "non_padded_namespaces.txt",
+            "tokens.txt",
+        }
 
         with open(vocab_path / "tokens.txt") as f:
             tokens = [line.strip() for line in f]
@@ -728,7 +733,12 @@ class TestDryRun(AllenNlpTestCase):
         train_model(self.params, extended_serialization_dir, dry_run=True)
 
         vocab_files = os.listdir(extended_vocab_path)
-        assert set(vocab_files) == {"labels.txt", "non_padded_namespaces.txt", "tokens.txt"}
+        assert set(vocab_files) == {
+            ".lock",
+            "labels.txt",
+            "non_padded_namespaces.txt",
+            "tokens.txt",
+        }
 
         with open(extended_vocab_path / "tokens.txt") as f:
             tokens = [line.strip() for line in f]


### PR DESCRIPTION
This should make our caching mechanism much more robust. It uses a lock file to ensure that if one process is caching a particular file, any other calls to `cached_path()` on the same file (from separate Python processes) will block until the writing process has finished.

I'm not sure if there's a good way to unit test this, or if it's even worth it because the logic is pretty simple. But you can give it a try by running a script like this from multiple terminals at the same time:

```python
import logging
from allennlp.common.file_utils import cached_path

logging.basicConfig(level=logging.INFO)

filename = "https://allennlp.s3.amazonaws.com/datasets/glove/glove.6B.100d.txt.gz"
print(cached_path(filename))
```

Also https://github.com/allenai/allennlp/pull/4298 may not be necessary if we merge this.