### PR TITLE
Fix tensor.nonzero() function overload warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ignore *args when constructing classes with `FromParams`.
-- Ensured some consistency in the types of the values that metrics return
+- Ensured some consistency in the types of the values that metrics return.
+- Fix a PyTorch warning by explicitly providing the `as_tuple` argument (leaving
+  it as its default value of `False`) to `Tensor.nonzero()`.
 
 ## [v1.1.0](https://github.com/allenai/allennlp/releases/tag/v1.1.0) - 2020-09-08
 

--- a/allennlp/modules/conditional_random_field.py
+++ b/allennlp/modules/conditional_random_field.py
@@ -396,7 +396,7 @@ class ConditionalRandomField(torch.nn.Module):
         tag_sequence = torch.Tensor(max_seq_length + 2, num_tags + 2)
 
         for prediction, prediction_mask in zip(logits, mask):
-            mask_indices = prediction_mask.nonzero().squeeze()
+            mask_indices = prediction_mask.nonzero(as_tuple=False).squeeze()
             masked_prediction = torch.index_select(prediction, 0, mask_indices)
             sequence_length = masked_prediction.shape[0]
 

--- a/tests/modules/conditional_random_field_test.py
+++ b/tests/modules/conditional_random_field_test.py
@@ -64,7 +64,7 @@ class TestConditionalRandomField(AllenNlpTestCase):
         best_scores = []
 
         for logit, mas in zip(logits, mask):
-            mask_indices = mas.nonzero().squeeze()
+            mask_indices = mas.nonzero(as_tuple=False).squeeze()
             logit = torch.index_select(logit, 0, mask_indices)
             sequence_length = logit.shape[0]
             most_likely, most_likelihood = None, -float("inf")


### PR DESCRIPTION
When running the CRF, I currently get this warning (reproduced it in py.test, too):

```
========================================== warnings summary ===========================================
tests/modules/conditional_random_field_test.py::TestConditionalRandomField::test_viterbi_tags
  /home/nfliu/git/allennlp/tests/modules/conditional_random_field_test.py:1: UserWarning: This overload of nonzero is deprecated:
  	nonzero()
  Consider using one of the following signatures instead:
  	nonzero(*, bool as_tuple) (Triggered internally at  /pytorch/torch/csrc/utils/python_arg_parser.cpp:766.)
    import itertools

-- Docs: https://docs.pytest.org/en/stable/warnings.html
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! _pytest.outcomes.Exit: Quitting debugger !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================ 2 passed, 951 deselected, 1 warning in 13.40s ============================
```

The fix is pretty simple--just provide the `as_tuple` keyword explicitly (and keep it at its default value, `False`)