### PR TITLE
Fixing bug in TextClassificationPredictor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where `PretrainedModelInitializer` fails to initialize a model with a 0-dim tensor
 - Fixed a bug with the layer unfreezing schedule of the `SlantedTriangular` learning rate scheduler.
 - Fixed a regression with logging in the distributed setting. Only the main worker should write log output to the terminal.
+- Fixed a bug in `TextClassificationPredictor` so that it passes tokenized inputs to the `DatasetReader`
+  in case it does not have a tokenizer.
 
 ### Added
 

--- a/allennlp/predictors/text_classifier.py
+++ b/allennlp/predictors/text_classifier.py
@@ -34,7 +34,7 @@ class TextClassifierPredictor(Predictor):
             self._dataset_reader, "_tokenizer"
         ):
             tokenizer = SpacyTokenizer()
-            sentence = [str(t) for t in tokenizer.tokenize(sentence)]
+            sentence = tokenizer.tokenize(sentence)
         return self._dataset_reader.text_to_instance(sentence)
 
     @overrides


### PR DESCRIPTION
Fixes #4059

TextClassificationPredictor now passes tokenized inputs to the DatasetReader's text_to_instance function if it does not have a tokenizer.