### PR TITLE
stricter typing for Optional[T] types, improve handling of Lazy params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make sure weights are first loaded to the cpu when using PretrainedModelInitializer, preventing wasted GPU memory.
 - Load dataset readers in `load_archive`.
 - Updated `AllenNlpTestCase` docstring to remove reference to `unittest.TestCase`
+- Enforced stricter typing requirements around the use of `Optional[T]` types.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Enforced stricter typing requirements around the use of `Optional[T]` types.
+- Changed the behavior of `Lazy` types in `from_params` methods. Previously, if you defined a `Lazy` parameter like
+  `foo: Lazy[Foo] = None` in a custom `from_params` classmethod, then `foo` would actually never be `None`.
+  This behavior is now different. If no params were given for `foo`, it will be `None`.
+  You can also now set default values for foo like `foo: Lazy[Foo] = Lazy(Foo)`.
+  Or, if you want you want a default value but also want to allow for `None` values, you can
+  write it like this: `foo: Optional[Lazy[Foo]] = Lazy(Foo)`.
+
 ### Fixed
 
 - Made it possible to instantiate `TrainerCallback` from config files.
@@ -63,13 +73,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make sure weights are first loaded to the cpu when using PretrainedModelInitializer, preventing wasted GPU memory.
 - Load dataset readers in `load_archive`.
 - Updated `AllenNlpTestCase` docstring to remove reference to `unittest.TestCase`
-- Enforced stricter typing requirements around the use of `Optional[T]` types.
-- Changed the behavior of `Lazy` types in `from_params` methods. Previously, if you defined a `Lazy` parameter like
-  `foo: Lazy[Foo] = None` in a custom `from_params` classmethod, then `foo` would actually never be `None`.
-  This behavior is now different. If no params were given for `foo`, it will be `None`.
-  You can also now set default values for foo like `foo: Lazy[Foo] = Lazy(Foo)`.
-  Or, if you want you want a default value but also want to allow for `None` values, you can
-  write it like this: `foo: Optional[Lazy[Foo]] = Lazy(Foo)`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Load dataset readers in `load_archive`.
 - Updated `AllenNlpTestCase` docstring to remove reference to `unittest.TestCase`
 - Enforced stricter typing requirements around the use of `Optional[T]` types.
+- Changed the behavior of `Lazy` types in `from_params` methods. Previously, if you defined a `Lazy` parameter like
+  `foo: Lazy[Foo] = None` in a custom `from_params` classmethod, then `foo` would actually never be `None`.
+  This behavior is now different. If no params were given for `foo`, it will be `None`.
+  You can also now set default values for foo like `foo: Lazy[Foo] = Lazy(Foo)`.
+  Or, if you want you want a default value but also want to allow for `None` values, you can
+  write it like this: `foo: Optional[Lazy[Foo]] = Lazy(Foo)`.
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,7 @@ format :
 
 .PHONY : typecheck
 typecheck :
-	mypy . \
-		--ignore-missing-imports \
-		--no-strict-optional \
-		--no-site-packages \
-		--cache-dir=/dev/null
+	mypy . --cache-dir=/dev/null
 
 .PHONY : test
 test :

--- a/allennlp/__main__.py
+++ b/allennlp/__main__.py
@@ -6,7 +6,7 @@ import sys
 if os.environ.get("ALLENNLP_DEBUG"):
     LEVEL = logging.DEBUG
 else:
-    level_name = os.environ.get("ALLENNLP_LOG_LEVEL")
+    level_name = os.environ.get("ALLENNLP_LOG_LEVEL", "INFO")
     LEVEL = logging._nameToLevel.get(level_name, logging.INFO)
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir))))

--- a/allennlp/commands/predict.py
+++ b/allennlp/commands/predict.py
@@ -128,16 +128,10 @@ class _PredictManager:
 
         self._predictor = predictor
         self._input_file = input_file
-        if output_file is not None:
-            self._output_file = open(output_file, "w")
-        else:
-            self._output_file = None
+        self._output_file = None if output_file is None else open(output_file, "w")
         self._batch_size = batch_size
         self._print_to_console = print_to_console
-        if has_dataset_reader:
-            self._dataset_reader = predictor._dataset_reader
-        else:
-            self._dataset_reader = None
+        self._dataset_reader = None if not has_dataset_reader else predictor._dataset_reader
 
     def _predict_json(self, batch_data: List[JsonDict]) -> Iterator[str]:
         if len(batch_data) == 1:

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -394,6 +394,8 @@ def _train_worker(
     include_package = include_package or []
 
     if distributed:
+        assert distributed_device_ids is not None
+
         # Since the worker is spawned and not forked, the extra imports need to be done again.
         # Both the ones from the plugins and the ones from `include_package`.
         import_plugins()
@@ -660,6 +662,7 @@ class TrainModel(Registrable):
         if not vocabulary_:
             vocabulary_ = Vocabulary.from_instances(instance_generator)
         model_ = model.construct(vocab=vocabulary_)
+        assert model_ is not None
 
         # Initializing the model can have side effect of expanding the vocabulary.
         # Save the vocab only in the master. In the degenerate non-distributed
@@ -710,6 +713,7 @@ class TrainModel(Registrable):
             data_loader=data_loader_,
             validation_data_loader=validation_data_loader_,
         )
+        assert trainer_ is not None
 
         return cls(
             serialization_dir=serialization_dir,

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -558,7 +558,7 @@ class TrainModel(Registrable):
         model: Lazy[Model],
         data_loader: Lazy[DataLoader],
         trainer: Lazy[Trainer],
-        vocabulary: Lazy[Vocabulary] = None,
+        vocabulary: Lazy[Vocabulary] = Lazy(Vocabulary),
         datasets_for_vocab_creation: List[str] = None,
         validation_dataset_reader: DatasetReader = None,
         validation_data_path: str = None,
@@ -612,7 +612,7 @@ class TrainModel(Registrable):
         trainer: `Lazy[Trainer]`
             The `Trainer` that actually implements the training loop.  This is a lazy object because
             it depends on the model that's going to be trained.
-        vocabulary: `Lazy[Vocabulary]`, optional (default=`None`)
+        vocabulary: `Lazy[Vocabulary]`, optional (default=`Lazy(Vocabulary)`)
             The `Vocabulary` that we will use to convert strings in the data to integer ids (and
             possibly set sizes of embedding matrices in the `Model`).  By default we construct the
             vocabulary from the instances that we read.
@@ -666,11 +666,8 @@ class TrainModel(Registrable):
         )
 
         vocabulary_ = vocabulary.construct(instances=instance_generator)
-        if not vocabulary_:
-            vocabulary_ = Vocabulary.from_instances(instance_generator)
 
         model_ = model.construct(vocab=vocabulary_, serialization_dir=serialization_dir)
-        assert model_ is not None
 
         # Initializing the model can have side effect of expanding the vocabulary.
         # Save the vocab only in the master. In the degenerate non-distributed
@@ -686,13 +683,9 @@ class TrainModel(Registrable):
 
         data_loader_ = data_loader.construct(dataset=datasets["train"])
         validation_data = datasets.get("validation")
+        validation_data_loader_: Optional[DataLoader] = None
         if validation_data is not None:
-            # Because of the way Lazy[T] works, we can't check it's existence
-            # _before_ we've tried to construct it. It returns None if it is not
-            # present, so we try to construct it first, and then afterward back off
-            # to the data_loader configuration used for training if it returns None.
-            validation_data_loader_ = validation_data_loader.construct(dataset=validation_data)
-            if validation_data_loader_ is None:
+            if validation_data_loader is None:
                 validation_data_loader_ = data_loader.construct(dataset=validation_data)
                 if getattr(validation_data_loader_, "_batches_per_epoch", None) is not None:
                     warnings.warn(
@@ -702,16 +695,16 @@ class TrainModel(Registrable):
                         "validation datasets for each epoch.",
                         UserWarning,
                     )
-        else:
-            validation_data_loader_ = None
+            else:
+                validation_data_loader_ = validation_data_loader.construct(dataset=validation_data)
 
         test_data = datasets.get("test")
+        test_data_loader: Optional[DataLoader] = None
         if test_data is not None:
-            test_data_loader = validation_data_loader.construct(dataset=test_data)
-            if test_data_loader is None:
+            if validation_data_loader is None:
                 test_data_loader = data_loader.construct(dataset=test_data)
-        else:
-            test_data_loader = None
+            else:
+                test_data_loader = validation_data_loader.construct(dataset=test_data)
 
         # We don't need to pass serialization_dir and local_rank here, because they will have been
         # passed through the trainer by from_params already, because they were keyword arguments to

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -445,7 +445,7 @@ class _Meta:
     The unix timestamp of when the corresponding resource was cached or extracted.
     """
 
-    size: int = None
+    size: int = 0
     """
     The size of the corresponding resource, in bytes.
     """

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -112,7 +112,9 @@ def remove_optional(annotation: type):
         return annotation
 
 
-def infer_params(cls: Type[T], constructor: Callable[..., T] = None) -> Dict[str, Any]:
+def infer_params(
+    cls: Type[T], constructor: Union[Callable[..., T], Callable[[T], None]] = None
+) -> Dict[str, Any]:
     if constructor is None:
         constructor = cls.__init__
 
@@ -509,7 +511,7 @@ class FromParams:
         cls: Type[T],
         params: Params,
         constructor_to_call: Callable[..., T] = None,
-        constructor_to_inspect: Callable[..., T] = None,
+        constructor_to_inspect: Union[Callable[..., T], Callable[[T], None]] = None,
         **extras,
     ) -> T:
         """
@@ -584,7 +586,7 @@ class FromParams:
                 constructor_to_inspect = subclass.__init__
                 constructor_to_call = subclass  # type: ignore
             else:
-                constructor_to_inspect = getattr(subclass, constructor_name)
+                constructor_to_inspect = cast(Callable[..., T], getattr(subclass, constructor_name))
                 constructor_to_call = constructor_to_inspect
 
             if hasattr(subclass, "from_params"):
@@ -623,6 +625,7 @@ class FromParams:
                 params.assert_empty(cls.__name__)
             else:
                 # This class has a constructor, so create kwargs for it.
+                constructor_to_inspect = cast(Callable[..., T], constructor_to_inspect)
                 kwargs = create_kwargs(constructor_to_inspect, cls, params, **extras)
 
             return constructor_to_call(**kwargs)  # type: ignore

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -300,9 +300,6 @@ def pop_and_construct_arg(
 
     popped_params = params.pop(name, default) if default != _NO_DEFAULT else params.pop(name)
     if popped_params is None:
-        origin = getattr(annotation, "__origin__", None)
-        if origin == Lazy:
-            return Lazy(lambda **kwargs: None)
         return None
 
     return construct_arg(class_name, name, popped_params, annotation, default, **extras)
@@ -452,7 +449,8 @@ def construct_arg(
         )
     elif origin == Lazy:
         if popped_params is default:
-            return Lazy(lambda **kwargs: default)
+            return default
+
         value_cls = args[0]
         subextras = create_extras(value_cls, extras)
 

--- a/allennlp/common/lazy.py
+++ b/allennlp/common/lazy.py
@@ -1,4 +1,4 @@
-from typing import Callable, Generic, TypeVar, Optional
+from typing import Callable, Generic, TypeVar, Optional, Type, Union
 
 T = TypeVar("T")
 
@@ -39,8 +39,8 @@ class Lazy(Generic[T]):
 
     """
 
-    def __init__(self, constructor: Callable[..., T]):
+    def __init__(self, constructor: Union[Type[T], Callable[..., Optional[T]]]):
         self._constructor = constructor
 
     def construct(self, **kwargs) -> Optional[T]:
-        return self._constructor(**kwargs)
+        return self._constructor(**kwargs)  # type: ignore[call-arg]

--- a/allennlp/common/lazy.py
+++ b/allennlp/common/lazy.py
@@ -1,4 +1,8 @@
-from typing import Callable, Generic, TypeVar, Optional, Type, Union
+import inspect
+from typing import Callable, Generic, TypeVar, Type, Union
+
+from allennlp.common.params import Params
+
 
 T = TypeVar("T")
 
@@ -6,9 +10,10 @@ T = TypeVar("T")
 class Lazy(Generic[T]):
     """
     This class is for use when constructing objects using `FromParams`, when an argument to a
-    constructor has a _sequential dependency_ with another argument to the same constructor.  For
-    example, in a `Trainer` class you might want to take a `Model` and an `Optimizer` as arguments,
-    but the `Optimizer` needs to be constructed using the parameters from the `Model`.  You can give
+    constructor has a _sequential dependency_ with another argument to the same constructor.
+
+    For example, in a `Trainer` class you might want to take a `Model` and an `Optimizer` as arguments,
+    but the `Optimizer` needs to be constructed using the parameters from the `Model`. You can give
     the type annotation `Lazy[Optimizer]` to the optimizer argument, then inside the constructor
     call `optimizer.construct(parameters=model.parameters)`.
 
@@ -21,26 +26,33 @@ class Lazy(Generic[T]):
     construction is actually found in `FromParams`, where we have a special case for a `Lazy` type
     annotation.
 
-    !!! Warning
-        The way this class is used in from_params means that optional constructor arguments CANNOT
-        be compared to `None` _before_ it is constructed. See the example below for correct usage.
-
-    ```
+    ```python
     @classmethod
-    def my_constructor(cls, some_object: Lazy[MyObject] = None) -> MyClass:
-        ...
-        # WRONG! some_object will never be None at this point, it will be
-        # a Lazy[] that returns None
-        obj = some_object or MyObjectDefault()
-        # CORRECT:
-        obj = some_object.construct(kwarg=kwarg) or MyObjectDefault()
-        ...
+    def my_constructor(
+        cls,
+        some_object: Lazy[MyObject],
+        optional_object: Lazy[MyObject] = None,
+        required_object_with_default: Lazy[MyObject] = Lazy(MyObjectDefault),
+    ) -> MyClass:
+        obj1 = some_object.construct()
+        obj2 = None if optional_object is None else optional_object.construct()
+        obj3 = required_object_with_default.construct()
     ```
 
     """
 
-    def __init__(self, constructor: Union[Type[T], Callable[..., Optional[T]]]):
-        self._constructor = constructor
+    def __init__(self, constructor: Union[Type[T], Callable[..., T]]):
+        constructor_to_use: Callable[..., T]
 
-    def construct(self, **kwargs) -> Optional[T]:
-        return self._constructor(**kwargs)  # type: ignore[call-arg]
+        if inspect.isclass(constructor):
+
+            def constructor_to_use(**kwargs):
+                return constructor.from_params(Params({}), **kwargs)  # type: ignore[union-attr]
+
+        else:
+            constructor_to_use = constructor
+
+        self._constructor = constructor_to_use
+
+    def construct(self, **kwargs) -> T:
+        return self._constructor(**kwargs)

--- a/allennlp/common/logging.py
+++ b/allennlp/common/logging.py
@@ -99,7 +99,7 @@ def prepare_global_logging(
     if os.environ.get("ALLENNLP_DEBUG"):
         LEVEL = logging.DEBUG
     else:
-        level_name = os.environ.get("ALLENNLP_LOG_LEVEL")
+        level_name = os.environ.get("ALLENNLP_LOG_LEVEL", "INFO")
         LEVEL = logging._nameToLevel.get(level_name, logging.INFO)
 
     file_handler.setLevel(LEVEL)

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -6,7 +6,7 @@ import zlib
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from os import PathLike
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Optional
 
 from overrides import overrides
 
@@ -250,7 +250,7 @@ class Params(MutableMapping):
         else:
             return self._check_is_dict(key, value)
 
-    def pop_int(self, key: str, default: Any = DEFAULT) -> int:
+    def pop_int(self, key: str, default: Any = DEFAULT) -> Optional[int]:
         """
         Performs a pop and coerces to an int.
         """
@@ -260,7 +260,7 @@ class Params(MutableMapping):
         else:
             return int(value)
 
-    def pop_float(self, key: str, default: Any = DEFAULT) -> float:
+    def pop_float(self, key: str, default: Any = DEFAULT) -> Optional[float]:
         """
         Performs a pop and coerces to a float.
         """
@@ -270,7 +270,7 @@ class Params(MutableMapping):
         else:
             return float(value)
 
-    def pop_bool(self, key: str, default: Any = DEFAULT) -> bool:
+    def pop_bool(self, key: str, default: Any = DEFAULT) -> Optional[bool]:
         """
         Performs a pop and coerces to a bool.
         """

--- a/allennlp/common/registrable.py
+++ b/allennlp/common/registrable.py
@@ -38,8 +38,8 @@ class Registrable(FromParams):
     a subclass to load all other subclasses and the abstract class).
     """
 
-    _registry: Dict[Type, Dict[str, Tuple[Type, str]]] = defaultdict(dict)
-    default_implementation: str = None
+    _registry: Dict[Type, Dict[str, Tuple[Type, Optional[str]]]] = defaultdict(dict)
+    default_implementation: Optional[str] = None
 
     @classmethod
     def register(cls: Type[T], name: str, constructor: str = None, exist_ok: bool = False):
@@ -152,7 +152,7 @@ class Registrable(FromParams):
         function to use).
         """
         if name in Registrable._registry[cls]:
-            subclass, constructor = Registrable._registry[cls].get(name)
+            subclass, constructor = Registrable._registry[cls][name]
             return subclass, constructor
         elif "." in name:
             # This might be a fully qualified class name, so we'll try importing its "module"

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -96,6 +96,7 @@ class ModelTestCase(AllenNlpTestCase):
         save_dir = self.TEST_DIR / "save_and_load_test"
         archive_file = save_dir / "model.tar.gz"
         model = train_model_from_file(param_file, save_dir, overrides=overrides)
+        assert model is not None
         metrics_file = save_dir / "metrics.json"
         if metric_to_check is not None:
             metrics = json.loads(metrics_file.read_text())

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -40,7 +40,7 @@ try:
     import resource
 except ImportError:
     # resource doesn't exist on Windows systems
-    resource = None
+    resource = None  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/allennlp/data/dataloader.py
+++ b/allennlp/data/dataloader.py
@@ -137,15 +137,10 @@ class PyTorchDataLoader(data.DataLoader, DataLoader):
         multiprocessing_context: str = None,
         batches_per_epoch: int = None,
     ) -> "PyTorchDataLoader":
-
-        if batch_sampler is not None:
-            batch_sampler_ = batch_sampler.construct(data_source=dataset)
-        else:
-            batch_sampler_ = None
-        if sampler is not None:
-            sampler_ = sampler.construct(data_source=dataset)
-        else:
-            sampler_ = None
+        batch_sampler_ = (
+            None if batch_sampler is None else batch_sampler.construct(data_source=dataset)
+        )
+        sampler_ = None if sampler is None else sampler.construct(data_source=dataset)
 
         return cls(
             dataset=dataset,

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -261,6 +261,7 @@ class DatasetReader(Registrable):
             return AllennlpDataset(instances)
 
     def _get_cache_location_for_file_path(self, file_path: str) -> str:
+        assert self._cache_directory is not None
         return str(self._cache_directory / util.flatten_filename(str(file_path)))
 
     def _read(self, file_path: str) -> Iterable[Instance]:

--- a/allennlp/data/fields/adjacency_field.py
+++ b/allennlp/data/fields/adjacency_field.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set, Tuple, Optional
 import logging
 import textwrap
 
@@ -68,7 +68,7 @@ class AdjacencyField(Field[torch.Tensor]):
         self.sequence_field = sequence_field
         self._label_namespace = label_namespace
         self._padding_value = padding_value
-        self._indexed_labels: List[int] = None
+        self._indexed_labels: Optional[List[int]] = None
 
         self._maybe_warn_for_namespace(label_namespace)
         field_length = sequence_field.sequence_length()

--- a/allennlp/data/fields/namespace_swapping_field.py
+++ b/allennlp/data/fields/namespace_swapping_field.py
@@ -28,12 +28,13 @@ class NamespaceSwappingField(Field[torch.Tensor]):
     def __init__(self, source_tokens: List[Token], target_namespace: str) -> None:
         self._source_tokens = source_tokens
         self._target_namespace = target_namespace
-        self._mapping_array: List[int] = None
+        self._mapping_array: List[int] = []
 
     @overrides
     def index(self, vocab: Vocabulary):
         self._mapping_array = [
-            vocab.get_token_index(x.text, self._target_namespace) for x in self._source_tokens
+            vocab.get_token_index(x.ensure_text(), self._target_namespace)
+            for x in self._source_tokens
         ]
 
     @overrides

--- a/allennlp/data/fields/sequence_label_field.py
+++ b/allennlp/data/fields/sequence_label_field.py
@@ -124,6 +124,10 @@ class SequenceLabelField(Field[torch.Tensor]):
 
     @overrides
     def as_tensor(self, padding_lengths: Dict[str, int]) -> torch.Tensor:
+        if self._indexed_labels is None:
+            raise ConfigurationError(
+                "You must call .index(vocabulary) on a field before calling .as_tensor()"
+            )
         desired_num_tokens = padding_lengths["num_tokens"]
         padded_tags = pad_sequence_to_length(self._indexed_labels, desired_num_tokens)
         tensor = torch.LongTensor(padded_tags)

--- a/allennlp/data/fields/text_field.py
+++ b/allennlp/data/fields/text_field.py
@@ -92,6 +92,11 @@ class TextField(SequenceField[TextFieldTensors]):
 
     @overrides
     def as_tensor(self, padding_lengths: Dict[str, int]) -> TextFieldTensors:
+        if self._indexed_tokens is None:
+            raise ConfigurationError(
+                "You must call .index(vocabulary) on a field before calling .as_tensor()"
+            )
+
         tensors = {}
 
         indexer_lengths: Dict[str, Dict[str, int]] = defaultdict(dict)

--- a/allennlp/data/instance.py
+++ b/allennlp/data/instance.py
@@ -48,8 +48,7 @@ class Instance(Mapping[str, Field]):
         it is necessary to supply the vocab.
         """
         self.fields[field_name] = field
-        if self.indexed:
-            assert vocab is not None
+        if self.indexed and vocab is not None:
             field.index(vocab)
 
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/data/instance.py
+++ b/allennlp/data/instance.py
@@ -49,6 +49,7 @@ class Instance(Mapping[str, Field]):
         """
         self.fields[field_name] = field
         if self.indexed:
+            assert vocab is not None
             field.index(vocab)
 
     def count_vocab_items(self, counter: Dict[str, Dict[str, int]]):

--- a/allennlp/data/samplers/bucket_batch_sampler.py
+++ b/allennlp/data/samplers/bucket_batch_sampler.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Iterable, Tuple
+from typing import List, Iterable, Tuple, Optional
 import random
 import math
 
@@ -98,7 +98,7 @@ class BucketBatchSampler(BatchSampler):
             # Make sure instance is indexed before calling .get_padding
             lengths = []
             noisy_lengths = []
-            for field_name in self.sorting_keys:
+            for field_name in self.sorting_keys:  # type: ignore
                 if field_name not in instance.fields:
                     raise ConfigurationError(
                         f'Sorting key "{field_name}" is not a field in instance. '
@@ -142,7 +142,7 @@ class BucketBatchSampler(BatchSampler):
             are not homogeneous, you might need more.
         """
         max_length = 0.0
-        longest_field: str = None
+        longest_field: Optional[str] = None
         for i, instance in enumerate(instances):
             instance.index_fields(self.vocab)
             for field_name, field in instance.fields.items():

--- a/allennlp/data/samplers/max_tokens_batch_sampler.py
+++ b/allennlp/data/samplers/max_tokens_batch_sampler.py
@@ -1,6 +1,6 @@
 import logging
 import random
-from typing import List, Iterable, Optional, Iterator, TypeVar
+from typing import List, Iterable, Iterator, TypeVar
 
 from allennlp.data.samplers import BatchSampler, BucketBatchSampler
 from torch.utils import data
@@ -54,7 +54,7 @@ class MaxTokensBatchSampler(BucketBatchSampler):
     def __init__(
         self,
         data_source: data.Dataset,
-        max_tokens: Optional[int] = None,
+        max_tokens: int,
         sorting_keys: List[str] = None,
         padding_noise: float = 0.1,
     ):

--- a/allennlp/data/token_indexers/elmo_indexer.py
+++ b/allennlp/data/token_indexers/elmo_indexer.py
@@ -3,7 +3,6 @@ from typing import Dict, List
 from overrides import overrides
 import torch
 
-from allennlp.common.checks import ConfigurationError
 from allennlp.common.util import pad_sequence_to_length
 from allennlp.data.tokenizers.token import Token
 from allennlp.data.token_indexers.token_indexer import TokenIndexer, IndexedTokenList
@@ -138,13 +137,9 @@ class ELMoTokenCharactersIndexer(TokenIndexer):
 
         # https://github.com/allenai/allennlp/blob/master/allennlp/data/token_indexers/wordpiece_indexer.py#L113
 
-        texts = [token.text for token in tokens]
-
-        if any(text is None for text in texts):
-            raise ConfigurationError(
-                "ELMoTokenCharactersIndexer needs a tokenizer that retains text"
-            )
-        return {"elmo_tokens": [self._mapper.convert_word_to_char_ids(text) for text in texts]}
+        return {
+            "elmo_tokens": [self._mapper.convert_word_to_char_ids(t.ensure_text()) for t in tokens]
+        }
 
     @overrides
     def as_padded_tensor_dict(

--- a/allennlp/data/token_indexers/pretrained_transformer_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_indexer.py
@@ -108,7 +108,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
         output: IndexedTokenList = {
             "token_ids": indices,
             "mask": [True] * len(indices),
-            "type_ids": type_ids,
+            "type_ids": type_ids or [0] * len(indices),
         }
 
         return self._postprocess_output(output)
@@ -141,7 +141,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
         indices: List[int] = []
         type_ids: List[int] = []
         for token in tokens:
-            if getattr(token, "text_id", None) is not None:
+            if token.text_id is not None:
                 # `text_id` being set on the token means that we aren't using the vocab, we just use
                 # this id instead. Id comes from the pretrained vocab.
                 # It is computed in PretrainedTransformerTokenizer.
@@ -152,7 +152,7 @@ class PretrainedTransformerIndexer(TokenIndexer):
                     f" for the following token: {token.text}"
                 )
 
-            if type_ids is not None and getattr(token, "type_id", None) is not None:
+            if type_ids is not None and token.type_id is not None:
                 type_ids.append(token.type_id)
             else:
                 type_ids.append(0)

--- a/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
+++ b/allennlp/data/token_indexers/pretrained_transformer_mismatched_indexer.py
@@ -75,7 +75,9 @@ class PretrainedTransformerMismatchedIndexer(TokenIndexer):
     def tokens_to_indices(self, tokens: List[Token], vocabulary: Vocabulary) -> IndexedTokenList:
         self._matched_indexer._add_encoding_to_vocabulary_if_needed(vocabulary)
 
-        wordpieces, offsets = self._allennlp_tokenizer.intra_word_tokenize([t.text for t in tokens])
+        wordpieces, offsets = self._allennlp_tokenizer.intra_word_tokenize(
+            [t.ensure_text() for t in tokens]
+        )
 
         # For tokens that don't correspond to any word pieces, we put (-1, -1) into the offsets.
         # That results in the embedding for the token to be all zeros.

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -109,7 +109,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         from allennlp.common import cached_transformers
 
         tokenizer_with_special_tokens = cached_transformers.get_tokenizer(
-            model_name, add_special_tokens=True, **tokenizer_kwargs
+            model_name, add_special_tokens=True, **(tokenizer_kwargs or {})
         )
         dummy_output = tokenizer_with_special_tokens.encode_plus(
             token_a,
@@ -383,7 +383,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
     def intra_word_tokenize_sentence_pair(
         self, string_tokens_a: List[str], string_tokens_b: List[str]
-    ) -> Tuple[List[Token], List[Tuple[int, int]], List[Tuple[int, int]]]:
+    ) -> Tuple[List[Token], List[Optional[Tuple[int, int]]], List[Optional[Tuple[int, int]]]]:
         """
         Tokenizes each word into wordpieces separately and returns the wordpiece IDs.
         Also calculates offsets such that wordpieces[offsets[i][0]:offsets[i][1] + 1]
@@ -421,15 +421,15 @@ class PretrainedTransformerTokenizer(Tokenizer):
         if tokens2 is None:
             return (
                 self.single_sequence_start_tokens
-                + with_new_type_id(tokens1, self.single_sequence_token_type_id)
+                + with_new_type_id(tokens1, self.single_sequence_token_type_id)  # type: ignore
                 + self.single_sequence_end_tokens
             )
         else:
             return (
                 self.sequence_pair_start_tokens
-                + with_new_type_id(tokens1, self.sequence_pair_first_token_type_id)
+                + with_new_type_id(tokens1, self.sequence_pair_first_token_type_id)  # type: ignore
                 + self.sequence_pair_mid_tokens
-                + with_new_type_id(tokens2, self.sequence_pair_second_token_type_id)
+                + with_new_type_id(tokens2, self.sequence_pair_second_token_type_id)  # type: ignore
                 + self.sequence_pair_end_tokens
             )
 

--- a/allennlp/data/tokenizers/token.py
+++ b/allennlp/data/tokenizers/token.py
@@ -101,6 +101,15 @@ class Token:
     def __repr__(self):
         return self.__str__()
 
+    def ensure_text(self) -> str:
+        """
+        Return the `text` field, raising an exception if it's `None`.
+        """
+        if self.text is None:
+            raise ValueError("Unexpected null text for token")
+        else:
+            return self.text
+
 
 def show_token(token: Token) -> str:
     return (

--- a/allennlp/data/vocabulary.py
+++ b/allennlp/data/vocabulary.py
@@ -548,6 +548,7 @@ class Vocabulary(Registrable):
         self._non_padded_namespaces.update(non_padded_namespaces)
 
         for namespace in counter:
+            pretrained_set: Optional[Set] = None
             if namespace in pretrained_files:
                 pretrained_list = _read_pretrained_tokens(pretrained_files[namespace])
                 min_embeddings = min_pretrained_embeddings.get(namespace, 0)
@@ -556,10 +557,9 @@ class Vocabulary(Registrable):
                     tokens_new = pretrained_list[:min_embeddings]
                     tokens_to_add[namespace] = tokens_old + tokens_new
                 pretrained_set = set(pretrained_list)
-            else:
-                pretrained_set = None
             token_counts = list(counter[namespace].items())
             token_counts.sort(key=lambda x: x[1], reverse=True)
+            max_vocab: Optional[int]
             try:
                 max_vocab = max_vocab_size[namespace]
             except KeyError:

--- a/allennlp/interpret/attackers/input_reduction.py
+++ b/allennlp/interpret/attackers/input_reduction.py
@@ -33,7 +33,7 @@ class InputReduction(Attacker):
 
     def attack_from_json(
         self,
-        inputs: JsonDict = None,
+        inputs: JsonDict,
         input_field_to_attack: str = "tokens",
         grad_input_field: str = "grad_input_1",
         ignore_tokens: List[str] = None,
@@ -117,9 +117,9 @@ class InputReduction(Attacker):
                 else:
                     # remove the mask where you remove the input token from.
                     if smallest_idx != -1:  # Don't delete on the very first iteration
-                        del beam_tag_mask[smallest_idx]
+                        del beam_tag_mask[smallest_idx]  # type: ignore
                     cur_tags = [
-                        outputs["tags"][x] for x in range(len(outputs["tags"])) if beam_tag_mask[x]
+                        outputs["tags"][x] for x in range(len(outputs["tags"])) if beam_tag_mask[x]  # type: ignore
                     ]
                     if cur_tags != original_tags:
                         continue
@@ -133,7 +133,7 @@ class InputReduction(Attacker):
                     grads[grad_input_field][0],
                     ignore_tokens,
                     self.beam_size,
-                    beam_tag_mask,
+                    beam_tag_mask,  # type: ignore
                 )
                 candidates.extend(reduced_instances_and_smallest)
         return current_tokens

--- a/allennlp/models/basic_classifier.py
+++ b/allennlp/models/basic_classifier.py
@@ -64,16 +64,11 @@ class BasicClassifier(Model):
 
         super().__init__(vocab, **kwargs)
         self._text_field_embedder = text_field_embedder
-
-        if seq2seq_encoder:
-            self._seq2seq_encoder = seq2seq_encoder
-        else:
-            self._seq2seq_encoder = None
-
+        self._seq2seq_encoder = seq2seq_encoder
         self._seq2vec_encoder = seq2vec_encoder
         self._feedforward = feedforward
         if feedforward is not None:
-            self._classifier_input_dim = self._feedforward.get_output_dim()
+            self._classifier_input_dim = feedforward.get_output_dim()
         else:
             self._classifier_input_dim = self._seq2vec_encoder.get_output_dim()
 

--- a/allennlp/models/simple_tagger.py
+++ b/allennlp/models/simple_tagger.py
@@ -94,6 +94,7 @@ class SimpleTagger(Model):
             calculate_span_f1 = label_encoding is not None
 
         self.calculate_span_f1 = calculate_span_f1
+        self._f1_metric: Optional[SpanBasedF1Measure] = None
         if calculate_span_f1:
             if not label_encoding:
                 raise ConfigurationError(
@@ -102,8 +103,6 @@ class SimpleTagger(Model):
             self._f1_metric = SpanBasedF1Measure(
                 vocab, tag_namespace=label_namespace, label_encoding=label_encoding
             )
-        else:
-            self._f1_metric = None
 
         initializer(self)
 
@@ -174,7 +173,7 @@ class SimpleTagger(Model):
             for metric in self.metrics.values():
                 metric(logits, tags, mask)
             if self.calculate_span_f1:
-                self._f1_metric(logits, tags, mask)
+                self._f1_metric(logits, tags, mask)  # type: ignore
             output_dict["loss"] = loss
 
         if metadata is not None:
@@ -213,7 +212,7 @@ class SimpleTagger(Model):
         }
 
         if self.calculate_span_f1:
-            f1_dict = self._f1_metric.get_metric(reset)
+            f1_dict = self._f1_metric.get_metric(reset)  # type: ignore
             if self._verbose_metrics:
                 metrics_to_return.update(f1_dict)
             else:

--- a/allennlp/modules/augmented_lstm.py
+++ b/allennlp/modules/augmented_lstm.py
@@ -139,7 +139,7 @@ class AugmentedLSTMCell(torch.nn.Module):
             ]
             timestep_output = (
                 highway_gate * timestep_output
-                + (1 - highway_gate) * highway_input_projection  # noqa
+                + (1 - highway_gate) * highway_input_projection  # type: ignore
             )
 
         return timestep_output, memory

--- a/allennlp/modules/elmo.py
+++ b/allennlp/modules/elmo.py
@@ -113,7 +113,7 @@ class Elmo(torch.nn.Module, FromParams):
                 raise ConfigurationError("Don't provide options_file or weight_file with module")
             self._elmo_lstm = module
         else:
-            self._elmo_lstm = _ElmoBiLm(
+            self._elmo_lstm = _ElmoBiLm(  # type: ignore
                 options_file,
                 weight_file,
                 requires_grad=requires_grad,
@@ -125,7 +125,7 @@ class Elmo(torch.nn.Module, FromParams):
         self._scalar_mixes: Any = []
         for k in range(num_output_representations):
             scalar_mix = ScalarMix(
-                self._elmo_lstm.num_layers,
+                self._elmo_lstm.num_layers,  # type: ignore
                 do_layer_norm=do_layer_norm,
                 initial_scalar_parameters=scalar_mix_parameters,
                 trainable=scalar_mix_parameters is None,
@@ -181,7 +181,7 @@ class Elmo(torch.nn.Module, FromParams):
             reshaped_word_inputs = word_inputs
 
         # run the biLM
-        bilm_output = self._elmo_lstm(reshaped_inputs, reshaped_word_inputs)
+        bilm_output = self._elmo_lstm(reshaped_inputs, reshaped_word_inputs)  # type: ignore
         layer_activations = bilm_output["activations"]
         mask_with_bos_eos = bilm_output["mask"]
 

--- a/allennlp/modules/elmo_lstm.py
+++ b/allennlp/modules/elmo_lstm.py
@@ -2,7 +2,7 @@
 A stacked bidirectional LSTM with skip connections between layers.
 """
 import warnings
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Any
 
 import numpy
 import torch
@@ -216,14 +216,13 @@ class ElmoLstm(_EncoderBase):
             forward_cache = forward_output_sequence
             backward_cache = backward_output_sequence
 
+            forward_state: Optional[Tuple[Any, Any]] = None
+            backward_state: Optional[Tuple[Any, Any]] = None
             if state is not None:
                 forward_hidden_state, backward_hidden_state = state[0].split(self.hidden_size, 2)
                 forward_memory_state, backward_memory_state = state[1].split(self.cell_size, 2)
                 forward_state = (forward_hidden_state, forward_memory_state)
                 backward_state = (backward_hidden_state, backward_memory_state)
-            else:
-                forward_state = None
-                backward_state = None
 
             forward_output_sequence, forward_state = forward_layer(
                 forward_output_sequence, batch_lengths, forward_state
@@ -243,8 +242,8 @@ class ElmoLstm(_EncoderBase):
             # the final states for all the layers.
             final_states.append(
                 (
-                    torch.cat([forward_state[0], backward_state[0]], -1),
-                    torch.cat([forward_state[1], backward_state[1]], -1),
+                    torch.cat([forward_state[0], backward_state[0]], -1),  # type: ignore
+                    torch.cat([forward_state[1], backward_state[1]], -1),  # type: ignore
                 )
             )
 

--- a/allennlp/modules/encoder_base.py
+++ b/allennlp/modules/encoder_base.py
@@ -315,6 +315,7 @@ class _EncoderBase(torch.nn.Module):
             mask_batch_size = mask.size(0)
             mask = mask.view(1, mask_batch_size, 1)
             new_states = []
+            assert self._states is not None
             for old_state in self._states:
                 old_state_batch_size = old_state.size(1)
                 if old_state_batch_size != mask_batch_size:

--- a/allennlp/modules/scalar_mix.py
+++ b/allennlp/modules/scalar_mix.py
@@ -83,6 +83,7 @@ class ScalarMix(torch.nn.Module):
             return self.gamma * sum(pieces)
 
         else:
+            assert mask is not None
             broadcast_mask = mask.unsqueeze(-1)
             input_dim = tensors[0].size(-1)
             num_elements_not_masked = torch.sum(mask) * input_dim

--- a/allennlp/modules/seq2vec_encoders/cls_pooler.py
+++ b/allennlp/modules/seq2vec_encoders/cls_pooler.py
@@ -16,7 +16,7 @@ class ClsPooler(Seq2VecEncoder):
 
     # Parameters
 
-    embedding_dim: `int`, optional
+    embedding_dim: `int`
         This isn't needed for any computation that we do, but we sometimes rely on `get_input_dim`
         and `get_output_dim` to check parameter settings, or to instantiate final linear layers.  In
         order to give the right values there, we need to know the embedding dimension.  If you're
@@ -28,7 +28,7 @@ class ClsPooler(Seq2VecEncoder):
         select at the end.
     """
 
-    def __init__(self, embedding_dim: int = None, cls_is_last_token: bool = False):
+    def __init__(self, embedding_dim: int, cls_is_last_token: bool = False):
         super().__init__()
         self._embedding_dim = embedding_dim
         self._cls_is_last_token = cls_is_last_token

--- a/allennlp/modules/seq2vec_encoders/cnn_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/cnn_encoder.py
@@ -63,7 +63,6 @@ class CnnEncoder(Seq2VecEncoder):
         self._num_filters = num_filters
         self._ngram_filter_sizes = ngram_filter_sizes
         self._activation = conv_layer_activation or Activation.by_name("relu")()
-        self._output_dim = output_dim
 
         self._convolution_layers = [
             Conv1d(
@@ -77,8 +76,9 @@ class CnnEncoder(Seq2VecEncoder):
             self.add_module("conv_layer_%d" % i, conv_layer)
 
         maxpool_output_dim = self._num_filters * len(self._ngram_filter_sizes)
-        if self._output_dim:
-            self.projection_layer = Linear(maxpool_output_dim, self._output_dim)
+        if output_dim:
+            self.projection_layer = Linear(maxpool_output_dim, output_dim)
+            self._output_dim = output_dim
         else:
             self.projection_layer = None
             self._output_dim = maxpool_output_dim

--- a/allennlp/modules/span_extractors/bidirectional_endpoint_span_extractor.py
+++ b/allennlp/modules/span_extractors/bidirectional_endpoint_span_extractor.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 from overrides import overrides
 from torch.nn.parameter import Parameter
@@ -90,6 +92,8 @@ class BidirectionalEndpointSpanExtractor(SpanExtractor):
                 "BidirectionalEndpointSpanExtractor assumes the embedded representation "
                 "is bidirectional (and hence divisible by 2)."
             )
+
+        self._span_width_embedding: Optional[Embedding] = None
         if num_width_embeddings is not None and span_width_embedding_dim is not None:
             self._span_width_embedding = Embedding(
                 num_embeddings=num_width_embeddings, embedding_dim=span_width_embedding_dim
@@ -99,8 +103,6 @@ class BidirectionalEndpointSpanExtractor(SpanExtractor):
                 "To use a span width embedding representation, you must"
                 "specify both num_width_buckets and span_width_embedding_dim."
             )
-        else:
-            self._span_width_embedding = None
 
         self._use_sentinels = use_sentinels
         if use_sentinels:
@@ -240,7 +242,7 @@ class BidirectionalEndpointSpanExtractor(SpanExtractor):
             # Embed the span widths and concatenate to the rest of the representations.
             if self._bucket_widths:
                 span_widths = util.bucket_values(
-                    span_ends - span_starts, num_total_buckets=self._num_width_embeddings
+                    span_ends - span_starts, num_total_buckets=self._num_width_embeddings  # type: ignore
                 )
             else:
                 span_widths = span_ends - span_starts

--- a/allennlp/modules/span_extractors/endpoint_span_extractor.py
+++ b/allennlp/modules/span_extractors/endpoint_span_extractor.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 from torch.nn.parameter import Parameter
 from overrides import overrides
@@ -5,7 +7,6 @@ from overrides import overrides
 from allennlp.modules.span_extractors.span_extractor import SpanExtractor
 from allennlp.modules.token_embedders.embedding import Embedding
 from allennlp.nn import util
-
 from allennlp.common.checks import ConfigurationError
 
 
@@ -70,6 +71,7 @@ class EndpointSpanExtractor(SpanExtractor):
         if use_exclusive_start_indices:
             self._start_sentinel = Parameter(torch.randn([1, 1, int(input_dim)]))
 
+        self._span_width_embedding: Optional[Embedding] = None
         if num_width_embeddings is not None and span_width_embedding_dim is not None:
             self._span_width_embedding = Embedding(
                 num_embeddings=num_width_embeddings, embedding_dim=span_width_embedding_dim
@@ -79,8 +81,6 @@ class EndpointSpanExtractor(SpanExtractor):
                 "To use a span width embedding representation, you must"
                 "specify both num_width_buckets and span_width_embedding_dim."
             )
-        else:
-            self._span_width_embedding = None
 
     def get_input_dim(self) -> int:
         return self._input_dim
@@ -152,7 +152,7 @@ class EndpointSpanExtractor(SpanExtractor):
             # Embed the span widths and concatenate to the rest of the representations.
             if self._bucket_widths:
                 span_widths = util.bucket_values(
-                    span_ends - span_starts, num_total_buckets=self._num_width_embeddings
+                    span_ends - span_starts, num_total_buckets=self._num_width_embeddings  # type: ignore
                 )
             else:
                 span_widths = span_ends - span_starts

--- a/allennlp/modules/token_embedders/embedding.py
+++ b/allennlp/modules/token_embedders/embedding.py
@@ -114,12 +114,13 @@ class Embedding(TokenEmbedder):
                 "Embedding must be constructed with either num_embeddings or a vocabulary."
             )
 
+        _vocab_namespace: Optional[str] = vocab_namespace
         if num_embeddings is None:
-            num_embeddings = vocab.get_vocab_size(vocab_namespace)
+            num_embeddings = vocab.get_vocab_size(_vocab_namespace)  # type: ignore
         else:
             # If num_embeddings is present, set default namespace to None so that extend_vocab
             # call doesn't misinterpret that some namespace was originally used.
-            vocab_namespace = None
+            _vocab_namespace = None  # type: ignore
 
         self.num_embeddings = num_embeddings
         self.padding_index = padding_index
@@ -127,7 +128,7 @@ class Embedding(TokenEmbedder):
         self.norm_type = norm_type
         self.scale_grad_by_freq = scale_grad_by_freq
         self.sparse = sparse
-        self._vocab_namespace = vocab_namespace
+        self._vocab_namespace = _vocab_namespace
         self._pretrained_file = pretrained_file
 
         self.output_dim = projection_dim or embedding_dim
@@ -152,7 +153,7 @@ class Embedding(TokenEmbedder):
             # extend_vocab method, which relies on the value of vocab_namespace being None
             # to infer at what stage the embedding has been constructed. Phew.
             weight = _read_pretrained_embeddings_file(
-                pretrained_file, embedding_dim, vocab, vocab_namespace or "tokens"
+                pretrained_file, embedding_dim, vocab, vocab_namespace
             )
             self.weight = torch.nn.Parameter(weight, requires_grad=trainable)
 

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -298,7 +298,9 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         # We want to remove all segment-level special tokens but maintain sequence-level ones
         num_wordpieces = num_segment_concat_wordpieces - (num_segments - 1) * self._num_added_tokens
 
-        embeddings = embeddings.reshape(batch_size, num_segments * self._max_length, embedding_size)  # type: ignore
+        embeddings = embeddings.reshape(
+            batch_size, num_segments * self._max_length, embedding_size  # type: ignore
+        )
         mask = mask.reshape(batch_size, num_segments * self._max_length)  # type: ignore
         # We assume that all 1s in the mask precede all 0s, and add an assert for that.
         # Open an issue on GitHub if this breaks for you.

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -170,6 +170,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             )
 
         transformer_mask = segment_concat_mask if self._max_length is not None else mask
+        assert transformer_mask is not None
         # Shape: [batch_size, num_wordpieces, embedding_size],
         # or if self._max_length is not None:
         # [batch_size * num_segments, self._max_length, embedding_size]
@@ -237,8 +238,8 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             Shape: [batch_size * num_segments, self._max_length].
         """
         num_segment_concat_wordpieces = token_ids.size(1)
-        num_segments = math.ceil(num_segment_concat_wordpieces / self._max_length)
-        padded_length = num_segments * self._max_length
+        num_segments = math.ceil(num_segment_concat_wordpieces / self._max_length)  # type: ignore
+        padded_length = num_segments * self._max_length  # type: ignore
         length_to_pad = padded_length - num_segment_concat_wordpieces
 
         def fold(tensor):  # Shape: [batch_size, num_segment_concat_wordpieces]
@@ -297,8 +298,8 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         # We want to remove all segment-level special tokens but maintain sequence-level ones
         num_wordpieces = num_segment_concat_wordpieces - (num_segments - 1) * self._num_added_tokens
 
-        embeddings = embeddings.reshape(batch_size, num_segments * self._max_length, embedding_size)
-        mask = mask.reshape(batch_size, num_segments * self._max_length)
+        embeddings = embeddings.reshape(batch_size, num_segments * self._max_length, embedding_size)  # type: ignore
+        mask = mask.reshape(batch_size, num_segments * self._max_length)  # type: ignore
         # We assume that all 1s in the mask precede all 0s, and add an assert for that.
         # Open an issue on GitHub if this breaks for you.
         # Shape: (batch_size,)

--- a/allennlp/training/checkpointer.py
+++ b/allennlp/training/checkpointer.py
@@ -48,7 +48,7 @@ class Checkpointer(Registrable):
 
     def __init__(
         self,
-        serialization_dir: str = None,
+        serialization_dir: str,
         keep_serialized_model_every_num_seconds: int = None,
         num_serialized_models_to_keep: int = 2,
         model_save_interval: float = None,
@@ -164,7 +164,7 @@ class Checkpointer(Registrable):
         # int (for end of epoch files) or with epoch and timestamp for
         # within epoch checkpoints, e.g. 5.2018-02-02-15-33-42
         found_epochs = [
-            re.search(r"model_state_epoch_([0-9\.\-]+)\.th", x).group(1) for x in model_checkpoints
+            re.search(r"model_state_epoch_([0-9\.\-]+)\.th", x).group(1) for x in model_checkpoints  # type: ignore
         ]
         int_epochs: Any = []
         for epoch in found_epochs:

--- a/allennlp/training/learning_rate_schedulers/linear_with_warmup.py
+++ b/allennlp/training/learning_rate_schedulers/linear_with_warmup.py
@@ -15,7 +15,7 @@ class LinearWithWarmup(PolynomialDecay):
         self,
         optimizer: torch.optim.Optimizer,
         num_epochs: int,
-        num_steps_per_epoch: int = None,
+        num_steps_per_epoch: int,
         warmup_steps: int = 100,
         last_epoch: int = -1,
     ) -> None:

--- a/allennlp/training/metric_tracker.py
+++ b/allennlp/training/metric_tracker.py
@@ -32,22 +32,18 @@ class MetricTracker:
     def __init__(
         self, patience: Optional[int] = None, metric_name: str = None, should_decrease: bool = None
     ) -> None:
-        self._best_so_far: float = None
+        self._best_so_far: Optional[float] = None
         self._patience = patience
         self._epochs_with_no_improvement = 0
         self._is_best_so_far = True
         self.best_epoch_metrics: Dict[str, float] = {}
         self._epoch_number = 0
-        self.best_epoch: int = None
+        self.best_epoch: Optional[int] = None
 
         # If the metric name starts with "+", we want it to increase.
         # If the metric name starts with "-", we want it to decrease.
         # We also allow you to not specify a metric name and just set `should_decrease` directly.
-        if should_decrease is None and metric_name is None:
-            raise ConfigurationError(
-                "must specify either `should_decrease` or `metric_name` (but not both)"
-            )
-        elif should_decrease is not None and metric_name is not None:
+        if should_decrease is not None and metric_name is not None:
             raise ConfigurationError(
                 "must specify either `should_decrease` or `metric_name` (but not both)"
             )
@@ -58,8 +54,12 @@ class MetricTracker:
                 self._should_decrease = False
             else:
                 raise ConfigurationError("metric_name must start with + or -")
-        else:
+        elif should_decrease is not None:
             self._should_decrease = should_decrease
+        else:
+            raise ConfigurationError(
+                "must specify either `should_decrease` or `metric_name` (but not both)"
+            )
 
     def clear(self) -> None:
         """

--- a/allennlp/training/metrics/fbeta_measure.py
+++ b/allennlp/training/metrics/fbeta_measure.py
@@ -199,13 +199,13 @@ class FBetaMeasure(Metric):
         if self._labels is not None:
             # Retain only selected labels and order them
             tp_sum = tp_sum[self._labels]
-            pred_sum = pred_sum[self._labels]
-            true_sum = true_sum[self._labels]
+            pred_sum = pred_sum[self._labels]  # type: ignore
+            true_sum = true_sum[self._labels]  # type: ignore
 
         if self._average == "micro":
             tp_sum = tp_sum.sum()
-            pred_sum = pred_sum.sum()
-            true_sum = true_sum.sum()
+            pred_sum = pred_sum.sum()  # type: ignore
+            true_sum = true_sum.sum()  # type: ignore
 
         beta2 = self._beta ** 2
         # Finally, we have all our sufficient statistics.
@@ -220,7 +220,7 @@ class FBetaMeasure(Metric):
             fscore = fscore.mean()
         elif self._average == "weighted":
             weights = true_sum
-            weights_sum = true_sum.sum()
+            weights_sum = true_sum.sum()  # type: ignore
             precision = _prf_divide((weights * precision).sum(), weights_sum)
             recall = _prf_divide((weights * recall).sum(), weights_sum)
             fscore = _prf_divide((weights * fscore).sum(), weights_sum)

--- a/allennlp/training/metrics/span_based_f1_measure.py
+++ b/allennlp/training/metrics/span_based_f1_measure.py
@@ -171,7 +171,7 @@ class SpanBasedF1Measure(Metric):
                 for label_id in sequence_gold_label[:length].tolist()
             ]
 
-            tags_to_spans_function = None
+            tags_to_spans_function: TAGS_TO_SPANS_FUNCTION_TYPE
             # `label_encoding` is empty and `tags_to_spans_function` is provided.
             if self._label_encoding is None and self._tags_to_spans_function:
                 tags_to_spans_function = self._tags_to_spans_function
@@ -184,6 +184,8 @@ class SpanBasedF1Measure(Metric):
                 tags_to_spans_function = bioul_tags_to_spans
             elif self._label_encoding == "BMES":
                 tags_to_spans_function = bmes_tags_to_spans
+            else:
+                raise ValueError(f"Unexpected label encoding scheme '{self._label_encoding}'")
 
             predicted_spans = tags_to_spans_function(predicted_string_labels, self._ignore_classes)
             gold_spans = tags_to_spans_function(gold_string_labels, self._ignore_classes)

--- a/allennlp/training/no_op_trainer.py
+++ b/allennlp/training/no_op_trainer.py
@@ -26,8 +26,8 @@ class NoOpTrainer(Trainer):
         self.model = model
 
     def train(self) -> Dict[str, Any]:
+        assert self._serialization_dir is not None
         self.model.vocab.save_to_files(os.path.join(self._serialization_dir, "vocabulary"))
-
         checkpointer = Checkpointer(self._serialization_dir)
         checkpointer.save_checkpoint(epoch=0, trainer=self, is_best_so_far=True)
         return {}

--- a/allennlp/training/optimizers.py
+++ b/allennlp/training/optimizers.py
@@ -165,7 +165,7 @@ def make_parameter_groups(
     return parameter_groups
 
 
-class Optimizer(Registrable):
+class Optimizer(torch.optim.Optimizer, Registrable):
     """
     This class just allows us to implement `Registrable` for Pytorch Optimizers.  We do something a
     little bit different with `Optimizers`, because they are implemented as classes in PyTorch, and

--- a/allennlp/training/tensorboard_writer.py
+++ b/allennlp/training/tensorboard_writer.py
@@ -88,7 +88,7 @@ class TensorboardWriter(FromParams):
 
         self._cumulative_batch_group_size = 0
         self._batches_this_epoch = 0
-        self._histogram_parameters: Set[str] = None
+        self._histogram_parameters: Optional[Set[str]] = None
 
     @staticmethod
     def _item(value: Any):
@@ -126,6 +126,7 @@ class TensorboardWriter(FromParams):
             self.log_metrics({"epoch_metrics/" + k: v for k, v in metrics.items()})
 
         if self.should_log_histograms_this_batch():
+            assert param_updates is not None
             self.log_histograms(model)
             self.log_gradient_updates(model, param_updates)
 
@@ -133,7 +134,7 @@ class TensorboardWriter(FromParams):
             # We're assuming here that `log_batch` will get called every batch, and only every
             # batch.  This is true with our current usage of this code (version 1.0); if that
             # assumption becomes wrong, this code will break.
-            batch_group_size = sum(training_util.get_batch_size(batch) for batch in batch_group)
+            batch_group_size = sum(training_util.get_batch_size(batch) for batch in batch_group)  # type: ignore
             self._batches_this_epoch += 1
             self._cumulative_batch_group_size += batch_group_size
 
@@ -148,32 +149,39 @@ class TensorboardWriter(FromParams):
         self._batches_this_epoch = 0
 
     def should_log_this_batch(self) -> bool:
+        assert self.get_batch_num_total is not None
         return self.get_batch_num_total() % self._summary_interval == 0
 
     def should_log_histograms_this_batch(self) -> bool:
+        assert self.get_batch_num_total is not None
         return (
             self._histogram_interval is not None
             and self.get_batch_num_total() % self._histogram_interval == 0
         )
 
     def add_train_scalar(self, name: str, value: float, timestep: int = None) -> None:
+        assert self.get_batch_num_total is not None
         timestep = timestep or self.get_batch_num_total()
         # get the scalar
         if self._train_log is not None:
             self._train_log.add_scalar(name, self._item(value), timestep)
 
     def add_train_histogram(self, name: str, values: torch.Tensor) -> None:
+        assert self.get_batch_num_total is not None
         if self._train_log is not None:
             if isinstance(values, torch.Tensor):
                 values_to_write = values.cpu().data.numpy().flatten()
                 self._train_log.add_histogram(name, values_to_write, self.get_batch_num_total())
 
     def add_validation_scalar(self, name: str, value: float, timestep: int = None) -> None:
+        assert self.get_batch_num_total is not None
         timestep = timestep or self.get_batch_num_total()
         if self._validation_log is not None:
             self._validation_log.add_scalar(name, self._item(value), timestep)
 
-    def log_parameter_and_gradient_statistics(self, model: Model, batch_grad_norm: float) -> None:
+    def log_parameter_and_gradient_statistics(
+        self, model: Model, batch_grad_norm: float = None
+    ) -> None:
         """
         Send the mean and std of all parameters and gradients to tensorboard, as well
         as logging the average gradient norm.
@@ -182,9 +190,9 @@ class TensorboardWriter(FromParams):
             # Log parameter values to Tensorboard
             for name, param in model.named_parameters():
                 if param.data.numel() > 0:
-                    self.add_train_scalar("parameter_mean/" + name, param.data.mean())
+                    self.add_train_scalar("parameter_mean/" + name, param.data.mean().item())
                 if param.data.numel() > 1:
-                    self.add_train_scalar("parameter_std/" + name, param.data.std())
+                    self.add_train_scalar("parameter_std/" + name, param.data.std().item())
                 if param.grad is not None:
                     if param.grad.is_sparse:
 
@@ -204,7 +212,7 @@ class TensorboardWriter(FromParams):
             if batch_grad_norm is not None:
                 self.add_train_scalar("gradient_norm", batch_grad_norm)
 
-    def log_learning_rates(self, model: Model, optimizer: torch.optim.Optimizer):
+    def log_learning_rates(self, model: Model, optimizer: Optimizer):
         """
         Send current parameter specific learning rates to tensorboard
         """

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -47,7 +47,7 @@ class Trainer(Registrable):
 
     def __init__(
         self,
-        serialization_dir: str,
+        serialization_dir: str = None,
         cuda_device: Optional[Union[int, torch.device]] = None,
         distributed: bool = False,
         local_rank: int = 0,
@@ -519,9 +519,8 @@ class GradientDescentTrainer(Trainer):
 
         self._num_epochs = num_epochs
 
-        if checkpointer is not None:
-            self._checkpointer = checkpointer
-        else:
+        self._checkpointer: Optional[Checkpointer] = checkpointer
+        if checkpointer is None and serialization_dir is not None:
             self._checkpointer = Checkpointer(serialization_dir)
 
         self._grad_norm = grad_norm
@@ -637,13 +636,9 @@ class GradientDescentTrainer(Trainer):
 
         train_loss = 0.0
         batch_loss = 0.0
+        train_reg_loss = None if regularization_penalty is None else 0.0
+        batch_reg_loss = None if regularization_penalty is None else 0.0
 
-        if regularization_penalty is not None:
-            train_reg_loss = 0.0
-            batch_reg_loss = 0.0
-        else:
-            train_reg_loss = None
-            batch_reg_loss = None
         # Set the model to "train" mode.
         self._pytorch_model.train()
 
@@ -717,7 +712,7 @@ class GradientDescentTrainer(Trainer):
                 with amp.autocast(self._use_amp):
                     batch_outputs = self.batch_outputs(batch, for_training=True)
                     batch_group_outputs.append(batch_outputs)
-                    loss = batch_outputs.get("loss")
+                    loss = batch_outputs["loss"]
                     reg_loss = batch_outputs.get("reg_loss")
                     if torch.isnan(loss):
                         raise ValueError("nan loss encountered")
@@ -727,7 +722,7 @@ class GradientDescentTrainer(Trainer):
                     if reg_loss is not None:
                         reg_loss = reg_loss / len(batch_group)
                         batch_reg_loss = reg_loss.item()
-                        train_reg_loss += batch_reg_loss
+                        train_reg_loss += batch_reg_loss  # type: ignore
 
                 if self._scaler is not None:
                     self._scaler.scale(loss).backward()
@@ -800,7 +795,8 @@ class GradientDescentTrainer(Trainer):
                     param_updates,
                 )
 
-                self._checkpointer.maybe_save_checkpoint(self, epoch, batches_this_epoch)
+                if self._checkpointer is not None:
+                    self._checkpointer.maybe_save_checkpoint(self, epoch, batches_this_epoch)
             for callback in self._batch_callbacks:
                 callback(
                     self,
@@ -844,7 +840,7 @@ class GradientDescentTrainer(Trainer):
             metrics["gpu_" + str(gpu_num) + "_memory_MB"] = memory / (1024 * 1024)
         return metrics
 
-    def _validation_loss(self, epoch: int) -> Tuple[float, float, int]:
+    def _validation_loss(self, epoch: int) -> Tuple[float, Optional[float], int]:
         """
         Computes the validation loss. Returns it and the number of batches.
         """
@@ -873,14 +869,10 @@ class GradientDescentTrainer(Trainer):
             val_generator_tqdm = validation_data_loader
 
         batches_this_epoch = 0
-        val_loss = 0
-        val_batch_loss = 0
-        if regularization_penalty is not None:
-            val_reg_loss = 0
-            val_batch_reg_loss = 0
-        else:
-            val_reg_loss = None
-            val_batch_reg_loss = None
+        val_loss = 0.0
+        val_batch_loss = 0.0
+        val_reg_loss = None if regularization_penalty is None else 0.0
+        val_batch_reg_loss = None if regularization_penalty is None else 0.0
         done_early = False
         for batch in val_generator_tqdm:
             if self._distributed:
@@ -913,11 +905,11 @@ class GradientDescentTrainer(Trainer):
                     # count those batches for which we actually have a loss.  If this variable ever
                     # gets used for something else, we might need to change things around a bit.
                     batches_this_epoch += 1
-                    val_batch_loss = loss.detach().cpu().numpy()
+                    val_batch_loss = loss.item()
                     val_loss += val_batch_loss
                     if reg_loss is not None:
-                        val_batch_reg_loss = reg_loss.detach().cpu().numpy()
-                        val_reg_loss += val_batch_reg_loss
+                        val_batch_reg_loss = reg_loss.item()
+                        val_reg_loss += val_batch_reg_loss  # type: ignore
 
             # Update the description with the latest metrics
             val_metrics = training_util.get_metrics(
@@ -987,7 +979,7 @@ class GradientDescentTrainer(Trainer):
         logger.info("Beginning training.")
 
         val_metrics: Dict[str, float] = {}
-        this_epoch_val_metric: float = None
+        this_epoch_val_metric: float
         metrics: Dict[str, Any] = {}
         epochs_trained = 0
         training_start_time = time.time()
@@ -1003,7 +995,7 @@ class GradientDescentTrainer(Trainer):
             epoch_start_time = time.time()
             train_metrics = self._train_epoch(epoch)
 
-            if self._master:
+            if self._master and self._checkpointer is not None:
                 self._checkpointer.save_checkpoint(epoch, self, save_model_only=True)
 
             # Wait for the master to finish saving the model checkpoint
@@ -1086,7 +1078,7 @@ class GradientDescentTrainer(Trainer):
             if self._momentum_scheduler:
                 self._momentum_scheduler.step(this_epoch_val_metric)
 
-            if self._master:
+            if self._master and self._checkpointer is not None:
                 self._checkpointer.save_checkpoint(
                     epoch, self, is_best_so_far=self._metric_tracker.is_best_so_far()
                 )
@@ -1115,7 +1107,9 @@ class GradientDescentTrainer(Trainer):
             callback(self, metrics=metrics, epoch=epoch, is_master=self._master)
 
         # Load the best model state before returning
-        best_model_state = self._checkpointer.best_model_state()
+        best_model_state = (
+            None if self._checkpointer is None else self._checkpointer.best_model_state()
+        )
         if best_model_state:
             self.model.load_state_dict(best_model_state)
 
@@ -1167,6 +1161,9 @@ class GradientDescentTrainer(Trainer):
             The epoch at which to resume training, which should be one after the epoch
             in the saved training state.
         """
+        if self._checkpointer is None:
+            return 0
+
         model_state, training_state = self._checkpointer.restore_checkpoint()
 
         if not training_state:
@@ -1222,7 +1219,7 @@ class GradientDescentTrainer(Trainer):
         cuda_device: Optional[Union[int, torch.device]] = None,
         grad_norm: float = None,
         grad_clipping: float = None,
-        distributed: bool = None,
+        distributed: bool = False,
         world_size: int = 1,
         num_gradient_accumulation_steps: int = 1,
         use_amp: bool = False,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+ignore_missing_imports = true
+no_site_packages = true
+
+[mypy-tests.*]
+strict_optional = false

--- a/tests/common/from_params_test.py
+++ b/tests/common/from_params_test.py
@@ -747,6 +747,46 @@ class TestFromParams(AllenNlpTestCase):
 
         Testing.from_params(Params({"lazy_object": {"string": test_string}}))
 
+    def test_optional_vs_required_lazy_objects(self):
+        class ConstructedObject(FromParams):
+            def __init__(self, a: int):
+                self.a = a
+
+        class Testing(FromParams):
+            def __init__(
+                self,
+                lazy1: Lazy[ConstructedObject],
+                lazy2: Lazy[ConstructedObject] = Lazy(ConstructedObject),
+                lazy3: Lazy[ConstructedObject] = None,
+                lazy4: Optional[Lazy[ConstructedObject]] = Lazy(ConstructedObject),
+            ) -> None:
+                self.lazy1 = lazy1.construct()
+                self.lazy2 = lazy2.construct(a=2)
+                self.lazy3 = None if lazy3 is None else lazy3.construct()
+                self.lazy4 = None if lazy4 is None else lazy4.construct(a=1)
+
+        test1 = Testing.from_params(Params({"lazy1": {"a": 1}}))
+        assert test1.lazy1.a == 1
+        assert test1.lazy2.a == 2
+        assert test1.lazy3 is None
+        assert test1.lazy4 is not None
+
+        test2 = Testing.from_params(Params({"lazy1": {"a": 1}, "lazy2": {"a": 3}}))
+        assert test2.lazy1.a == 1
+        assert test2.lazy2.a == 3
+        assert test2.lazy3 is None
+        assert test2.lazy4 is not None
+
+        test3 = Testing.from_params(Params({"lazy1": {"a": 1}, "lazy3": {"a": 3}, "lazy4": None}))
+        assert test3.lazy1.a == 1
+        assert test3.lazy2.a == 2
+        assert test3.lazy3 is not None
+        assert test3.lazy3.a == 3
+        assert test3.lazy4 is None
+
+        with pytest.raises(ConfigurationError, match='key "lazy1" is required'):
+            Testing.from_params(Params({}))
+
     def test_iterable(self):
         from allennlp.common.registrable import Registrable
 

--- a/tests/training/checkpointer_test.py
+++ b/tests/training/checkpointer_test.py
@@ -106,10 +106,12 @@ class TestCheckpointer(AllenNlpTestCase):
         Tests that registering Checkpointer subclasses works correctly.
         """
 
+        serialization_dir = str(self.TEST_DIR)
+
         @Checkpointer.register("checkpointer_subclass")
         class CheckpointerSubclass(Checkpointer):
             def __init__(self, x: int, y: int) -> None:
-                super().__init__()
+                super().__init__(serialization_dir)
                 self.x = x
                 self.y = y
 

--- a/tests/training/checkpointer_test.py
+++ b/tests/training/checkpointer_test.py
@@ -122,4 +122,4 @@ class TestCheckpointer(AllenNlpTestCase):
         assert sub_inst.x == 1 and sub_inst.y == 3
 
     def test_base_class_from_params(self):
-        Checkpointer.from_params(Params({}))
+        Checkpointer.from_params(Params({}), serialization_dir=self.TEST_DIR)


### PR DESCRIPTION
Closes #4742 and improves the [`Lazy` API](https://github.com/allenai/allennlp/blob/01644caf4de31710a6614fb96a9d4ea291353486/allennlp/common/lazy.py) (see below for details). Also fixes a bug where the serialization directory wouldn't get passed to custom `Checkpointers` and `TensorboardWriters`.

This PR seems to do a lot of different things, but it all has to do with the conventions we've adopted and assumptions we make about `Optional[T]` types, which, to be precise, are types which are `Union[NoneType, T]`. I will refer to these types loosely as "optionals".

We currently have two conventions around the use and type-checking of optionals:

1. First, in a class, method, or function signature, a parameter annotation such as `x: int = None` implies that `x` is actually optional, i.e. that `x: Optional[int] = None`. So these two annotations are equivalent. MyPy doesn't complain about you writing `x: int = None` because we don't use the [`--no-implicit-optional`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-no_implicit_optional) flag.

    Personally, I am completely fine with this as it cuts down on a lot of verbosity. Writing out `Optional`s everywhere gets very annoying.

2. The second convention we currently have is to pass the [`--no-strict-optional`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-strict_optional) flag to MyPy. This is CRAZY, as I brought up in https://github.com/allenai/allennlp/issues/4742, because it means MyPy will never check whether an optional type is `None` or non-`None` in a logical branch. That opens up the possibility for a ton of errors that can only be found at runtime.

Now, related to these conventions is our `Lazy` API. Currently, when we write a custom `from_params` classmethod constructor for a class, and do something like `foo: Lazy[Foo] = None`, **we are violating convention 1** because `foo` will actually never be `None` due to the logic in `from_params.py`. But MyPy doesn't care either way due to convention 2.

So, if we want to be more strict about our type checking by removing convention 2, we will also have to change the way we handle `Lazy`-ness.

This got me thinking more about the `Lazy` API, and I realized there are some other things wrong with it too. Maybe "wrong" is too strong of a word, but the issue is that because `foo: Lazy[Foo] = None` is actually never `None`, there is no way to make this `foo` `None` when you actually want `None`. For context, this issue came up around the use of our `TensorboardWriter`, which is created `Lazy`-ly, so there is no way to disable it (see [this thread](https://github.com/allenai/allennlp/pull/4674#issuecomment-713871415)).

So this PR makes the `Lazy` API a little more flexible in that you *can* in fact force a `Lazy` object to be `None` (by setting that field to `null` in your config) and at the same time it removes the violation of convention 1, i.e. `foo: Lazy[Foo] = None` is equivalent to `foo: Optional[Lazy[Foo]] = None`.

You can now do things like this:

```python
@classmethod
def my_constructor(
    cls,
    some_object: Lazy[MyObject],
    optional_object: Lazy[MyObject] = None,
    required_object_with_default: Lazy[MyObject] = Lazy(MyObjectDefault),
) -> MyClass:
    obj1 = some_object.construct()
    obj2 = None if optional_object is None else optional_object.construct()
    obj3 = required_object_with_default.construct()
```

For examples of this, see the changes to the `from_params` test: https://github.com/allenai/allennlp/pull/4743/files#diff-d2f18035610a7ffeac715f1e63c1856d6e0a64be671142972b4ea10e11144800