### PR TITLE
fix reported batch_loss with gradient accumulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a bug where the reported `batch_loss` metric was incorrect when training with gradient accumulation.
 - Class decorators now displayed in API docs.
 - Fixed up the documentation for the `allennlp.nn.beam_search` module.
 - Ignore `*args` when constructing classes with `FromParams`.

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -588,6 +588,7 @@ class GradientDescentTrainer(Trainer):
                 for p in param_group["params"]:
                     p.grad = None
 
+            batch_loss = 0.0
             batch_group_outputs = []
             for batch in batch_group:
                 with amp.autocast(self._use_amp):
@@ -599,8 +600,7 @@ class GradientDescentTrainer(Trainer):
                         raise ValueError("nan loss encountered")
                     loss = loss / len(batch_group)
 
-                    batch_loss = loss.item()
-                    train_loss += batch_loss
+                    batch_loss += loss.item()
                     if reg_loss is not None:
                         reg_loss = reg_loss / len(batch_group)
                         batch_reg_loss = reg_loss.item()
@@ -610,6 +610,8 @@ class GradientDescentTrainer(Trainer):
                     self._scaler.scale(loss).backward()
                 else:
                     loss.backward()
+
+            train_loss += batch_loss
 
             batch_grad_norm = self.rescale_gradients()
 


### PR DESCRIPTION
Currently, when training with gradient accumulation (i.e. with `num_gradient_accumulation_steps > 1`), the reported `batch_loss` metric is always just the loss from last batch in the batch group divided by the number of batches in the group. By itself, this is arbitrary and kind of meaningless. Instead, `batch_loss` should report the cumulative loss for the entire group.

By the way, this came up in https://stackoverflow.com/questions/64181843/calculate-loss-in-train-epoch-function.