### PR TITLE
improve memory helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `transformers` dependency updated to version 3.1.0.
 - When `cached_path` is called on a local archive with `extract_archive=True`, the archive is now extracted into a unique subdirectory of the cache root instead of a subdirectory of the archive's directory. The extraction directory is also unique to the modification time of the archive, so if the file changes, subsequent calls to `cached_path` will know to re-extract the archive.
 - Removed the `truncation_strategy` parameter to `PretrainedTransformerTokenizer`. The way we're calling the tokenizer, the truncation strategy takes no effect anyways.
+- `allennlp.common.util.peak_memory_mb` renamed to `peak_cpu_memory`, and `allennlp.common.util.gpu_memory_mb` renamed to `peak_gpu_memory`,
+  and they both now return the results in bytes as integers. Also, the `peak_gpu_memory` function now utilizes PyTorch functions to find the memory
+  usage instead of shelling out to the `nvidia-smi` command. This is more efficient and also more accurate because it only takes
+  into account the tensor allocations of the current PyTorch process.
 
 ### Fixed
 

--- a/allennlp/commands/cached_path.py
+++ b/allennlp/commands/cached_path.py
@@ -13,7 +13,6 @@ from allennlp.common.file_utils import (
     CACHE_DIRECTORY,
     inspect_cache,
     remove_cache_entries,
-    format_size,
 )
 
 
@@ -80,6 +79,8 @@ def _cached_path(args: argparse.Namespace):
             )
         inspect_cache(patterns=args.resources, cache_dir=args.cache_dir)
     elif args.remove:
+        from allennlp.common.util import format_size
+
         if args.extract_archive or args.force_extract or args.inspect:
             raise RuntimeError(
                 "cached-path cannot accept --extract-archive, --force-extract, or --inspect "

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -635,47 +635,6 @@ def _get_resource_size(path: str) -> int:
     return total_size
 
 
-def format_timedelta(td: timedelta) -> str:
-    """
-    Format a timedelta for humans.
-    """
-    if td.days > 1:
-        return f"{td.days} days"
-    elif td.days > 0:
-        return f"{td.days} day"
-    else:
-        hours, remainder = divmod(td.seconds, 3600)
-        minutes, _ = divmod(remainder, 60)
-        if hours > 1:
-            return f"{hours} hours"
-        elif hours > 0:
-            return f"{hours} hour, {minutes} mins"
-        else:
-            return f"{minutes} mins"
-
-
-def format_size(size: int) -> str:
-    """
-    Format a size (in bytes) for humans.
-    """
-    GBs = size / (1024 * 1024 * 1024)
-    if GBs >= 10:
-        return f"{int(round(GBs, 0))}G"
-    if GBs >= 1:
-        return f"{round(GBs, 1):.1f}G"
-    MBs = size / (1024 * 1024)
-    if MBs >= 10:
-        return f"{int(round(MBs, 0))}M"
-    if MBs >= 1:
-        return f"{round(MBs, 1):.1f}M"
-    KBs = size / 1024
-    if KBs >= 10:
-        return f"{int(round(KBs, 0))}K"
-    if KBs >= 1:
-        return f"{round(KBs, 1):.1f}K"
-    return f"{size}B"
-
-
 class _CacheEntry(NamedTuple):
     regular_files: List[_Meta]
     extraction_dirs: List[_Meta]
@@ -742,6 +701,8 @@ def inspect_cache(patterns: List[str] = None, cache_dir: Union[str, Path] = None
     """
     Print out useful information about the cache directory.
     """
+    from allennlp.common.util import format_timedelta, format_size
+
     cache_dir = os.path.expanduser(cache_dir or CACHE_DIRECTORY)
 
     # Gather cache entries by resource.

--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -98,15 +98,15 @@ class TensorboardWriter(FromParams):
             val = value
         return val
 
-    def log_memory_usage(
-        self, cpu_memory_usage: Dict[int, float], gpu_memory_usage: Dict[int, int]
-    ):
+    def log_memory_usage(self, cpu_memory_usage: Dict[int, int], gpu_memory_usage: Dict[int, int]):
         cpu_memory_usage_total = 0.0
-        for worker, memory in cpu_memory_usage.items():
+        for worker, mem_bytes in cpu_memory_usage.items():
+            memory = int(mem_bytes / (1024 * 1024))
             self.add_train_scalar(f"memory_usage/worker_{worker}_cpu", memory)
             cpu_memory_usage_total += memory
         self.add_train_scalar("memory_usage/cpu", cpu_memory_usage_total)
-        for gpu, memory in gpu_memory_usage.items():
+        for gpu, mem_bytes in gpu_memory_usage.items():
+            memory = int(mem_bytes / (1024 * 1024))
             self.add_train_scalar(f"memory_usage/gpu_{gpu}", memory)
 
     def log_batch(

--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -101,12 +101,12 @@ class TensorboardWriter(FromParams):
     def log_memory_usage(self, cpu_memory_usage: Dict[int, int], gpu_memory_usage: Dict[int, int]):
         cpu_memory_usage_total = 0.0
         for worker, mem_bytes in cpu_memory_usage.items():
-            memory = int(mem_bytes / (1024 * 1024))
+            memory = mem_bytes / (1024 * 1024)
             self.add_train_scalar(f"memory_usage/worker_{worker}_cpu", memory)
             cpu_memory_usage_total += memory
         self.add_train_scalar("memory_usage/cpu", cpu_memory_usage_total)
         for gpu, mem_bytes in gpu_memory_usage.items():
-            memory = int(mem_bytes / (1024 * 1024))
+            memory = mem_bytes / (1024 * 1024)
             self.add_train_scalar(f"memory_usage/gpu_{gpu}", memory)
 
     def log_batch(

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -713,9 +713,9 @@ class GradientDescentTrainer(Trainer):
         )
 
         for (worker, memory) in cpu_memory_usage:
-            metrics["worker_" + str(worker) + "_memory_MB"] = int(memory / (1024 * 1024))
+            metrics["worker_" + str(worker) + "_memory_MB"] = memory / (1024 * 1024)
         for (gpu_num, memory) in gpu_memory_usage:
-            metrics["gpu_" + str(gpu_num) + "_memory_MB"] = int(memory / (1024 * 1024))
+            metrics["gpu_" + str(gpu_num) + "_memory_MB"] = memory / (1024 * 1024)
         return metrics
 
     def _validation_loss(self, epoch: int) -> Tuple[float, float, int]:

--- a/tests/commands/train_test.py
+++ b/tests/commands/train_test.py
@@ -219,6 +219,16 @@ class TestTrain(AllenNlpTestCase):
         assert "out_worker0.log" in serialized_files
         assert "out_worker1.log" in serialized_files
         assert "model.tar.gz" in serialized_files
+        assert "metrics.json" in serialized_files
+
+        # Make sure the metrics look right.
+        with open(os.path.join(out_dir, "metrics.json")) as f:
+            metrics = json.load(f)
+            assert metrics["peak_worker_0_memory_MB"] > 0
+            assert metrics["peak_worker_1_memory_MB"] > 0
+            if torch.cuda.device_count() >= 2:
+                assert metrics["peak_gpu_0_memory_MB"] > 0
+                assert metrics["peak_gpu_1_memory_MB"] > 0
 
         # Check we can load the serialized model
         assert load_archive(out_dir).model

--- a/tests/common/file_utils_test.py
+++ b/tests/common/file_utils_test.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from collections import Counter
 import os
 import pathlib
@@ -20,8 +19,6 @@ from allennlp.common.file_utils import (
     open_compressed,
     CacheFile,
     _Meta,
-    format_size,
-    format_timedelta,
     _find_entries,
     inspect_cache,
     remove_cache_entries,
@@ -452,35 +449,3 @@ class TestCacheFile(AllenNlpTestCase):
                 raise IOError("I made this up")
         assert not os.path.exists(handle.name)
         assert not os.path.exists(cache_filename)
-
-
-@pytest.mark.parametrize(
-    "size, result",
-    [
-        (12, "12B"),
-        (int(1.2 * 1024), "1.2K"),
-        (12 * 1024, "12K"),
-        (120 * 1024, "120K"),
-        (int(1.2 * 1024 * 1024), "1.2M"),
-        (12 * 1024 * 1024, "12M"),
-        (120 * 1024 * 1024, "120M"),
-        (int(1.2 * 1024 * 1024 * 1024), "1.2G"),
-        (12 * 1024 * 1024 * 1024, "12G"),
-    ],
-)
-def test_format_size(size: int, result: str):
-    assert format_size(size) == result
-
-
-@pytest.mark.parametrize(
-    "td, result",
-    [
-        (timedelta(days=2, hours=3), "2 days"),
-        (timedelta(days=1, hours=3), "1 day"),
-        (timedelta(hours=3, minutes=12), "3 hours"),
-        (timedelta(hours=1, minutes=12), "1 hour, 12 mins"),
-        (timedelta(minutes=12), "12 mins"),
-    ],
-)
-def test_format_timedelta(td: timedelta, result: str):
-    assert format_timedelta(td) == result

--- a/tests/common/util_test.py
+++ b/tests/common/util_test.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import sys
 from collections import OrderedDict
 
@@ -134,3 +135,35 @@ class TestCommonUtils(AllenNlpTestCase):
         for ptb_string, expected in test_cases:
             actual = util.sanitize_ptb_tokenized_string(ptb_string)
             assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "size, result",
+    [
+        (12, "12B"),
+        (int(1.2 * 1024), "1.2K"),
+        (12 * 1024, "12K"),
+        (120 * 1024, "120K"),
+        (int(1.2 * 1024 * 1024), "1.2M"),
+        (12 * 1024 * 1024, "12M"),
+        (120 * 1024 * 1024, "120M"),
+        (int(1.2 * 1024 * 1024 * 1024), "1.2G"),
+        (12 * 1024 * 1024 * 1024, "12G"),
+    ],
+)
+def test_format_size(size: int, result: str):
+    assert util.format_size(size) == result
+
+
+@pytest.mark.parametrize(
+    "td, result",
+    [
+        (timedelta(days=2, hours=3), "2 days"),
+        (timedelta(days=1, hours=3), "1 day"),
+        (timedelta(hours=3, minutes=12), "3 hours"),
+        (timedelta(hours=1, minutes=12), "1 hour, 12 mins"),
+        (timedelta(minutes=12), "12 mins"),
+    ],
+)
+def test_format_timedelta(td: timedelta, result: str):
+    assert util.format_timedelta(td) == result

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -107,7 +107,7 @@ class TestTrainer(TrainerTestBase):
         assert "best_epoch" in metrics
         assert isinstance(metrics["best_epoch"], int)
         assert "peak_worker_0_memory_MB" in metrics
-        assert isinstance(metrics["peak_worker_0_memory_MB"], float)
+        assert isinstance(metrics["peak_worker_0_memory_MB"], int)
         assert metrics["peak_worker_0_memory_MB"] > 0
 
     def test_trainer_can_run_exponential_moving_average(self):
@@ -130,7 +130,7 @@ class TestTrainer(TrainerTestBase):
         )
         metrics = trainer.train()
         assert "peak_worker_0_memory_MB" in metrics
-        assert isinstance(metrics["peak_worker_0_memory_MB"], float)
+        assert isinstance(metrics["peak_worker_0_memory_MB"], int)
         assert metrics["peak_worker_0_memory_MB"] > 0
         assert "peak_gpu_0_memory_MB" in metrics
         assert isinstance(metrics["peak_gpu_0_memory_MB"], int)

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -107,7 +107,7 @@ class TestTrainer(TrainerTestBase):
         assert "best_epoch" in metrics
         assert isinstance(metrics["best_epoch"], int)
         assert "peak_worker_0_memory_MB" in metrics
-        assert isinstance(metrics["peak_worker_0_memory_MB"], int)
+        assert isinstance(metrics["peak_worker_0_memory_MB"], float)
         assert metrics["peak_worker_0_memory_MB"] > 0
 
     def test_trainer_can_run_exponential_moving_average(self):
@@ -130,10 +130,10 @@ class TestTrainer(TrainerTestBase):
         )
         metrics = trainer.train()
         assert "peak_worker_0_memory_MB" in metrics
-        assert isinstance(metrics["peak_worker_0_memory_MB"], int)
+        assert isinstance(metrics["peak_worker_0_memory_MB"], float)
         assert metrics["peak_worker_0_memory_MB"] > 0
         assert "peak_gpu_0_memory_MB" in metrics
-        assert isinstance(metrics["peak_gpu_0_memory_MB"], int)
+        assert isinstance(metrics["peak_gpu_0_memory_MB"], float)
 
     @requires_multi_gpu
     def test_passing_trainer_multiple_gpus_raises_error(self):


### PR DESCRIPTION
While training some jobs on beaker today I realized the GPU memory metrics were completely inaccurate, which motivated me to make some improvements to our memory reporting util functions.

- Renames `allennlp.common.util.peak_memory_mb` to `peak_cpu_memory` and returns results in bytes as integers.
- Renames `allennlp.common.util.gpu_memory_mb` to `peak_gpu_memory` and returns results in bytes as integers.
- The `peak_gpu_memory` function now utilizes PyTorch functions to find the memory usage instead of shelling out to the `nvidia-smi` command. This is more efficient and also more accurate because it only takes into account the tensor allocations of the current PyTorch process.