### PR TITLE
fix Average metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PretrainedTransformerMismatchedIndexer`.
 - Improved robustness of `cached_path` when extracting archives so that the cache won't be corrupted
   if a failure occurs during extraction.
-- Fixed a bug with the `Average` metric in distributed training.
+- Fixed a bug with the `average` and `evalb_bracketing_score` metrics in distributed training.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PretrainedTransformerMismatchedIndexer`.
 - Improved robustness of `cached_path` when extracting archives so that the cache won't be corrupted
   if a failure occurs during extraction.
+- Fixed a bug with the `Average` metric in distributed training.
 
 ### Added
 

--- a/allennlp/common/testing/distributed_test.py
+++ b/allennlp/common/testing/distributed_test.py
@@ -69,5 +69,5 @@ def run_distributed_test(
         init_process,
         args=(device_ids, world_size, func, args, kwargs),
         nprocs=nprocs,
-        start_method="fork",
+        start_method="spawn",
     )

--- a/allennlp/common/testing/distributed_test.py
+++ b/allennlp/common/testing/distributed_test.py
@@ -62,12 +62,12 @@ def run_distributed_test(
     func: `Callable`
         `func` needs to be global for spawning the processes, so that it can be pickled.
     """
-
     check_for_gpu(device_ids)
+    start_method = "spawn" if any(x >= 0 for x in device_ids) else "fork"
     nprocs = world_size = len(device_ids)
     mp.start_processes(
         init_process,
         args=(device_ids, world_size, func, args, kwargs),
         nprocs=nprocs,
-        start_method="spawn",
+        start_method=start_method,
     )

--- a/allennlp/common/testing/distributed_test.py
+++ b/allennlp/common/testing/distributed_test.py
@@ -63,6 +63,8 @@ def run_distributed_test(
         `func` needs to be global for spawning the processes, so that it can be pickled.
     """
     check_for_gpu(device_ids)
+    # "fork" start method is the default and should be preferred, except when we're
+    # running the tests on GPU, in which case we need to use "spawn".
     start_method = "spawn" if any(x >= 0 for x in device_ids) else "fork"
     nprocs = world_size = len(device_ids)
     mp.start_processes(

--- a/allennlp/training/metrics/attachment_scores.py
+++ b/allennlp/training/metrics/attachment_scores.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, List
 
 from overrides import overrides
 import torch
@@ -105,7 +105,6 @@ class AttachmentScores(Metric):
     def get_metric(
         self,
         reset: bool = False,
-        cuda_device: Union[int, torch.device] = torch.device("cpu"),
     ):
         """
         # Returns

--- a/allennlp/training/metrics/average.py
+++ b/allennlp/training/metrics/average.py
@@ -31,8 +31,10 @@ class Average(Metric):
         _total_value = list(self.detach_tensors(value))[0]
         _count = 1
         if is_distributed():
-            count = torch.tensor(_count)
-            total_value = torch.tensor(_total_value)
+            device_name = "cpu" if dist.get_backend() != "nccl" else torch.cuda.get_device_name()
+            device = torch.device(device_name)
+            count = torch.tensor(_count).to(device)
+            total_value = torch.tensor(_total_value).to(device)
             dist.all_reduce(count, op=dist.ReduceOp.SUM)
             dist.all_reduce(total_value, op=dist.ReduceOp.SUM)
             _count = count.item()

--- a/allennlp/training/metrics/average.py
+++ b/allennlp/training/metrics/average.py
@@ -31,9 +31,8 @@ class Average(Metric):
         _total_value = list(self.detach_tensors(value))[0]
         _count = 1
         if is_distributed():
-            device = torch.device("cpu")
-            count = torch.tensor(_count).to(device)
-            total_value = torch.tensor(_total_value).to(device)
+            count = torch.tensor(_count)
+            total_value = torch.tensor(_total_value)
             dist.all_reduce(count, op=dist.ReduceOp.SUM)
             dist.all_reduce(total_value, op=dist.ReduceOp.SUM)
             _count = count.item()

--- a/allennlp/training/metrics/average.py
+++ b/allennlp/training/metrics/average.py
@@ -31,8 +31,7 @@ class Average(Metric):
         _total_value = list(self.detach_tensors(value))[0]
         _count = 1
         if is_distributed():
-            device_name = "cpu" if dist.get_backend() != "nccl" else "cuda"
-            device = torch.device(device_name)
+            device = torch.device("cuda" if dist.get_backend() == "nccl" else "cpu")
             count = torch.tensor(_count).to(device)
             total_value = torch.tensor(_total_value).to(device)
             dist.all_reduce(count, op=dist.ReduceOp.SUM)

--- a/allennlp/training/metrics/average.py
+++ b/allennlp/training/metrics/average.py
@@ -31,7 +31,7 @@ class Average(Metric):
         _total_value = list(self.detach_tensors(value))[0]
         _count = 1
         if is_distributed():
-            device_name = "cpu" if dist.get_backend() != "nccl" else torch.cuda.get_device_name()
+            device_name = "cpu" if dist.get_backend() != "nccl" else "cuda"
             device = torch.device(device_name)
             count = torch.tensor(_count).to(device)
             total_value = torch.tensor(_total_value).to(device)

--- a/allennlp/training/metrics/evalb_bracketing_scorer.py
+++ b/allennlp/training/metrics/evalb_bracketing_scorer.py
@@ -154,9 +154,10 @@ class EvalbBracketingScorer(Metric):
         shutil.rmtree(tempdir)
 
         if is_distributed():
-            correct_predicted_brackets = torch.tensor(_correct_predicted_brackets)
-            predicted_brackets = torch.tensor(_predicted_brackets)
-            gold_brackets = torch.tensor(_gold_brackets)
+            device = torch.device("cuda" if dist.get_backend() == "nccl" else "cpu")
+            correct_predicted_brackets = torch.tensor(_correct_predicted_brackets).to(device)
+            predicted_brackets = torch.tensor(_predicted_brackets).to(device)
+            gold_brackets = torch.tensor(_gold_brackets).to(device)
             dist.all_reduce(correct_predicted_brackets, op=dist.ReduceOp.SUM)
             dist.all_reduce(predicted_brackets, op=dist.ReduceOp.SUM)
             dist.all_reduce(gold_brackets, op=dist.ReduceOp.SUM)

--- a/allennlp/training/metrics/evalb_bracketing_scorer.py
+++ b/allennlp/training/metrics/evalb_bracketing_scorer.py
@@ -154,11 +154,9 @@ class EvalbBracketingScorer(Metric):
         shutil.rmtree(tempdir)
 
         if is_distributed():
-            # Setting the device to CPU since this metric is not expected to run on GPUs.
-            device = torch.device("cpu")
-            correct_predicted_brackets = torch.tensor(_correct_predicted_brackets).to(device)
-            predicted_brackets = torch.tensor(_predicted_brackets).to(device)
-            gold_brackets = torch.tensor(_gold_brackets).to(device)
+            correct_predicted_brackets = torch.tensor(_correct_predicted_brackets)
+            predicted_brackets = torch.tensor(_predicted_brackets)
+            gold_brackets = torch.tensor(_gold_brackets)
             dist.all_reduce(correct_predicted_brackets, op=dist.ReduceOp.SUM)
             dist.all_reduce(predicted_brackets, op=dist.ReduceOp.SUM)
             dist.all_reduce(gold_brackets, op=dist.ReduceOp.SUM)

--- a/allennlp/training/metrics/pearson_correlation.py
+++ b/allennlp/training/metrics/pearson_correlation.py
@@ -45,7 +45,6 @@ class PearsonCorrelation(Metric):
         self._predictions_labels_covariance = Covariance()
         self._predictions_variance = Covariance()
         self._labels_variance = Covariance()
-        self._device = torch.device("cpu")
 
     def __call__(
         self,
@@ -64,7 +63,6 @@ class PearsonCorrelation(Metric):
             A tensor of the same shape as `predictions`.
         """
         predictions, gold_labels, mask = self.detach_tensors(predictions, gold_labels, mask)
-        self._device = gold_labels.device
         if not is_distributed():
             self._predictions_labels_covariance(predictions, gold_labels, mask)
             self._predictions_variance(predictions, predictions, mask)

--- a/tests/training/metrics/average_test.py
+++ b/tests/training/metrics/average_test.py
@@ -1,0 +1,28 @@
+from allennlp.common.testing import (
+    AllenNlpTestCase,
+    multi_device,
+    run_distributed_test,
+    global_distributed_metric,
+)
+from allennlp.training.metrics import Average
+
+
+class AverageTest(AllenNlpTestCase):
+    def setup_method(self):
+        super().setup_method()
+        self.metric = Average()
+
+    @multi_device
+    def test_distributed_average(self, device: str):
+        device_ids = [-1, -1] if device == "cpu" else [0, 1]
+        metric_kwargs = {
+            "value": [1.0, 2.0],
+        }
+        run_distributed_test(
+            device_ids,
+            global_distributed_metric,
+            self.metric,
+            metric_kwargs,
+            1.5,
+            exact=True,
+        )


### PR DESCRIPTION
Closes https://github.com/allenai/allennlp/issues/4623.

There was a bug with the `average` and `evalb_bracketing_scorer` metrics during distributed training on GPU.