### PR TITLE
make existing readers work with multi-process loading

### DIFF
--- a/allennlp/data/dataset_readers/babi.py
+++ b/allennlp/data/dataset_readers/babi.py
@@ -127,6 +127,7 @@ class BabiReader(DatasetReader):
 
         return Instance(fields)
 
+    @overrides
     def apply_token_indexers(self, instance: Instance) -> None:
         if self._keep_sentences:
             for text_field in instance.fields["context"]:  # type: ignore

--- a/allennlp/data/dataset_readers/babi.py
+++ b/allennlp/data/dataset_readers/babi.py
@@ -85,21 +85,14 @@ class BabiReader(DatasetReader):
 
         if self._keep_sentences:
             context_field_ks = ListField(
-                [
-                    TextField(
-                        [Token(word) for word in line],
-                    )
-                    for line in context
-                ]
+                [TextField([Token(word) for word in line]) for line in context]
             )
 
             fields["supports"] = ListField(
                 [IndexField(support, context_field_ks) for support in supports]
             )
         else:
-            context_field = TextField(
-                [Token(word) for line in context for word in line],
-            )
+            context_field = TextField([Token(word) for line in context for word in line])
 
         fields["context"] = context_field_ks if self._keep_sentences else context_field
         fields["question"] = TextField(

--- a/allennlp/data/dataset_readers/babi.py
+++ b/allennlp/data/dataset_readers/babi.py
@@ -88,10 +88,6 @@ class BabiReader(DatasetReader):
                 [
                     TextField(
                         [Token(word) for word in line],
-                        # Token indexers are applied later during multi-process loading with
-                        # the `apply_token_indexers` method, so we only apply them now if there
-                        # is a single worker.
-                        None if self._worker_info is not None else self._token_indexers,
                     )
                     for line in context
                 ]
@@ -103,27 +99,13 @@ class BabiReader(DatasetReader):
         else:
             context_field = TextField(
                 [Token(word) for line in context for word in line],
-                # Token indexers are applied later during multi-process loading with
-                # the `apply_token_indexers` method, so we only apply them now if there
-                # is a single worker.
-                None if self._worker_info is not None else self._token_indexers,
             )
 
         fields["context"] = context_field_ks if self._keep_sentences else context_field
         fields["question"] = TextField(
             [Token(word) for word in question],
-            # Token indexers are applied later during multi-process loading with
-            # the `apply_token_indexers` method, so we only apply them now if there
-            # is a single worker.
-            None if self._worker_info is not None else self._token_indexers,
         )
-        fields["answer"] = TextField(
-            [Token(answer)],
-            # Token indexers are applied later during multi-process loading with
-            # the `apply_token_indexers` method, so we only apply them now if there
-            # is a single worker.
-            None if self._worker_info is not None else self._token_indexers,
-        )
+        fields["answer"] = TextField([Token(answer)])
 
         return Instance(fields)
 

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -143,13 +143,7 @@ class Conll2003DatasetReader(DatasetReader):
         We take `pre-tokenized` input here, because we don't have a tokenizer in this class.
         """
 
-        sequence = TextField(
-            tokens,
-            # Token indexers are applied later during multi-process loading with
-            # the `apply_token_indexers` method, so we only apply them now if there
-            # is a single worker.
-            None if self._worker_info is not None else self._token_indexers,
-        )
+        sequence = TextField(tokens)
         instance_fields: Dict[str, Field] = {"tokens": sequence}
         instance_fields["metadata"] = MetadataField({"words": [x.text for x in tokens]})
 

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -205,5 +205,6 @@ class Conll2003DatasetReader(DatasetReader):
 
         return Instance(instance_fields)
 
+    @overrides
     def apply_token_indexers(self, instance: Instance) -> None:
         instance.fields["tokens"]._token_indexers = self._token_indexers  # type: ignore

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -143,7 +143,13 @@ class Conll2003DatasetReader(DatasetReader):
         We take `pre-tokenized` input here, because we don't have a tokenizer in this class.
         """
 
-        sequence = TextField(tokens, self._token_indexers)
+        sequence = TextField(
+            tokens,
+            # Token indexers are applied later during multi-process loading with
+            # the `apply_token_indexers` method, so we only apply them now if there
+            # is a single worker.
+            None if self._worker_info is not None else self._token_indexers,
+        )
         instance_fields: Dict[str, Field] = {"tokens": sequence}
         instance_fields["metadata"] = MetadataField({"words": [x.text for x in tokens]})
 
@@ -198,3 +204,6 @@ class Conll2003DatasetReader(DatasetReader):
             )
 
         return Instance(instance_fields)
+
+    def apply_token_indexers(self, instance: Instance) -> None:
+        instance.fields["tokens"]._token_indexers = self._token_indexers  # type: ignore

--- a/allennlp/data/dataset_readers/nlvr2_reader.py
+++ b/allennlp/data/dataset_readers/nlvr2_reader.py
@@ -184,13 +184,7 @@ class Nlvr2LxmertReader(DatasetReader):
         only_predictions: bool = False,
     ) -> Instance:
         tokenized_sentence = self._tokenizer.tokenize(question)
-        sentence_field = TextField(
-            tokenized_sentence,
-            # Token indexers are applied later during multi-process loading with
-            # the `apply_token_indexers` method, so we only apply them now if there
-            # is a single worker.
-            None if self._worker_info is not None else self._token_indexers,
-        )
+        sentence_field = TextField(tokenized_sentence)
 
         original_identifier = identifier
         all_boxes = []

--- a/allennlp/data/dataset_readers/nlvr2_reader.py
+++ b/allennlp/data/dataset_readers/nlvr2_reader.py
@@ -227,5 +227,6 @@ class Nlvr2LxmertReader(DatasetReader):
             fields["denotation"] = LabelField(int(denotation), skip_indexing=True)
         return Instance(fields)
 
+    @overrides
     def apply_token_indexers(self, instance: Instance) -> None:
         instance.fields["sentence_field"]._token_indexers = self._token_indexers  # type: ignore

--- a/allennlp/data/dataset_readers/nlvr2_reader.py
+++ b/allennlp/data/dataset_readers/nlvr2_reader.py
@@ -184,7 +184,13 @@ class Nlvr2LxmertReader(DatasetReader):
         only_predictions: bool = False,
     ) -> Instance:
         tokenized_sentence = self._tokenizer.tokenize(question)
-        sentence_field = TextField(tokenized_sentence, self._token_indexers)
+        sentence_field = TextField(
+            tokenized_sentence,
+            # Token indexers are applied later during multi-process loading with
+            # the `apply_token_indexers` method, so we only apply them now if there
+            # is a single worker.
+            None if self._worker_info is not None else self._token_indexers,
+        )
 
         original_identifier = identifier
         all_boxes = []
@@ -220,3 +226,6 @@ class Nlvr2LxmertReader(DatasetReader):
         if denotation is not None:
             fields["denotation"] = LabelField(int(denotation), skip_indexing=True)
         return Instance(fields)
+
+    def apply_token_indexers(self, instance: Instance) -> None:
+        instance.fields["sentence_field"]._token_indexers = self._token_indexers  # type: ignore

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -86,13 +86,7 @@ class SequenceTaggingDatasetReader(DatasetReader):
         """
 
         fields: Dict[str, Field] = {}
-        sequence = TextField(
-            tokens,
-            # Token indexers are applied later during multi-process loading with
-            # the `apply_token_indexers` method, so we only apply them now if there
-            # is a single worker.
-            None if self._worker_info is not None else self._token_indexers,
-        )
+        sequence = TextField(tokens)
         fields["tokens"] = sequence
         fields["metadata"] = MetadataField({"words": [x.text for x in tokens]})
         if tags is not None:

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -99,5 +99,6 @@ class SequenceTaggingDatasetReader(DatasetReader):
             fields["tags"] = SequenceLabelField(tags, sequence)
         return Instance(fields)
 
+    @overrides
     def apply_token_indexers(self, instance: Instance) -> None:
         instance.fields["tokens"]._token_indexers = self._token_indexers  # type: ignore

--- a/allennlp/data/dataset_readers/text_classification_json.py
+++ b/allennlp/data/dataset_readers/text_classification_json.py
@@ -124,13 +124,34 @@ class TextClassificationJsonReader(DatasetReader):
                 word_tokens = self._tokenizer.tokenize(sentence)
                 if self._max_sequence_length is not None:
                     word_tokens = self._truncate(word_tokens)
-                sentences.append(TextField(word_tokens, self._token_indexers))
+                sentences.append(
+                    TextField(
+                        word_tokens,
+                        # Token indexers are applied later during multi-process loading with
+                        # the `apply_token_indexers` method, so we only apply them now if there
+                        # is a single worker.
+                        None if self._worker_info is not None else self._token_indexers,
+                    )
+                )
             fields["tokens"] = ListField(sentences)
         else:
             tokens = self._tokenizer.tokenize(text)
             if self._max_sequence_length is not None:
                 tokens = self._truncate(tokens)
-            fields["tokens"] = TextField(tokens, self._token_indexers)
+            fields["tokens"] = TextField(
+                tokens,
+                # Token indexers are applied later during multi-process loading with
+                # the `apply_token_indexers` method, so we only apply them now if there
+                # is a single worker.
+                None if self._worker_info is not None else self._token_indexers,
+            )
         if label is not None:
             fields["label"] = LabelField(label, skip_indexing=self._skip_label_indexing)
         return Instance(fields)
+
+    def apply_token_indexers(self, instance: Instance) -> None:
+        if self._segment_sentences:
+            for text_field in instance.fields["tokens"]:  # type: ignore
+                text_field._token_indexers = self._token_indexers
+        else:
+            instance.fields["tokens"]._token_indexers = self._token_indexers  # type: ignore

--- a/allennlp/data/dataset_readers/text_classification_json.py
+++ b/allennlp/data/dataset_readers/text_classification_json.py
@@ -124,27 +124,13 @@ class TextClassificationJsonReader(DatasetReader):
                 word_tokens = self._tokenizer.tokenize(sentence)
                 if self._max_sequence_length is not None:
                     word_tokens = self._truncate(word_tokens)
-                sentences.append(
-                    TextField(
-                        word_tokens,
-                        # Token indexers are applied later during multi-process loading with
-                        # the `apply_token_indexers` method, so we only apply them now if there
-                        # is a single worker.
-                        None if self._worker_info is not None else self._token_indexers,
-                    )
-                )
+                sentences.append(TextField(word_tokens))
             fields["tokens"] = ListField(sentences)
         else:
             tokens = self._tokenizer.tokenize(text)
             if self._max_sequence_length is not None:
                 tokens = self._truncate(tokens)
-            fields["tokens"] = TextField(
-                tokens,
-                # Token indexers are applied later during multi-process loading with
-                # the `apply_token_indexers` method, so we only apply them now if there
-                # is a single worker.
-                None if self._worker_info is not None else self._token_indexers,
-            )
+            fields["tokens"] = TextField(tokens)
         if label is not None:
             fields["label"] = LabelField(label, skip_indexing=self._skip_label_indexing)
         return Instance(fields)

--- a/allennlp/data/dataset_readers/text_classification_json.py
+++ b/allennlp/data/dataset_readers/text_classification_json.py
@@ -149,6 +149,7 @@ class TextClassificationJsonReader(DatasetReader):
             fields["label"] = LabelField(label, skip_indexing=self._skip_label_indexing)
         return Instance(fields)
 
+    @overrides
     def apply_token_indexers(self, instance: Instance) -> None:
         if self._segment_sentences:
             for text_field in instance.fields["tokens"]:  # type: ignore

--- a/allennlp/interpret/attackers/hotflip.py
+++ b/allennlp/interpret/attackers/hotflip.py
@@ -194,6 +194,7 @@ class Hotflip(Attacker):
             whatever it was to `"she"`.
         """
         instance = self.predictor._json_to_instance(inputs)
+        self.predictor._dataset_reader.apply_token_indexers(instance)
         if target is None:
             output_dict = self.predictor._model.forward_on_instance(instance)
         else:

--- a/allennlp/predictors/predictor.py
+++ b/allennlp/predictors/predictor.py
@@ -60,6 +60,7 @@ class Predictor(Registrable):
         """
 
         instance = self._json_to_instance(inputs)
+        self._dataset_reader.apply_token_indexers(instance)
         outputs = self._model.forward_on_instance(instance)
         new_instances = self.predictions_to_labeled_instances(instance, outputs)
         return new_instances
@@ -96,6 +97,9 @@ class Predictor(Registrable):
 
         embedding_gradients: List[Tensor] = []
         hooks: List[RemovableHandle] = self._register_embedding_gradient_hooks(embedding_gradients)
+
+        for instance in instances:
+            self._dataset_reader.apply_token_indexers(instance)
 
         dataset = Batch(instances)
         dataset.index_instances(self._model.vocab)
@@ -179,6 +183,7 @@ class Predictor(Registrable):
             hook.remove()
 
     def predict_instance(self, instance: Instance) -> JsonDict:
+        self._dataset_reader.apply_token_indexers(instance)
         outputs = self._model.forward_on_instance(instance)
         return sanitize(outputs)
 
@@ -210,6 +215,8 @@ class Predictor(Registrable):
         return self.predict_batch_instance(instances)
 
     def predict_batch_instance(self, instances: List[Instance]) -> List[JsonDict]:
+        for instance in instances:
+            self._dataset_reader.apply_token_indexers(instance)
         outputs = self._model.forward_on_instances(instances)
         return sanitize(outputs)
 
@@ -302,9 +309,9 @@ class Predictor(Registrable):
             model_type = config.get("model").get("type")
             model_class, _ = Model.resolve_class_name(model_type)
             predictor_name = model_class.default_predictor
-        predictor_class: Type[Predictor] = Predictor.by_name(  # type: ignore
-            predictor_name
-        ) if predictor_name is not None else cls
+        predictor_class: Type[Predictor] = (
+            Predictor.by_name(predictor_name) if predictor_name is not None else cls  # type: ignore
+        )
 
         if dataset_reader_to_load == "validation" and "validation_dataset_reader" in config:
             dataset_reader_params = config["validation_dataset_reader"]

--- a/tests/predictors/predictor_test.py
+++ b/tests/predictors/predictor_test.py
@@ -45,6 +45,7 @@ class TestPredictor(AllenNlpTestCase):
         predictor = Predictor.from_archive(archive)
 
         instance = predictor._json_to_instance(inputs)
+        predictor._dataset_reader.apply_token_indexers(instance)
         outputs = predictor._model.forward_on_instance(instance)
         labeled_instances = predictor.predictions_to_labeled_instances(instance, outputs)
         for instance in labeled_instances:
@@ -70,6 +71,7 @@ class TestPredictor(AllenNlpTestCase):
         embedding_layer = util.find_embedding_layer(predictor._model)
         assert not embedding_layer.weight.requires_grad
         instance = predictor._json_to_instance(inputs)
+        predictor._dataset_reader.apply_token_indexers(instance)
         outputs = predictor._model.forward_on_instance(instance)
         labeled_instances = predictor.predictions_to_labeled_instances(instance, outputs)
         # ensure that gradients are always present, despite requires_grad being false on the embedding layer

--- a/tests/predictors/sentence_tagger_test.py
+++ b/tests/predictors/sentence_tagger_test.py
@@ -13,6 +13,7 @@ class TestSentenceTaggerPredictor(AllenNlpTestCase):
         predictor = Predictor.from_archive(archive, "sentence_tagger")
 
         instance = predictor._json_to_instance(inputs)
+        predictor._dataset_reader.apply_token_indexers(instance)
         outputs = predictor._model.forward_on_instance(instance)
         new_instances = predictor.predictions_to_labeled_instances(instance, outputs)
         assert len(new_instances) > 1

--- a/tests/predictors/text_classifier_test.py
+++ b/tests/predictors/text_classifier_test.py
@@ -90,6 +90,7 @@ class TestTextClassifierPredictor(AllenNlpTestCase):
         predictor = Predictor.from_archive(archive, "text_classifier")
 
         instance = predictor._json_to_instance(inputs)
+        predictor._dataset_reader.apply_token_indexers(instance)
         outputs = predictor._model.forward_on_instance(instance)
         new_instances = predictor.predictions_to_labeled_instances(instance, outputs)
         assert "label" in new_instances[0].fields


### PR DESCRIPTION
This makes it so the dataset readers we provide can be used efficiently with the multi-process data loader.