### PR TITLE
Fix pretrained model initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplified logging so that all logging output always goes to one file.
 - Fixed interaction with the python command line debugger.
 - Log the grad norm properly even when we're not clipping it.
+- Fixed a bug where `PretrainedModelInitializer` fails to initialize a model with a 0-dim tensor
 
 ### Added
 

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -403,7 +403,7 @@ class PretrainedModelInitializer(Initializer):
             )
 
         # Copy the parameters from the source to the destination
-        tensor.data[:] = source_weights[:]
+        tensor.data.copy_(source_weights.data)
 
 
 class InitializerApplicator(FromParams):

--- a/tests/nn/pretrained_model_initializer_test.py
+++ b/tests/nn/pretrained_model_initializer_test.py
@@ -15,6 +15,7 @@ class _Net1(torch.nn.Module):
         super().__init__()
         self.linear_1 = torch.nn.Linear(5, 10)
         self.linear_2 = torch.nn.Linear(10, 5)
+        self.scalar = torch.nn.Parameter(torch.rand(()))
 
     def forward(self, inputs):
         pass
@@ -25,6 +26,7 @@ class _Net2(torch.nn.Module):
         super().__init__()
         self.linear_1 = torch.nn.Linear(5, 10)
         self.linear_3 = torch.nn.Linear(10, 5)
+        self.scalar = torch.nn.Parameter(torch.rand(()))
 
     def forward(self, inputs):
         pass
@@ -103,6 +105,13 @@ class TestPretrainedModelInitializer(AllenNlpTestCase):
         applicator = self._get_applicator("linear_1.*", self.temp_file, name_overrides)
         with pytest.raises(ConfigurationError):
             applicator(self.net1)
+
+    def test_zero_dim_tensor(self):
+        # This test will verify that a 0-dim tensor can be initialized.
+        # It raises IndexError if slicing a tensor to copy the parameter.
+        applicator = self._get_applicator("scalar", self.temp_file)
+        applicator(self.net1)
+        assert torch.equal(self.net1.scalar, self.net2.scalar)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device registered.")
     def test_load_to_gpu_from_gpu(self):


### PR DESCRIPTION
This PR fixes #4427. As described, slicing a 0-dim tensor raises `IndexError`, so used `copy_` method instead.

I added scalar parameters to the models in `pretrained_model_initializer_test.py` and added a test case, which had failed before this fix.