### PR TITLE
remove deadlock warning in DataLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Tqdm` output now looks much better when the output is being piped or redirected.
 - Small improvements to how the API documentation is rendered.
 - Only show validation progress bar from main process in distributed training.
+- Removed unnecessary warning about deadlocks in `DataLoader`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Removed unnecessary warning about deadlocks in `DataLoader`.
+
 ## [v1.1.0rc1](https://github.com/allenai/allennlp/releases/tag/v1.1.0rc1) - 2020-07-14
 
 ### Fixed
@@ -35,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Tqdm` output now looks much better when the output is being piped or redirected.
 - Small improvements to how the API documentation is rendered.
 - Only show validation progress bar from main process in distributed training.
-- Removed unnecessary warning about deadlocks in `DataLoader`.
 
 ### Added
 

--- a/allennlp/data/dataloader.py
+++ b/allennlp/data/dataloader.py
@@ -1,5 +1,4 @@
 from typing import List, Dict, Union, Iterator
-import warnings
 
 import torch
 from torch.utils import data
@@ -7,7 +6,6 @@ from torch.utils import data
 from allennlp.common.registrable import Registrable
 from allennlp.common.lazy import Lazy
 from allennlp.data.instance import Instance
-from allennlp.data.dataset_readers.dataset_reader import AllennlpLazyDataset
 from allennlp.data.batch import Batch
 from allennlp.data.samplers import Sampler, BatchSampler
 
@@ -87,13 +85,6 @@ class PyTorchDataLoader(data.DataLoader, DataLoader):
         multiprocessing_context: str = None,
         batches_per_epoch: int = None,
     ):
-        if num_workers and isinstance(dataset, AllennlpLazyDataset):
-            warnings.warn(
-                "Using multi-process data loading with a lazy dataset could lead to "
-                "deadlocks with certain tokenizers. See:\n"
-                "  https://github.com/allenai/allennlp/issues/4330\n",
-                UserWarning,
-            )
         super().__init__(
             dataset=dataset,
             batch_size=batch_size,

--- a/tests/data/dataloader_test.py
+++ b/tests/data/dataloader_test.py
@@ -5,20 +5,7 @@ import pytest
 from allennlp.data.fields import LabelField
 from allennlp.data.instance import Instance
 from allennlp.data.dataloader import PyTorchDataLoader
-from allennlp.data.dataset_readers.dataset_reader import (
-    DatasetReader,
-    AllennlpLazyDataset,
-)
-
-
-def test_multi_processing_with_lazy_dataset_warns():
-    def fake_instance_generator(file_name: str) -> Iterable[Instance]:
-        yield from []
-
-    with pytest.warns(UserWarning, match=r".*deadlocks.*"):
-        PyTorchDataLoader(
-            AllennlpLazyDataset(fake_instance_generator, "nonexistent_file"), num_workers=1
-        )
+from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 
 
 @pytest.mark.parametrize("lazy", (True, False))


### PR DESCRIPTION
This warning is no longer relevant since the tokenizers upgrade.