### PR TITLE
Update vocabulary load to a system-agnostic newline

### DIFF
--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -443,7 +443,7 @@ class Vocabulary(Registrable):
             self._token_to_index[namespace] = {}
             self._index_to_token[namespace] = {}
         with codecs.open(filename, "r", "utf-8") as input_file:
-            lines = input_file.read().split("\n")
+            lines = input_file.read().splitlines()
             # Be flexible about having final newline or not
             if lines and lines[-1] == "":
                 lines = lines[:-1]


### PR DESCRIPTION
Hello, 
I had a problem about training a model on a Linux machine and loading on a Windows machine.  The error was:
AssertionError: OOV token not found!

After some debugging I found out that during the vocabulary loading, it was splitting by '\n', where this can cause a difference between Linux and Windows. This PR change the split to OS agnostic method of new-line splitting.