### PR TITLE
Fix device mismatch bug for categorical accuracy metric in distributed training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `common.util.is_master` function.
 
 ### Fixed
-
+- Fix distributed metrics error.
 - Fixed a bug where the reported `batch_loss` metric was incorrect when training with gradient accumulation.
 - Class decorators now displayed in API docs.
 - Fixed up the documentation for the `allennlp.nn.beam_search` module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `common.util.is_master` function.
 
 ### Fixed
-- Fix distributed metrics error.
+
+- Fix CUDA/CPU device mismatch bug during distributed training for categorical accuracy metric.
 - Fixed a bug where the reported `batch_loss` metric was incorrect when training with gradient accumulation.
 - Class decorators now displayed in API docs.
 - Fixed up the documentation for the `allennlp.nn.beam_search` module.

--- a/allennlp/training/metrics/categorical_accuracy.py
+++ b/allennlp/training/metrics/categorical_accuracy.py
@@ -99,6 +99,9 @@ class CategoricalAccuracy(Metric):
         _correct_count = correct.sum()
 
         if is_distributed():
+            device = torch.device("cuda" if dist.get_backend() == "nccl" else "cpu")
+            _correct_count = _correct_count.to(device)
+            _total_count = _total_count.to(device)
             dist.all_reduce(_correct_count, op=dist.ReduceOp.SUM)
             dist.all_reduce(_total_count, op=dist.ReduceOp.SUM)
 


### PR DESCRIPTION
I got same error( `RuntimeError: Tensors must be CUDA and dense` )  in #4623 when I used distributed training with **allennlp 1.1.0** and **pytorch 1.6**.
I read your PR in #4570 , seem you only fix it in `Average` Class. When I use `CategoricalAccuracy `, the same error occur. 
So I try to fix it by move these tensors to GPU (same in `Average`), it works well.
Maybe you could help me check my solution, then I could update all related Metrics Classes ?