### PR TITLE
Don't use PretrainedModelInitializer when loading a model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `transformers` dependency updated to version 3.1.0.
 - When `cached_path` is called on a local archive with `extract_archive=True`, the archive is now extracted into a unique subdirectory of the cache root instead of a subdirectory of the archive's directory. The extraction directory is also unique to the modification time of the archive, so if the file changes, subsequent calls to `cached_path` will know to re-extract the archive.
 - Removed the `truncation_strategy` parameter to `PretrainedTransformerTokenizer`. The way we're calling the tokenizer, the truncation strategy takes no effect anyways.
-- Don't load weights with PretrainedModelInitializer when loading a model, as it is not needed.
+- Don't use initializers when loading a model, as it is not needed.
 - Distributed training will now automatically search for a local open port if the `master_port` parameter is not provided.
 - In training, save model weights before evaluation.
 - `allennlp.common.util.peak_memory_mb` renamed to `peak_cpu_memory`, and `allennlp.common.util.gpu_memory_mb` renamed to `peak_gpu_memory`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `transformers` dependency updated to version 3.1.0.
 - When `cached_path` is called on a local archive with `extract_archive=True`, the archive is now extracted into a unique subdirectory of the cache root instead of a subdirectory of the archive's directory. The extraction directory is also unique to the modification time of the archive, so if the file changes, subsequent calls to `cached_path` will know to re-extract the archive.
 - Removed the `truncation_strategy` parameter to `PretrainedTransformerTokenizer`. The way we're calling the tokenizer, the truncation strategy takes no effect anyways.
+- Don't load weights with PretrainedModelInitializer when loading a model, as it is not needed.
 
 ### Removed
 

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -598,3 +598,14 @@ def _replace_none(params: Any) -> Any:
     elif isinstance(params, list):
         return [_replace_none(value) for value in params]
     return params
+
+
+def remove_keys_from_params(params: Params, keys: List[str] = ["pretrained_file", "initializer"]):
+    if isinstance(params, Params):  # The model could possibly be a string, for example.
+        param_keys = params.keys()
+        for key in keys:
+            if key in param_keys:
+                del params[key]
+        for value in params.values():
+            if isinstance(value, Params):
+                remove_keys_from_params(value, keys)

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -289,10 +289,10 @@ class Model(torch.nn.Module, Registrable):
         model_params = config.get("model")
 
         # The experiment config tells us how to _train_ a model, including where to get pre-trained
-        # embeddings from.  We're now _loading_ the model, so those embeddings will already be
-        # stored in our weights.  We don't need any pretrained weight file anymore, and we don't
+        # embeddings/weights from.  We're now _loading_ the model, so those weights will already be
+        # stored in our model.  We don't need any pretrained weight file anymore, and we don't
         # want the code to look for it, so we remove it from the parameters here.
-        remove_pretrained_embedding_params(model_params)
+        remove_pretrained_weights_params(model_params)
         model = Model.from_params(vocab=vocab, params=model_params)
 
         # Force model to cpu or gpu, as appropriate, to make sure that the embeddings are
@@ -449,11 +449,13 @@ class Model(torch.nn.Module, Registrable):
 Model.register("from_archive", constructor="from_archive")(Model)
 
 
-def remove_pretrained_embedding_params(params: Params):
+def remove_pretrained_weights_params(params: Params):
     if isinstance(params, Params):  # The model could possibly be a string, for example.
         keys = params.keys()
         if "pretrained_file" in keys:
             del params["pretrained_file"]
+        if "weights_file_path" in keys:
+            del params["weights_file_path"]
         for value in params.values():
             if isinstance(value, Params):
-                remove_pretrained_embedding_params(value)
+                remove_pretrained_weights_params(value)

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -13,7 +13,7 @@ import numpy
 import torch
 
 from allennlp.common.checks import ConfigurationError
-from allennlp.common.params import Params
+from allennlp.common.params import Params, remove_keys_from_params
 from allennlp.common.registrable import Registrable
 from allennlp.data import Instance, Vocabulary
 from allennlp.data.batch import Batch
@@ -289,10 +289,10 @@ class Model(torch.nn.Module, Registrable):
         model_params = config.get("model")
 
         # The experiment config tells us how to _train_ a model, including where to get pre-trained
-        # embeddings/weights from.  We're now _loading_ the model, so those weights will already be
-        # stored in our model.  We don't need any pretrained weight file anymore, and we don't
-        # want the code to look for it, so we remove it from the parameters here.
-        remove_pretrained_weights_params(model_params)
+        # embeddings/weights from. We're now _loading_ the model, so those weights will already be
+        # stored in our model. We don't need any pretrained weight file or initializers anymore,
+        # and we don't want the code to look for it, so we remove it from the parameters here.
+        remove_keys_from_params(model_params)
         model = Model.from_params(vocab=vocab, params=model_params)
 
         # Force model to cpu or gpu, as appropriate, to make sure that the embeddings are
@@ -449,13 +449,7 @@ class Model(torch.nn.Module, Registrable):
 Model.register("from_archive", constructor="from_archive")(Model)
 
 
-def remove_pretrained_weights_params(params: Params):
-    if isinstance(params, Params):  # The model could possibly be a string, for example.
-        keys = params.keys()
-        if "pretrained_file" in keys:
-            del params["pretrained_file"]
-        if "weights_file_path" in keys:
-            del params["weights_file_path"]
-        for value in params.values():
-            if isinstance(value, Params):
-                remove_pretrained_weights_params(value)
+def remove_weights_related_keys_from_params(
+    params: Params, keys: List[str] = ["pretrained_file", "initializer"]
+):
+    remove_keys_from_params(params, keys)

--- a/allennlp/models/model.py
+++ b/allennlp/models/model.py
@@ -453,3 +453,9 @@ def remove_weights_related_keys_from_params(
     params: Params, keys: List[str] = ["pretrained_file", "initializer"]
 ):
     remove_keys_from_params(params, keys)
+
+
+def remove_pretrained_embedding_params(params: Params):
+    """This function only exists for backwards compatibility.
+    Please use `remove_weights_related_keys_from_params()` instead."""
+    remove_keys_from_params(params, ["pretrained_file"])

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -382,10 +382,8 @@ class PretrainedModelInitializer(Initializer):
     """
 
     def __init__(
-        self, weights_file_path: str = None, parameter_name_overrides: Dict[str, str] = None
+        self, weights_file_path: str, parameter_name_overrides: Dict[str, str] = None
     ) -> None:
-        if weights_file_path is None:
-            return
         self.weights: Dict[str, torch.Tensor] = torch.load(weights_file_path, map_location="cpu")
         self.parameter_name_overrides = parameter_name_overrides or {}
 

--- a/allennlp/nn/initializers.py
+++ b/allennlp/nn/initializers.py
@@ -382,8 +382,10 @@ class PretrainedModelInitializer(Initializer):
     """
 
     def __init__(
-        self, weights_file_path: str, parameter_name_overrides: Dict[str, str] = None
+        self, weights_file_path: str = None, parameter_name_overrides: Dict[str, str] = None
     ) -> None:
+        if weights_file_path is None:
+            return
         self.weights: Dict[str, torch.Tensor] = torch.load(weights_file_path)
         self.parameter_name_overrides = parameter_name_overrides or {}
 

--- a/tests/common/params_test.py
+++ b/tests/common/params_test.py
@@ -321,14 +321,14 @@ class TestParams(AllenNlpTestCase):
         filename = self.FIXTURES_ROOT / "simple_tagger" / "experiment.json"
         params = Params.from_file(filename)
 
-        assert params["dataloader"]["batch_sampler"]["type"] == "bucket"
-        assert params["dataloader"]["batch_sampler"]["batch_size"] == 80
+        assert params["data_loader"]["batch_sampler"]["type"] == "bucket"
+        assert params["data_loader"]["batch_sampler"]["batch_size"] == 80
 
         remove_keys_from_params(params, keys=["batch_size"])
-        assert "batch_size" not in params["dataloader"]["batch_sampler"]
+        assert "batch_size" not in params["data_loader"]["batch_sampler"]
 
         remove_keys_from_params(params, keys=["type", "batch_size"])
-        assert "type" not in params["dataloader"]["batch_sampler"]
+        assert "type" not in params["data_loader"]["batch_sampler"]
 
-        remove_keys_from_params(params, keys=["dataloader"])
-        assert "dataloader" not in params
+        remove_keys_from_params(params, keys=["data_loader"])
+        assert "data_loader" not in params

--- a/tests/common/params_test.py
+++ b/tests/common/params_test.py
@@ -6,7 +6,14 @@ from collections import OrderedDict
 import pytest
 
 from allennlp.common.checks import ConfigurationError
-from allennlp.common.params import infer_and_cast, Params, parse_overrides, unflatten, with_fallback
+from allennlp.common.params import (
+    infer_and_cast,
+    Params,
+    parse_overrides,
+    unflatten,
+    with_fallback,
+    remove_keys_from_params,
+)
 from allennlp.common.testing import AllenNlpTestCase
 
 
@@ -309,3 +316,19 @@ class TestParams(AllenNlpTestCase):
         params = Params({"model": "module.submodule.ModelName"})
         with pytest.raises(ConfigurationError):
             params.pop_choice("model", choices, allow_class_names=False)
+
+    def test_remove_keys_from_params(self):
+        filename = self.FIXTURES_ROOT / "simple_tagger" / "experiment.json"
+        params = Params.from_file(filename)
+
+        assert params["dataloader"]["batch_sampler"]["type"] == "bucket"
+        assert params["dataloader"]["batch_sampler"]["batch_size"] == 80
+
+        remove_keys_from_params(params, keys=["batch_size"])
+        assert "batch_size" not in params["dataloader"]["batch_sampler"]
+
+        remove_keys_from_params(params, keys=["type", "batch_size"])
+        assert "type" not in params["dataloader"]["batch_sampler"]
+
+        remove_keys_from_params(params, keys=["dataloader"])
+        assert "dataloader" not in params


### PR DESCRIPTION
When loading a model, pretrained embeddings are not loaded as it is not needed.
This change make the same thing happen with pretrained weights from PretrainedModelInitializer.

Goes with https://github.com/allenai/allennlp-models/pull/141