### PR TITLE
Assign an empty mapping array to empty fields of `NamespaceSwappingField`

### DIFF
--- a/allennlp/data/fields/namespace_swapping_field.py
+++ b/allennlp/data/fields/namespace_swapping_field.py
@@ -49,7 +49,10 @@ class NamespaceSwappingField(Field[torch.Tensor]):
 
     @overrides
     def empty_field(self) -> "NamespaceSwappingField":
-        return NamespaceSwappingField([], self._target_namespace)
+        empty_filed = NamespaceSwappingField([], self._target_namespace)
+        empty_filed._mapping_array = []
+
+        return empty_filed
 
     def __len__(self):
         return len(self._source_tokens)


### PR DESCRIPTION
Assign an empty mapping array to empty fields created by `NamespaceSwappingField`. Leaving `._mapping_array ` unassigned (`None`) will cause issues in batching when `NamespaceSwappingField` is used as members in `ListField`.