### PR TITLE
allow to set gradient checkpointing for transformer token embedders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v1.1.0rc2](https://github.com/allenai/allennlp/releases/tag/v1.1.0rc2) - 2020-07-31
+
+### Changed
+
+- Upgraded PyTorch requirement to 1.6.
+- Replaced the NVIDIA Apex AMP module with torch's native AMP module. The default trainer (`GradientDescentTrainer`)
+  now takes a `use_amp: bool` parameter instead of the old `opt_level: str` parameter.
+
 ### Fixed
 
 - Removed unnecessary warning about deadlocks in `DataLoader`.
 - Fixed testing models that only return a loss when they are in training mode.
-- Fixed a bug in `FromParams` that causes silent failure in case of the parameter type being Optional[Union[...]].
-- Cleanup/fix to module docstring in `allennlp/models/seq2seq_encoders/__init__.py`.
+- Fixed a bug in `FromParams` that caused silent failure in case of the parameter type being `Optional[Union[...]]`.
+- Fixed a bug where the program crashes if `evaluation_data_loader` is a `AllennlpLazyDataset`.
 
 ### Added
 
-- Added the option to specify `requires_grad: false` within an optimizers parameter groups.
+- Added the option to specify `requires_grad: false` within an optimizer's parameter groups.
 - Added the `file-friendly-logging` flag back to the `train` command. Also added this flag to the `predict`, `evaluate`, and `find-learning-rate` commands.
+- Added an `EpochCallback` to track current epoch as a model class member. 
+- Added the option to enable or disable gradient checkpointing for transformer token embedders via boolean parameter `gradient_checkpointing`.
+
+### Removed
+
+- Removed the `opt_level` parameter to `Model.load` and `load_archive`. In order to use AMP with a loaded
+  model now, just run the model's forward pass within torch's [`autocast`](https://pytorch.org/docs/stable/amp.html#torch.cuda.amp.autocast)
+  context.
 
 ## [v1.1.0rc1](https://github.com/allenai/allennlp/releases/tag/v1.1.0rc1) - 2020-07-14
 

--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,11 @@ install :
 	# Due to a weird thing with pip, we may need egg-info before running `pip install -e`.
 	# See https://github.com/pypa/pip/issues/4537.
 	python setup.py install_egg_info
-	# Install allennlp as editable and all dependencies except apex since that requires torch to already be installed.
-	grep -Ev 'NVIDIA/apex\.git' dev-requirements.txt | pip install --upgrade --upgrade-strategy eager -e . -r /dev/stdin
-	# The above command will probably install the typing backport because of pydoc-markdown,
+	# Install allennlp as editable and all dependencies.
+	pip install --upgrade --upgrade-strategy eager -e . -r dev-requirements.txt
+	# The above command might install the typing backport because of pydoc-markdown,
 	# so we have to uninstall it again.
 	pip uninstall -y typing
-	# Now install apex.
-	grep -E 'NVIDIA/apex\.git' dev-requirements.txt | pip install --upgrade -r /dev/stdin
 
 #
 # Documention helpers.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -38,7 +38,7 @@ Then you can copy and paste the commands below without worrying about mistyping 
     ```
 
 4. Find the tag you just pushed [on GitHub](https://github.com/allenai/allennlp/tags) and
-click edit. Now copy over the latest section from the `CHANGELOG.md`. And finally, add a section called "Commits" with the output of a command like the following:
+click edit. Now copy over the latest section from the [`CHANGELOG.md`](https://raw.githubusercontent.com/allenai/allennlp/master/CHANGELOG.md). And finally, add a section called "Commits" with the output of a command like the following:
 
     ```bash
     OLD_TAG=$(git describe --always --tags --abbrev=0 $TAG^)

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -506,7 +506,7 @@ class TrainModel(Registrable):
 
             for key, value in test_metrics.items():
                 metrics["test_" + key] = value
-        elif self.evaluation_data_loader:
+        elif self.evaluation_data_loader is not None:
             logger.info(
                 "To evaluate on the test set after training, pass the "
                 "'evaluate_on_test' flag, or use the 'allennlp evaluate' command."

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -312,7 +312,7 @@ def _find_latest_cached(url: str, cache_dir: Union[str, Path]) -> Optional[str]:
             continue
         mtime = os.path.getmtime(path)
         candidates.append((path, mtime))
-    # Sort candidates by modification time, neweste first.
+    # Sort candidates by modification time, newest first.
     candidates.sort(key=lambda x: x[1], reverse=True)
     if candidates:
         return candidates[0][0]
@@ -382,7 +382,7 @@ def get_from_cache(url: str, cache_dir: Union[str, Path] = None) -> str:
         # target resource, if it exists. We'll only throw an exception if we
         # haven't cached the resource at all yet.
         logger.warning(
-            "Connection error occured while trying to fetch ETag for %s. "
+            "Connection error occurred while trying to fetch ETag for %s. "
             "Will attempt to use latest cached version of resource",
             url,
         )

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -130,11 +130,7 @@ def archive_model(
 
 
 def load_archive(
-    archive_file: str,
-    cuda_device: int = -1,
-    opt_level: str = None,
-    overrides: str = "",
-    weights_file: str = None,
+    archive_file: str, cuda_device: int = -1, overrides: str = "", weights_file: str = None,
 ) -> Archive:
     """
     Instantiates an Archive from an archived `tar.gz` file.
@@ -146,12 +142,6 @@ def load_archive(
     cuda_device : `int`, optional (default = `-1`)
         If `cuda_device` is >= 0, the model will be loaded onto the
         corresponding GPU. Otherwise it will be loaded onto the CPU.
-    opt_level : `str`, optional, (default = `None`)
-        Each `opt_level` establishes a set of properties that govern Amp’s implementation of pure or mixed
-        precision training. Must be a choice of `"O0"`, `"O1"`, `"O2"`, or `"O3"`.
-        See the Apex [documentation](https://nvidia.github.io/apex/amp.html#opt-levels-and-properties) for
-        more details. If `None`, defaults to the `opt_level` found in the model params. If `cuda_device==-1`,
-        Amp is not used and this argument is ignored.
     overrides : `str`, optional (default = `""`)
         JSON overrides to apply to the unarchived `Params` object.
     weights_file : `str`, optional (default = `None`)
@@ -196,7 +186,6 @@ def load_archive(
         weights_file=weights_path,
         serialization_dir=serialization_dir,
         cuda_device=cuda_device,
-        opt_level=opt_level,
     )
 
     return Archive(model=model, config=config)

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -31,6 +31,8 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         When `True` (the default), only the final layer of the pretrained transformer is taken
         for the embeddings. But if set to `False`, a scalar mix of all of the layers
         is used.
+    gradient_checkpointing: `bool`, optional (default = `None`)
+        Enable or disable gradient checkpointing.
     """
 
     def __init__(
@@ -39,6 +41,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         max_length: int = None,
         train_parameters: bool = True,
         last_layer_only: bool = True,
+        gradient_checkpointing: Optional[bool] = None,
     ) -> None:
         super().__init__()
         # The matched version v.s. mismatched
@@ -47,6 +50,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
             max_length=max_length,
             train_parameters=train_parameters,
             last_layer_only=last_layer_only,
+            gradient_checkpointing=gradient_checkpointing,
         )
 
     @overrides

--- a/allennlp/training/__init__.py
+++ b/allennlp/training/__init__.py
@@ -1,4 +1,10 @@
 from allennlp.training.checkpointer import Checkpointer
 from allennlp.training.tensorboard_writer import TensorboardWriter
 from allennlp.training.no_op_trainer import NoOpTrainer
-from allennlp.training.trainer import Trainer, GradientDescentTrainer, BatchCallback, EpochCallback
+from allennlp.training.trainer import (
+    Trainer,
+    GradientDescentTrainer,
+    BatchCallback,
+    EpochCallback,
+    TrackEpochCallback,
+)

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -10,12 +10,9 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from allennlp.common.util import int_to_device
 
-try:
-    from apex import amp
-except ImportError:
-    amp = None
 import torch
 import torch.distributed as dist
+from torch.cuda import amp
 import torch.optim.lr_scheduler
 from torch.nn.parallel import DistributedDataParallel
 from torch.nn.utils import clip_grad_norm_
@@ -179,6 +176,29 @@ class EpochCallback(Registrable):
 EpochCallback.register("null")(EpochCallback)
 
 
+@EpochCallback.register("track_epoch_callback")
+class TrackEpochCallback:
+    """
+    A callback that you can pass to the `GradientDescentTrainer` to access the current epoch number
+    in your model during training. This callback sets `model.epoch`, which can be read inside of
+    `model.forward()`. Since the EpochCallback passes `epoch=-1`
+    at the start of the training, we set `model.epoch = epoch + 1` which now denotes the number of
+    completed epochs at a given training state.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def __call__(
+        self,
+        trainer: "GradientDescentTrainer",
+        metrics: Dict[str, Any],
+        epoch: int,
+        is_master: bool,
+    ) -> None:
+        trainer.model.epoch = epoch + 1
+
+
 @Trainer.register("gradient_descent", constructor="from_partial_objects")
 class GradientDescentTrainer(Trainer):
     """
@@ -194,7 +214,6 @@ class GradientDescentTrainer(Trainer):
     `from_partial_objects`.
 
     [0]: https://tinyurl.com/y5mv44fw
-    [1]: https://nvidia.github.io/apex/amp.html#opt-levels-and-properties
 
     # Parameters
 
@@ -323,11 +342,8 @@ class GradientDescentTrainer(Trainer):
         be useful to accommodate batches that are larger than the RAM size. Refer [Thomas Wolf's
         post][0] for details on Gradient Accumulation.
 
-    opt_level : `str`, optional, (default = `None`)
-        Each opt_level establishes a set of properties that govern Amp’s implementation of pure or mixed
-        precision training. Must be a choice of `"O0"`, `"O1"`, `"O2"`, or `"O3"`.
-        See [the Apex documentation][1] for
-        more details. If `None`, Amp is not used. Defaults to `None`.
+    use_amp : `bool`, optional, (default = `False`)
+        If `True`, we'll train using [Automatic Mixed Precision](https://pytorch.org/docs/stable/amp.html).
 
     """
 
@@ -355,7 +371,7 @@ class GradientDescentTrainer(Trainer):
         local_rank: int = 0,
         world_size: int = 1,
         num_gradient_accumulation_steps: int = 1,
-        opt_level: Optional[str] = None,
+        use_amp: bool = False,
     ) -> None:
         super().__init__(serialization_dir, cuda_device, distributed, local_rank, world_size)
 
@@ -413,20 +429,13 @@ class GradientDescentTrainer(Trainer):
 
         self._num_gradient_accumulation_steps = num_gradient_accumulation_steps
 
-        # Enable automatic mixed precision training with NVIDIA Apex.
-        self._opt_level = opt_level
-        if self._opt_level is not None:
-            if amp is None:
-                raise ConfigurationError(
-                    (
-                        "Apex not installed but opt_level was provided. Please install NVIDIA's Apex to enable"
-                        " automatic mixed precision (AMP) training. See: https://github.com/NVIDIA/apex."
-                    )
-                )
-
-            self.model, self.optimizer = amp.initialize(
-                self.model, self.optimizer, opt_level=self._opt_level
-            )
+        # Enable automatic mixed precision training.
+        self._scaler: Optional[amp.GradScaler] = None
+        self._use_amp = use_amp
+        if self._use_amp:
+            if self.cuda_device == torch.device("cpu"):
+                raise ValueError("Using AMP requires a cuda device")
+            self._scaler = amp.GradScaler()
 
         # Using `DistributedDataParallel`(ddp) brings in a quirk wrt AllenNLP's `Model` interface and its
         # usage. A `Model` object is wrapped by `ddp`, but assigning the wrapped model to `self.model`
@@ -450,14 +459,11 @@ class GradientDescentTrainer(Trainer):
 
         Returns the norm of the gradients.
         """
-        if self._opt_level is not None:
-            # See: https://nvidia.github.io/apex/advanced.html#gradient-clipping
-            parameters_to_clip = [
-                p for p in amp.master_params(self.optimizer) if p.grad is not None
-            ]
-        else:
-            parameters_to_clip = [p for p in self.model.parameters() if p.grad is not None]
+        parameters_to_clip = [p for p in self.model.parameters() if p.grad is not None]
         if self._grad_norm:
+            if self._scaler is not None:
+                # Need to first unscale gradients in order to clip as usual.
+                self._scaler.unscale_(self.optimizer)
             return clip_grad_norm_(parameters_to_clip, self._grad_norm)
         else:
             return torch.norm(
@@ -579,24 +585,26 @@ class GradientDescentTrainer(Trainer):
 
             batch_group_outputs = []
             for batch in batch_group:
-                batch_outputs = self.batch_outputs(batch, for_training=True)
-                batch_group_outputs.append(batch_outputs)
-                loss = batch_outputs.get("loss")
-                reg_loss = batch_outputs.get("reg_loss")
-                if torch.isnan(loss):
-                    raise ValueError("nan loss encountered")
-                loss = loss / len(batch_group)
-                if self._opt_level is not None:
-                    with amp.scale_loss(loss, self.optimizer) as scaled_loss:
-                        scaled_loss.backward()
+                with amp.autocast(self._use_amp):
+                    batch_outputs = self.batch_outputs(batch, for_training=True)
+                    batch_group_outputs.append(batch_outputs)
+                    loss = batch_outputs.get("loss")
+                    reg_loss = batch_outputs.get("reg_loss")
+                    if torch.isnan(loss):
+                        raise ValueError("nan loss encountered")
+                    loss = loss / len(batch_group)
+
+                    batch_loss = loss.item()
+                    train_loss += batch_loss
+                    if reg_loss is not None:
+                        reg_loss = reg_loss / len(batch_group)
+                        batch_reg_loss = reg_loss.item()
+                        train_reg_loss += batch_reg_loss
+
+                if self._scaler is not None:
+                    self._scaler.scale(loss).backward()
                 else:
                     loss.backward()
-                batch_loss = loss.item()
-                train_loss += batch_loss
-                if reg_loss is not None:
-                    reg_loss = reg_loss / len(batch_group)
-                    batch_reg_loss = reg_loss.item()
-                    train_reg_loss += batch_reg_loss
 
             batch_grad_norm = self.rescale_gradients()
 
@@ -617,11 +625,21 @@ class GradientDescentTrainer(Trainer):
                     name: param.detach().cpu().clone()
                     for name, param in self.model.named_parameters()
                 }
-                self.optimizer.step()
+
+                if self._scaler is not None:
+                    self._scaler.step(self.optimizer)
+                    self._scaler.update()
+                else:
+                    self.optimizer.step()
+
                 for name, param in self.model.named_parameters():
                     param_updates[name].sub_(param.detach().cpu())
             else:
-                self.optimizer.step()
+                if self._scaler is not None:
+                    self._scaler.step(self.optimizer)
+                    self._scaler.update()
+                else:
+                    self.optimizer.step()
 
             # Update moving averages
             if self._moving_average is not None:
@@ -754,21 +772,22 @@ class GradientDescentTrainer(Trainer):
                     )
                     break
 
-            batch_outputs = self.batch_outputs(batch, for_training=False)
-            loss = batch_outputs.get("loss")
-            reg_loss = batch_outputs.get("reg_loss")
-            if loss is not None:
-                # You shouldn't necessarily have to compute a loss for validation, so we allow for
-                # `loss` to be None.  We need to be careful, though - `batches_this_epoch` is
-                # currently only used as the divisor for the loss function, so we can safely only
-                # count those batches for which we actually have a loss.  If this variable ever
-                # gets used for something else, we might need to change things around a bit.
-                batches_this_epoch += 1
-                val_batch_loss = loss.detach().cpu().numpy()
-                val_loss += val_batch_loss
-                if reg_loss is not None:
-                    val_batch_reg_loss = reg_loss.detach().cpu().numpy()
-                    val_reg_loss += val_batch_reg_loss
+            with amp.autocast(self._use_amp):
+                batch_outputs = self.batch_outputs(batch, for_training=False)
+                loss = batch_outputs.get("loss")
+                reg_loss = batch_outputs.get("reg_loss")
+                if loss is not None:
+                    # You shouldn't necessarily have to compute a loss for validation, so we allow for
+                    # `loss` to be None.  We need to be careful, though - `batches_this_epoch` is
+                    # currently only used as the divisor for the loss function, so we can safely only
+                    # count those batches for which we actually have a loss.  If this variable ever
+                    # gets used for something else, we might need to change things around a bit.
+                    batches_this_epoch += 1
+                    val_batch_loss = loss.detach().cpu().numpy()
+                    val_loss += val_batch_loss
+                    if reg_loss is not None:
+                        val_batch_reg_loss = reg_loss.detach().cpu().numpy()
+                        val_reg_loss += val_batch_reg_loss
 
             # Update the description with the latest metrics
             val_metrics = training_util.get_metrics(
@@ -978,9 +997,6 @@ class GradientDescentTrainer(Trainer):
             training_states["learning_rate_scheduler"] = self._learning_rate_scheduler.state_dict()
         if self._momentum_scheduler is not None:
             training_states["momentum_scheduler"] = self._momentum_scheduler.state_dict()
-        # If model was trained with amp, we should persist the amp state.
-        if self._opt_level is not None:
-            training_states["amp"] = amp.state_dict()
 
         try:
             yield model_state, training_states
@@ -1012,12 +1028,6 @@ class GradientDescentTrainer(Trainer):
             # No checkpoint to restore, start at 0
             return 0
 
-        # The apex docs recommend calling amp.initialize before calling load_state_dict.
-        if self._opt_level is not None and "amp" in training_state:
-            self.model, self.optimizer = amp.initialize(
-                self.model, self.optimizer, opt_level=self._opt_level
-            )
-            amp.load_state_dict(training_state["amp"])
         self.model.load_state_dict(model_state)
         self.optimizer.load_state_dict(training_state["optimizer"])
         if (
@@ -1070,7 +1080,7 @@ class GradientDescentTrainer(Trainer):
         distributed: bool = None,
         world_size: int = 1,
         num_gradient_accumulation_steps: int = 1,
-        opt_level: Optional[str] = None,
+        use_amp: bool = False,
         no_grad: List[str] = None,
         optimizer: Lazy[Optimizer] = None,
         learning_rate_scheduler: Lazy[LearningRateScheduler] = None,
@@ -1161,5 +1171,5 @@ class GradientDescentTrainer(Trainer):
             local_rank=local_rank,
             world_size=world_size,
             num_gradient_accumulation_steps=num_gradient_accumulation_steps,
-            opt_level=opt_level,
+            use_amp=use_amp,
         )

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -19,9 +19,6 @@ codecov
 # Optional dependencies, which we install for testing purposes.
 matplotlib>=2.2.3
 
-# Required for automatic mixed precision (AMP) training
-git+https://github.com/NVIDIA/apex.git@master
-
 # For mocking HTTP requests/responses.
 responses>=0.7
 
@@ -42,7 +39,7 @@ nr.databind.core<0.0.17
 nr.interface<0.0.4
 
 mkdocs==1.1.2
-mkdocs-material==5.5.0
+mkdocs-material==5.5.3
 markdown-include==0.5.1
 
 #### PACKAGE-UPLOAD PACKAGES ####

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         ]
     ),
     install_requires=[
-        "torch>=1.5.0,<1.6.0",
+        "torch>=1.6.0,<1.7.0",
         "jsonnet>=0.10.0 ; sys.platform != 'win32'",
         "overrides==3.1.0",
         "nltk",


### PR DESCRIPTION
Gradient checkpointing has been released with huggingface/transformers v3.0.0. Gradient checkpointing reduces memory by 5x which makes it possible to process longer sequences on smaller GPUs. This PR allows to fine-tune transformer token embedders on a more regular GPU with high(er) max_length values.

Sorry for not providing any tests, I have no clue how to create a simple test case and no resources at the moment to figure that out. But I tried it succesfully with Longformer (max_length: 4096) and SciBert (max_length: 512) on a single RTX 2080 Ti.