### PR TITLE
ensure only rank 0 worker writes to terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log the grad norm properly even when we're not clipping it.
 - Fixed a bug where `PretrainedModelInitializer` fails to initialize a model with a 0-dim tensor
 - Fixed a bug with the layer unfreezing schedule of the `SlantedTriangular` learning rate scheduler.
+- Fixed a regression with logging in the distributed setting. Only the main worker should write log output to the terminal.
 
 ### Added
 

--- a/allennlp/common/logging.py
+++ b/allennlp/common/logging.py
@@ -92,8 +92,10 @@ def prepare_global_logging(serialization_dir: str, rank: int = 0, world_size: in
     root_logger.setLevel(LEVEL)
 
     # put all the handlers on the root logger
-    for handler in [file_handler, stdout_handler, stderr_handler]:
-        root_logger.addHandler(handler)
+    root_logger.addHandler(file_handler)
+    if rank == 0:
+        root_logger.addHandler(stdout_handler)
+        root_logger.addHandler(stderr_handler)
 
     # write uncaught exceptions to the logs
     def excepthook(exctype, value, traceback):


### PR DESCRIPTION
@dirkgr, I'm not sure if this was intentional, but https://github.com/allenai/allennlp/pull/4383 caused all trainer workers to write log output to the terminal, which makes it hard to read.