### PR TITLE
issue warning when multi-process data loading used with lazy dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously it would always return 1.
 - Removed old tutorials, in favor of [the new AllenNLP Guide](https://guide.allennlp.org)
 
+### Removed
+
+- Removed the `num_workers` parameter from the `allennlp.data.DataLoader` since PyTorch's multi-process data loading doesn't play well with lazy dataset readers, and provides very little, if any, speed up with non-lazy readers.
+
 ## [v1.0.0rc5](https://github.com/allenai/allennlp/releases/tag/v1.0.0rc5) - 2020-05-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,10 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously it would always return 1.
 - Removed old tutorials, in favor of [the new AllenNLP Guide](https://guide.allennlp.org)
 
-### Removed
-
-- Removed the `num_workers` parameter from the `allennlp.data.DataLoader` since PyTorch's multi-process data loading doesn't play well with lazy dataset readers, and provides very little, if any, speed up with non-lazy readers.
-
 ## [v1.0.0rc5](https://github.com/allenai/allennlp/releases/tag/v1.0.0rc5) - 2020-05-26
 
 ### Fixed

--- a/allennlp/data/dataloader.py
+++ b/allennlp/data/dataloader.py
@@ -69,8 +69,8 @@ class DataLoader(Registrable, data.DataLoader):
         if num_workers and isinstance(dataset, AllennlpLazyDataset):
             warnings.warn(
                 "You specified 'num_workers' in your DataLoader while using a lazy dataset.\n\n"
-                "This could lead to duplicated if your dataset reader wasn't implemented to handle "
-                "multi-process data loading. See:\n"
+                "This could lead to duplicate data if your dataset reader wasn't implemented to "
+                "handle multi-process data loading. See:\n"
                 "  https://pytorch.org/docs/stable/data.html#multi-process-data-loading\n\n"
                 "This could also lead to deadlocks when using certain tokenizers. See:\n"
                 "  https://github.com/allenai/allennlp/issues/4330\n",

--- a/allennlp/data/dataloader.py
+++ b/allennlp/data/dataloader.py
@@ -1,9 +1,9 @@
 from typing import List, Dict, Union
+import warnings
 
 import torch
 from torch.utils import data
 
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.lazy import Lazy
 from allennlp.common.registrable import Registrable
 from allennlp.data.instance import Instance
@@ -67,10 +67,14 @@ class DataLoader(Registrable, data.DataLoader):
         batches_per_epoch: int = None,
     ):
         if num_workers and isinstance(dataset, AllennlpLazyDataset):
-            raise ConfigurationError(
-                "You specified the 'num_workers' parameter, but multi-process data loading is "
-                "currently incompatible with lazy datasets. You should either use a non-lazy "
-                "dataset reader or set 'num_workers' to 'None'."
+            warnings.warn(
+                "You specified 'num_workers' in your DataLoader while using a lazy dataset.\n\n"
+                "This could lead to duplicated if your dataset reader wasn't implemented to handle "
+                "multi-process data loading. See:\n"
+                "  https://pytorch.org/docs/stable/data.html#multi-process-data-loading\n\n"
+                "This could also lead to deadlocks when using certain tokenizers. See:\n"
+                "  https://github.com/allenai/allennlp/issues/4330\n",
+                UserWarning,
             )
         super().__init__(
             dataset=dataset,

--- a/allennlp/data/dataloader.py
+++ b/allennlp/data/dataloader.py
@@ -53,7 +53,6 @@ class DataLoader(Registrable, data.DataLoader):
         shuffle: bool = False,
         sampler: Sampler = None,
         batch_sampler: BatchSampler = None,
-        num_workers: int = 0,
         # NOTE: The default for collate_fn is different from the normal `None`.
         # We assume that if you are using this class you are using an
         # allennlp dataset of instances, which would require this.
@@ -71,7 +70,6 @@ class DataLoader(Registrable, data.DataLoader):
             shuffle=shuffle,
             sampler=sampler,
             batch_sampler=batch_sampler,
-            num_workers=num_workers,
             collate_fn=collate_fn,
             pin_memory=pin_memory,
             drop_last=drop_last,
@@ -106,7 +104,6 @@ class DataLoader(Registrable, data.DataLoader):
         shuffle: bool = False,
         sampler: Lazy[Sampler] = None,
         batch_sampler: Lazy[BatchSampler] = None,
-        num_workers: int = 0,
         pin_memory: bool = False,
         drop_last: bool = False,
         timeout: int = 0,
@@ -130,7 +127,6 @@ class DataLoader(Registrable, data.DataLoader):
             shuffle=shuffle,
             sampler=sampler_,
             batch_sampler=batch_sampler_,
-            num_workers=num_workers,
             # NOTE: The default for collate_fn is different from the normal `None`.
             # We assume that if you are using this class you are using an
             # allennlp dataset of instances, which would require this.

--- a/tests/data/dataloader_test.py
+++ b/tests/data/dataloader_test.py
@@ -4,6 +4,6 @@ from allennlp.data.dataloader import DataLoader
 from allennlp.data.dataset_readers.dataset_reader import _LazyInstances
 
 
-def test_multi_processing_with_lazy_dataset_raises():
+def test_multi_processing_with_lazy_dataset_warns():
     with pytest.warns(UserWarning, match=r".*'num_workers'.*"):
         DataLoader(_LazyInstances(iter([]), "nonexistent_file"), num_workers=1)

--- a/tests/data/dataloader_test.py
+++ b/tests/data/dataloader_test.py
@@ -1,10 +1,9 @@
 import pytest
 
-from allennlp.common.checks import ConfigurationError
 from allennlp.data.dataloader import DataLoader
 from allennlp.data.dataset_readers.dataset_reader import _LazyInstances
 
 
 def test_multi_processing_with_lazy_dataset_raises():
-    with pytest.raises(ConfigurationError, match=r".*'num_workers'.*"):
+    with pytest.warns(UserWarning, match=r".*'num_workers'.*"):
         DataLoader(_LazyInstances(iter([]), "nonexistent_file"), num_workers=1)

--- a/tests/data/dataloader_test.py
+++ b/tests/data/dataloader_test.py
@@ -1,0 +1,10 @@
+import pytest
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.data.dataloader import DataLoader
+from allennlp.data.dataset_readers.dataset_reader import _LazyInstances
+
+
+def test_multi_processing_with_lazy_dataset_raises():
+    with pytest.raises(ConfigurationError, match=r".*'num_workers'.*"):
+        DataLoader(_LazyInstances(iter([]), "nonexistent_file"), num_workers=1)


### PR DESCRIPTION
There are several issues with using [PyTorch's native multi-process data loading](https://pytorch.org/docs/stable/data.html#multi-process-data-loading), which is enabled by setting the `DataLoader`'s `num_workers` to a positive number.

1. The main issue with PyTorch's multi-process data loading is that it's fundamentally incompatible with our `AllennlpLazyDataset`, unless using a `ShardedDatasetReader`. This is because our dataset readers don't take into account that there are other workers since they never check [`torch.data.get_worker_info()`](https://pytorch.org/docs/stable/data.html#torch.utils.data.get_worker_info). Hence each worker will read all of the instances, and so you'll get `num_workers` multiples of each instance.

    This is easy to see by running this example:

    ```python
    from allennlp.data import DataLoader, Vocabulary
    from allennlp_models.pair_classification.dataset_readers import SnliReader
    
    reader = SnliReader(lazy=True, max_instances=10)
    
    print("initialized dataset")
    ds = reader.read("https://allennlp.s3.amazonaws.com/datasets/snli/snli_1.0_dev.jsonl")
    
    print("creating vocab")
    vocab = Vocabulary.from_instances(ds)
    
    ds.index_with(vocab)
    
    print("reading instances")
    i = 0
    for instance in DataLoader(ds, num_workers=2):
        print(instance["hypothesis"])
        i += 1
    print(f"read {i} instances")
    ```

    The only way to fix this would be to handle it at the `DatasetReader` level, which might require significant changes.


2. Another issue is that using some `PretrainedTransformerTokenizer`s or, more generally, any tokenizer from the [tokenizers](https://github.com/huggingface/tokenizers) Python package will result in a deadlock if the tokenizer is used from the master process and then used again from a forked thread. So any time one of these tokenizers is used within a lazy dataset reader in a multi-process data loader, you'll get a deadlock. See https://github.com/allenai/allennlp/issues/4330.

2. ~~Lastly, even though multi-process data loading works correctly with non-lazy dataset readers, the only thing that the workers will be doing in parallel is calling `instance.index_fields(self.vocab)` (which comes from [`AllennlpDataset.__getitem__(self, idx)`](https://github.com/allenai/allennlp/blob/master/allennlp/data/dataset_readers/dataset_reader.py#L24)).~~

    ~~This is probably not worth the overhead.~~

~~So this PR just removes the `num_workers` parameter to effectively barricade off the multi-process data loading feature.~~