### PR TITLE
Remove link to self-attention modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use slower tqdm intervals when output is being piped or redirected.
 - Fixed testing models that only return a loss when they are in training mode.
 - Fixed a bug in `FromParams` that causes silent failure in case of the parameter type being Optional[Union[...]].
-- Cleanup/fix to encoder modules in `allennlp/models/seq2seq_encoders/__init__.py`.
+- Cleanup/fix to module docstring in `allennlp/models/seq2seq_encoders/__init__.py`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use slower tqdm intervals when output is being piped or redirected.
 - Fixed testing models that only return a loss when they are in training mode.
 - Fixed a bug in `FromParams` that causes silent failure in case of the parameter type being Optional[Union[...]].
+- Cleanup/fix to encoder modules in `allennlp/models/seq2seq_encoders/__init__.py`.
+
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug in `FromParams` that causes silent failure in case of the parameter type being Optional[Union[...]].
 - Cleanup/fix to encoder modules in `allennlp/models/seq2seq_encoders/__init__.py`.
 
-
 ### Added
 
 - Added the option to specify `requires_grad: false` within an optimizers parameter groups.

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -11,7 +11,6 @@ The available Seq2Seq encoders are
 - `"rnn"` : https://pytorch.org/docs/master/generated/torch.nn.RNN.html#torch.nn.RNN
 - `"augmented_lstm"` : allennlp.modules.seq2seq_encoders.AugmentedLstmSeq2SeqEncoder
 - `"alternating_lstm"` : allennlp.modules.seq2seq_encoders.StackedAlternatingLstmSeq2SeqEncoder
-- `"alternating_highway_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm (GPU only)
 - `"pass_through"` : allennlp.modules.seq2seq_encoders.PassThroughEncoder
 - `"feedforward"` : allennlp.modules.seq2seq_encoders.FeedForwardEncoder
 - `"pytorch_transformer"` : allennlp.modules.seq2seq_encoders.PytorchTransformer

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -12,8 +12,8 @@ The available Seq2Seq encoders are
 - `"augmented_lstm"` : allennlp.modules.augmented_lstm.AugmentedLstm
 - `"alternating_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm
 - `"alternating_highway_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm (GPU only)
-- `"pass_through"` : allennlp.modules.pass_through_encoder.PassThroughEncoder
-- `"feedforward"` : allennlp.modules.feedforward_encoder.FeedForwardEncoder
+- `"pass_through"` : allennlp.modules.seq2seq_encoders.PassThroughEncoder
+- `"feedforward"` : allennlp.modules.seq2seq_encoders.FeedForwardEncoder
 - `"pytorch_transformer"` : allennlp.modules.seq2seq_encoders.PytorchTransformer
 - `"compose"` : allennlp.modules.seq2seq_encoders.ComposeEncoder
 - `"gated-cnn-encoder"` : allennlp.momdules.seq2seq_encoders.GatedCnnEncoder

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -6,9 +6,9 @@ others are AllenNLP modules.
 
 The available Seq2Seq encoders are
 
-- `"gru"` : https://pytorch.org/docs/master/nn.html#torch.nn.GRU
-- `"lstm"` : https://pytorch.org/docs/master/nn.html#torch.nn.LSTM
-- `"rnn"` : https://pytorch.org/docs/master/nn.html#torch.nn.RNN
+- `"gru"` : https://pytorch.org/docs/master/generated/torch.nn.GRU.html#torch.nn.GRU
+- `"lstm"` : https://pytorch.org/docs/master/generated/torch.nn.LSTM.html#torch.nn.LSTM
+- `"rnn"` : https://pytorch.org/docs/master/generated/torch.nn.RNN.html#torch.nn.RNN
 - `"augmented_lstm"` : allennlp.modules.augmented_lstm.AugmentedLstm
 - `"alternating_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm
 - `"alternating_highway_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm (GPU only)

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -12,8 +12,6 @@ The available Seq2Seq encoders are
 - `"augmented_lstm"` : allennlp.modules.augmented_lstm.AugmentedLstm
 - `"alternating_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm
 - `"alternating_highway_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm (GPU only)
-- `"stacked_self_attention"` : allennlp.modules.stacked_self_attention.StackedSelfAttentionEncoder
-- `"multi_head_self_attention"` : allennlp.modules.multi_head_self_attention.MultiHeadSelfAttention
 - `"pass_through"` : allennlp.modules.pass_through_encoder.PassThroughEncoder
 - `"feedforward"` : allennlp.modules.feedforward_encoder.FeedforwardEncoder
 - `"pytorch_transformer"` : allennlp.modules.seq2seq_encoders.PytorchTransformer

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -16,6 +16,7 @@ The available Seq2Seq encoders are
 - `"pytorch_transformer"` : allennlp.modules.seq2seq_encoders.PytorchTransformer
 - `"compose"` : allennlp.modules.seq2seq_encoders.ComposeEncoder
 - `"gated-cnn-encoder"` : allennlp.momdules.seq2seq_encoders.GatedCnnEncoder
+- `"stacked_bidirectional_lstm"`: allennlp.modules.seq2seq_encoders.StackedBidirectionalLstmSeq2SeqEncoder
 """
 
 from allennlp.modules.seq2seq_encoders.compose_encoder import ComposeEncoder

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -15,6 +15,8 @@ The available Seq2Seq encoders are
 - `"pass_through"` : allennlp.modules.pass_through_encoder.PassThroughEncoder
 - `"feedforward"` : allennlp.modules.feedforward_encoder.FeedForwardEncoder
 - `"pytorch_transformer"` : allennlp.modules.seq2seq_encoders.PytorchTransformer
+- `"compose"` : allennlp.modules.seq2seq_encoders.ComposeEncoder
+- `"gated-cnn-encoder"` : allennlp.momdules.seq2seq_encoders.GatedCnnEncoder
 """
 
 from allennlp.modules.seq2seq_encoders.compose_encoder import ComposeEncoder

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -13,7 +13,7 @@ The available Seq2Seq encoders are
 - `"alternating_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm
 - `"alternating_highway_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm (GPU only)
 - `"pass_through"` : allennlp.modules.pass_through_encoder.PassThroughEncoder
-- `"feedforward"` : allennlp.modules.feedforward_encoder.FeedforwardEncoder
+- `"feedforward"` : allennlp.modules.feedforward_encoder.FeedForwardEncoder
 - `"pytorch_transformer"` : allennlp.modules.seq2seq_encoders.PytorchTransformer
 """
 

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -6,9 +6,9 @@ others are AllenNLP modules.
 
 The available Seq2Seq encoders are
 
-- `"gru"` : https://pytorch.org/docs/master/generated/torch.nn.GRU.html#torch.nn.GRU
-- `"lstm"` : https://pytorch.org/docs/master/generated/torch.nn.LSTM.html#torch.nn.LSTM
-- `"rnn"` : https://pytorch.org/docs/master/generated/torch.nn.RNN.html#torch.nn.RNN
+- `"gru"` : allennlp.modules.seq2seq_encoders.GruSeq2SeqEncoder
+- `"lstm"` : allennlp.modules.seq2seq_encoders.LstmSeq2SeqEncoder
+- `"rnn"` : allennlp.modules.seq2seq_encoders.RnnSeq2SeqEncoder
 - `"augmented_lstm"` : allennlp.modules.seq2seq_encoders.AugmentedLstmSeq2SeqEncoder
 - `"alternating_lstm"` : allennlp.modules.seq2seq_encoders.StackedAlternatingLstmSeq2SeqEncoder
 - `"pass_through"` : allennlp.modules.seq2seq_encoders.PassThroughEncoder

--- a/allennlp/modules/seq2seq_encoders/__init__.py
+++ b/allennlp/modules/seq2seq_encoders/__init__.py
@@ -9,8 +9,8 @@ The available Seq2Seq encoders are
 - `"gru"` : https://pytorch.org/docs/master/generated/torch.nn.GRU.html#torch.nn.GRU
 - `"lstm"` : https://pytorch.org/docs/master/generated/torch.nn.LSTM.html#torch.nn.LSTM
 - `"rnn"` : https://pytorch.org/docs/master/generated/torch.nn.RNN.html#torch.nn.RNN
-- `"augmented_lstm"` : allennlp.modules.augmented_lstm.AugmentedLstm
-- `"alternating_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm
+- `"augmented_lstm"` : allennlp.modules.seq2seq_encoders.AugmentedLstmSeq2SeqEncoder
+- `"alternating_lstm"` : allennlp.modules.seq2seq_encoders.StackedAlternatingLstmSeq2SeqEncoder
 - `"alternating_highway_lstm"` : allennlp.modules.stacked_alternating_lstm.StackedAlternatingLstm (GPU only)
 - `"pass_through"` : allennlp.modules.seq2seq_encoders.PassThroughEncoder
 - `"feedforward"` : allennlp.modules.seq2seq_encoders.FeedForwardEncoder


### PR DESCRIPTION
Follow-up for #3941.

I was looking for self-attention modules to find that these were moved to allennlp-model.
I removed the links with no destination.