### PR TITLE
fix FromParams bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue with `GradientDescentTrainer` when constructed with `validation_data_loader=None` and `learning_rate_scheduler!=None`.
 - Fixed a bug when removing all handlers in root logger.
 - `ShardedDatasetReader` now inherits parameters from `base_reader` when required.
+- Fixed an issue in `FromParams` where parameters in the `params` object used to a construct a class
+  were not passed to the constructor if the value of the parameter was equal to the default value.
+  This caused bugs in some edge cases where a subclass that takes `**kwargs` needs to inspect
+  `kwargs` before passing them to its superclass.
 
 
 ## [v1.2.2](https://github.com/allenai/allennlp/releases/tag/v1.2.2) - 2020-11-17

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -195,16 +195,18 @@ def create_kwargs(
         # and an __args__ field indicating `(str, int)`. We capture both.
         annotation = remove_optional(param.annotation)
 
+        explicitly_set = param_name in params
         constructed_arg = pop_and_construct_arg(
             cls.__name__, param_name, annotation, param.default, params, **extras
         )
 
-        # If we just ended up constructing the default value for the parameter, we can just omit it.
+        # If the param wasn't explicitly set in `params` and we just ended up constructing
+        # the default value for the parameter, we can just omit it.
         # Leaving it in can cause issues with **kwargs in some corner cases, where you might end up
         # with multiple values for a single parameter (e.g., the default value gives you lazy=False
         # for a dataset reader inside **kwargs, but a particular dataset reader actually hard-codes
         # lazy=True - the superclass sees both lazy=True and lazy=False in its constructor).
-        if constructed_arg is not param.default:
+        if explicitly_set or constructed_arg is not param.default:
             kwargs[param_name] = constructed_arg
 
     if accepts_kwargs:

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -195,10 +195,19 @@ def create_kwargs(
         # and an __args__ field indicating `(str, int)`. We capture both.
         annotation = remove_optional(param.annotation)
 
+        explicitly_set = param_name in params
         constructed_arg = pop_and_construct_arg(
             cls.__name__, param_name, annotation, param.default, params, **extras
         )
-        kwargs[param_name] = constructed_arg
+
+        # If the param wasn't explicitly set in `params` and we just ended up constructing
+        # the default value for the parameter, we can just omit it.
+        # Leaving it in can cause issues with **kwargs in some corner cases, where you might end up
+        # with multiple values for a single parameter (e.g., the default value gives you lazy=False
+        # for a dataset reader inside **kwargs, but a particular dataset reader actually hard-codes
+        # lazy=True - the superclass sees both lazy=True and lazy=False in its constructor).
+        if explicitly_set or constructed_arg is not param.default:
+            kwargs[param_name] = constructed_arg
 
     if accepts_kwargs:
         kwargs.update(params)

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -195,19 +195,10 @@ def create_kwargs(
         # and an __args__ field indicating `(str, int)`. We capture both.
         annotation = remove_optional(param.annotation)
 
-        explicitly_set = param_name in params
         constructed_arg = pop_and_construct_arg(
             cls.__name__, param_name, annotation, param.default, params, **extras
         )
-
-        # If the param wasn't explicitly set in `params` and we just ended up constructing
-        # the default value for the parameter, we can just omit it.
-        # Leaving it in can cause issues with **kwargs in some corner cases, where you might end up
-        # with multiple values for a single parameter (e.g., the default value gives you lazy=False
-        # for a dataset reader inside **kwargs, but a particular dataset reader actually hard-codes
-        # lazy=True - the superclass sees both lazy=True and lazy=False in its constructor).
-        if explicitly_set or constructed_arg is not param.default:
-            kwargs[param_name] = constructed_arg
+        kwargs[param_name] = constructed_arg
 
     if accepts_kwargs:
         kwargs.update(params)

--- a/tests/common/from_params_test.py
+++ b/tests/common/from_params_test.py
@@ -873,14 +873,11 @@ class TestFromParams(AllenNlpTestCase):
         A.from_params(Params({"lazy": False}))
 
         class B(Base):
-            def __init__(self, lazy: bool = True, **kwargs) -> None:
-                super().__init__(lazy=lazy, **kwargs)
+            def __init__(self, **kwargs) -> None:
+                super().__init__(lazy=True, **kwargs)
 
         b = B.from_params(Params({}))
         assert b.lazy is True
-
-        b = B.from_params(Params({"lazy": False}))
-        assert b.lazy is False
 
     def test_raises_when_there_are_no_implementations(self):
         class A(Registrable):

--- a/tests/common/from_params_test.py
+++ b/tests/common/from_params_test.py
@@ -859,6 +859,18 @@ class TestFromParams(AllenNlpTestCase):
         with pytest.raises(ConfigurationError, match="Extra parameters"):
             A.from_params(Params({"some_spurious": "key", "value": "pairs"}))
 
+    def test_explicit_kwargs_always_passed_to_constructor(self):
+        class Base(FromParams):
+            def __init__(self, lazy: bool = False) -> None:
+                self.lazy = lazy
+
+        class A(Base):
+            def __init__(self, **kwargs) -> None:
+                assert "lazy" in kwargs
+                super().__init__(**kwargs)
+
+        A.from_params(Params({"lazy": False}))
+
     def test_raises_when_there_are_no_implementations(self):
         class A(Registrable):
             pass

--- a/tests/common/from_params_test.py
+++ b/tests/common/from_params_test.py
@@ -861,8 +861,9 @@ class TestFromParams(AllenNlpTestCase):
 
     def test_explicit_kwargs_always_passed_to_constructor(self):
         class Base(FromParams):
-            def __init__(self, lazy: bool = False) -> None:
+            def __init__(self, lazy: bool = False, x: int = 0) -> None:
                 self.lazy = lazy
+                self.x = x
 
         class A(Base):
             def __init__(self, **kwargs) -> None:
@@ -870,6 +871,16 @@ class TestFromParams(AllenNlpTestCase):
                 super().__init__(**kwargs)
 
         A.from_params(Params({"lazy": False}))
+
+        class B(Base):
+            def __init__(self, lazy: bool = True, **kwargs) -> None:
+                super().__init__(lazy=lazy, **kwargs)
+
+        b = B.from_params(Params({}))
+        assert b.lazy is True
+
+        b = B.from_params(Params({"lazy": False}))
+        assert b.lazy is False
 
     def test_raises_when_there_are_no_implementations(self):
         class A(Registrable):
@@ -942,6 +953,16 @@ class TestFromParams(AllenNlpTestCase):
         assert bar.b == "hi"
         assert bar.c == {"2": "3"}
         assert bar.d == 0
+
+        class Baz(Foo):
+            def __init__(self, a: int, b: Optional[str] = "a", **kwargs) -> None:
+                super().__init__(a, b=b, **kwargs)
+
+        baz = Baz.from_params(Params({"a": 2, "b": None}))
+        assert baz.b is None
+
+        baz = Baz.from_params(Params({"a": 2}))
+        assert baz.b == "a"
 
     def test_from_params_base_class_kwargs_crashes_if_params_not_handled(self):
         class Bar(FromParams):


### PR DESCRIPTION
This was an interesting one. I found this after digging into the test that seemed to fail out of nowhere in this (unrelated) PR: https://github.com/allenai/allennlp-models/pull/175/checks?check_run_id=1499712028. This bug only manifested itself because of a different bug fix regarding the `ShardedDatasetReader` (https://github.com/allenai/allennlp/pull/4830).

Basically, the `ShardedDatasetReader` needs to inspect its `**kwargs` for the "lazy" parameter. The behavior depends on whether or not "lazy" is present. But the current `FromParams` logic removes the "lazy" param from `kwargs` if it's the same as the default value in the superclass.

So this fixes the behavior of `FromParams` so that parameters in the `Params` object will ALWAYS be passed to the constructor.