### PR TITLE
Bugfix for attribute inheritance in ShardedDatasetReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed issue with GradientDescentTrainer when constructed with validation_data_loader==None and learning_rate_scheduler!=None.
+- Fixed issue with `GradientDescentTrainer` when constructed with `validation_data_loader=None` and `learning_rate_scheduler!=None`.
 - Fixed a bug when removing all handlers in root logger.
-
-### Fixed
-
 - `ShardedDatasetReader` now inherits parameters from `base_reader` when required.
 
 ## [v1.2.2](https://github.com/allenai/allennlp/releases/tag/v1.2.2) - 2020-11-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added links to source code in docs.
 - Fixed issue with GradientDescentTrainer when constructed with validation_data_loader==None and learning_rate_scheduler!=None.
 
+### Fixed
+
+- `ShardedDatasetReader` now inherits parameters from `base_reader` when required.
 
 ## [v1.2.2](https://github.com/allenai/allennlp/releases/tag/v1.2.2) - 2020-11-17
 

--- a/allennlp/data/dataset_readers/sharded_dataset_reader.py
+++ b/allennlp/data/dataset_readers/sharded_dataset_reader.py
@@ -13,6 +13,8 @@ from allennlp.data.instance import Instance
 
 logger = logging.getLogger(__name__)
 
+_INHERITED_DATASET_PARAMS = ("lazy",)
+
 
 @DatasetReader.register("sharded")
 class ShardedDatasetReader(DatasetReader):
@@ -67,7 +69,8 @@ class ShardedDatasetReader(DatasetReader):
         # can be safely inherited. However, ShardedDatasetReader is a class instance of a DatasetReader as well.
         # So we give priority to the parameters for the current instance stored in 'kwargs'.
         # If not present, we check the ones in the base reader
-        for attr_name, attr_val in self.reader.__dict__.items():
+        for attr_name in _INHERITED_DATASET_PARAMS:
+            attr_val = getattr(self.reader, attr_name)
             # copy over only shared attributes between the two classes
             if attr_name in self.__dict__:
                 setattr(self, attr_name, kwargs.get(attr_name, attr_val))

--- a/tests/data/dataset_readers/sharded_dataset_reader_test.py
+++ b/tests/data/dataset_readers/sharded_dataset_reader_test.py
@@ -1,7 +1,7 @@
-from collections import Counter
 import glob
 import os
 import tarfile
+from collections import Counter
 from typing import Tuple
 
 import pytest
@@ -91,3 +91,20 @@ class TestShardedDatasetReader(AllenNlpTestCase):
 
     def test_sharded_read_archive(self):
         self.read_and_check_instances(str(self.archive_filename))
+
+    def test_attributes_inheritance(self):
+        # current reader has lazy set to true
+        base_reader = SequenceTaggingDatasetReader(lazy=True)
+        reader = ShardedDatasetReader(base_reader=base_reader)
+
+        assert (
+            reader.lazy
+        ), "The ShardedDatasetReader didn't inherit the 'lazy' attribute from base_reader"
+
+    def test_set_attributes_main(self):
+        base_reader = SequenceTaggingDatasetReader(lazy=True)
+        reader = ShardedDatasetReader(base_reader=base_reader, lazy=False)
+
+        assert (
+            not reader.lazy
+        ), "The ShardedDatasetReader inherited the 'lazy' attribute from base_reader. It should be False"


### PR DESCRIPTION
Implemented automatic parameters inheritance from `base_reader` in `ShardedDatasetReader`. This allows the user to specify parameters like `lazy` or `max_instances` either for the `base_reader` or the `ShardedDatasetReader` itself. 

Fixes the issue reported in https://github.com/allenai/allennlp/issues/4825