### PR TITLE
add 'use_amp' option to transformer embedders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- A `use_amp` option to `PretrainedTransformerEmbedder` and `PretrainedTransformerMismatchedEmbedder`,
+  which you can set to `True` if you want automatic mixed precision enabled only for the transformer
+  part of your model.
+
 ## [v1.1.0rc2](https://github.com/allenai/allennlp/releases/tag/v1.1.0rc2) - 2020-07-31
 
 ### Changed

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -31,10 +31,10 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         When `True` (the default), only the final layer of the pretrained transformer is taken
         for the embeddings. But if set to `False`, a scalar mix of all of the layers
         is used.
-    use_amp: `bool`, optional (default = `False`)
-        If `True`, automatic mixed precision through `torch.cuda.amp` will be enabled for the
-        transformer model. Note that this setting will override any `use_amp` setting
-        higher up (such as in the `Trainer` object) for this module only.
+    use_amp: `Optional[bool]`, optional (default = `None`)
+        If specified, automatic mixed precision will be enabled (if `True`) or disabled
+        (if `False`) on the forward pass. This would override any global `use_amp`
+        setting for this module only.
     """
 
     def __init__(
@@ -43,7 +43,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         max_length: int = None,
         train_parameters: bool = True,
         last_layer_only: bool = True,
-        use_amp: bool = False,
+        use_amp: Optional[bool] = None,
     ) -> None:
         super().__init__()
         # The matched version v.s. mismatched

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -31,6 +31,10 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         When `True` (the default), only the final layer of the pretrained transformer is taken
         for the embeddings. But if set to `False`, a scalar mix of all of the layers
         is used.
+    use_amp: `bool`, optional (default = `False`)
+        If `True`, automatic mixed precision through `torch.cuda.amp` will be enabled for the
+        transformer model. Note that this setting will override any `use_amp` setting
+        higher up (such as in the `Trainer` object) for this module only.
     """
 
     def __init__(
@@ -39,6 +43,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         max_length: int = None,
         train_parameters: bool = True,
         last_layer_only: bool = True,
+        use_amp: bool = False,
     ) -> None:
         super().__init__()
         # The matched version v.s. mismatched
@@ -47,6 +52,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
             max_length=max_length,
             train_parameters=train_parameters,
             last_layer_only=last_layer_only,
+            use_amp=use_amp,
         )
 
     @overrides

--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -6,6 +6,7 @@ import copy
 import json
 import logging
 from collections import defaultdict
+from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
 
 import math
@@ -1897,3 +1898,18 @@ def tiny_value_of_dtype(dtype: torch.dtype):
         return 1e-4
     else:
         raise TypeError("Does not support dtype " + str(dtype))
+
+
+@contextmanager
+def maybe_autocast(enabled: Optional[bool] = None):
+    """
+    This is a context manager that is really just a wrapper around
+    [`torch.cuda.amp.autocast`](https://pytorch.org/docs/stable/amp.html#torch.cuda.amp.autocast).
+
+    The only difference is that `enabled` can also be `None`, in which case this is a no-op.
+    """
+    if enabled is not None:
+        with torch.cuda.amp.autocast(enabled):
+            yield
+    else:
+        yield


### PR DESCRIPTION
This adds an option to enable AMP for just the transformer part of your model. I found this was helpful because AMP currently fails with certain core torch modules, like anything that's an RNN, and so in those cases enabling AMP at the trainer level will result in a crash.

See https://github.com/pytorch/pytorch/issues/36428, for example, and also the failure in [this build](https://github.com/allenai/allennlp-models/pull/104/checks?check_run_id=933149196) where I tried to get AMP working with CopyNet.

That said, it feels like this solution is a little too ad hoc. Maybe there's a clean way to make this more general so that you could easily configure any part of your model to use AMP individually. On the other hand, doing this to the transformer part of a model will probably be the most common use case, and so the complexity involved in making this more general may not be worth it.