### PR TITLE
Add GELU Activation

### DIFF
--- a/allennlp/nn/activations.py
+++ b/allennlp/nn/activations.py
@@ -98,4 +98,5 @@ Registrable._registry[Activation] = {
     "softsign": (torch.nn.Softsign, None),
     "tanhshrink": (torch.nn.Tanhshrink, None),
     "selu": (torch.nn.SELU, None),
+    "gelu": (torch.nn.GELU, None)
 }


### PR DESCRIPTION
Following up from Issue #4823. This PR adds the Gaussian Error Linear Unit activation to the Activations class in AllenNLP. 