### PR TITLE
Fix handling of max length with transformer tokenizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed a warning from `transformers` tokenizers when `max_length` is set.
+- Fixed how truncation was handled with `PretrainedTransformerTokenizer`.
+  Previously, if `max_length` was set to `None`, the tokenizer would still do truncation if the
+  transformer model had a default max length in its config.
+  Also, when `max_length` was set to a non-`None` value, several warnings would appear
+  for certain transformer models around the use of the `truncation` parameter.
 
 ## [v1.1.0rc2](https://github.com/allenai/allennlp/releases/tag/v1.1.0rc2) - 2020-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a warning from `transformers` tokenizers when `max_length` is set.
+
 ## [v1.1.0rc2](https://github.com/allenai/allennlp/releases/tag/v1.1.0rc2) - 2020-07-31
 
 ### Changed

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -236,7 +236,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
             add_special_tokens=False,
             max_length=self._max_length,
             stride=self._stride,
-            truncation_strategy=self._truncation_strategy,
+            truncation=self._truncation_strategy if self._max_length is not None else False,
             return_tensors=None,
             return_offsets_mapping=self.tokenizer.is_fast,
             return_attention_mask=False,

--- a/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -139,6 +139,24 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
         idxs = [t.idx for t in tokenized]
         assert idxs == expected_idxs
 
+    def test_max_length(self):
+        tokenizer = PretrainedTransformerTokenizer(
+            "bert-base-cased", max_length=10, add_special_tokens=False
+        )
+        tokens = tokenizer.tokenize(
+            "hi there, this should be at least 10 tokens, but some will be truncated"
+        )
+        assert len(tokens) == 10
+
+    def test_no_max_length(self):
+        tokenizer = PretrainedTransformerTokenizer(
+            "bert-base-cased", max_length=None, add_special_tokens=False
+        )
+        # Even though the bert model has a max input length of 512, when we tokenize
+        # with `max_length = None`, we should not get any truncation.
+        tokens = tokenizer.tokenize(" ".join(["a"] * 550))
+        assert len(tokens) == 550
+
     def test_token_idx_roberta(self):
         sentence = "A, naïve <mask> AllenNLP sentence."
         expected_tokens = [


### PR DESCRIPTION
Fixes how truncation was handled with `PretrainedTransformerTokenizer`.

Currently, if `max_length` is set to `None`, the tokenizer will still do truncation if the transformer model has a default max length in its config.

Also, when `max_length` is set to a non-`None` value, several warnings appear for certain transformer models around the use of the `truncation` parameter.

The warnings come from this function: https://github.com/huggingface/transformers/blob/b390a5672aea995e65d031b3759274d92188e553/src/transformers/tokenization_utils_base.py#L1705, and for reference, this is the signature of the `encode_plus` method: https://github.com/huggingface/transformers/blob/b390a5672aea995e65d031b3759274d92188e553/src/transformers/tokenization_utils_base.py#L1946.