### PR TITLE
Ensure len(self.evaluation_data_loader) is not called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unnecessary warning about deadlocks in `DataLoader`.
 - Fixed testing models that only return a loss when they are in training mode.
 - Fixed a bug in `FromParams` that caused silent failure in case of the parameter type being `Optional[Union[...]]`.
+- Fixed a bug where the program crashes if `evaluation_data_loader` is a `AllennlpLazyDataset`.
 
 ### Added
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -506,7 +506,7 @@ class TrainModel(Registrable):
 
             for key, value in test_metrics.items():
                 metrics["test_" + key] = value
-        elif self.evaluation_data_loader:
+        elif self.evaluation_data_loader is not None:
             logger.info(
                 "To evaluate on the test set after training, pass the "
                 "'evaluate_on_test' flag, or use the 'allennlp evaluate' command."


### PR DESCRIPTION
A follow-up on this [issue](https://github.com/allenai/allennlp/pull/4328/files#r436138651), in which if we use `AllennlpLazyDataset`, the dataloader in pytorch will attempt to call `len(self.evaluation_data_loader)`, which will crash the program.

@epwalsh patched the first condition but forgot to patch the second condition. This PR patches the second condition.