### PR TITLE
Pass strings, not tokens, to the dataset reader in TextClassifierPredictor

### DIFF
--- a/allennlp/predictors/text_classifier.py
+++ b/allennlp/predictors/text_classifier.py
@@ -36,7 +36,7 @@ class TextClassifierPredictor(Predictor):
         )
         if not reader_has_tokenizer:
             tokenizer = SpacyTokenizer()
-            sentence = tokenizer.tokenize(sentence)
+            sentence = [t.text for t in tokenizer.tokenize(sentence)]
         return self._dataset_reader.text_to_instance(sentence)
 
     @overrides


### PR DESCRIPTION
I got an error when trying to diagnose #4360 with current code, and this fixes that error.  Not sure what other side effects this will have; hopefully tests will catch it.