### PR TITLE
Set the device for an auto-created mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with respect to the embedding layer, and aggregate wordpieces to tokens separately.
 - Fixed the heuristics for finding embedding layers in the case of RoBERTa. An update in the
   `transformers` library broke our old heuristic.
+- Fixed default masks that were erroneously created on the CPU even when a GPU is available.
 
 
 ## [v1.2.0](https://github.com/allenai/allennlp/releases/tag/v1.2.0) - 2020-10-29

--- a/allennlp/modules/seq2vec_encoders/cnn_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/cnn_encoder.py
@@ -131,7 +131,11 @@ class CnnEncoder(Seq2VecEncoder):
 
             # Create activation mask.
             # shape: (batch_size, pool_length)
-            indices = torch.arange(pool_length).unsqueeze(0).expand(batch_size, pool_length)
+            indices = (
+                torch.arange(pool_length, device=activations.device)
+                .unsqueeze(0)
+                .expand(batch_size, pool_length)
+            )
             # shape: (batch_size, pool_length)
             activations_mask = indices.ge(
                 last_unmasked_tokens - convolution_layer.kernel_size[0] + 1

--- a/allennlp/modules/seq2vec_encoders/cnn_encoder.py
+++ b/allennlp/modules/seq2vec_encoders/cnn_encoder.py
@@ -97,7 +97,7 @@ class CnnEncoder(Seq2VecEncoder):
             tokens = tokens * mask.unsqueeze(-1)
         else:
             # If mask doesn't exist create one of shape (batch_size, num_tokens)
-            mask = torch.ones(tokens.shape[0], tokens.shape[1]).bool()
+            mask = torch.ones(tokens.shape[0], tokens.shape[1], device=tokens.device).bool()
 
         # Our input is expected to have shape `(batch_size, num_tokens, embedding_dim)`.  The
         # convolution layers expect input of shape `(batch_size, in_channels, sequence_length)`,


### PR DESCRIPTION
When we create completely new tensors outside of a dataset reader, we almost always have to be careful where we put them.