### PR TITLE
Add GELU activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added links to source code in docs.
 - Fixed issue with GradientDescentTrainer when constructed with validation_data_loader==None and learning_rate_scheduler!=None.
-
+- Added [Gaussian Error Linear Unit (GELU)](https://pytorch.org/docs/stable/generated/torch.nn.GELU.html) as an Activation.
 
 ## [v1.2.2](https://github.com/allenai/allennlp/releases/tag/v1.2.2) - 2020-11-17
 

--- a/allennlp/nn/activations.py
+++ b/allennlp/nn/activations.py
@@ -98,4 +98,5 @@ Registrable._registry[Activation] = {
     "softsign": (torch.nn.Softsign, None),
     "tanhshrink": (torch.nn.Tanhshrink, None),
     "selu": (torch.nn.SELU, None),
+    "gelu": (torch.nn.GELU, None),
 }


### PR DESCRIPTION
Following up from Issue #4823. This PR adds the Gaussian Error Linear Unit activation to the Activations class in AllenNLP. 