### PR TITLE
Fix division by zero when there are zero-length spans in MismatchedEmbedder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Predictor.capture_model_internals()` now accepts a regex specifying
   which modules to capture
 
+
+### Fixed
+
+- Fixed division by zero error when there are zero-length spans in the input to a `PretrainedTransformerMismatchedIndexer`.
+
+
 ## [v1.1.0rc4](https://github.com/allenai/allennlp/releases/tag/v1.1.0rc4) - 2020-08-20
 
 ### Added
@@ -58,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the option to specify `requires_grad: false` within an optimizer's parameter groups.
 - Added the `file-friendly-logging` flag back to the `train` command. Also added this flag to the `predict`, `evaluate`, and `find-learning-rate` commands.
-- Added an `EpochCallback` to track current epoch as a model class member. 
+- Added an `EpochCallback` to track current epoch as a model class member.
 - Added the option to enable or disable gradient checkpointing for transformer token embedders via boolean parameter `gradient_checkpointing`.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed handling of some edge cases when constructing classes with `FromParams` where the class
   accepts `**kwargs`.
+- Fixed division by zero error when there are zero-length spans in the input to a
+  `PretrainedTransformerMismatchedIndexer`.
 
 ### Added
 
 - `Predictor.capture_model_internals()` now accepts a regex specifying
   which modules to capture
-
-
-### Fixed
-
-- Fixed division by zero error when there are zero-length spans in the input to a `PretrainedTransformerMismatchedIndexer`.
 
 
 ## [v1.1.0rc4](https://github.com/allenai/allennlp/releases/tag/v1.1.0rc4) - 2020-08-20

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -105,7 +105,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         span_embeddings_sum = span_embeddings.sum(2)
         span_embeddings_len = span_mask.sum(2)
         # Shape: (batch_size, num_orig_tokens, embedding_size)
-        orig_embeddings = span_embeddings_sum / span_embeddings_len
+        orig_embeddings = span_embeddings_sum / torch.clamp_min(span_embeddings_len, 1)
 
         # All the places where the span length is zero, write in zeros.
         orig_embeddings[(span_embeddings_len == 0).expand(orig_embeddings.shape)] = 0

--- a/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
+++ b/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
@@ -156,7 +156,8 @@ class TestPretrainedTransformerMismatchedEmbedder(AllenNlpTestCase):
         vocab = Vocabulary()
 
         token_embedder = BasicTextFieldEmbedder(
-            {"bert": PretrainedTransformerMismatchedEmbedder("bert-base-uncased")})
+            {"bert": PretrainedTransformerMismatchedEmbedder("bert-base-uncased")}
+        )
 
         instance1 = Instance({"tokens": TextField(tokens1, {"bert": token_indexer})})
         instance2 = Instance({"tokens": TextField(tokens2, {"bert": token_indexer})})

--- a/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
+++ b/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
@@ -8,6 +8,7 @@ from allennlp.data.fields import TextField
 from allennlp.data.instance import Instance
 from allennlp.data.token_indexers import PretrainedTransformerMismatchedIndexer
 from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
+from allennlp.modules.token_embedders import PretrainedTransformerMismatchedEmbedder
 from allennlp.common.testing import AllenNlpTestCase
 
 
@@ -153,17 +154,9 @@ class TestPretrainedTransformerMismatchedEmbedder(AllenNlpTestCase):
         tokens1 = [Token(word) for word in sentence1]
         tokens2 = [Token(word) for word in sentence2]
         vocab = Vocabulary()
-        params = Params(
-            {
-                "token_embedders": {
-                    "bert": {
-                        "type": "pretrained_transformer_mismatched",
-                        "model_name": "bert-base-uncased",
-                    }
-                }
-            }
-        )
-        token_embedder = BasicTextFieldEmbedder.from_params(vocab=vocab, params=params)
+
+        token_embedder = BasicTextFieldEmbedder(
+            {"bert": PretrainedTransformerMismatchedEmbedder("bert-base-uncased")})
 
         instance1 = Instance({"tokens": TextField(tokens1, {"bert": token_indexer})})
         instance2 = Instance({"tokens": TextField(tokens2, {"bert": token_indexer})})


### PR DESCRIPTION
Fixes #4612 and adds a unit test to confirm that missing or exotic tokens to not lead to `nan` gradients in BERT-style embedder.