### PR TITLE
make transformer tests run on self-hosted runner

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -32,7 +32,26 @@ jobs:
 
     - name: Run GPU tests
       run: |
-        make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='gpu-test'
+        make docker-test-run-with-gpus DOCKER_TAG=$DOCKER_TAG ARGS='gpu-test'
+
+  transformer_checks:
+    name: Transformer Checks
+    runs-on: [self-hosted]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set Docker tag
+      run: |
+        echo "::set-env name=DOCKER_TAG::$GITHUB_SHA";
+
+    - name: Build test image
+      run: |
+        make docker-test-image DOCKER_TAG=$DOCKER_TAG
+
+    - name: Run GPU tests
+      run: |
+        make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='transformer-test'
 
   check_core:
     name: Check Core
@@ -440,7 +459,7 @@ jobs:
   # Publish the core distribution files to PyPI.
   publish:
     name: PyPI
-    needs: [check_core, check_models, gpu_checks, build_package, test_package, docker, docs]
+    needs: [check_core, check_models, gpu_checks, transformer_checks, build_package, test_package, docker, docs]
     # Only publish to PyPI on releases and nightly builds to "allenai/allennlp" (not forks).
     if: github.repository == 'allenai/allennlp' && github.event_name != 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         make docker-test-image DOCKER_TAG=$DOCKER_TAG
 
-    - name: Run GPU tests
+    - name: Run transformer tests
       run: |
         make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='transformer-test'
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,7 +58,7 @@ jobs:
       run: |
         make docker-test-image DOCKER_TAG=$DOCKER_TAG
 
-    - name: Run GPU tests
+    - name: Run transformer tests
       run: |
         make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='transformer-test'
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,26 @@ jobs:
 
     - name: Run GPU tests
       run: |
-        make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='gpu-test'
+        make docker-test-run-with-gpus DOCKER_TAG=$DOCKER_TAG ARGS='gpu-test'
+
+  transformer_checks:
+    name: Transformer Checks
+    runs-on: [self-hosted]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set Docker tag
+      run: |
+        echo "::set-env name=DOCKER_TAG::$GITHUB_SHA";
+
+    - name: Build test image
+      run: |
+        make docker-test-image DOCKER_TAG=$DOCKER_TAG
+
+    - name: Run GPU tests
+      run: |
+        make docker-test-run DOCKER_TAG=$DOCKER_TAG ARGS='transformer-test'
 
   check_core:
     name: Check Core

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,11 @@ test-with-cov :
 
 .PHONY : gpu-test
 gpu-test : check-for-cuda
-	pytest --color=yes -v -rf -m gpu
+	pytest --color=yes -v -rf --durations=10 -m gpu
 
 .PHONY : transformer-test
 transformer-test :
-	pytest --color=yes -v -rf -m transformer
+	pytest --color=yes -v -rf --durations=5 -m transformer
 
 .PHONY : benchmarks
 benchmarks :

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ log_level = DEBUG
 markers =
     java
     gpu: marks tests that need at least one GPU
+    transformer: transformer tests often take longer to run or involve large files
 filterwarnings =
 # Note: When a warning matches more than one option in the list,
 # the action for the _last_ matching option is performed.

--- a/tests/data/fields/list_field_test.py
+++ b/tests/data/fields/list_field_test.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import numpy
 import torch
+import pytest
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Token, Vocabulary, Instance
@@ -320,6 +321,7 @@ class TestListField(AllenNlpTestCase):
         batch = next(iter(loader))
         model.forward(**batch)
 
+    @pytest.mark.transformer
     def test_list_of_text_padding(self):
         from allennlp.data.token_indexers import PretrainedTransformerIndexer
         from allennlp.data.tokenizers import Token

--- a/tests/data/instance_test.py
+++ b/tests/data/instance_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Instance
 from allennlp.data.fields import TextField, LabelField
@@ -22,6 +24,7 @@ class TestInstance(AllenNlpTestCase):
         assert words_field in values
         assert label_field in values
 
+    @pytest.mark.transformer
     def test_duplicate(self):
         # Verify the `duplicate()` method works with a `PretrainedTransformerIndexer` in
         # a `TextField`. See https://github.com/allenai/allennlp/issues/4270.

--- a/tests/data/token_indexers/pretrained_transformer_indexer_test.py
+++ b/tests/data/token_indexers/pretrained_transformer_indexer_test.py
@@ -1,4 +1,5 @@
 from transformers.tokenization_auto import AutoTokenizer
+import pytest
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Vocabulary
@@ -6,6 +7,7 @@ from allennlp.data.token_indexers import PretrainedTransformerIndexer
 from allennlp.data.tokenizers import PretrainedTransformerTokenizer
 
 
+@pytest.mark.transformer
 class TestPretrainedTransformerIndexer(AllenNlpTestCase):
     def test_as_array_produces_token_sequence_bert_uncased(self):
         tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")

--- a/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
+++ b/tests/data/token_indexers/pretrained_transformer_mismatched_indexer_test.py
@@ -1,10 +1,12 @@
 from transformers.tokenization_auto import AutoTokenizer
+import pytest
 
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Token, Vocabulary
 from allennlp.data.token_indexers import PretrainedTransformerMismatchedIndexer
 
 
+@pytest.mark.transformer
 class TestPretrainedTransformerMismatchedIndexer(AllenNlpTestCase):
     def test_bert(self):
         tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")

--- a/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -1,4 +1,5 @@
 from typing import Iterable, List
+import pytest
 
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
@@ -6,6 +7,7 @@ from allennlp.data import Token
 from allennlp.data.tokenizers import PretrainedTransformerTokenizer
 
 
+@pytest.mark.transformer
 class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
     def test_splits_roberta(self):
         tokenizer = PretrainedTransformerTokenizer("roberta-base")

--- a/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
+++ b/tests/modules/text_field_embedders/basic_text_field_embedder_test.py
@@ -160,6 +160,7 @@ class TestBasicTextFieldEmbedder(AllenNlpTestCase):
         }
         token_embedder(inputs)
 
+    @pytest.mark.transformer
     def test_forward_runs_with_bijective_and_non_bijective_mapping(self):
         params = Params(
             {

--- a/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -14,6 +14,9 @@ from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
 from allennlp.modules.token_embedders import PretrainedTransformerEmbedder
 
 
+# Only run this on the self-hosted runner since it involves big downloads which
+# can be cached on the runner.
+@pytest.mark.transformer
 class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
     def test_forward_runs_when_initialized_from_params(self):
         # This code just passes things off to `transformers`, so we only have a very simple

--- a/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
+++ b/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
@@ -11,6 +11,9 @@ from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
 from allennlp.common.testing import AllenNlpTestCase
 
 
+# Only run this on the self-hosted runner since it involves big downloads which
+# can be cached on the runner.
+@pytest.mark.transformer
 class TestPretrainedTransformerMismatchedEmbedder(AllenNlpTestCase):
     @pytest.mark.parametrize("train_parameters", [True, False])
     def test_end_to_end(self, train_parameters: bool):


### PR DESCRIPTION
Tests that involve pre-trained transformers are often longer-running and require big downloads that can't be cached on GitHub runners. Therefore it makes sense to run these on the self-hosted runner so we can utilize the runner's local cache and not have to continuously keep downloading the same files.