### PR TITLE
Fix: typo in metric, rogue -> rouge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with respect to the embedding layer, and aggregate wordpieces to tokens separately.
 - Fixed the heuristics for finding embedding layers in the case of RoBERTa. An update in the
   `transformers` library broke our old heuristic.
-- Fixed typo `rogue` to `rouge` in `allennlp.training.metrics.rouge`.
+- Fixed typo with registered name of ROUGE metric. Previously was `rogue`, fixed to `rouge`.
 
 
 ## [v1.2.0](https://github.com/allenai/allennlp/releases/tag/v1.2.0) - 2020-10-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with respect to the embedding layer, and aggregate wordpieces to tokens separately.
 - Fixed the heuristics for finding embedding layers in the case of RoBERTa. An update in the
   `transformers` library broke our old heuristic.
+- Fixed typo `rogue` to `rouge` in `allennlp.training.metrics.rouge`.
 
 
 ## [v1.2.0](https://github.com/allenai/allennlp/releases/tag/v1.2.0) - 2020-10-29

--- a/allennlp/training/metrics/rouge.py
+++ b/allennlp/training/metrics/rouge.py
@@ -9,7 +9,7 @@ from allennlp.common.util import is_distributed
 from allennlp.training.metrics.metric import Metric
 
 
-@Metric.register("rogue")
+@Metric.register("rouge")
 class ROUGE(Metric):
     """
     Recall-Oriented Understudy for Gisting Evaluation (ROUGE)


### PR DESCRIPTION
typo in registered string. if ones use registered metric by string `rogue`, they need to fix.
Just fixing typo, I didn't update CHANGELOG.