### PR TITLE
Fix typo in __str__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed typo with LabelField string representation: removed trailing apostrophe.
+- Fixed typo with `LabelField` string representation: removed trailing apostrophe.
 
 ## [v1.3.0](https://github.com/allenai/allennlp/releases/tag/v1.3.0) - 2020-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a new learning rate scheduler: `CombinedLearningRateScheduler`. This can be used to combine different LR schedulers, using one after the other.
 
+### Fixed
+
+- Fixed typo with LabelField string representation: removed trailing apostrophe.
 
 ## [v1.3.0](https://github.com/allenai/allennlp/releases/tag/v1.3.0) - 2020-12-15
 

--- a/allennlp/data/fields/label_field.py
+++ b/allennlp/data/fields/label_field.py
@@ -106,7 +106,7 @@ class LabelField(Field[torch.Tensor]):
         return LabelField(-1, self._label_namespace, skip_indexing=True)
 
     def __str__(self) -> str:
-        return f"LabelField with label: {self.label} in namespace: '{self._label_namespace}'.'"
+        return f"LabelField with label: {self.label} in namespace: '{self._label_namespace}'."
 
     def __len__(self):
         return 1


### PR DESCRIPTION
Minor typo in `LabelField.__str__` function.