### PR TITLE
add seed option to ModelTestCase.set_up_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added an optional `seed` parameter to `ModelTestCase.set_up_model` which sets the random
+  seed for `random`, `numpy`, and `torch`.
+
 ### Fixed
 
 - Fixed the computation of saliency maps in the Interpret code when using mismatched indexing.

--- a/allennlp/common/testing/model_test_case.py
+++ b/allennlp/common/testing/model_test_case.py
@@ -1,9 +1,11 @@
 import copy
 import json
 from os import PathLike
+import random
 from typing import Any, Dict, Iterable, Set, Union
 
 import torch
+import numpy
 from numpy.testing import assert_allclose
 
 from allennlp.commands.train import train_model_from_file
@@ -22,9 +24,19 @@ class ModelTestCase(AllenNlpTestCase):
     with added methods for testing [`Model`](../../models/model.md) subclasses.
     """
 
-    def set_up_model(self, param_file, dataset_file, serialization_dir=None):
+    def set_up_model(
+        self,
+        param_file: PathLike,
+        dataset_file: PathLike,
+        serialization_dir: PathLike = None,
+        seed: int = None,
+    ):
+        if seed is not None:
+            random.seed(seed)
+            numpy.random.seed(seed)
+            torch.manual_seed(seed)
 
-        self.param_file = param_file
+        self.param_file = str(param_file)
         params = Params.from_file(self.param_file)
 
         reader = DatasetReader.from_params(


### PR DESCRIPTION
This is an alternative to ad hoc patches like https://github.com/allenai/allennlp-models/pull/162. It should allow us to make some model tests less flaky by setting the seed.