### PR TITLE
add a requires_grad option to param groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-
 ### Fixed
 
 - Removed unnecessary warning about deadlocks in `DataLoader`.
 - Use slower tqdm intervals when output is being piped or redirected.
+
+### Added
+
+- Added the option to specify `requires_grad: false` within an optimizers parameter groups.
 
 
 ## [v1.1.0rc1](https://github.com/allenai/allennlp/releases/tag/v1.1.0rc1) - 2020-07-14

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -1115,12 +1115,12 @@ class GradientDescentTrainer(Trainer):
                 if any(re.search(regex, name) for regex in no_grad):
                     parameter.requires_grad_(False)
 
-        common_util.log_frozen_and_tunable_parameter_names(model)
-
         parameters = [[n, p] for n, p in model.named_parameters() if p.requires_grad]
         optimizer_ = optimizer.construct(model_parameters=parameters)
         if not optimizer_:
             optimizer_ = Optimizer.default(parameters)
+
+        common_util.log_frozen_and_tunable_parameter_names(model)
 
         batches_per_epoch: Optional[int]
         try:


### PR DESCRIPTION
Closes #4482

Per the discussion in #4482, we decided to have the optimizer handle freezing layers. This PR accomplishes that by having the optimizer module check for a `requires_grad: false` key-value pair in the parameter groups. So, for example, if you want to freeze the first few layers in a BERT model, you could do something like this:

```jsonnet
    // ... config snippet ...
    "trainer": {
        "optimizer": {
            "type": "huggingface_adamw",
            "lr": 2e-4,
            "eps": 1e-8,
            "weight_decay": 0.01,
            "parameter_groups": [
                [
                    [
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.embeddings\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.0\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.1\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.2\\..*",
                    ],
                    {"requires_grad": false},
                ],
                [
                    [
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.3\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.4\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.5\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.6\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.7\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.8\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.9\\..*",
                    ],
                    {"lr": 2e-06},
                ],
                [
                    [
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.10\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.encoder\\.layer\\.11\\..*",
                        "_source_embedder\\.token_embedder_tokens\\.transformer_model\\.pooler\\..*",
                    ],
                    {"lr": 2e-05},
                ],
                // ...
            ],
        },
        "learning_rate_scheduler": {
            "type": "slanted_triangular",
            "num_epochs": 10,
            "cut_frac": 0.1,
        },
        "grad_clipping": 1.0,
        "num_epochs": 10,
    },
```