### PR TITLE
ensure base reader of ShardedDatasetReader doesn't implement sharding itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to pass an archive file instead of a local directory to `Vocab.from_files`.
 - Added the ability to pass an archive file instead of a glob to `ShardedDatasetReader`.
 - Added a new `"linear_with_warmup"` learning rate scheduler.
-- Added a check `ShardedDatasetReader` that ensures the base reader doesn't implement manual
+- Added a check in `ShardedDatasetReader` that ensures the base reader doesn't implement manual
   distributed sharding itself.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log the grad norm properly even when we're not clipping it.
 - Fixed a bug where `PretrainedModelInitializer` fails to initialize a model with a 0-dim tensor
 - Fixed a bug with the layer unfreezing schedule of the `SlantedTriangular` learning rate scheduler.
+- Fixed a regression with logging in the distributed setting. Only the main worker should write log output to the terminal.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to pass an archive file instead of a local directory to `Vocab.from_files`.
 - Added the ability to pass an archive file instead of a glob to `ShardedDatasetReader`.
 - Added a new `"linear_with_warmup"` learning rate scheduler.
+- Added a check `ShardedDatasetReader` that ensures the base reader doesn't implement manual
+  distributed sharding itself.
 
 ### Changed
 

--- a/allennlp/common/logging.py
+++ b/allennlp/common/logging.py
@@ -92,8 +92,10 @@ def prepare_global_logging(serialization_dir: str, rank: int = 0, world_size: in
     root_logger.setLevel(LEVEL)
 
     # put all the handlers on the root logger
-    for handler in [file_handler, stdout_handler, stderr_handler]:
-        root_logger.addHandler(handler)
+    root_logger.addHandler(file_handler)
+    if rank == 0:
+        root_logger.addHandler(stdout_handler)
+        root_logger.addHandler(stderr_handler)
 
     # write uncaught exceptions to the logs
     def excepthook(exctype, value, traceback):

--- a/allennlp/data/dataset_readers/sharded_dataset_reader.py
+++ b/allennlp/data/dataset_readers/sharded_dataset_reader.py
@@ -47,11 +47,16 @@ class ShardedDatasetReader(DatasetReader):
             self._world_size = 1
 
         self.reader = base_reader
+        # We have to check that the base reader doesn't implement manual distributed
+        # sharding itself, because if it does, then only a fraction of the instances
+        # will be read.
         if getattr(self.reader, "manual_distributed_sharding", False):
             raise ValueError(
                 "The base reader of a sharded dataset reader should not implement "
                 "manual distributed sharding itself."
             )
+        # However we still need to set this flag to `True` after the fact so that
+        # all of the instances within each shard are used.
         self.reader.manual_distributed_sharding = True
 
     def text_to_instance(self, *args, **kwargs) -> Instance:

--- a/allennlp/data/dataset_readers/sharded_dataset_reader.py
+++ b/allennlp/data/dataset_readers/sharded_dataset_reader.py
@@ -47,6 +47,11 @@ class ShardedDatasetReader(DatasetReader):
             self._world_size = 1
 
         self.reader = base_reader
+        if getattr(self.reader, "manual_distributed_sharding", False):
+            raise ValueError(
+                "The base reader of a sharded dataset reader should not implement "
+                "manual distributed sharding itself."
+            )
         self.reader.manual_distributed_sharding = True
 
     def text_to_instance(self, *args, **kwargs) -> Instance:

--- a/tests/data/dataset_readers/sharded_dataset_reader_test.py
+++ b/tests/data/dataset_readers/sharded_dataset_reader_test.py
@@ -33,11 +33,11 @@ def ensure_exception_raised_when_base_reader_implements_sharding():
         def _read(self, file_path: str):
             pass
 
-        def text_to_instance(self, text: str):
+        def text_to_instance(self, text: str):  # type: ignore
             pass
 
     with pytest.raises(ValueError, match="should not implement manual distributed sharding"):
-        reader = ShardedDatasetReader(ManuallyShardedBaseReader())
+        ShardedDatasetReader(ManuallyShardedBaseReader())
 
 
 class TestShardedDatasetReader(AllenNlpTestCase):

--- a/tests/data/dataset_readers/sharded_dataset_reader_test.py
+++ b/tests/data/dataset_readers/sharded_dataset_reader_test.py
@@ -25,7 +25,7 @@ def fingerprint(instance: Instance) -> Tuple[str, ...]:
     return text_tuple + labels_tuple
 
 
-def ensure_exception_raised_when_base_reader_implements_sharding():
+def test_exception_raised_when_base_reader_implements_sharding():
     class ManuallyShardedBaseReader(DatasetReader):
         def __init__(self, **kwargs):
             super().__init__(manual_distributed_sharding=True, **kwargs)


### PR DESCRIPTION
The base reader of a `ShardedDatasetReader` should never implement manual distributed sharding itself, otherwise only a fraction of the instances would be read. This just adds a check for that.