### PR TITLE
ensure CUDA available in GPU checks workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,6 +30,10 @@ jobs:
       run: |
         make docker-test-image DOCKER_TAG=$DOCKER_TAG
 
+    - name: Ensure CUDA available
+      run: |
+        make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='check-for-cuda'
+
     - name: Run GPU tests
       run: |
         make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='gpu-test'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,6 +39,10 @@ jobs:
       run: |
         make docker-test-image DOCKER_TAG=$DOCKER_TAG
 
+    - name: Ensure CUDA available
+      run: |
+        make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='check-for-cuda'
+
     - name: Run GPU tests
       run: |
         make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='gpu-test'

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ endif
 version :
 	@python -c 'from allennlp.version import VERSION; print(f"AllenNLP v{VERSION}")'
 
+.PHONY : check-for-cuda
+check-for-cuda :
+	@python -c 'import torch; assert torch.cuda.is_available(); print("Cuda is available")'
+
 #
 # Testing helpers.
 #


### PR DESCRIPTION
Occasionally CUDA becomes unavailable on the self-hosted runner, for whatever reason. When this happens, the GPU workflow will always pass even though it doesn't actually run any GPU checks.