### PR TITLE
Return consistent types from metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ignore *args when constructing classes with `FromParams`.
+- Ensured some consistency in the types of the values that metrics return
 
 ## [v1.1.0](https://github.com/allenai/allennlp/releases/tag/v1.1.0) - 2020-09-08
 

--- a/allennlp/training/metrics/average.py
+++ b/allennlp/training/metrics/average.py
@@ -49,10 +49,10 @@ class Average(Metric):
         The average of all values that were passed to `__call__`.
         """
 
-        average_value = self._total_value / self._count if self._count > 0 else 0
+        average_value = self._total_value / self._count if self._count > 0 else 0.0
         if reset:
             self.reset()
-        return average_value
+        return float(average_value)
 
     @overrides
     def reset(self):

--- a/allennlp/training/metrics/perplexity.py
+++ b/allennlp/training/metrics/perplexity.py
@@ -1,5 +1,4 @@
 from overrides import overrides
-import torch
 import math
 
 from allennlp.training.metrics.average import Average

--- a/allennlp/training/metrics/perplexity.py
+++ b/allennlp/training/metrics/perplexity.py
@@ -1,5 +1,6 @@
 from overrides import overrides
 import torch
+import math
 
 from allennlp.training.metrics.average import Average
 from allennlp.training.metrics.metric import Metric
@@ -26,9 +27,7 @@ class Perplexity(Average):
         """
         average_loss = super().get_metric(reset)
         if average_loss == 0:
-            perplexity = 0.0
+            return 0.0
 
         # Exponentiate the loss to compute perplexity
-        perplexity = float(torch.exp(average_loss))
-
-        return perplexity
+        return math.exp(average_loss)


### PR DESCRIPTION
I think we need to decide what type metrics return. Here are some changes to make sure it's always `float` (as opposed to `FloatTensor` or `int`).

I don't care much what we decide, but it causes problems in some places when the types change. It _especially_ causes problems when we have `if something(): return 0; else return FloatTensor(...).`, where the types differ depending on when you call it.