### PR TITLE
Bug fix for case when param type is Optional[Union...]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed unnecessary warning about deadlocks in `DataLoader`.
 - Use slower tqdm intervals when output is being piped or redirected.
-- Fixed testing models that only return a loss when they are in training mode
+- Fixed testing models that only return a loss when they are in training mode.
+- Fixed a bug in `FromParams` that causes silent failure in case of the parameter type being Optional[Union[...]].
 
 ### Added
 

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -105,8 +105,9 @@ def remove_optional(annotation: type):
     """
     origin = getattr(annotation, "__origin__", None)
     args = getattr(annotation, "__args__", ())
-    if origin == Union and len(args) == 2 and args[1] == type(None):  # noqa
-        return args[0]
+
+    if origin == Union:
+        return Union[tuple([arg for arg in args if arg != type(None)])]  # noqa: E721
     else:
         return annotation
 

--- a/tests/common/from_params_test.py
+++ b/tests/common/from_params_test.py
@@ -845,3 +845,19 @@ class TestFromParams(AllenNlpTestCase):
 
         with pytest.raises(ConfigurationError, match="no registered concrete types"):
             B.from_params(Params({}))
+
+    def test_from_params_raises_error_on_wrong_parameter_name_in_optional_union(self):
+        class NestedClass(FromParams):
+            def __init__(self, varname: Optional[str] = None):
+                self.varname = varname
+
+        class WrapperClass(FromParams):
+            def __init__(self, nested_class: Optional[Union[str, NestedClass]] = None):
+                if isinstance(nested_class, str):
+                    nested_class = NestedClass(varname=nested_class)
+                self.nested_class = nested_class
+
+        with pytest.raises(ConfigurationError):
+            WrapperClass.from_params(
+                params=Params({"nested_class": {"wrong_varname": "varstring"}})
+            )


### PR DESCRIPTION
When `FromParams` needs to construct parameters for cases when the type is Optional[Union[...]], it fails silently if the parameter name is incorrect.

Steps to reproduce:

1. This fails silently and returns the type as `dict` (it should be `NestedClass`):

```from typing import Optional, Union
from allennlp.common import Params, FromParams
class NestedClass(FromParams):
    def __init__(self, 
                 varname: Optional[str] = None
                ):
        self.varname = varname
class WrapperClass(FromParams):
    def __init__(self, nested_class: Optional[Union[str, NestedClass]] = None):
        if isinstance(nested_class, str):
            nested_class = NestedClass(varname=nested_class)
        self.nested_class = nested_class

m = WrapperClass.from_params(params=Params({"nested_class": {"wrong_varname": "varstring"}}))
type(m.nested_class)
```

2. This raises error as it should:
```
from typing import Optional, Union
from allennlp.common import Params, FromParams
class NestedClass(FromParams):
    def __init__(self, 
                 varname: Optional[str] = None
                ):
        self.varname = varname
class WrapperClass(FromParams):
    def __init__(self, nested_class: Union[NestedClass, str] = None):  #This is the part that is different.
        if isinstance(nested_class, str):
            nested_class = NestedClass(varname=nested_class)
        self.nested_class = nested_class

m = WrapperClass.from_params(params=Params({"nested_class": {"wrong_varname": "varstring"}}))
type(m.nested_class)
```

I found that the issue stems from `remove_optional` function, which only accounts for representation of `Optional[X]` as `Union[X, None]` but does not consider `Union[X, Y, ..., None]` (or `Union[X, ..., None, ..., Y]` for that matter).

The code change in this PR fixes silent failure and raises an error, but due to the special case for `Union` in `construct_arg`, we end up suppressing the actual error (wrong parameter name), and throw a generic error (failed to construct argument with type).

@matt-gardner Is there a reason to suppress `ConfigurationError` here? Should we write a special case so that it throws the more informative exception?