### PR TITLE
Add a method to ModelTestCase for use without config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reduced the amount of log messages produced by `allennlp.common.file_utils`.
 
+### Added
+
+- A method to ModelTestCase for running basic model tests when you aren't using config files.
+
 ## [v1.0.0](https://github.com/allenai/allennlp/releases/tag/v1.0.0) - 2020-06-16
 
 ### Fixed

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -549,6 +549,7 @@ class TrainModel(Registrable):
         dependencies when we call their `construct()` method, which you can see in the code below.
 
         # Parameters
+
         serialization_dir: `str`
             The directory where logs and model archives will be saved.
 

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -198,6 +198,9 @@ class ModelTestCase(AllenNlpTestCase):
 
         # Parameters
 
+        trainer: `GradientDescentTrainer`
+            The `Trainer` to use for the test, which already has references to a `Model` and a
+            `DataLoader`, which we will use in the test.
         gradients_to_ignore : `Set[str]`, optional (default=`None`)
             This test runs a gradient check to make sure that we're actually computing gradients
             for all of the parameters in the model.  If you really want to ignore certain

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -218,7 +218,7 @@ class GradientDescentTrainer(Trainer):
         after `patience` epochs with no improvement. If given, it must be `> 0`.
         If None, early stopping is disabled.
 
-    validation_metric : `str`, optional (default=`"loss"`)
+    validation_metric : `str`, optional (default=`"-loss"`)
         Validation metric to measure for whether to stop training using patience
         and whether to serialize an `is_best` model each epoch. The metric name
         must be prepended with either "+" or "-", which specifies whether the metric


### PR DESCRIPTION
This was necessary to have tests for the no-config-file template repo.  I also noticed a few other small typos in the documentation, which are fixed in here.