### PR TITLE
Make returning token type id default in transformers intra word tokenization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `allennlp.nn.util.add_sentence_boundary_token_ids()` to use `device` parameter of input tensor.
 - Be sure to close the TensorBoard writer even when training doesn't finish.
 - Fixed the docstring for `PyTorchSeq2VecWrapper`.
+- Fix intra word tokenization for `PretrainedTransformerTokenizer` when disabling fast tokenizer.
 
 ## [v1.1.0](https://github.com/allenai/allennlp/releases/tag/v1.1.0) - 2020-09-08
 

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -351,7 +351,6 @@ class PretrainedTransformerTokenizer(Tokenizer):
                 return_tensors=None,
                 return_offsets_mapping=False,
                 return_attention_mask=False,
-                return_token_type_ids=False,
             )
             wp_ids = wordpieces["input_ids"]
 


### PR DESCRIPTION
Addressing #4757 bug - check description there.

I can duplicate intra tokenizer test with use_fast False flag, but not sure if you want to keep such tests (there can be multiple of such tests with different flags).