### PR TITLE
Toolkit: Adding documentation and small changes for `BiModalAttention`

### DIFF
--- a/allennlp/models/vision_text_model.py
+++ b/allennlp/models/vision_text_model.py
@@ -185,24 +185,21 @@ class VisionTextModel(Model):
 
         # All batch instances will always have the same number of images and boxes, so no masking
         # is necessary, and this is just a tensor of ones.
-        image_attention_mask = torch.ones_like(box_coordinates[:, :, 0], dtype=torch.bool)
+        image_attention_mask = torch.ones_like(box_coordinates[:, :, 0])
 
         # (batch_size, num_tokens, embedding_dim)
         embedding_output = self.embeddings(token_ids, token_type_ids)
         num_tokens = embedding_output.size(1)
 
-        # We create a 3D attention mask from a 2D tensor mask.
-        # Sizes are [batch_size, 1, 1, to_seq_length]
-        # So we can broadcast to [batch_size, num_heads, from_seq_length, to_seq_length]
         # this attention mask is more simple than the triangular masking of
         # causal attention used in OpenAI GPT, we just need to prepare the
         # broadcast dimension here.
         if attention_mask is not None:
-            extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
+            extended_attention_mask = attention_mask
         else:
             extended_attention_mask = None
 
-        extended_image_attention_mask = image_attention_mask.unsqueeze(1).unsqueeze(2)
+        extended_image_attention_mask = image_attention_mask
 
         extended_co_attention_mask = torch.zeros(
             batch_size,

--- a/allennlp/models/vision_text_model.py
+++ b/allennlp/models/vision_text_model.py
@@ -185,7 +185,7 @@ class VisionTextModel(Model):
 
         # All batch instances will always have the same number of images and boxes, so no masking
         # is necessary, and this is just a tensor of ones.
-        image_attention_mask = torch.ones_like(box_coordinates[:, :, 0])
+        image_attention_mask = torch.ones_like(box_coordinates[:, :, 0], dtype=torch.bool)
 
         # (batch_size, num_tokens, embedding_dim)
         embedding_output = self.embeddings(token_ids, token_type_ids)
@@ -198,11 +198,11 @@ class VisionTextModel(Model):
         # causal attention used in OpenAI GPT, we just need to prepare the
         # broadcast dimension here.
         if attention_mask is not None:
-            extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2).float().log()
+            extended_attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
         else:
             extended_attention_mask = None
 
-        extended_image_attention_mask = image_attention_mask.unsqueeze(1).unsqueeze(2).float().log()
+        extended_image_attention_mask = image_attention_mask.unsqueeze(1).unsqueeze(2)
 
         extended_co_attention_mask = torch.zeros(
             batch_size,

--- a/allennlp/modules/transformer/bimodal_attention.py
+++ b/allennlp/modules/transformer/bimodal_attention.py
@@ -119,7 +119,7 @@ class BiModalAttention(TransformerModule, FromParams):
             # to `batch_size x num_attention_heads x source_seq_len x target_seq_len`
             mask = mask.unsqueeze(1).unsqueeze(2)
         # `mask==1` to convert float tensors.
-        mask = (~(mask == 1)) * -10e5  # to ensure that the model also works in half-precision mode.
+        mask = (~(mask == 1)) * -10e5  # -10e5 to ensure that the model also works in half-precision mode.
         return values + mask
 
     def forward(

--- a/allennlp/modules/transformer/bimodal_attention.py
+++ b/allennlp/modules/transformer/bimodal_attention.py
@@ -3,7 +3,6 @@ import torch
 from allennlp.common import FromParams
 from allennlp.modules.attention import Attention
 from allennlp.modules.transformer.transformer_module import TransformerModule
-from allennlp.nn import util as nn_util
 
 
 class BiModalAttention(TransformerModule, FromParams):
@@ -120,7 +119,7 @@ class BiModalAttention(TransformerModule, FromParams):
             # to `batch_size x num_attention_heads x source_seq_len x target_seq_len`
             mask = mask.unsqueeze(1).unsqueeze(2)
         # `mask==1` to convert float tensors.
-        mask = (~(mask == 1)) * nn_util.min_value_of_dtype(values.dtype)
+        mask = (~(mask == 1)) * -10e5  # to ensure that the model also works in half-precision mode.
         return values + mask
 
     def forward(

--- a/allennlp/modules/transformer/self_attention.py
+++ b/allennlp/modules/transformer/self_attention.py
@@ -4,7 +4,6 @@ import torch
 from allennlp.common import FromParams
 from allennlp.modules.attention import Attention
 from allennlp.modules.transformer.transformer_module import TransformerModule
-from allennlp.nn import util as nn_util
 
 
 class SelfAttention(TransformerModule, FromParams):
@@ -81,7 +80,7 @@ class SelfAttention(TransformerModule, FromParams):
             # to `batch_size x num_attention_heads x seq_len x seq_len`
             mask = mask.unsqueeze(1).unsqueeze(2)
         # `mask==1` to convert float tensors.
-        mask = (~(mask == 1)) * nn_util.min_value_of_dtype(values.dtype)
+        mask = (~(mask == 1)) * -10e5  # to ensure that the model also works in half-precision mode.
         return values + mask
 
     def forward(

--- a/allennlp/modules/transformer/util.py
+++ b/allennlp/modules/transformer/util.py
@@ -1,0 +1,25 @@
+from typing import Union
+import torch
+
+
+def apply_mask(
+    values: torch.FloatTensor, mask: Union[torch.BoolTensor, torch.IntTensor, torch.FloatTensor]
+) -> torch.FloatTensor:
+    """
+    # Parameters
+
+    values : `torch.FloatTensor`
+        Shape `batch_size x num_attention_heads x source_seq_len x target_seq_len`
+    mask : `torch.BoolTensor`
+        Shape `batch_size x target_seq_len` OR `batch_size x 1 x 1 x target_seq_len`
+    """
+    if len(mask.shape) == 2:
+        # We create a 4D attention mask from a 2D tensor mask.
+        # The shape is `batch_size x 1 x 1 x target_seq_len` which is broadcast
+        # to `batch_size x num_attention_heads x source_seq_len x target_seq_len`
+        mask = mask.unsqueeze(1).unsqueeze(2)
+    # `mask==1` to convert float tensors.
+    mask = (
+        ~(mask == 1)
+    ) * -10e5  # -10e5 to ensure that the model also works in half-precision mode.
+    return values + mask

--- a/test_fixtures/vilbert_ve/experiment_from_huggingface.jsonnet
+++ b/test_fixtures/vilbert_ve/experiment_from_huggingface.jsonnet
@@ -38,7 +38,7 @@ local model_name = "epwalsh/bert-xsmall-dummy";
     "text_fixed_layer": 0,
 
     "combined_hidden_size": 200,
-    "combined_num_attention_heads": 2,
+    "combined_num_attention_heads": 4,
 
     "pooled_output_dim": 100,
     "fusion_method": "sum",

--- a/tests/modules/transformer/bimodal_attention_test.py
+++ b/tests/modules/transformer/bimodal_attention_test.py
@@ -50,6 +50,6 @@ class TestBiModalAttention(AllenNlpTestCase):
         self.biattention.forward(
             torch.randn(2, 3, 6),
             torch.randn(2, 3, 4),
-            torch.randn(2, 2, 3, 3),
-            torch.randn(2, 2, 3, 3),
+            torch.randint(0, 2, (2, 2, 3, 3)) == 1,  # creating boolean tensors
+            torch.randint(0, 2, (2, 2, 3, 3)) == 1,
         )

--- a/tests/modules/transformer/bimodal_encoder_test.py
+++ b/tests/modules/transformer/bimodal_encoder_test.py
@@ -49,8 +49,8 @@ class TestBiModalEncoder(AllenNlpTestCase):
 
         embedding1 = torch.randn(16, 34, self.params_dict["hidden_size1"])
         embedding2 = torch.randn(16, 2, self.params_dict["hidden_size2"])
-        attn_mask1 = torch.randn(16, 1, 1, 34)
-        attn_mask2 = torch.randn(16, 1, 1, 2)
+        attn_mask1 = torch.randint(0, 2, (16, 1, 1, 34)) == 1
+        attn_mask2 = torch.randint(0, 2, (16, 1, 1, 2)) == 1
 
         self.bimodal_encoder.forward(embedding1, embedding2, attn_mask1, attn_mask2)
 
@@ -89,7 +89,7 @@ class TestBiModalEncoder(AllenNlpTestCase):
         encoder = BiModalEncoder()
         embedding1 = torch.randn(16, 34, 1024)
         embedding2 = torch.randn(16, 2, 1024)
-        attn_mask1 = torch.randn(16, 1, 1, 34)
-        attn_mask2 = torch.randn(16, 1, 1, 2)
+        attn_mask1 = torch.randint(0, 2, (16, 1, 1, 34)) == 1
+        attn_mask2 = torch.randint(0, 2, (16, 1, 1, 2)) == 1
 
         encoder.forward(embedding1, embedding2, attn_mask1, attn_mask2)


### PR DESCRIPTION
@dirkgr This includes the `_apply_mask` function that you added in `torchvision`, with minor changes. I shifted the reshaping part to the module (though it will still work if the reshaping happens outside) to make it consistent with `SelfAttention`. 