### PR TITLE
[FOR DISCUSSION] Automatically capture params on object construction

### DIFF
--- a/tmp.py
+++ b/tmp.py
@@ -1,0 +1,76 @@
+from typing import Any, Dict, Type
+import inspect
+
+
+def get_arg_params(argument: Any, annotation: Type) -> Any:
+    existing_params = getattr(argument, '_params', None)
+    if existing_params is not None:
+        return existing_params
+    elif annotation in {float, int}:
+        return argument
+    else:
+        # There are several more cases to handle here if we want to actually do this, but not *that*
+        # many more.  We just have to cover all base python types.  Unions might be tricky to figure
+        # out, but should still be doable.  This logic basically mirrors what we do when creating
+        # objects in FromParams, we're just going the other way.
+        raise ValueError()
+
+
+def get_params(init, *args, **kwargs) -> Dict[str, Any]:
+    signature = inspect.signature(init)
+    parameters = dict(signature.parameters)
+    # need some fancy logic here to match *args and **kwargs with the parametrs.  It's deterministic
+    # and doable, but more than I want to write right now.  The below is a quick and dirty first
+    # pass.  Oh, hmm, super classes and **kwargs _inside_ the __init__ method make this more tricky,
+    # but still doable.
+    arg_list = list(args)
+    saved_params = {}
+    for param_name, param in parameters.items():
+        if param_name == "self":
+            continue
+        if param_name in kwargs:
+            argument = kwargs.pop(param_name)
+        else:
+            argument = arg_list.pop(0)
+        argument_params = get_arg_params(argument, param.annotation)
+        saved_params[param_name] = argument_params
+    return saved_params
+
+
+class Meta(type):
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        new_cls = super(Meta, mcs).__new__(mcs, name, bases, namespace, **kwargs)
+        user_init = new_cls.__init__
+        def __init__(self, *args, **kwargs):
+            self._params = get_params(user_init, *args, **kwargs)
+            user_init(self, *args, **kwargs)
+        setattr(new_cls, '__init__', __init__)
+        return new_cls
+
+
+class FromParams(metaclass=Meta):
+    pass
+
+
+class Gaussian(FromParams):
+    def __init__(self, mean: float, variance: float):
+        self.mean = mean
+        self.variance = variance
+
+
+class NestedGaussian(FromParams):
+    def __init__(self, gaussian: Gaussian, alpha: float):
+        self.gaussian = gaussian
+        self.alpha = alpha
+
+
+g = Gaussian(1.3, 2.3)
+print(g._params)
+# {'mean': 1.3, 'variance': 2.3}
+g = Gaussian(mean=1.8, variance=4.3)
+print(g._params)
+# {'mean': 1.8, 'variance': 4.3}
+
+n = NestedGaussian(Gaussian(mean=1.8, variance=4.3), alpha=.01)
+print(n._params)
+# {'gaussian': {'mean': 1.8, 'variance': 4.3}, 'alpha': 0.01}


### PR DESCRIPTION
As I was writing parts of the guide, one thing that bothered me was that we don't have a good story around model saving and loading when you're not using config files.  Also, I saw examples of huggingface code where you could just call `.save_pretrained()` on your in-python object and have things just work.  For us to do that, we have to be able to save objects for which we don't have implementation code, but I think we can still do it.  I got to thinking about this problem this morning, and was playing around with something that actually works, pretty simply.

Basic idea: use a single metaclass on `FromParams` to make it so that all `FromParams` objects (including subclasses) have a `_params` field, which stores the config that they would have been created with.  Then the model can just implement a simple `.save()` method which saves `_params` as a json object, then calls the archive code.  We could probably even just remove the archive code altogether and have it live as methods on `Model`, because this would make it much easier.

I implemented a quick prototype that works for simple classes.  I put it as a pull request instead of an issue so that the code could be more easily commented on.  There are three major hurdles that I see to getting this to actually work, which may or may not be surmountable:

1. We allow subclasses to take `**kwargs`, and inspect the superclass to grab those arguments.  This one should be pretty straightforward - we can directly use the existing logic to get the parameter list, and that might just be enough by itself.

2. When we use non-standard constructors, like `from_partial_objects`, or what we do in `Vocabulary`.  We have to know a priori what things are registered that way, and override them accordingly.  This might be possible if we have this metaclass inspect the `Registry` somehow.

3. We need to know which parameters don't need to get saved in the config file.  Things like the `Vocabulary` for the `Model` object (because it's actually specified higher up in the config).  We don't have a way of programmatically detecting this, and I'm not sure how to do it.  The goal of this is just for use in saving models, so we could feasibly special-case a thing or two (we'd want to serialize the vocabulary separately anyway), but that's not ideal.  This one needs some more thought.

A possible side-benefit of this is being able to pickle and recover some objects for use in multi-processing using just the saved `_params`.

@epwalsh, @dirkgr, what do you think?