### PR TITLE
improve how cached_path extracts archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ignore `*args` when constructing classes with `FromParams`.
-- Ensured some consistency in the types of the values that metrics return
+- Ensured some consistency in the types of the values that metrics return.
 - Fix a PyTorch warning by explicitly providing the `as_tuple` argument (leaving
   it as its default value of `False`) to `Tensor.nonzero()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `transformers` dependency updated to version 3.1.0.
+- When `cached_path` is called on a local archive with `extract=True`, the archive is now extracted into a unique subdirectory of the cache root instead of a subdirectory of the archive's directory. The extraction directory is also unique to the modification time of the archive, so if the file changes, subsequent calls to `cached_path` will know to re-extract the archive.
 
 ### Fixed
 
-- Ignore *args when constructing classes with `FromParams`.
+- Ignore `*args` when constructing classes with `FromParams`.
 - Ensured some consistency in the types of the values that metrics return
 
 ## [v1.1.0](https://github.com/allenai/allennlp/releases/tag/v1.1.0) - 2020-09-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `transformers` dependency updated to version 3.1.0.
-- When `cached_path` is called on a local archive with `extract=True`, the archive is now extracted into a unique subdirectory of the cache root instead of a subdirectory of the archive's directory. The extraction directory is also unique to the modification time of the archive, so if the file changes, subsequent calls to `cached_path` will know to re-extract the archive.
+- When `cached_path` is called on a local archive with `extract_archive=True`, the archive is now extracted into a unique subdirectory of the cache root instead of a subdirectory of the archive's directory. The extraction directory is also unique to the modification time of the archive, so if the file changes, subsequent calls to `cached_path` will know to re-extract the archive.
 
 ### Fixed
 

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -151,7 +151,6 @@ def cached_path(
     parsed = urlparse(url_or_filename)
 
     extraction_path: Optional[str] = None
-    extraction_lock_path: Optional[str] = None
 
     if parsed.scheme in ("http", "https", "s3"):
         # URL, so get it from the cache (downloading if necessary)
@@ -161,7 +160,6 @@ def cached_path(
             # This is the path the file should be extracted to.
             # For example ~/.allennlp/cache/234234.21341 -> ~/.allennlp/cache/234234.21341-extracted
             extraction_path = file_path + "-extracted"
-            extraction_lock_path = file_path + ".lock"
 
     elif os.path.exists(url_or_filename):
         # File, and it exists.
@@ -175,7 +173,6 @@ def cached_path(
                 _resource_to_filename(file_path, str(os.path.getmtime(file_path))) + "-extracted"
             )
             extraction_path = os.path.join(cache_dir, extraction_name)
-            extraction_lock_path = extraction_path + ".lock"
 
     elif parsed.scheme == "":
         # File, but it doesn't exist.
@@ -192,7 +189,7 @@ def cached_path(
             return extraction_path
 
         # Extract it.
-        with FileLock(extraction_lock_path):
+        with FileLock(extraction_path + ".lock"):
             shutil.rmtree(extraction_path, ignore_errors=True)
 
             # We extract first to a temporary directory in case something goes wrong

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -46,7 +46,7 @@ if os.path.exists(DEPRECATED_CACHE_DIRECTORY):
     )
 
 
-def resource_to_filename(resource: str, etag: str = None) -> str:
+def _resource_to_filename(resource: str, etag: str = None) -> str:
     """
     Convert a `resource` into a hashed filename in a repeatable way.
     If `etag` is specified, append its hash to the resources's, delimited
@@ -172,7 +172,7 @@ def cached_path(
             # The name of the directoy is a hash of the resource file path and it's modification
             # time. That way, if the file changes, we'll know when to extract it again.
             extraction_name = (
-                resource_to_filename(file_path, str(os.path.getmtime(file_path))) + "-extracted"
+                _resource_to_filename(file_path, str(os.path.getmtime(file_path))) + "-extracted"
             )
             extraction_path = os.path.join(cache_dir, extraction_name)
             extraction_lock_path = extraction_path + ".lock"
@@ -331,7 +331,7 @@ def _http_get(url: str, temp_file: IO) -> None:
 
 
 def _find_latest_cached(url: str, cache_dir: Union[str, Path]) -> Optional[str]:
-    filename = resource_to_filename(url)
+    filename = _resource_to_filename(url)
     cache_path = os.path.join(cache_dir, filename)
     candidates: List[Tuple[str, float]] = []
     for path in glob.glob(cache_path + "*"):
@@ -432,7 +432,7 @@ def get_from_cache(url: str, cache_dir: Union[str, Path] = None) -> str:
         # If this is the case, try to proceed without eTag check.
         etag = None
 
-    filename = resource_to_filename(url, etag)
+    filename = _resource_to_filename(url, etag)
 
     # Get cache path to put the file.
     cache_path = os.path.join(cache_dir, filename)

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -119,6 +119,8 @@ def cached_path(
     if cache_dir is None:
         cache_dir = CACHE_DIRECTORY
 
+    os.makedirs(cache_dir, exist_ok=True)
+
     if isinstance(url_or_filename, PathLike):
         url_or_filename = str(url_or_filename)
 
@@ -392,8 +394,6 @@ def get_from_cache(url: str, cache_dir: Union[str, Path] = None) -> str:
     """
     if cache_dir is None:
         cache_dir = CACHE_DIRECTORY
-
-    os.makedirs(cache_dir, exist_ok=True)
 
     # Get eTag to add to filename, if it exists.
     try:

--- a/tests/common/file_utils_test.py
+++ b/tests/common/file_utils_test.py
@@ -11,7 +11,7 @@ from requests.exceptions import ConnectionError
 
 from allennlp.common import file_utils
 from allennlp.common.file_utils import (
-    url_to_filename,
+    resource_to_filename,
     filename_to_url,
     get_from_cache,
     cached_path,
@@ -77,7 +77,7 @@ class TestFileUtils(AllenNlpTestCase):
 
         # We'll create two cached versions of this fake resource using two different etags.
         etags = ['W/"3e5885bfcbf4c47bc4ee9e2f6e5ea916"', 'W/"3e5885bfcbf4c47bc4ee9e2f6e5ea918"']
-        filenames = [os.path.join(self.TEST_DIR, url_to_filename(url, etag)) for etag in etags]
+        filenames = [os.path.join(self.TEST_DIR, resource_to_filename(url, etag)) for etag in etags]
         for filename, etag in zip(filenames, etags):
             meta_filename = filename + ".json"
             with open(filename, "w") as f:
@@ -93,7 +93,7 @@ class TestFileUtils(AllenNlpTestCase):
 
         # We also want to make sure this works when the latest cached version doesn't
         # have a corresponding etag.
-        filename = os.path.join(self.TEST_DIR, url_to_filename(url))
+        filename = os.path.join(self.TEST_DIR, resource_to_filename(url))
         meta_filename = filename + ".json"
         with open(filename, "w") as f:
             f.write("some random data")
@@ -102,7 +102,7 @@ class TestFileUtils(AllenNlpTestCase):
 
         assert get_from_cache(url, cache_dir=self.TEST_DIR) == filename
 
-    def test_url_to_filename(self):
+    def test_resource_to_filename(self):
         for url in [
             "http://allenai.org",
             "http://allennlp.org",
@@ -110,7 +110,7 @@ class TestFileUtils(AllenNlpTestCase):
             "http://pytorch.org",
             "https://allennlp.s3.amazonaws.com" + "/long" * 20 + "/url",
         ]:
-            filename = url_to_filename(url)
+            filename = resource_to_filename(url)
             assert "http" not in filename
             with pytest.raises(FileNotFoundError):
                 filename_to_url(filename, cache_dir=self.TEST_DIR)
@@ -125,14 +125,14 @@ class TestFileUtils(AllenNlpTestCase):
             assert back_to_url == url
             assert etag is None
 
-    def test_url_to_filename_with_etags(self):
+    def test_resource_to_filename_with_etags(self):
         for url in [
             "http://allenai.org",
             "http://allennlp.org",
             "https://www.google.com",
             "http://pytorch.org",
         ]:
-            filename = url_to_filename(url, etag="mytag")
+            filename = resource_to_filename(url, etag="mytag")
             assert "http" not in filename
             pathlib.Path(os.path.join(self.TEST_DIR, filename)).touch()
             json.dump(
@@ -143,16 +143,16 @@ class TestFileUtils(AllenNlpTestCase):
             assert back_to_url == url
             assert etag == "mytag"
         baseurl = "http://allenai.org/"
-        assert url_to_filename(baseurl + "1") != url_to_filename(baseurl, etag="1")
+        assert resource_to_filename(baseurl + "1") != resource_to_filename(baseurl, etag="1")
 
-    def test_url_to_filename_with_etags_eliminates_quotes(self):
+    def test_resource_to_filename_with_etags_eliminates_quotes(self):
         for url in [
             "http://allenai.org",
             "http://allennlp.org",
             "https://www.google.com",
             "http://pytorch.org",
         ]:
-            filename = url_to_filename(url, etag='"mytag"')
+            filename = resource_to_filename(url, etag='"mytag"')
             assert "http" not in filename
             pathlib.Path(os.path.join(self.TEST_DIR, filename)).touch()
             json.dump(
@@ -180,7 +180,7 @@ class TestFileUtils(AllenNlpTestCase):
         set_up_glove(url, self.glove_bytes, change_etag_every=2)
 
         filename = get_from_cache(url, cache_dir=self.TEST_DIR)
-        assert filename == os.path.join(self.TEST_DIR, url_to_filename(url, etag="0"))
+        assert filename == os.path.join(self.TEST_DIR, resource_to_filename(url, etag="0"))
 
         # We should have made one HEAD request and one GET request.
         method_counts = Counter(call.request.method for call in responses.calls)
@@ -208,7 +208,7 @@ class TestFileUtils(AllenNlpTestCase):
         # A third call should have a different ETag and should force a new download,
         # which means another HEAD call and another GET call.
         filename3 = get_from_cache(url, cache_dir=self.TEST_DIR)
-        assert filename3 == os.path.join(self.TEST_DIR, url_to_filename(url, etag="1"))
+        assert filename3 == os.path.join(self.TEST_DIR, resource_to_filename(url, etag="1"))
 
         method_counts = Counter(call.request.method for call in responses.calls)
         assert len(method_counts) == 2
@@ -238,7 +238,7 @@ class TestFileUtils(AllenNlpTestCase):
         filename = cached_path(url, cache_dir=self.TEST_DIR)
 
         assert len(responses.calls) == 2
-        assert filename == os.path.join(self.TEST_DIR, url_to_filename(url, etag="0"))
+        assert filename == os.path.join(self.TEST_DIR, resource_to_filename(url, etag="0"))
 
         with open(filename, "rb") as cached_file:
             assert cached_file.read() == self.glove_bytes
@@ -274,20 +274,18 @@ class TestCachedPathWithArchive(AllenNlpTestCase):
             self.FIXTURES_ROOT / "utf-8_sample" / "archives" / "utf-8.zip", self.zip_file
         )
 
-    @staticmethod
-    def check_extracted(extracted: str):
+    def check_extracted(self, extracted: str):
         assert os.path.isdir(extracted)
+        assert pathlib.Path(extracted).parent == self.TEST_DIR
         assert os.path.exists(os.path.join(extracted, "dummy.txt"))
         assert os.path.exists(os.path.join(extracted, "folder/utf-8_sample.txt"))
 
     def test_cached_path_extract_local_tar(self):
         extracted = cached_path(self.tar_file, cache_dir=self.TEST_DIR, extract_archive=True)
-        assert os.path.basename(extracted) == "utf-8-tar-gz-extracted"
         self.check_extracted(extracted)
 
     def test_cached_path_extract_local_zip(self):
         extracted = cached_path(self.zip_file, cache_dir=self.TEST_DIR, extract_archive=True)
-        assert os.path.basename(extracted) == "utf-8-zip-extracted"
         self.check_extracted(extracted)
 
     @responses.activate

--- a/tests/common/file_utils_test.py
+++ b/tests/common/file_utils_test.py
@@ -77,7 +77,9 @@ class TestFileUtils(AllenNlpTestCase):
 
         # We'll create two cached versions of this fake resource using two different etags.
         etags = ['W/"3e5885bfcbf4c47bc4ee9e2f6e5ea916"', 'W/"3e5885bfcbf4c47bc4ee9e2f6e5ea918"']
-        filenames = [os.path.join(self.TEST_DIR, _resource_to_filename(url, etag)) for etag in etags]
+        filenames = [
+            os.path.join(self.TEST_DIR, _resource_to_filename(url, etag)) for etag in etags
+        ]
         for filename, etag in zip(filenames, etags):
             meta_filename = filename + ".json"
             with open(filename, "w") as f:

--- a/tests/common/file_utils_test.py
+++ b/tests/common/file_utils_test.py
@@ -245,7 +245,9 @@ class TestFileUtils(AllenNlpTestCase):
 
         # archives
         filename = cached_path(
-            self.FIXTURES_ROOT / "common" / "quote.tar.gz!quote.txt", extract_archive=True
+            self.FIXTURES_ROOT / "common" / "quote.tar.gz!quote.txt",
+            extract_archive=True,
+            cache_dir=self.TEST_DIR,
         )
         with open(filename, "r") as f:
             assert f.read().startswith("I mean, ")


### PR DESCRIPTION
Currently, when `cached_path()` is called with `extract_archive=True` on a local archive file, the archive is extracted in the same directory. For example,

```python
>>> cached_path("~/vocab.tar.gz", extract_archive=True)
#> ~/vocab-tar-gz-extracted
```

But I don't think this is a good way to do it because we shouldn't be messing with peoples' local file system outside of the designated cache directory.

This PR changes the behavior so that local archives are extracted to unique sub-directories of the cache root. The name of the sub-directory is derived in a similar way that we derive the cached path for remote resources: with a hash of the path and a hash of the ETag. Except, instead of an ETag in this case, we use the last modified time of the local file.

This approach has the added benefit that if a local archive is modified after an initial call to `cached_path()`, subsequent calls to `cached_path()` will automatically know to re-extract.