### PR TITLE
pin some doc building requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -39,7 +39,7 @@ ruamel.yaml
 # Generating markdown files from Python modules.
 git+https://github.com/NiklasRosenstein/pydoc-markdown.git@f0bf8af1db4f11581c19d206d4ed1ab34b4854c1
 nr.databind.core<0.0.17
-nr.interface==0.0.3
+nr.interface<0.0.4
 
 markdown-include==0.5.1
 # Package for the material theme for mkdocs

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -38,6 +38,8 @@ ruamel.yaml
 
 # Generating markdown files from Python modules.
 git+https://github.com/NiklasRosenstein/pydoc-markdown.git@f0bf8af1db4f11581c19d206d4ed1ab34b4854c1
+nr.databind.core<0.0.17
+nr.interface==0.0.3
 
 markdown-include==0.5.1
 # Package for the material theme for mkdocs


### PR DESCRIPTION
This should fix the errors we're seeing in the "Build docs" CI step.