### PR TITLE
smooth out release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a script: `scripts/release_notes.py`, which automatically prepares markdown release notes from the
+  CHANGELOG and commit history.
 - Added a flag `--predictions-output-file` to the `evaluate` command, which tells AllenNLP to write the
   predictions from the given dataset to the file as JSON lines.
 - Added the ability to ignore certain missing keys when loading a model from an archive. This is done
@@ -22,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Ignore *args when constructing classes with `FromParams`.
+- Ignore *args* when constructing classes with `FromParams`.
 - Ensured some consistency in the types of the values that metrics return.
 - Fix a PyTorch warning by explicitly providing the `as_tuple` argument (leaving
   it as its default value of `False`) to `Tensor.nonzero()`.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -7,7 +7,7 @@ to `git@github.com:allenai/allennlp.git` (or the `HTTPS` equivalent).
 
 ## Steps
 
-1. Set the environment variable `TAG`, which should be of the from `v{VERSION}`.
+1. Set the environment variable `TAG`, which should be of the form `v{VERSION}`.
 
     For example, if the version of the release is `1.0.0`, you should set `TAG` to `v1.0.0`:
 
@@ -34,24 +34,16 @@ to `git@github.com:allenai/allennlp.git` (or the `HTTPS` equivalent).
 4. Commit and push these changes with:
 
     ```
-    git commit -a -m "Prepare for release $TAG"
-    git push
+    git commit -a -m "Prepare for release $TAG" && git push
     ```
     
 5. Then add the tag in git to mark the release:
 
     ```
-    git tag $TAG -m "Release $TAG"
+    git tag $TAG -m "Release $TAG" && git push --tags
     ```
 
-6. Push the tag to the main repo.
-
-    ```
-    git push --tags origin master
-    ```
-
-7. Find the tag you just pushed [on GitHub](https://github.com/allenai/allennlp/tags) and
-click edit. Now copy output of:
+6. Find the tag you just pushed [on GitHub](https://github.com/allenai/allennlp/tags), click edit, then copy over the output of:
 
     ```
     python scripts/release_notes.py
@@ -59,12 +51,12 @@ click edit. Now copy output of:
 
     On a Mac, for example, you can just pipe the above command into `pbcopy`.
 
-8. Click "Publish Release", and if this is a pre-release make sure you check that box.
+7. Check the box "This is a pre-release" if the release is a release candidate (ending with `rc*`). Otherwise leave it unchecked.
 
-    GitHub Actions will then handle the rest, including publishing the package to PyPI a the Docker image to Docker Hub.
+7. Click "Publish Release". GitHub Actions will then handle the rest, including publishing the package to PyPI the Docker image to Docker Hub.
 
 
-9. After publishing the release for the core repo, follow the same process to publish a release for the `allennlp-models` repo.
+8. After publishing the release for the core repo, follow the same process to publish a release for the `allennlp-models` repo.
 
 
 ## Fixing a failed release

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,63 +1,70 @@
 # AllenNLP GitHub and PyPI Release Process
 
 This document describes the procedure for releasing new versions of the core library.
-Most of the heavy lifting is actually done on GitHub Actions.
-All you have to do is ensure the version in `allennlp/version.py` matches the target release version
-and then trigger a GitHub release with the right tag.
 
 > ❗️ This assumes you are using a clone of the main repo with the remote `origin` pointed
 to `git@github.com:allenai/allennlp.git` (or the `HTTPS` equivalent).
 
-The format of the tag should be `v{VERSION}`, i.e. the intended version of the release preceeded with a `v`.
-So for the version `1.0.0` release the tag will be `v1.0.0`.
-
-To make things easier, start by setting the tag to an environment variable, `TAG`.
-Then you can copy and paste the commands below without worrying about mistyping the tag.
-
 ## Steps
 
-1. Update `allennlp/version.py` (if needed) with the correct version and the `CHANGELOG.md` so that everything under the "Unreleased" section is now under a section corresponding to this release. Then commit and push these changes with:
+1. Set the environment variable `TAG`, which should be of the from `v{VERSION}`.
+
+    For example, if the version of the release is `1.0.0`, you should set `TAG` to `v1.0.0`:
+
+    ```bash
+    export TAG='v1.0.0'
+    ```
+
+    Or if you use `fish`:
+
+    ```fish
+    set -x TAG 'v1.0.0'
+    ```
+
+2. Update `allennlp/version.py` with the correct version. Then check that the output of
+
+    ```
+    python scripts/get_version.py current
+    ```
+
+    matches the `TAG` environment variable.
+
+3. Update the `CHANGELOG.md` so that everything under the "Unreleased" section is now under a section corresponding to this release.
+
+4. Commit and push these changes with:
 
     ```
     git commit -a -m "Prepare for release $TAG"
     git push
     ```
     
-    At this point `echo $TAG` should exactly match the output of `./scripts/get_version.py current`.
-
-2. Then add the tag in git to mark the release:
+5. Then add the tag in git to mark the release:
 
     ```
     git tag $TAG -m "Release $TAG"
     ```
 
-3. Push the tag to the main repo.
+6. Push the tag to the main repo.
 
     ```
     git push --tags origin master
     ```
 
-4. Find the tag you just pushed [on GitHub](https://github.com/allenai/allennlp/tags) and
-click edit. Now copy over the latest section from the [`CHANGELOG.md`](https://raw.githubusercontent.com/allenai/allennlp/master/CHANGELOG.md). And finally, add a section called "Commits" with the output of a command like the following:
+7. Find the tag you just pushed [on GitHub](https://github.com/allenai/allennlp/tags) and
+click edit. Now copy output of:
 
-    ```bash
-    OLD_TAG=$(git describe --always --tags --abbrev=0 $TAG^)
-    git log $OLD_TAG..$TAG --oneline
     ```
-    
-    ```fish
-    set -x OLD_TAG (git describe --always --tags --abbrev=0 $TAG^)
-    git log $OLD_TAG..$TAG --oneline
+    python scripts/release_notes.py
     ```
 
     On a Mac, for example, you can just pipe the above command into `pbcopy`.
 
-5. Click "Publish Release", and if this is a pre-release make sure you check that box.
+8. Click "Publish Release", and if this is a pre-release make sure you check that box.
 
-That's it! GitHub Actions will handle the rest.
+    GitHub Actions will then handle the rest, including publishing the package to PyPI a the Docker image to Docker Hub.
 
 
-6. After publishing the release for the core repo, follow the same process to publish a release for the `allennlp-models` repo.
+9. After publishing the release for the core repo, follow the same process to publish a release for the `allennlp-models` repo.
 
 
 ## Fixing a failed release

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -56,7 +56,7 @@ to `git@github.com:allenai/allennlp.git` (or the `HTTPS` equivalent).
 7. Click "Publish Release". GitHub Actions will then handle the rest, including publishing the package to PyPI the Docker image to Docker Hub.
 
 
-8. After publishing the release for the core repo, follow the same process to publish a release for the `allennlp-models` repo.
+8. After the [GitHub Actions workflow](https://github.com/allenai/allennlp/actions?query=workflow%3AMaster+event%3Arelease) finishes, follow the same process to publish a release for the `allennlp-models` repo.
 
 
 ## Fixing a failed release

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,61 @@
+# encoding: utf-8
+
+"""
+Prepares markdown release notes for GitHub releases.
+"""
+
+import os
+from typing import List
+
+from allennlp.version import VERSION
+
+TAG = os.environ["TAG"]
+
+
+ADDED_HEADER = "### Added 🎉"
+CHANGED_HEADER = "### Changed ⚠️"
+FIXED_HEADER = "### Fixed ✅"
+REMOVED_HEADER = "### Removed 👋"
+
+
+def get_change_log_notes() -> str:
+    in_current_section = False
+    current_section_notes: List[str] = []
+    with open("CHANGELOG.md") as changelog:
+        for line in changelog:
+            if line.startswith("## "):
+                if line.startswith("## Unreleased"):
+                    continue
+                if line.startswith(f"## [{TAG}]"):
+                    in_current_section = True
+                    continue
+                break
+            if in_current_section:
+                if line.startswith("### Added"):
+                    line = ADDED_HEADER + "\n"
+                elif line.startswith("### Changed"):
+                    line = CHANGED_HEADER + "\n"
+                elif line.startswith("### Fixed"):
+                    line = FIXED_HEADER + "\n"
+                elif line.startswith("### Removed"):
+                    line = REMOVED_HEADER + "\n"
+                current_section_notes.append(line)
+    assert current_section_notes
+    return "## What's new\n\n" + "".join(current_section_notes).strip() + "\n"
+
+
+def get_commit_history() -> str:
+    stream = os.popen(
+        f"git log $(git describe --always --tags --abbrev=0 {TAG}^^)..{TAG}^ --oneline"
+    )
+    return "## Commits\n\n" + stream.read()
+
+
+def main():
+    assert TAG == f"v{VERSION}"
+    print(get_change_log_notes())
+    print(get_commit_history())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR does two things:

1. Adds a script `scripts/release_notes.py` which automatically prepares markdown release notes from the `CHANGELOG` and commit history.
2. Updates `RELEASE_PROCESS.md` to include using the new script, and also clarifies some other things.