### PR TITLE
Fix handling of "datasets_for_vocab_creation" param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Predictor.from_path` now automatically loads plugins (unless you specify `load_plugins=False`) so
   that you don't have to manually import a bunch of modules when instantiating predictors from
   an archive path.
-- A bug where where all datasets would be loaded for vocab creation if `datasets_for_vocab_creation`
-  was set to `[]` in the config.
+- A bug where where all datasets would be loaded for vocab creation even if not needed.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+
+- A bug where where all datasets would be loaded for vocab creation even if not needed.
+
 ## [v1.0.0rc6](https://github.com/allenai/allennlp/releases/tag/v1.0.0rc6) - 2020-06-11
 
 ### Fixed
@@ -26,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that you don't have to manually import a bunch of modules when instantiating predictors from
   an archive path.
 - `allennlp-server` automatically found as a plugin once again.
-- A bug where where all datasets would be loaded for vocab creation even if not needed.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Predictor.from_path` now automatically loads plugins (unless you specify `load_plugins=False`) so
   that you don't have to manually import a bunch of modules when instantiating predictors from
   an archive path.
+- A bug where where all datasets would be loaded for vocab creation if `datasets_for_vocab_creation`
+  was set to `[]` in the config.
 
 ### Added
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -614,10 +614,15 @@ class TrainModel(Registrable):
                 if key not in datasets:
                     raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {key}")
 
+            logger.info(
+                "From dataset instances, %s will be considered for vocabulary creation.",
+                ", ".join(datasets_for_vocab_creation),
+            )
+
         instance_generator = (
             instance
             for key, dataset in datasets.items()
-            if not datasets_for_vocab_creation or key in datasets_for_vocab_creation
+            if datasets_for_vocab_creation is None or key in datasets_for_vocab_creation
             for instance in dataset
         )
 

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -450,6 +450,9 @@ def make_vocab_from_params(
         for instance in dataset
     )
 
+    if print_statistics:
+        instances = list(instances)
+
     vocab = Vocabulary.from_params(vocab_params, instances=instances)
 
     logger.info(f"writing the vocabulary to {vocab_dir}.")

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -431,14 +431,15 @@ def make_vocab_from_params(
     all_datasets = datasets_from_params(params)
     datasets_for_vocab_creation = set(params.pop("datasets_for_vocab_creation", all_datasets))
 
-    for dataset in datasets_for_vocab_creation:
-        if dataset not in all_datasets:
-            raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {dataset}")
+    if datasets_for_vocab_creation:
+        for dataset in datasets_for_vocab_creation:
+            if dataset not in all_datasets:
+                raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {dataset}")
 
-    logger.info(
-        "From dataset instances, %s will be considered for vocabulary creation.",
-        ", ".join(datasets_for_vocab_creation),
-    )
+        logger.info(
+            "From dataset instances, %s will be considered for vocabulary creation.",
+            ", ".join(datasets_for_vocab_creation),
+        )
 
     instances: Iterable[Instance] = (
         instance

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -425,7 +425,8 @@ def make_vocab_from_params(
         datasets = datasets_from_params(params)
     else:
         for dataset in datasets_for_vocab_creation:
-            if dataset not in {"train", "test", "validation"}:
+            data_path = f"{dataset}_data_path"
+            if data_path not in params:
                 raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {dataset}")
         datasets = datasets_from_params(
             params,

--- a/tests/training/util_test.py
+++ b/tests/training/util_test.py
@@ -1,0 +1,164 @@
+import logging
+import os
+
+import pytest
+
+from allennlp.common.checks import ConfigurationError
+from allennlp.common.params import Params
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.data.instance import Instance
+from allennlp.data.dataset_readers import DatasetReader
+from allennlp.data.fields import LabelField
+from allennlp.training.util import make_vocab_from_params
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def train_util_test_reader():
+    @DatasetReader.register("train-util-test-reader")
+    class TrainUtilTestReader(DatasetReader):
+        def _read(self, data_path):
+            logger.info("...train-util-test-reader reading from %s", data_path)
+            for i in range(10):
+                yield self.text_to_instance(i)
+
+        def text_to_instance(self, index: int) -> Instance:  # type: ignore
+            return Instance({"index": LabelField(index, skip_indexing=True)})
+
+    yield TrainUtilTestReader
+
+    del DatasetReader._registry[DatasetReader]["train-util-test-reader"]
+
+
+class TestMakeVocabFromParams(AllenNlpTestCase):
+    @pytest.mark.parametrize(
+        "params",
+        [
+            Params(
+                {
+                    "dataset_reader": {"type": "train-util-test-reader"},
+                    "train_data_path": "path-to-training-file",
+                    "validation_data_path": "path-to-validation-file",
+                    "test_data_path": "path-to-validation-file",
+                    "datasets_for_vocab_creation": [],
+                }
+            ),
+            Params(
+                {
+                    "dataset_reader": {"type": "train-util-test-reader"},
+                    "train_data_path": "path-to-training-file",
+                    "datasets_for_vocab_creation": [],
+                }
+            ),
+            Params(
+                {
+                    "dataset_reader": {"type": "train-util-test-reader"},
+                    "train_data_path": "path-to-training-file",
+                    "validation_data_path": "path-to-validation-file",
+                    "test_data_path": "path-to-validation-file",
+                    "vocabulary": {"type": "empty"},
+                }
+            ),
+        ],
+    )
+    def test_no_instances_read_for_vocab(self, caplog, params):
+        _ = make_vocab_from_params(params, str(self.TEST_DIR))
+        log_messages = "\n".join([rec.message for rec in caplog.records])
+        assert "...train-util-test-reader reading from" not in log_messages
+        assert "Reading training data" not in log_messages
+        assert "Reading validation data" not in log_messages
+        assert "Reading test data" not in log_messages
+
+    def test_only_train_read_for_vocab(self, caplog):
+        params = Params(
+            {
+                "dataset_reader": {"type": "train-util-test-reader"},
+                "train_data_path": "path-to-training-file",
+            }
+        )
+        _ = make_vocab_from_params(params, str(self.TEST_DIR))
+        log_messages = "\n".join([rec.message for rec in caplog.records])
+        assert "...train-util-test-reader reading from path-to-training-file" in log_messages
+        assert "...train-util-test-reader reading from path-to-validation-file" not in log_messages
+        assert "...train-util-test-reader reading from path-to-test-file" not in log_messages
+        assert "Reading training data" in log_messages
+        assert "Reading validation data" not in log_messages
+        assert "Reading test data" not in log_messages
+
+    def test_all_datasets_read_for_vocab(self, caplog):
+        params = Params(
+            {
+                "dataset_reader": {"type": "train-util-test-reader"},
+                "train_data_path": "path-to-training-file",
+                "validation_data_path": "path-to-validation-file",
+                "test_data_path": "path-to-test-file",
+            }
+        )
+        _ = make_vocab_from_params(params, str(self.TEST_DIR))
+        log_messages = "\n".join([rec.message for rec in caplog.records])
+        assert "...train-util-test-reader reading from path-to-training-file" in log_messages
+        assert "...train-util-test-reader reading from path-to-validation-file" in log_messages
+        assert "...train-util-test-reader reading from path-to-test-file" in log_messages
+        assert "Reading training data" in log_messages
+        assert "Reading validation data" in log_messages
+        assert "Reading test data" in log_messages
+
+    def test_only_specified_datasets_read_for_vocab(self, caplog):
+        params = Params(
+            {
+                "dataset_reader": {"type": "train-util-test-reader"},
+                "train_data_path": "path-to-training-file",
+                "validation_data_path": "path-to-validation-file",
+                "test_data_path": "path-to-test-file",
+                "datasets_for_vocab_creation": ["train", "validation"],
+            }
+        )
+        _ = make_vocab_from_params(params, str(self.TEST_DIR))
+        log_messages = "\n".join([rec.message for rec in caplog.records])
+        assert "...train-util-test-reader reading from path-to-training-file" in log_messages
+        assert "...train-util-test-reader reading from path-to-validation-file" in log_messages
+        assert "...train-util-test-reader reading from path-to-test-file" not in log_messages
+        assert "Reading training data" in log_messages
+        assert "Reading validation data" in log_messages
+        assert "Reading test data" not in log_messages
+
+    def test_using_seperate_validation_reader(self, caplog):
+        params = Params(
+            {
+                "dataset_reader": {"type": "train-util-test-reader"},
+                "validation_dataset_reader": {"type": "train-util-test-reader"},
+                "train_data_path": "path-to-training-file",
+                "validation_data_path": "path-to-validation-file",
+            }
+        )
+        _ = make_vocab_from_params(params, str(self.TEST_DIR))
+        log_messages = "\n".join([rec.message for rec in caplog.records])
+        assert "Using a separate dataset reader to load validation and test data" in log_messages
+
+    def test_invalid_datasets_for_vocab_creation(self):
+        params = Params(
+            {
+                "dataset_reader": {"type": "train-util-test-reader"},
+                "train_data_path": "path-to-training-file",
+                "validation_data_path": "path-to-validation-file",
+                "datasets_for_vocab_creation": ["train", "validation", "test"],
+            }
+        )
+        with pytest.raises(ConfigurationError, match="invalid 'datasets_for_vocab_creation' test"):
+            make_vocab_from_params(params, str(self.TEST_DIR))
+
+    def test_raise_error_if_directory_non_empty(self):
+        params = Params(
+            {
+                "dataset_reader": {"type": "train-util-test-reader"},
+                "train_data_path": "path-to-training-file",
+                "validation_data_path": "path-to-validation-file",
+            }
+        )
+        os.makedirs(self.TEST_DIR / "vocabulary")
+        with open(self.TEST_DIR / "vocabulary" / "blah", "w") as random_file:
+            random_file.write("BLAH!")
+        with pytest.raises(ConfigurationError, match="The 'vocabulary' directory in the provided"):
+            make_vocab_from_params(params, str(self.TEST_DIR))


### PR DESCRIPTION
This fixes a couple of bugs related to the `datasets_for_vocab_creation` config parameter.

The main bug is that `datasets_for_vocab_creation: []` ends up being treated like `datasets_for_vocab_creation: null` due to this statement in `commands.train.TrainModel.from_partial_objects`:

```python
        instance_generator = (
            instance
            for key, dataset in datasets.items()
            if not datasets_for_vocab_creation or key in datasets_for_vocab_creation
            for instance in dataset
        )
```

which should be

```python
        instance_generator = (
            instance
            for key, dataset in datasets.items()
            if datasets_for_vocab_creation is None or key in datasets_for_vocab_creation
            for instance in dataset
        )
```

The 2nd bug occurs when `training.util.vocab_from_params(...)` is called. Even if `datasets_for_vocab_creation` is set to `[]`, all of the datasets will be initialized. This means that with non-lazy readers, you read all of the data unnecessarily.