### PR TITLE
Improve the band-aid solution for seg faults and the static TLS error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   were not passed to the constructor if the value of the parameter was equal to the default value.
   This caused bugs in some edge cases where a subclass that takes `**kwargs` needs to inspect
   `kwargs` before passing them to its superclass.
-- Improved the band-aid solution for segmentation faults and the "ImportError: dlopen: cannot load any more object with static TLS" error.
+- Improved the band-aid solution for segmentation faults and the "ImportError: dlopen: cannot load any more object with static TLS" 
+  by adding a `transformers` import.
 
 
 ## [v1.2.2](https://github.com/allenai/allennlp/releases/tag/v1.2.2) - 2020-11-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   were not passed to the constructor if the value of the parameter was equal to the default value.
   This caused bugs in some edge cases where a subclass that takes `**kwargs` needs to inspect
   `kwargs` before passing them to its superclass.
+- Improved the band-aid solution for segmentation faults and the "ImportError: dlopen: cannot load any more object with static TLS" error.
 
 
 ## [v1.2.2](https://github.com/allenai/allennlp/releases/tag/v1.2.2) - 2020-11-17

--- a/allennlp/__init__.py
+++ b/allennlp/__init__.py
@@ -15,7 +15,7 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 try:
     # On some systems this prevents the dreaded
     # ImportError: dlopen: cannot load any more object with static TLS
-    import spacy, torch, numpy  # noqa
+    import transformers, spacy, torch, numpy  # noqa
 
 except ModuleNotFoundError:
     print(


### PR DESCRIPTION
I kept getting "ImportError: dlopen: cannot load any more object with static TLS" and segmentation faults.
At first, it seemed the cause is the import of `sklearn` in the AUC metric. After adding `sklearn` import before everything else, I didn't get the static TLS error anymore, but continued getting seg faults which came from imports from `transformers`.
Adding a `transformers` import before all other imports helped with both errors.