### PR TITLE
Consistently use underscores in Predictor names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes `PretrainedTransformerMismatchedIndexer` in the case where a token consists of zero word pieces.
 - Fixes a bug when using a lazy dataset reader that results in a `UserWarning` from PyTorch being printed at
   every iteration during training.
+- Predictors names were inconsistently switching between dashes and underscores. Now they all use underscores.
 
 ### Added
 

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -220,4 +220,4 @@ class SimpleTagger(Model):
                 metrics_to_return.update({x: y for x, y in f1_dict.items() if "overall" in x})
         return metrics_to_return
 
-    default_predictor = "sentence-tagger"
+    default_predictor = "sentence_tagger"

--- a/allennlp/predictors/sentence_tagger.py
+++ b/allennlp/predictors/sentence_tagger.py
@@ -11,7 +11,7 @@ from allennlp.models import Model
 from allennlp.predictors.predictor import Predictor
 
 
-@Predictor.register("sentence-tagger")
+@Predictor.register("sentence_tagger")
 class SentenceTaggerPredictor(Predictor):
     """
     Predictor for any model that takes in a sentence and returns
@@ -19,7 +19,7 @@ class SentenceTaggerPredictor(Predictor):
     the [`CrfTagger`](../models/crf_tagger.md) model
     and also the [`SimpleTagger`](../models/simple_tagger.md) model.
 
-    Registered as a `Predictor` with name "sentence-tagger".
+    Registered as a `Predictor` with name "sentence_tagger".
     """
 
     def __init__(

--- a/tests/interpret/input_reduction_test.py
+++ b/tests/interpret/input_reduction_test.py
@@ -32,7 +32,7 @@ class TestInputReduction(AllenNlpTestCase):
         archive = load_archive(
             self.FIXTURES_ROOT / "simple_tagger" / "serialization" / "model.tar.gz"
         )
-        predictor = Predictor.from_archive(archive, "sentence-tagger")
+        predictor = Predictor.from_archive(archive, "sentence_tagger")
 
         reducer = InputReduction(predictor)
         reduced = reducer.attack_from_json(inputs, "tokens", "grad_input_1")

--- a/tests/predictors/predictor_test.py
+++ b/tests/predictors/predictor_test.py
@@ -9,10 +9,10 @@ class TestPredictor(AllenNlpTestCase):
         archive = load_archive(
             self.FIXTURES_ROOT / "simple_tagger" / "serialization" / "model.tar.gz"
         )
-        Predictor.from_archive(archive, "sentence-tagger")
+        Predictor.from_archive(archive, "sentence_tagger")
 
         # If it consumes the params, this will raise an exception
-        Predictor.from_archive(archive, "sentence-tagger")
+        Predictor.from_archive(archive, "sentence_tagger")
 
     def test_loads_correct_dataset_reader(self):
         # This model has a different dataset reader configuration for train and validation. The
@@ -21,16 +21,16 @@ class TestPredictor(AllenNlpTestCase):
             self.FIXTURES_ROOT / "simple_tagger_with_span_f1" / "serialization" / "model.tar.gz"
         )
 
-        predictor = Predictor.from_archive(archive, "sentence-tagger")
+        predictor = Predictor.from_archive(archive, "sentence_tagger")
         assert predictor._dataset_reader._token_indexers["tokens"].namespace == "test_tokens"
 
         predictor = Predictor.from_archive(
-            archive, "sentence-tagger", dataset_reader_to_load="train"
+            archive, "sentence_tagger", dataset_reader_to_load="train"
         )
         assert predictor._dataset_reader._token_indexers["tokens"].namespace == "tokens"
 
         predictor = Predictor.from_archive(
-            archive, "sentence-tagger", dataset_reader_to_load="validation"
+            archive, "sentence_tagger", dataset_reader_to_load="validation"
         )
         assert predictor._dataset_reader._token_indexers["tokens"].namespace == "test_tokens"
 

--- a/tests/predictors/sentence_tagger_test.py
+++ b/tests/predictors/sentence_tagger_test.py
@@ -10,7 +10,7 @@ class TestSentenceTaggerPredictor(AllenNlpTestCase):
         archive = load_archive(
             self.FIXTURES_ROOT / "simple_tagger" / "serialization" / "model.tar.gz"
         )
-        predictor = Predictor.from_archive(archive, "sentence-tagger")
+        predictor = Predictor.from_archive(archive, "sentence_tagger")
 
         instance = predictor._json_to_instance(inputs)
         outputs = predictor._model.forward_on_instance(instance)


### PR DESCRIPTION
This seems like a nit-picky thing, but we had situations where the model was using underscores, and the corresponding predictor was using the exact same name except with dashes.