### PR TITLE
remove duplicate padding calculations in collate fn

### DIFF
--- a/allennlp/data/data_loaders/data_loader.py
+++ b/allennlp/data/data_loaders/data_loader.py
@@ -20,7 +20,7 @@ def allennlp_collate(instances: List[Instance]) -> TensorDict:
     batch.
     """
     batch = Batch(instances)
-    return batch.as_tensor_dict(batch.get_padding_lengths())
+    return batch.as_tensor_dict()
 
 
 class DataLoader(Registrable):


### PR DESCRIPTION
There is no need to pass the result of `Batch.get_padding_lengths()` to `Batch.as_tensor_dict()` since, internally, `Batch.as_tensor_dict()` will call `Batch.get_padding_lengths()` anyway.