### PR TITLE
fix bug with SlantedTriangular LR scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed interaction with the python command line debugger.
 - Log the grad norm properly even when we're not clipping it.
 - Fixed a bug where `PretrainedModelInitializer` fails to initialize a model with a 0-dim tensor
+- Fixed a bug with the layer unfreezing schedule of the `SlantedTriangular` learning rate scheduler.
 
 ### Added
 


### PR DESCRIPTION
There is a bug related to gradual unfreezing with the Slanted Triangular Learning Rate schedule. During the first epoch, only the top layer is trained (as expected) but, during the 2nd epoch, the top **3** layers are trained when it should just be the top 2:

![image](https://user-images.githubusercontent.com/8812459/86622295-86fc1380-bf74-11ea-8877-5fd9e3800b29.png)

This also causes training to crash on the last "freezing" epoch:

![image](https://user-images.githubusercontent.com/8812459/86622413-b579ee80-bf74-11ea-8af7-d7cefc624c22.png)
