### PR TITLE
Add link to new template repo for config file development

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@
 - [Nightly Releases](https://pypi.org/project/allennlp/#history)
 - [Officially Supported Models](https://github.com/allenai/allennlp-models)
 
+## Getting Started Using the Library
+
+If you're interested in using AllenNLP for model development, we recommend you check out the
+[AllenNLP Guide](https://guide.allennlp.org).  When you're ready to start your project, we've
+created a template repository that you can use as a starting place:
+https://github.com/allenai/allennlp-template-config-files.
+
 ## Package Overview
 
 <table>


### PR DESCRIPTION
Partial fix for #4339.  Not saying it closes that issue, because there are two more templates to make first.