### PR TITLE
display class decorators in API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Class decorators now displayed in API docs.
 - Fixed up the documentation for the `allennlp.nn.beam_search` module.
 - Ignore `*args` when constructing classes with `FromParams`.
 - Ensured some consistency in the types of the values that metrics return.

--- a/scripts/py2md.py
+++ b/scripts/py2md.py
@@ -371,13 +371,17 @@ class AllenNlpRenderer(MarkdownRenderer):
             return signature
 
     def _format_classdef_signature(self, cls: Class) -> str:
+        code = ""
+        if cls.decorators:
+            for dec in cls.decorators:
+                code += "@{}{}\n".format(dec.name, dec.args or "")
         bases = ", ".join(map(str, cls.bases))
         if cls.metaclass:
             bases += ", metaclass=" + str(cls.metaclass)
         if bases:
-            code = "class {}({})".format(cls.name, bases)
+            code += "class {}({})".format(cls.name, bases)
         else:
-            code = "class {}".format(cls.name)
+            code += "class {}".format(cls.name)
         if self.signature_python_help_style:
             code = cls.path() + " = " + code
         if self.classdef_render_init_signature_if_needed and (

--- a/scripts/tests/py2md/basic_example.py
+++ b/scripts/tests/py2md/basic_example.py
@@ -5,6 +5,8 @@ And this is a multi-line line: [http://example.com]
 (https://example.com/blah/blah/blah.html).
 """
 
+from dataclasses import dataclass
+
 SOME_GLOBAL_VAR = "Ahhhh I'm a global var!!"
 """
 This is a global var.
@@ -116,6 +118,11 @@ class AnotherClassWithReallyLongConstructor:
         self.b = another_long_name
         self.c = these_variable_names_are_terrible
         self.other = kwargs
+
+
+@dataclass
+class ClassWithDecorator:
+    x: int
 
 
 class _PrivateClass:

--- a/scripts/tests/py2md/basic_example_expected_output.md
+++ b/scripts/tests/py2md/basic_example_expected_output.md
@@ -150,3 +150,20 @@ class AnotherClassWithReallyLongConstructor:
  | ) -> None
 ```
 
+<a name=".scripts.tests.py2md.basic_example.ClassWithDecorator"></a>
+## ClassWithDecorator
+
+```python
+@dataclass
+class ClassWithDecorator
+```
+
+<a name=".scripts.tests.py2md.basic_example.ClassWithDecorator.x"></a>
+### x
+
+```python
+class ClassWithDecorator:
+ | ...
+ | x: int = None
+```
+


### PR DESCRIPTION
Updates the doc generation script so that class decorators are displayed like this:

<img width="806" alt="Screen Shot 2020-09-29 at 4 10 20 PM" src="https://user-images.githubusercontent.com/8812459/94626026-05fca180-026f-11eb-85cd-1510cb1a15e4.png">

One obvious benefit to this is that you can see what a class is registered under.