### PR TITLE
Fix bug with lazy data loading, un-implement __len__ on AllennlpLazyDataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_text_field_mask()` now supports padding indices that are not `0`.
 - A bug where `predictor.get_gradients()` would return an empty dictionary if an embedding layer had trainable set to false
 - Fixes `PretrainedTransformerMismatchedIndexer` in the case where a token consists of zero word pieces.
+- Fixes a bug when using a lazy dataset reader that results in a `UserWarning` from PyTorch being printed at
+  every iteration during training.
 
 ### Added
 
@@ -38,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SimpleTagger will no longer calculate span-based F1 metric when `calculate_span_f1` is `False`.
 - CPU memory for every worker is now reported in the logs and the metrics. Previously this was only reporting the CPU memory of the master process, and so it was only
   correct in the non-distributed setting.
+- To be consistent with PyTorch `IterableDataset`, `AllennlpLazyDataset` no longer implements `__len__()`.
+  Previously it would always return 1.
 
 ## [v1.0.0rc5](https://github.com/allenai/allennlp/releases/tag/v1.0.0rc5) - 2020-05-26
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -490,7 +490,7 @@ class TrainModel(Registrable):
         return self.trainer.train()
 
     def finish(self, metrics: Dict[str, Any]):
-        if self.evaluation_data_loader and self.evaluate_on_test:
+        if self.evaluation_data_loader is not None and self.evaluate_on_test:
             logger.info("The model will be evaluated using the best epoch weights.")
             test_metrics = training_util.evaluate(
                 self.model,

--- a/allennlp/common/tqdm.py
+++ b/allennlp/common/tqdm.py
@@ -46,5 +46,17 @@ class Tqdm:
     @staticmethod
     def tqdm(*args, **kwargs):
         new_kwargs = {"mininterval": Tqdm.default_mininterval, **kwargs}
+        # TODO(epwalsh): check up on these issues later to see if we can remove this logic.
+        # Due to some bugs in Tqdm, we need to make sure to set `total` when were working
+        # with iterators/generators that don't implement `__len__()`.
+        # See
+        # - https://github.com/tqdm/tqdm/issues/624
+        # - https://github.com/tqdm/tqdm/issues/457
+        if "total" not in new_kwargs:
+            try:
+                len(args[0])
+            except (TypeError, NotImplementedError):
+                total = float("inf")
+                new_kwargs["total"] = total
 
         return _tqdm(*args, **new_kwargs)

--- a/allennlp/common/tqdm.py
+++ b/allennlp/common/tqdm.py
@@ -46,17 +46,5 @@ class Tqdm:
     @staticmethod
     def tqdm(*args, **kwargs):
         new_kwargs = {"mininterval": Tqdm.default_mininterval, **kwargs}
-        # TODO(epwalsh): check up on these issues later to see if we can remove this logic.
-        # Due to some bugs in Tqdm, we need to make sure to set `total` when were working
-        # with iterators/generators that don't implement `__len__()`.
-        # See
-        # - https://github.com/tqdm/tqdm/issues/624
-        # - https://github.com/tqdm/tqdm/issues/457
-        if "total" not in new_kwargs:
-            try:
-                len(args[0])
-            except (TypeError, NotImplementedError):
-                total = float("inf")
-                new_kwargs["total"] = total
 
         return _tqdm(*args, **new_kwargs)

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -48,9 +48,6 @@ class AllennlpLazyDataset(IterableDataset):
     def index_with(self, vocab: Vocabulary):
         self.vocab = vocab
 
-    def __len__(self):
-        raise NotImplementedError
-
 
 class _LazyInstances(AllennlpLazyDataset):
     """
@@ -116,9 +113,6 @@ class _MaxLazyInstances(AllennlpLazyDataset):
     def index_with(self, vocab: Vocabulary):
         self.inner.index_with(vocab)
 
-    def __len__(self):
-        return len(self.inner)
-
 
 class _DistributedLazyInstances(AllennlpLazyDataset):
     def __init__(self, inner: AllennlpLazyDataset) -> None:
@@ -137,9 +131,6 @@ class _DistributedLazyInstances(AllennlpLazyDataset):
 
     def index_with(self, vocab: Vocabulary):
         self.inner.index_with(vocab)
-
-    def __len__(self):
-        return len(self.inner)
 
 
 class DatasetReader(Registrable):

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -49,13 +49,7 @@ class AllennlpLazyDataset(IterableDataset):
         self.vocab = vocab
 
     def __len__(self):
-        """
-        We rely in a couple of places that calling len on the dataloader
-        (which in turn calls len on the dataset) doesn't raise an error.
-        In the case that you have an IterableDataset and you call len, the pytorch dataloader
-        actually spits out a warning - but we need actually calling it to not crash.
-        """
-        return 1
+        raise NotImplementedError
 
 
 class _LazyInstances(AllennlpLazyDataset):

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -630,11 +630,10 @@ class EmbeddingsTextFile(Iterator[str]):
         return next(self._iterator)
 
     def __len__(self) -> Optional[int]:
-        """ Hack for tqdm: no need for explicitly passing `total=file.num_tokens` """
         if self.num_tokens:
             return self.num_tokens
-        raise AttributeError(
-            'an object of type EmbeddingsTextFile has "len()" only if the underlying '
+        raise NotImplementedError(
+            "an object of type EmbeddingsTextFile implements `__len__` only if the underlying "
             "text file declares the number of tokens (i.e. the number of lines following)"
             "in the first line. That is not the case of this particular instance."
         )

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -632,7 +632,7 @@ class EmbeddingsTextFile(Iterator[str]):
     def __len__(self) -> Optional[int]:
         if self.num_tokens:
             return self.num_tokens
-        raise NotImplementedError(
+        raise AttributeError(
             "an object of type EmbeddingsTextFile implements `__len__` only if the underlying "
             "text file declares the number of tokens (i.e. the number of lines following)"
             "in the first line. That is not the case of this particular instance."

--- a/allennlp/training/learning_rate_schedulers/slanted_triangular.py
+++ b/allennlp/training/learning_rate_schedulers/slanted_triangular.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 from overrides import overrides
 import torch
@@ -33,7 +33,7 @@ class SlantedTriangular(LearningRateScheduler):
         This argument does not get an entry in a configuration file for the object.
     num_epochs : `int`, required.
         The total number of epochs for which the model should be trained.
-    num_steps_per_epoch : `int`, required.
+    num_steps_per_epoch : `Optional[int]`, optional (default = `None`)
         The number of steps (updates, batches) per training epoch.
     cut_frac : `float`, optional (default = `0.1`).
         The fraction of the steps to increase the learning rate.
@@ -53,7 +53,7 @@ class SlantedTriangular(LearningRateScheduler):
         self,
         optimizer: torch.optim.Optimizer,
         num_epochs: int,
-        num_steps_per_epoch: int,
+        num_steps_per_epoch: Optional[int] = None,
         cut_frac: float = 0.1,
         ratio: int = 32,
         last_epoch: int = -1,
@@ -138,7 +138,9 @@ class SlantedTriangular(LearningRateScheduler):
                 self.batch_num_total_epoch_end[-1] / (len(self.batch_num_total_epoch_end) - 1)
             )
         else:
-            actual_num_steps_per_epoch = max(self.num_steps_per_epoch, self.last_batch_num_total)
+            actual_num_steps_per_epoch = max(
+                self.num_steps_per_epoch or 1, self.last_batch_num_total
+            )
 
         if self.freezing_current:
             # if we still freeze, we restrict the schedule to the current epoch

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -1067,11 +1067,12 @@ class GradientDescentTrainer(Trainer):
         if not optimizer_:
             optimizer_ = Optimizer.default(parameters)
 
+        batches_per_epoch: Optional[int]
         try:
             batches_per_epoch = len(data_loader)
+            batches_per_epoch = math.ceil(batches_per_epoch / num_gradient_accumulation_steps)
         except TypeError:
-            batches_per_epoch = 1
-        batches_per_epoch = math.ceil(batches_per_epoch / num_gradient_accumulation_steps)
+            batches_per_epoch = None
 
         moving_average_ = moving_average.construct(parameters=parameters)
         learning_rate_scheduler_ = learning_rate_scheduler.construct(

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -514,7 +514,7 @@ class GradientDescentTrainer(Trainer):
             num_training_batches = math.ceil(
                 len_data_loader / self._num_gradient_accumulation_steps
             )
-        except NotImplementedError:
+        except TypeError:
             num_training_batches = float("inf")
 
         # Having multiple tqdm bars in case of distributed training will be a mess. Hence only the master's
@@ -1069,7 +1069,7 @@ class GradientDescentTrainer(Trainer):
 
         try:
             batches_per_epoch = len(data_loader)
-        except NotImplementedError:
+        except TypeError:
             batches_per_epoch = 1
         batches_per_epoch = math.ceil(batches_per_epoch / num_gradient_accumulation_steps)
 

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -333,7 +333,7 @@ def evaluate(
 
         iterator = iter(data_loader)
         logger.info("Iterating over dataset")
-        generator_tqdm = Tqdm.tqdm(iterator, total=len(data_loader))
+        generator_tqdm = Tqdm.tqdm(iterator)
 
         # Number of batches in instances.
         batch_count = 0


### PR DESCRIPTION
This fixes a bug that occurs when using a lazy dataset reader where you'd get a `PyTorch` warning on every single batch during training. It does so by making `AllennlpLazyDataset` consistent with `torch.data.IterableDataset` in that it no longer implements `__len__()` (previously `len()` would just return 1).

![image](https://user-images.githubusercontent.com/8812459/83914497-2d5eba00-a726-11ea-814e-9498be6e92d9.png)

To reproduce this bug just run `allennlp train` on a experiment with a lazy dataset reader like this:

```
{
  "dataset_reader": {
    "type": "squad",
    "lazy": true,
    "token_indexers": {
      "tokens": {
        "type": "single_id",
        "lowercase_tokens": true
      },
      "token_characters": {
        "type": "characters",
        "character_tokenizer": {
          "byte_encoding": "utf-8",
          "start_tokens": [259],
          "end_tokens": [260]
        },
        "min_padding_length": 5
      }
    }
  },
  "train_data_path": "https://allennlp.s3.amazonaws.com/datasets/squad/squad-train-v1.1.json",
  "validation_data_path": "https://allennlp.s3.amazonaws.com/datasets/squad/squad-dev-v1.1.json",
  "model": {
    "type": "bidaf",
    "text_field_embedder": {
      "token_embedders": {
        "tokens": {
          "type": "embedding",
          "pretrained_file": "https://allennlp.s3.amazonaws.com/datasets/glove/glove.6B.100d.txt.gz",
          "embedding_dim": 100,
          "trainable": false
        },
        "token_characters": {
          "type": "character_encoding",
          "embedding": {
            "num_embeddings": 262,
            "embedding_dim": 16
          },
          "encoder": {
            "type": "cnn",
            "embedding_dim": 16,
            "num_filters": 100,
            "ngram_filter_sizes": [5]
          },
          "dropout": 0.2
        }
      }
    },
    "num_highway_layers": 2,
    "phrase_layer": {
      "type": "lstm",
      "bidirectional": true,
      "input_size": 200,
      "hidden_size": 100,
      "num_layers": 1
    },
    "matrix_attention": {
      "type": "linear",
      "combination": "x,y,x*y",
      "tensor_1_dim": 200,
      "tensor_2_dim": 200
    },
    "modeling_layer": {
      "type": "lstm",
      "bidirectional": true,
      "input_size": 800,
      "hidden_size": 100,
      "num_layers": 2,
      "dropout": 0.2,
    },
    "span_end_encoder": {
      "type": "lstm",
      "bidirectional": true,
      "input_size": 1400,
      "hidden_size": 100,
      "num_layers": 1,
    },
    "dropout": 0.2,
  },
  "data_loader": {
    "batch_size": 40,
    "num_workers": 1,
  },
  "trainer": {
    "num_epochs": 20,
    "grad_norm": 5.0,
    // "patience": 10,
    "validation_metric": "+em",
    "cuda_device": 0,
    "learning_rate_scheduler": {
      "type": "reduce_on_plateau",
      "factor": 0.5,
      "mode": "max",
      "patience": 2,
    },
    "optimizer": {
      "type": "adam",
      "betas": [0.9, 0.9],
    },
  },
}
```