### PR TITLE
Updated AllenNlpTestCase docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   usage instead of shelling out to the `nvidia-smi` command. This is more efficient and also more accurate because it only takes
   into account the tensor allocations of the current PyTorch process.
 - Make sure weights are first loaded to the cpu when using PretrainedModelInitializer, preventing wasted GPU memory.
+- Updated `AllenNlpTestCase` docstring to remove reference to `unittest.TestCase`
 
 ### Removed
 

--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -11,7 +11,7 @@ TEST_DIR = tempfile.mkdtemp(prefix="allennlp_tests")
 
 class AllenNlpTestCase:
     """
-    A custom subclass of `unittest.TestCase` that disables some of the more verbose AllenNLP
+    A custom testing class that disables some of the more verbose AllenNLP
     logging and that creates and destroys a temp directory as a test fixture.
     """
 


### PR DESCRIPTION
Updated AllenNlpTestCase test case to remove reference to `unittest.TestCase` as per issue #4716 