### PR TITLE
support global plugins file, improve plugins docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added an optional `seed` parameter to `ModelTestCase.set_up_model` which sets the random
   seed for `random`, `numpy`, and `torch`.
+- Added support for a global plugins file at `~/.allennlp/plugins`.
+- Added more documentation about plugins.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ $(MD_DOCS_ROOT)README.md : README.md
 	# Alter the relative path of the README image for the docs.
 	$(SED) -i '1s/docs/./' $@
 	# Alter external doc links to relative links.
-	$(SED) -i 's|https://docs.allennlp.org/master||' $@
+	$(SED) -i 's|https://docs.allennlp.org/master/api/|/api/|' $@
 
 $(MD_DOCS_ROOT)%.md : %.md
 	cp $< $@

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,8 @@ $(MD_DOCS_ROOT)README.md : README.md
 	cp $< $@
 	# Alter the relative path of the README image for the docs.
 	$(SED) -i '1s/docs/./' $@
+	# Alter external doc links to relative links.
+	$(SED) -i 's|https://docs.allennlp.org/master||' $@
 
 $(MD_DOCS_ROOT)%.md : %.md
 	cp $< $@

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ There are several official [default plugins](https://docs.allennlp.org/master/ap
 In order for AllenNLP to find personal or third-party plugins, you have to create either a local plugins file named `.allennlp_plugins`
 in the directory where the `allennlp` command is run, or a global plugins file at `~/.allennlp/plugins`.
 The file should list the plugin modules that you want to be loaded, one per line.
-A plugins file in the current directory will take precedence over a global plugins file in `~/.allennlp/`.
 
 To test that your plugins can be found and imported by AllenNLP, you can run the `allennlp test-install` command.
 Each discovered plugin will be logged to the terminal.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,26 @@ In addition, there are external tutorials:
 
 And others on the [AI2 AllenNLP blog](https://medium.com/ai2-blog/allennlp/home).
 
+## Plugins
+
+AllenNLP supports loading "plugins" dynamically. A plugin is just a Python package that
+provides custom registered classes or additional `allennlp` subcommands.
+
+There are several official [default plugins](https://docs.allennlp.org/master/api/common/plugins/#default_plugins) and an ecosystem of third-party plugins, including:
+
+* [allennlp-optuna](https://github.com/himkt/allennlp-optuna)
+
+In order for AllenNLP to find personal or third-party plugins, you have to create either a local plugins file named `.allennlp_plugins`
+in the directory where the `allennlp` command is run, or a global plugins file at `~/.allennlp/plugins`.
+The file should list the plugin modules that you want to be loaded, one per line.
+A plugins file in the current directory will take precedence over a global plugins file in `~/.allennlp/`.
+
+To test that your plugins can be found and imported by AllenNLP, you can run the `allennlp test-install` command.
+Each discovered plugin will be logged to the terminal.
+
+For more information about plugins, see the [plugins API docs](https://docs.allennlp.org/master/api/common/plugins/). And for information on how to create a custom subcommand
+to distribute as a plugin, see the [subcommand API docs](https://docs.allennlp.org/master/api/commands/subcommand/).
+
 ## Package Overview
 
 <table>

--- a/allennlp/commands/subcommand.py
+++ b/allennlp/commands/subcommand.py
@@ -26,8 +26,9 @@ class Subcommand(Registrable):
 
     requires_plugins: bool = True
     """
-    If `True`, the sub-command will trigger a call to `import_plugins` and will also
-    have an additional `--include-package` flag.
+    If `True`, the sub-command will trigger a call to `import_plugins()` (except for custom
+    subcommands which come from plugins, since plugins will already have been imported by the
+    time the subcommand is discovered), and will also have an additional `--include-package` flag.
     """
 
     _reverse_registry: Dict[Type, str] = {}

--- a/allennlp/common/plugins.py
+++ b/allennlp/common/plugins.py
@@ -7,8 +7,7 @@ provides custom registered classes or additional `allennlp` subcommands.
 In order for AllenNLP to find your plugins, you have to create either a local plugins
 file named `.allennlp_plugins` in the directory where the `allennlp` command is run, or a global
 plugins file at `~/.allennlp/plugins`. The file should list the plugin modules that you want to
-be loaded, one per line. A plugins file in the current directory will take precedence
-over a global plugins file in `~/.allennlp/`.
+be loaded, one per line.
 """
 
 import importlib
@@ -56,13 +55,20 @@ def discover_plugins() -> Iterable[str]:
     """
     Returns an iterable of the plugins found.
     """
+    plugins: Set[str] = set()
     if os.path.isfile(LOCAL_PLUGINS_FILENAME):
         with push_python_path("."):
-            yield from discover_file_plugins(LOCAL_PLUGINS_FILENAME)
-    elif os.path.isfile(GLOBAL_PLUGINS_FILENAME):
-        yield from discover_file_plugins(GLOBAL_PLUGINS_FILENAME)
-    else:
-        yield from []
+            for plugin in discover_file_plugins(LOCAL_PLUGINS_FILENAME):
+                if plugin in plugins:
+                    continue
+                yield plugin
+                plugins.add(plugin)
+    if os.path.isfile(GLOBAL_PLUGINS_FILENAME):
+        for plugin in discover_file_plugins(GLOBAL_PLUGINS_FILENAME):
+            if plugin in plugins:
+                continue
+            yield plugin
+            plugins.add(plugin)
 
 
 def import_plugins() -> None:

--- a/allennlp/common/plugins.py
+++ b/allennlp/common/plugins.py
@@ -15,7 +15,7 @@ import logging
 import os
 from pathlib import Path
 import sys
-from typing import Iterable
+from typing import Iterable, Set
 
 from allennlp.common.util import push_python_path, import_module_and_submodules
 

--- a/allennlp/common/plugins.py
+++ b/allennlp/common/plugins.py
@@ -4,10 +4,11 @@
 AllenNLP supports loading "plugins" dynamically. A plugin is just a Python package that
 provides custom registered classes or additional `allennlp` subcommands.
 
-In order for AllenNLP to find your plugins, you have to create either a local plugins file named `.allennlp_plugins`
-in the directory where the `allennlp` command is run, or a global plugins file at `~/.allennlp/plugins`.
-The file should list the plugin modules that you want to be loaded, one per line.
-A plugins file in the current directory will take precedence over a global plugins file in `~/.allennlp/`.
+In order for AllenNLP to find your plugins, you have to create either a local plugins
+file named `.allennlp_plugins` in the directory where the `allennlp` command is run, or a global
+plugins file at `~/.allennlp/plugins`. The file should list the plugin modules that you want to
+be loaded, one per line. A plugins file in the current directory will take precedence
+over a global plugins file in `~/.allennlp/`.
 """
 
 import importlib
@@ -40,7 +41,7 @@ be imported when they are installed in the current Python environment.
 """
 
 
-def discover_file_plugins(plugins_filename: os.PathLike = LOCAL_PLUGINS_FILENAME) -> Iterable[str]:
+def discover_file_plugins(plugins_filename: str = LOCAL_PLUGINS_FILENAME) -> Iterable[str]:
     """
     Returns an iterable of the plugins found, declared within a file whose path is `plugins_filename`.
     """


### PR DESCRIPTION
Adds support for declaring a global plugins file at `~/.allennlp/plugins` and improves the documentation for plugins. This also closes https://github.com/allenai/allennlp/issues/4775 by added a place to display third-party plugins.