### PR TITLE
Scaled Dot-Product Attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This makes it possible to use the `FileLock` class on a read-only file system.
 - Added a new learning rate scheduler: `CombinedLearningRateScheduler`. This can be used to combine different LR schedulers, using one after the other.
 - Moving `ModelCard` and `TaskCard` abstractions into the main repository.
+- Added a new `Attention`: `ScaledDotProductAttention`. This is the "Scaled Dot-Product Attention" introduced in https://arxiv.org/abs/1706.03762.
 
 ### Changed
 

--- a/allennlp/modules/attention/__init__.py
+++ b/allennlp/modules/attention/__init__.py
@@ -1,4 +1,5 @@
 from allennlp.modules.attention.attention import Attention
+from allennlp.modules.attention.scaled_dot_product_attention import ScaledDotProductAttention
 from allennlp.modules.attention.bilinear_attention import BilinearAttention
 from allennlp.modules.attention.additive_attention import AdditiveAttention
 from allennlp.modules.attention.cosine_attention import CosineAttention

--- a/allennlp/modules/attention/scaled_dot_product_attention.py
+++ b/allennlp/modules/attention/scaled_dot_product_attention.py
@@ -17,4 +17,4 @@ class ScaledDotProductAttention(Attention):
 
     @overrides
     def _forward_internal(self, vector: torch.Tensor, matrix: torch.Tensor) -> torch.Tensor:
-        return matrix.bmm(vector.unsqueeze(-1)).squeeze(-1) / math.sqrt(vector.size(-1))
+        return matrix.bmm(vector.unsqueeze(-1)).squeeze(-1) / math.sqrt(matrix.size(-1))

--- a/allennlp/modules/attention/scaled_dot_product_attention.py
+++ b/allennlp/modules/attention/scaled_dot_product_attention.py
@@ -1,0 +1,20 @@
+import torch
+from overrides import overrides
+from allennlp.modules.attention.attention import Attention
+import math
+
+
+@Attention.register("scaled_dot_product")
+class ScaledDotProductAttention(Attention):
+    """
+    Computes attention between a vector and a matrix using scaled dot product.
+
+    This attention is often referred to as "Scaled Dot-Product Attention". It was introduced in
+    <https://arxiv.org/abs/1706.03762> by Vaswani et al.
+
+    Registered as an `Attention` with name "scaled_dot_product".
+    """
+
+    @overrides
+    def _forward_internal(self, vector: torch.Tensor, matrix: torch.Tensor) -> torch.Tensor:
+        return matrix.bmm(vector.unsqueeze(-1)).squeeze(-1) / math.sqrt(vector.size(-1))

--- a/tests/modules/attention/scaled_dot_product_attention_test.py
+++ b/tests/modules/attention/scaled_dot_product_attention_test.py
@@ -9,11 +9,11 @@ from allennlp.modules.attention.scaled_dot_product_attention import ScaledDotPro
 
 
 class TestScaledDotProductAttention(AllenNlpTestCase):
-    def test_can_init_dot(self):
+    def test_can_init_scaled_dot(self):
         legacy_attention = Attention.from_params(Params({"type": "dot_product"}))
         isinstance(legacy_attention, ScaledDotProductAttention)
 
-    def test_dot_product_similarity(self):
+    def test_scaled_dot_product_similarity(self):
         linear = ScaledDotProductAttention(normalize=False)
         output = linear(
             torch.FloatTensor([[0, 0, 0], [1, 1, 1]]),

--- a/tests/modules/attention/scaled_dot_product_attention_test.py
+++ b/tests/modules/attention/scaled_dot_product_attention_test.py
@@ -1,0 +1,23 @@
+import torch
+from numpy.testing import assert_almost_equal
+import numpy
+
+from allennlp.common import Params
+from allennlp.common.testing.test_case import AllenNlpTestCase
+from allennlp.modules.attention.attention import Attention
+from allennlp.modules.attention.scaled_dot_product_attention import ScaledDotProductAttention
+
+
+class TestScaledDotProductAttention(AllenNlpTestCase):
+    def test_can_init_dot(self):
+        legacy_attention = Attention.from_params(Params({"type": "dot_product"}))
+        isinstance(legacy_attention, ScaledDotProductAttention)
+
+    def test_dot_product_similarity(self):
+        linear = ScaledDotProductAttention(normalize=False)
+        output = linear(
+            torch.FloatTensor([[0, 0, 0], [1, 1, 1]]),
+            torch.FloatTensor([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]),
+        )
+
+        assert_almost_equal(output.numpy(), numpy.array([[0.0, 0.0], [13.86, 19.05]]), decimal=2)


### PR DESCRIPTION
<!-- Please reference the issue number here -->

Changes proposed in this pull request:

Add a new `Attention` class, `ScaledDotProductAttention` that implements "Scaled Dot-Product Attention" introduced in https://arxiv.org/abs/1706.03762.

I wanted to use scaled dot-product attention as the cross-attention mechanism in a seq2seq model implemented in AllenNLP and was surprised that it didn't already exist, so I decided to open this PR. It is a only a tiny tweak to the existing `DotProductAttention` class, so I copied that classes documentation and tests and modified them accordingly. I also tested `ScaledDotProductAttention` in my seq2seq class and did find a small boost to validation scores.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
