### PR TITLE
Developer-friendly changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be used from the `cached-path` command with `allennlp cached-path --inspect`.
 - Added a function `remove_cache_entries` to `common.file_utils` that removes any cache entries matching the given
   glob patterns. This can used from the `cached-path` command with `allennlp cached-path --remove some-files-*`.
+- Developer-friendly changes
 
 ### Changed
 

--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -135,9 +135,9 @@ def evaluate_from_args(args: argparse.Namespace) -> Dict[str, Any]:
     # to the default dataset_reader used for both training and validation.
     validation_dataset_reader_params = config.pop("validation_dataset_reader", None)
     if validation_dataset_reader_params is not None:
-        dataset_reader = DatasetReader.from_params(validation_dataset_reader_params)
+        dataset_reader = DatasetReader.from_params(validation_dataset_reader_params, serialization_dir=archive.serialization_dir)
     else:
-        dataset_reader = DatasetReader.from_params(config.pop("dataset_reader"))
+        dataset_reader = DatasetReader.from_params(config.pop("dataset_reader"), serialization_dir=archive.serialization_dir)
     evaluation_data_path = args.input_file
     logger.info("Reading evaluation data from %s", evaluation_data_path)
     instances = dataset_reader.read(evaluation_data_path)

--- a/allennlp/commands/evaluate.py
+++ b/allennlp/commands/evaluate.py
@@ -135,9 +135,13 @@ def evaluate_from_args(args: argparse.Namespace) -> Dict[str, Any]:
     # to the default dataset_reader used for both training and validation.
     validation_dataset_reader_params = config.pop("validation_dataset_reader", None)
     if validation_dataset_reader_params is not None:
-        dataset_reader = DatasetReader.from_params(validation_dataset_reader_params, serialization_dir=archive.serialization_dir)
+        dataset_reader = DatasetReader.from_params(
+            validation_dataset_reader_params, serialization_dir=archive.serialization_dir
+        )
     else:
-        dataset_reader = DatasetReader.from_params(config.pop("dataset_reader"), serialization_dir=archive.serialization_dir)
+        dataset_reader = DatasetReader.from_params(
+            config.pop("dataset_reader"), serialization_dir=archive.serialization_dir
+        )
     evaluation_data_path = args.input_file
     logger.info("Reading evaluation data from %s", evaluation_data_path)
     instances = dataset_reader.read(evaluation_data_path)

--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -165,7 +165,7 @@ def find_learning_rate_model(
     # See https://github.com/allenai/allennlp/issues/3658
     assert not distributed_params, "find-lr is not compatible with DistributedDataParallel."
 
-    all_datasets = datasets_from_params(params)
+    all_datasets = datasets_from_params(params, serialization_dir=serialization_dir)
     datasets_for_vocab_creation = set(params.pop("datasets_for_vocab_creation", all_datasets))
 
     for dataset in datasets_for_vocab_creation:
@@ -188,7 +188,7 @@ def find_learning_rate_model(
 
     train_data = all_datasets["train"]
     train_data.index_with(vocab)
-    model = Model.from_params(vocab=vocab, params=params.pop("model"))
+    model = Model.from_params(vocab=vocab, params=params.pop("model"), serialization_dir=serialization_dir)
     data_loader = DataLoader.from_params(dataset=train_data, params=params.pop("data_loader"))
 
     trainer_params = params.pop("trainer")

--- a/allennlp/commands/find_learning_rate.py
+++ b/allennlp/commands/find_learning_rate.py
@@ -188,7 +188,9 @@ def find_learning_rate_model(
 
     train_data = all_datasets["train"]
     train_data.index_with(vocab)
-    model = Model.from_params(vocab=vocab, params=params.pop("model"), serialization_dir=serialization_dir)
+    model = Model.from_params(
+        vocab=vocab, params=params.pop("model"), serialization_dir=serialization_dir
+    )
     data_loader = DataLoader.from_params(dataset=train_data, params=params.pop("data_loader"))
 
     trainer_params = params.pop("trainer")

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -249,6 +249,12 @@ def train_model(
 
     # Otherwise, we are running multiple processes for training.
     else:
+        common_logging.prepare_global_logging(
+            serialization_dir,
+            rank=0,
+            world_size=1,
+        )
+
         # We are careful here so that we can raise a good error if someone
         # passed the wrong thing - cuda_devices are required.
         device_ids = distributed_params.pop("cuda_devices", None)

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -645,7 +645,7 @@ class TrainModel(Registrable):
         vocabulary_ = vocabulary.construct(instances=instance_generator)
         if not vocabulary_:
             vocabulary_ = Vocabulary.from_instances(instance_generator)
-        model_ = model.construct(vocab=vocabulary_)
+        model_ = model.construct(vocab=vocabulary_, serialization_dir=serialization_dir)
 
         # Initializing the model can have side effect of expanding the vocabulary.
         # Save the vocab only in the master. In the degenerate non-distributed

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -22,12 +22,12 @@ class ModelTestCase(AllenNlpTestCase):
     with added methods for testing [`Model`](../../models/model.md) subclasses.
     """
 
-    def set_up_model(self, param_file, dataset_file):
+    def set_up_model(self, param_file, dataset_file, serialization_dir=None):
 
         self.param_file = param_file
         params = Params.from_file(self.param_file)
 
-        reader = DatasetReader.from_params(params["dataset_reader"])
+        reader = DatasetReader.from_params(params["dataset_reader"], serialization_dir=serialization_dir)
         # The dataset reader might be lazy, but a lazy list here breaks some of our tests.
         instances = reader.read(str(dataset_file))
         # Use parameters for vocabulary if they are present in the config file, so that choices like
@@ -40,7 +40,7 @@ class ModelTestCase(AllenNlpTestCase):
         self.vocab = vocab
         self.instances = instances
         self.instances.index_with(vocab)
-        self.model = Model.from_params(vocab=self.vocab, params=params["model"])
+        self.model = Model.from_params(vocab=self.vocab, params=params["model"], serialization_dir=serialization_dir)
 
         # TODO(joelgrus) get rid of these
         # (a lot of the model tests use them, so they'll have to be changed)
@@ -117,7 +117,7 @@ class ModelTestCase(AllenNlpTestCase):
                 err_msg=key,
             )
         params = Params.from_file(param_file, params_overrides=overrides)
-        reader = DatasetReader.from_params(params["dataset_reader"])
+        reader = DatasetReader.from_params(params["dataset_reader"], serialization_dir=save_dir)
 
         print("Reading with original model")
         model_dataset = reader.read(params["validation_data_path"])

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -27,7 +27,9 @@ class ModelTestCase(AllenNlpTestCase):
         self.param_file = param_file
         params = Params.from_file(self.param_file)
 
-        reader = DatasetReader.from_params(params["dataset_reader"], serialization_dir=serialization_dir)
+        reader = DatasetReader.from_params(
+            params["dataset_reader"], serialization_dir=serialization_dir
+        )
         # The dataset reader might be lazy, but a lazy list here breaks some of our tests.
         instances = reader.read(str(dataset_file))
         # Use parameters for vocabulary if they are present in the config file, so that choices like
@@ -40,7 +42,9 @@ class ModelTestCase(AllenNlpTestCase):
         self.vocab = vocab
         self.instances = instances
         self.instances.index_with(vocab)
-        self.model = Model.from_params(vocab=self.vocab, params=params["model"], serialization_dir=serialization_dir)
+        self.model = Model.from_params(
+            vocab=self.vocab, params=params["model"], serialization_dir=serialization_dir
+        )
 
         # TODO(joelgrus) get rid of these
         # (a lot of the model tests use them, so they'll have to be changed)

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -529,7 +529,8 @@ def is_master(
     # rank == 0 would do in a single-node multi-GPU setup. However,
     # in a multi-node case, every node has a logical master and hence
     # the mod(%) op.
-    return global_rank % (world_size / num_procs_per_node) == 0
+    num_of_nodes = world_size / num_procs_per_node
+    return (global_rank % num_of_nodes if num_of_nodes > 1 else global_rank) == 0
 
 
 def is_distributed() -> bool:

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -529,8 +529,7 @@ def is_master(
     # rank == 0 would do in a single-node multi-GPU setup. However,
     # in a multi-node case, every node has a logical master and hence
     # the mod(%) op.
-    num_of_nodes = world_size / num_procs_per_node
-    return (global_rank % num_of_nodes if num_of_nodes > 1 else global_rank) == 0
+    return global_rank % (world_size / num_procs_per_node) == 0
 
 
 def is_distributed() -> bool:

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -154,6 +154,7 @@ class DatasetReader(Registrable):
         max_instances: Optional[int] = None,
         manual_distributed_sharding: bool = False,
         manual_multi_process_sharding: bool = False,
+        serialization_dir: Optional[str] = None,
     ) -> None:
         self.lazy = lazy
         self.max_instances = max_instances
@@ -163,6 +164,7 @@ class DatasetReader(Registrable):
             os.makedirs(self._cache_directory, exist_ok=True)
         self.manual_distributed_sharding = manual_distributed_sharding
         self.manual_multi_process_sharding = manual_multi_process_sharding
+        self._serialization_dir = serialization_dir
 
     def read(self, file_path: Union[Path, str]) -> Union[AllennlpDataset, AllennlpLazyDataset]:
         """

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -25,7 +25,7 @@ class Archive(NamedTuple):
 
     model: Model
     config: Params
-    serialization_dir: str
+    serialization_dir: Union[str, PathLike]
 
     def extract_module(self, path: str, freeze: bool = True) -> Module:
         """

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -25,6 +25,7 @@ class Archive(NamedTuple):
 
     model: Model
     config: Params
+    serialization_dir: str
 
     def extract_module(self, path: str, freeze: bool = True) -> Module:
         """
@@ -194,4 +195,4 @@ def load_archive(
             logger.info(f"removing temporary unarchived model dir at {tempdir}")
             shutil.rmtree(tempdir, ignore_errors=True)
 
-    return Archive(model=model, config=config)
+    return Archive(model=model, config=config, serialization_dir=serialization_dir)

--- a/allennlp/models/archival.py
+++ b/allennlp/models/archival.py
@@ -181,9 +181,11 @@ def load_archive(
     load_from_archive = functools.partial(_load_from_archive, cuda_device, overrides, weights_file)
     if os.path.isdir(resolved_archive_file):
         serialization_dir = resolved_archive_file
-        model, config = load_from_archive(serialization_dir)
+        model, config, serialization_dir = load_from_archive(serialization_dir)
     else:
-        model, config = extract_archive_temporarily(resolved_archive_file, load_from_archive)
+        model, config, serialization_dir = extract_archive_temporarily(
+            resolved_archive_file, load_from_archive
+        )
 
     return Archive(model=model, config=config, serialization_dir=serialization_dir)
 
@@ -208,7 +210,7 @@ def _load_from_archive(cuda_device, overrides, weights_file, serialization_dir):
         cuda_device=cuda_device,
     )
 
-    return model, config
+    return model, config, serialization_dir
 
 
 def extract_archive_temporarily(resolved_archive_file, callback):

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -71,10 +71,11 @@ class Model(torch.nn.Module, Registrable):
     _warn_for_unseparable_batches: Set[str] = set()
     default_predictor: Optional[str] = None
 
-    def __init__(self, vocab: Vocabulary, regularizer: RegularizerApplicator = None) -> None:
+    def __init__(self, vocab: Vocabulary, regularizer: RegularizerApplicator = None, serialization_dir: Optional[str] = None) -> None:
         super().__init__()
         self.vocab = vocab
         self._regularizer = regularizer
+        self.serialization_dir = serialization_dir
 
     def get_regularization_penalty(self) -> Optional[torch.Tensor]:
         """
@@ -293,7 +294,7 @@ class Model(torch.nn.Module, Registrable):
         # stored in our weights.  We don't need any pretrained weight file anymore, and we don't
         # want the code to look for it, so we remove it from the parameters here.
         remove_pretrained_embedding_params(model_params)
-        model = Model.from_params(vocab=vocab, params=model_params)
+        model = Model.from_params(vocab=vocab, params=model_params, serialization_dir=serialization_dir)
 
         # Force model to cpu or gpu, as appropriate, to make sure that the embeddings are
         # in sync with the weights

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -298,7 +298,7 @@ class Model(torch.nn.Module, Registrable):
         # embeddings/weights from.  We're now _loading_ the model, so those weights will already be
         # stored in our model.  We don't need any pretrained weight file anymore, and we don't
         # want the code to look for it, so we remove it from the parameters here.
-        remove_pretrained_weights_params(model_params)
+        remove_pretrained_embedding_params(model_params)
         model = Model.from_params(
             vocab=vocab, params=model_params, serialization_dir=serialization_dir
         )
@@ -457,7 +457,8 @@ class Model(torch.nn.Module, Registrable):
 Model.register("from_archive", constructor="from_archive")(Model)
 
 
-def remove_pretrained_weights_params(params: Params):
+def remove_pretrained_embedding_params(params: Params):
+    # TODO(eladsegal): Rename to remove_pretrained_weights_params
     if isinstance(params, Params):  # The model could possibly be a string, for example.
         keys = params.keys()
         if "pretrained_file" in keys:
@@ -466,4 +467,4 @@ def remove_pretrained_weights_params(params: Params):
             del params["weights_file_path"]
         for value in params.values():
             if isinstance(value, Params):
-                remove_pretrained_weights_params(value)
+                remove_pretrained_embedding_params(value)

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -295,10 +295,10 @@ class Model(torch.nn.Module, Registrable):
         model_params = config.get("model")
 
         # The experiment config tells us how to _train_ a model, including where to get pre-trained
-        # embeddings from.  We're now _loading_ the model, so those embeddings will already be
-        # stored in our weights.  We don't need any pretrained weight file anymore, and we don't
+        # embeddings/weights from.  We're now _loading_ the model, so those weights will already be
+        # stored in our model.  We don't need any pretrained weight file anymore, and we don't
         # want the code to look for it, so we remove it from the parameters here.
-        remove_pretrained_embedding_params(model_params)
+        remove_pretrained_weights_params(model_params)
         model = Model.from_params(
             vocab=vocab, params=model_params, serialization_dir=serialization_dir
         )
@@ -457,11 +457,13 @@ class Model(torch.nn.Module, Registrable):
 Model.register("from_archive", constructor="from_archive")(Model)
 
 
-def remove_pretrained_embedding_params(params: Params):
+def remove_pretrained_weights_params(params: Params):
     if isinstance(params, Params):  # The model could possibly be a string, for example.
         keys = params.keys()
         if "pretrained_file" in keys:
             del params["pretrained_file"]
+        if "weights_file_path" in keys:
+            del params["weights_file_path"]
         for value in params.values():
             if isinstance(value, Params):
-                remove_pretrained_embedding_params(value)
+                remove_pretrained_weights_params(value)

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -71,7 +71,12 @@ class Model(torch.nn.Module, Registrable):
     _warn_for_unseparable_batches: Set[str] = set()
     default_predictor: Optional[str] = None
 
-    def __init__(self, vocab: Vocabulary, regularizer: RegularizerApplicator = None, serialization_dir: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        vocab: Vocabulary,
+        regularizer: RegularizerApplicator = None,
+        serialization_dir: Optional[str] = None,
+    ) -> None:
         super().__init__()
         self.vocab = vocab
         self._regularizer = regularizer
@@ -294,7 +299,9 @@ class Model(torch.nn.Module, Registrable):
         # stored in our weights.  We don't need any pretrained weight file anymore, and we don't
         # want the code to look for it, so we remove it from the parameters here.
         remove_pretrained_embedding_params(model_params)
-        model = Model.from_params(vocab=vocab, params=model_params, serialization_dir=serialization_dir)
+        model = Model.from_params(
+            vocab=vocab, params=model_params, serialization_dir=serialization_dir
+        )
 
         # Force model to cpu or gpu, as appropriate, to make sure that the embeddings are
         # in sync with the weights

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -384,7 +384,7 @@ class PretrainedModelInitializer(Initializer):
     def __init__(
         self, weights_file_path: str, parameter_name_overrides: Dict[str, str] = None
     ) -> None:
-        self.weights: Dict[str, torch.Tensor] = torch.load(weights_file_path)
+        self.weights: Dict[str, torch.Tensor] = torch.load(weights_file_path, map_location="cpu")
         self.parameter_name_overrides = parameter_name_overrides or {}
 
     @overrides

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -382,8 +382,10 @@ class PretrainedModelInitializer(Initializer):
     """
 
     def __init__(
-        self, weights_file_path: str, parameter_name_overrides: Dict[str, str] = None
+        self, weights_file_path: str = None, parameter_name_overrides: Dict[str, str] = None
     ) -> None:
+        if weights_file_path is None:
+            return
         self.weights: Dict[str, torch.Tensor] = torch.load(weights_file_path, map_location="cpu")
         self.parameter_name_overrides = parameter_name_overrides or {}
 

--- a/allennlp/predictors/predictor.py
+++ b/allennlp/predictors/predictor.py
@@ -320,7 +320,9 @@ class Predictor(Registrable):
             dataset_reader_params = config["validation_dataset_reader"]
         else:
             dataset_reader_params = config["dataset_reader"]
-        dataset_reader = DatasetReader.from_params(dataset_reader_params, serialization_dir=archive.serialization_dir)
+        dataset_reader = DatasetReader.from_params(
+            dataset_reader_params, serialization_dir=archive.serialization_dir
+        )
 
         model = archive.model
         if frozen:

--- a/allennlp/predictors/predictor.py
+++ b/allennlp/predictors/predictor.py
@@ -320,7 +320,7 @@ class Predictor(Registrable):
             dataset_reader_params = config["validation_dataset_reader"]
         else:
             dataset_reader_params = config["dataset_reader"]
-        dataset_reader = DatasetReader.from_params(dataset_reader_params)
+        dataset_reader = DatasetReader.from_params(dataset_reader_params, serialization_dir=archive.serialization_dir)
 
         model = archive.model
         if frozen:

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -128,7 +128,7 @@ def datasets_from_params(
     train: bool = True,
     validation: bool = True,
     test: bool = True,
-    serialization_dir: Optional[str] = None,
+    serialization_dir: Optional[Union[str, PathLike]] = None,
 ) -> Dict[str, Union["AllennlpDataset", "AllennlpLazyDataset"]]:
     """
     Load datasets specified by the config.

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -124,7 +124,11 @@ def read_all_datasets(
 
 
 def datasets_from_params(
-    params: Params, train: bool = True, validation: bool = True, test: bool = True, serialization_dir: Optional[str] = None
+    params: Params,
+    train: bool = True,
+    validation: bool = True,
+    test: bool = True,
+    serialization_dir: Optional[str] = None,
 ) -> Dict[str, Union["AllennlpDataset", "AllennlpLazyDataset"]]:
     """
     Load datasets specified by the config.
@@ -139,7 +143,9 @@ def datasets_from_params(
         return datasets
 
     dataset_reader_params = params.pop("dataset_reader")
-    dataset_reader = DatasetReader.from_params(dataset_reader_params, serialization_dir=serialization_dir)
+    dataset_reader = DatasetReader.from_params(
+        dataset_reader_params, serialization_dir=serialization_dir
+    )
 
     if train:
         train_data_path = params.pop("train_data_path")

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -124,7 +124,7 @@ def read_all_datasets(
 
 
 def datasets_from_params(
-    params: Params, train: bool = True, validation: bool = True, test: bool = True
+    params: Params, train: bool = True, validation: bool = True, test: bool = True, serialization_dir: Optional[str] = None
 ) -> Dict[str, Union["AllennlpDataset", "AllennlpLazyDataset"]]:
     """
     Load datasets specified by the config.
@@ -139,7 +139,7 @@ def datasets_from_params(
         return datasets
 
     dataset_reader_params = params.pop("dataset_reader")
-    dataset_reader = DatasetReader.from_params(dataset_reader_params)
+    dataset_reader = DatasetReader.from_params(dataset_reader_params, serialization_dir=serialization_dir)
 
     if train:
         train_data_path = params.pop("train_data_path")
@@ -157,7 +157,7 @@ def datasets_from_params(
     if validation_dataset_reader_params is not None:
         logger.info("Using a separate dataset reader to load validation and test data.")
         validation_and_test_dataset_reader = DatasetReader.from_params(
-            validation_dataset_reader_params
+            validation_dataset_reader_params, serialization_dir=serialization_dir
         )
 
     if validation:
@@ -464,7 +464,7 @@ def make_vocab_from_params(
     if datasets_for_vocab_creation is None:
         # If `datasets_for_vocab_creation` was not specified, we'll use all datasets
         # from the config.
-        datasets = datasets_from_params(params)
+        datasets = datasets_from_params(params, serialization_dir=serialization_dir)
     else:
         for dataset_name in datasets_for_vocab_creation:
             data_path = f"{dataset_name}_data_path"
@@ -472,6 +472,7 @@ def make_vocab_from_params(
                 raise ConfigurationError(f"invalid 'datasets_for_vocab_creation' {dataset_name}")
         datasets = datasets_from_params(
             params,
+            serialization_dir=serialization_dir,
             train=("train" in datasets_for_vocab_creation),
             validation=("validation" in datasets_for_vocab_creation),
             test=("test" in datasets_for_vocab_creation),


### PR DESCRIPTION
This pull request fixes a few things that I found missing/problematic during development with AllenNLP.
Some of the changes can be achieved without changing the library, however it isn't as clean.
The changes are small and shouldn't interfere with anything (they are also pretty separated by commits, but let me know if you prefer that I split it to multiple pull requests):
- Pass serialization_dir to Model and DatasetReader: Serves as a working directory for either classes (https://github.com/allenai/allennlp/pull/4702/commits/459c6809ee8175164a41c1eb17f18aa125ff501b)
- Define paths in serialization_dir that should be archived, in addition to config/best.th/vocab: Complements using serialization_dir as a working directory. (https://github.com/allenai/allennlp/pull/4702/commits/e5e6dcd8cb02ac0c2d576159b58d88b048bd38ab)
- When running in distributed mode, log also the stuff that happens before multiprocessing: This change logs the first DatasetReader run, and also logs an error in case it happens in of the multiprocess workers. (https://github.com/allenai/allennlp/pull/4702/commits/8e938c1ea729beabdfc31a4d3425b19095a55cf7)
- When using PretrainedModelInitializer, load weights to the cpu explicitly and save usage of expensive GPU memory. (https://github.com/allenai/allennlp/pull/4702/commits/ee580de81e40a0eddddd1716439c9f4891e734b5)
- Pretrained embeddings are not loaded when loading a model, but pretrained weights from PretrainedModelInitializer unnecessarily are: With this change they are both treated the same. https://github.com/allenai/allennlp/pull/4702/commits/bb23e9b9ac14fcc12322956b626fba1c599d0a22
- Allow usage of .tar.gz with PretrainedModelInitializer. (https://github.com/allenai/allennlp/pull/4702/commits/e6a0c076cc6a1fbece083c392283739745a92b8b)

I also snuck in a small bug fix - moved to https://github.com/allenai/allennlp/pull/4705:
common.util.is_master returned wrong result when there was only a single node. It was only used when saving vocabulary, so no harm done.

---
There's another developer-friendly change I wanted to make:
- Save training and model checkpoints *before* evaluation: Sometimes an error occurs when evaluating on the dev set. This change prevents the loss of the model weights of the epoch, and allows for easier debugging to find exactly what has caused the error.

I saw it is more complex than the other changes since it requires separating checkpointing, so I did it an another pull request: https://github.com/allenai/allennlp/pull/4704
