### PR TITLE
add gradient checkpointing for transformer token embedders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the option to specify `requires_grad: false` within an optimizer's parameter groups.
 - Added the `file-friendly-logging` flag back to the `train` command. Also added this flag to the `predict`, `evaluate`, and `find-learning-rate` commands.
 - Added an `EpochCallback` to track current epoch as a model class member. 
+- Added the option to enable or disable gradient checkpointing for transformer token embedders via boolean parameter `gradient_checkpointing`.
 
 ### Removed
 

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -40,6 +40,8 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         When `True` (the default), only the final layer of the pretrained transformer is taken
         for the embeddings. But if set to `False`, a scalar mix of all of the layers
         is used.
+    gradient_checkpointing: `bool`, optional (default = `None`)
+        Enable or disable gradient checkpointing.
     """
 
     def __init__(
@@ -51,7 +53,8 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         train_parameters: bool = True,
         last_layer_only: bool = True,
         override_weights_file: Optional[str] = None,
-        override_weights_strip_prefix: Optional[str] = None
+        override_weights_strip_prefix: Optional[str] = None,
+        gradient_checkpointing: Optional[bool] = None,
     ) -> None:
         super().__init__()
         from allennlp.common import cached_transformers
@@ -59,6 +62,10 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         self.transformer_model = cached_transformers.get(
             model_name, True, override_weights_file, override_weights_strip_prefix
         )
+
+        if gradient_checkpointing is not None:
+            self.transformer_model.config.update({"gradient_checkpointing": gradient_checkpointing})
+
         self.config = self.transformer_model.config
         if sub_module:
             assert hasattr(self.transformer_model, sub_module)

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -31,6 +31,8 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         When `True` (the default), only the final layer of the pretrained transformer is taken
         for the embeddings. But if set to `False`, a scalar mix of all of the layers
         is used.
+    gradient_checkpointing: `bool`, optional (default = `None`)
+        Enable or disable gradient checkpointing.
     """
 
     def __init__(
@@ -39,6 +41,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         max_length: int = None,
         train_parameters: bool = True,
         last_layer_only: bool = True,
+        gradient_checkpointing: Optional[bool] = None,
     ) -> None:
         super().__init__()
         # The matched version v.s. mismatched
@@ -47,6 +50,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
             max_length=max_length,
             train_parameters=train_parameters,
             last_layer_only=last_layer_only,
+            gradient_checkpointing=gradient_checkpointing,
         )
 
     @overrides

--- a/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -26,10 +26,22 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
         assert tuple(output.size()) == (1, 4, 768)
 
     @pytest.mark.parametrize(
-        "train_parameters, last_layer_only",
-        [(True, True), (False, True), (True, False), (False, False)],
+        "train_parameters, last_layer_only, gradient_checkpointing",
+        [
+            (True, True, False),
+            (False, True, False),
+            (True, False, False),
+            (False, False, False),
+            (
+                True,
+                False,
+                True,
+            ),  # checkpointing only makes sense when we're actually training the layers
+        ],
     )
-    def test_end_to_end(self, train_parameters: bool, last_layer_only: bool):
+    def test_end_to_end(
+        self, train_parameters: bool, last_layer_only: bool, gradient_checkpointing: bool
+    ):
         tokenizer = PretrainedTransformerTokenizer(model_name="bert-base-uncased")
         token_indexer = PretrainedTransformerIndexer(model_name="bert-base-uncased")
 
@@ -53,6 +65,7 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
                         "model_name": "bert-base-uncased",
                         "train_parameters": train_parameters,
                         "last_layer_only": last_layer_only,
+                        "gradient_checkpointing": gradient_checkpointing,
                     }
                 }
             }


### PR DESCRIPTION
Gradient checkpointing has been released with huggingface/transformers v3.0.0. Gradient checkpointing reduces memory by 5x which makes it possible to process longer sequences on smaller GPUs. This PR allows to fine-tune transformer token embedders on a more regular GPU with high(er) max_length values.

Sorry for not providing any tests, I have no clue how to create a simple test case and no resources at the moment to figure that out. But I tried it succesfully with Longformer (max_length: 4096) and SciBert (max_length: 512) on a single RTX 2080 Ti.