### PR TITLE
ensure vision CI runs on each commit

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -292,7 +292,7 @@ jobs:
 
     - name: Upload master image
       # Only run this for pushes to master on the main repo, not forks.
-      if: github.repository == 'allenai/allennlp' && github.event_name == 'push' && github.ref == "refs/heads/master"
+      if: github.repository == 'allenai/allennlp' && github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: |
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
         docker push $DOCKER_IMAGE_NAME
@@ -425,7 +425,7 @@ jobs:
     - name: Deploy docs
       # Only run this on main repo (not forks) master branch for commits and releases,
       # but not for nightly builds.
-      if: github.repository == 'allenai/allennlp' && github.event_name != 'schedule' && github.ref == "refs/heads/master"
+      if: github.repository == 'allenai/allennlp' && github.event_name != 'schedule' && github.ref == 'refs/heads/master'
       run: |
         # And push them up to GitHub
         cd ~/allennlp-docs/

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - vision
   release:
     types: [published]
   schedule:
@@ -291,7 +292,7 @@ jobs:
 
     - name: Upload master image
       # Only run this for pushes to master on the main repo, not forks.
-      if: github.repository == 'allenai/allennlp' && github.event_name == 'push'
+      if: github.repository == 'allenai/allennlp' && github.event_name == 'push' && github.ref == "refs/heads/master"
       run: |
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
         docker push $DOCKER_IMAGE_NAME
@@ -422,9 +423,9 @@ jobs:
         EOL
 
     - name: Deploy docs
-      # Only run this on main repo (not forks) for commits and releases but not for
-      # nightly builds.
-      if: github.repository == 'allenai/allennlp' && github.event_name != 'schedule'
+      # Only run this on main repo (not forks) master branch for commits and releases,
+      # but not for nightly builds.
+      if: github.repository == 'allenai/allennlp' && github.event_name != 'schedule' && github.ref == "refs/heads/master"
       run: |
         # And push them up to GitHub
         cd ~/allennlp-docs/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         # If this step fails, this means you haven't updated the CHANGELOG.md
         # file with notes on your contribution.
-        git diff --name-only $(git merge-base origin/master HEAD) | grep '^CHANGELOG.md$' && echo "Thanks for helping keep our CHANGELOG up-to-date!"
+        git diff --name-only $(git merge-base origin/${{ github.base_ref }} HEAD) | grep '^CHANGELOG.md$' && echo "Thanks for helping keep our CHANGELOG up-to-date!"
 
   gpu_checks:
     name: GPU Checks


### PR DESCRIPTION
Ensures the GitHub Actions workflow runs on commits to the vision branch but doesn't deploy the docs or docker image. Also fixes the CHANGELOG check on pull requests to the vision branch.