### PR TITLE
fix: removes all handlers from the root logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added links to source code in docs.
+
+### Fixed
+
 - Fixed issue with GradientDescentTrainer when constructed with validation_data_loader==None and learning_rate_scheduler!=None.
+- Fixed a bug when removing all handlers in root logger.
 
 
 ## [v1.2.2](https://github.com/allenai/allennlp/releases/tag/v1.2.2) - 2020-11-17
@@ -102,7 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ability to pass additional key word arguments to `cached_transformers.get()`, which will be passed on to `AutoModel.from_pretrained()`.
 - Added an `overrides` argument to `Predictor.from_path()`.
 - Added a `cached-path` command.
-- Added a function `inspect_cache` to `common.file_utils` that prints useful information about the cache. This can also 
+- Added a function `inspect_cache` to `common.file_utils` that prints useful information about the cache. This can also
   be used from the `cached-path` command with `allennlp cached-path --inspect`.
 - Added a function `remove_cache_entries` to `common.file_utils` that removes any cache entries matching the given
   glob patterns. This can used from the `cached-path` command with `allennlp cached-path --remove some-files-*`.

--- a/allennlp/common/logging.py
+++ b/allennlp/common/logging.py
@@ -93,8 +93,7 @@ def prepare_global_logging(
 
     # Remove the already set handlers in root logger.
     # Not doing this will result in duplicate log messages
-    for handler in root_logger.handlers:
-        root_logger.removeHandler(handler)
+    root_logger.handlers.clear()
 
     if os.environ.get("ALLENNLP_DEBUG"):
         LEVEL = logging.DEBUG


### PR DESCRIPTION
We should not mutate (insert/remove elements) the list you're currently iterating on. In fact, this causes handlers to not be completely deleted on my side.

For more discussion, see https://stackoverflow.com/questions/7484454/removing-handlers-from-pythons-logging-loggers