### PR TITLE
Fix issue in GradientDescentTrainer, when validation data is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added links to source code in docs.
+- Fixed issue with GradientDescentTrainer when constructed with validation_data_loader==None and learning_rate_scheduler!=None.
 
 
 ## [v1.2.2](https://github.com/allenai/allennlp/releases/tag/v1.2.2) - 2020-11-17

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -984,7 +984,7 @@ class GradientDescentTrainer(Trainer):
         logger.info("Beginning training.")
 
         val_metrics: Dict[str, float] = {}
-        this_epoch_val_metric: float = 0.
+        this_epoch_val_metric: float = 0.0
         metrics: Dict[str, Any] = {}
         epochs_trained = 0
         training_start_time = time.time()

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -984,7 +984,7 @@ class GradientDescentTrainer(Trainer):
         logger.info("Beginning training.")
 
         val_metrics: Dict[str, float] = {}
-        this_epoch_val_metric: float
+        this_epoch_val_metric: float = 0.
         metrics: Dict[str, Any] = {}
         epochs_trained = 0
         training_start_time = time.time()


### PR DESCRIPTION
* Prevent an error when GradientDescentTrainer is constructed with
validation_data_loader=None and learning_rate_scheduler!=None

This pull request fixes issue: https://github.com/allenai/allennlp/issues/4810