### PR TITLE
remove setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[aliases]
-test=pytest


### PR DESCRIPTION
I don't think there's any reason to have this since we don't do `python setup.py test` to run pytest, which is deprecated anyway: https://github.com/pytest-dev/pytest-runner/#deprecation-notice