### PR TITLE
rename 'multi_process_*' -> 'multiprocess' for consistency

### DIFF
--- a/allennlp/data/data_loaders/__init__.py
+++ b/allennlp/data/data_loaders/__init__.py
@@ -1,5 +1,5 @@
 from allennlp.data.data_loaders.data_loader import DataLoader, TensorDict, allennlp_collate
-from allennlp.data.data_loaders.multi_process_data_loader import MultiProcessDataLoader, WorkerError
+from allennlp.data.data_loaders.multiprocess_data_loader import MultiProcessDataLoader, WorkerError
 from allennlp.data.data_loaders.multitask_data_loader import MultiTaskDataLoader
 
 from allennlp.data.data_loaders.pytorch_data_loader import (

--- a/allennlp/data/data_loaders/data_loader.py
+++ b/allennlp/data/data_loaders/data_loader.py
@@ -41,10 +41,10 @@ class DataLoader(Registrable):
     Additionally, this class should also implement `__len__()` when possible.
 
     The default implementation is
-    [`MultiProcessDataLoader`](../multi_process_data_loader/#multiprocessdataloader).
+    [`MultiProcessDataLoader`](../multiprocess_data_loader/#multiprocessdataloader).
     """
 
-    default_implementation = "multi_process"
+    default_implementation = "multiprocess"
 
     def __len__(self) -> int:
         raise TypeError

--- a/allennlp/data/data_loaders/multiprocess_data_loader.py
+++ b/allennlp/data/data_loaders/multiprocess_data_loader.py
@@ -24,7 +24,7 @@ import allennlp.nn.util as nn_util
 logger = logging.getLogger(__name__)
 
 
-@DataLoader.register("multi_process")
+@DataLoader.register("multiprocess")
 class MultiProcessDataLoader(DataLoader):
     """
     The `MultiProcessDataLoader` is a [`DataLoader`](../data_loader/#dataloader)
@@ -82,7 +82,7 @@ class MultiProcessDataLoader(DataLoader):
 
         This means that in order for multi-process loading to be efficient when `num_workers > 1`,
         the `reader` needs to implement
-        [`manual_multi_process_sharding`](/api/data/dataset_readers/dataset_reader/#datasetreader).
+        [`manual_multiprocess_sharding`](/api/data/dataset_readers/dataset_reader/#datasetreader).
 
     max_instances_in_memory: `int`, optional (default = `None`)
         If not specified, all instances will be read and cached in memory for the duration

--- a/allennlp/data/data_loaders/multitask_data_loader.py
+++ b/allennlp/data/data_loaders/multitask_data_loader.py
@@ -8,7 +8,7 @@ from overrides import overrides
 from allennlp.common import util
 from allennlp.data.batch import Batch
 from allennlp.data.data_loaders.data_loader import DataLoader, TensorDict
-from allennlp.data.data_loaders.multi_process_data_loader import MultiProcessDataLoader
+from allennlp.data.data_loaders.multiprocess_data_loader import MultiProcessDataLoader
 from allennlp.data.data_loaders.multitask_scheduler import (
     MultiTaskScheduler,
     HomogeneousRoundRobinScheduler,

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -89,7 +89,7 @@ class Conll2003DatasetReader(DatasetReader):
         **kwargs,
     ) -> None:
         super().__init__(
-            manual_distributed_sharding=True, manual_multi_process_sharding=True, **kwargs
+            manual_distributed_sharding=True, manual_multiprocess_sharding=True, **kwargs
         )
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
         if tag_label is not None and tag_label not in self._VALID_LABELS:

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -98,7 +98,7 @@ class DatasetReader(Registrable):
 
         See the section below about how to do this.
 
-    manual_multi_process_sharding : `bool`, optional (default=`False`)
+    manual_multiprocess_sharding : `bool`, optional (default=`False`)
         This is similar to the `manual_distributed_sharding` parameter, but applies to
         multi-process data loading. By default, when this reader is used by a multi-process
         data loader (i.e. a `DataLoader` with `num_workers > 1`), each worker will
@@ -107,7 +107,7 @@ class DatasetReader(Registrable):
 
         However, there is really no benefit to using multiple workers in your `DataLoader`
         unless you implement the sharding within your `_read()` method, in which
-        case you should set `manual_multi_process_sharding` to `True`, just as with
+        case you should set `manual_multiprocess_sharding` to `True`, just as with
         `manual_distributed_sharding`.
 
         See the section below about how to do this.
@@ -144,7 +144,7 @@ class DatasetReader(Registrable):
         Remember though that when you handle the sharding manually within `_read()`, you need
         to let the `DatasetReader` know about this so that it doesn't do any additional
         filtering. Therefore you need to ensure that both `self.manual_distributed_sharding` and
-        `self.manual_multi_process_sharding` are set to `True`.
+        `self.manual_multiprocess_sharding` are set to `True`.
 
         If you call the helper method `shard_iterable()` without setting these to `True`,
         you'll get an exception.
@@ -164,7 +164,7 @@ class DatasetReader(Registrable):
         self,
         max_instances: Optional[int] = None,
         manual_distributed_sharding: bool = False,
-        manual_multi_process_sharding: bool = False,
+        manual_multiprocess_sharding: bool = False,
         serialization_dir: Optional[str] = None,
     ) -> None:
         # Do some validation.
@@ -173,7 +173,7 @@ class DatasetReader(Registrable):
 
         self.max_instances = max_instances
         self.manual_distributed_sharding = manual_distributed_sharding
-        self.manual_multi_process_sharding = manual_multi_process_sharding
+        self.manual_multiprocess_sharding = manual_multiprocess_sharding
         self.serialization_dir = serialization_dir
         self._worker_info: Optional[WorkerInfo] = None
         self._distributed_info: Optional[DistributedInfo] = None
@@ -279,11 +279,11 @@ class DatasetReader(Registrable):
         Helper method that determines which items in an iterable object to skip based
         on the current node rank (for distributed training) and worker ID (for multi-process data loading).
         """
-        if not self.manual_distributed_sharding or not self.manual_multi_process_sharding:
+        if not self.manual_distributed_sharding or not self.manual_multiprocess_sharding:
             raise ValueError(
                 "self.shard_iterable() was called but self.manual_distributed_sharding and "
-                "self.manual_multi_process_sharding was not set to True. Did you forget to call "
-                "super().__init__(manual_distributed_sharding=True, manual_multi_process_sharding=True) "
+                "self.manual_multiprocess_sharding was not set to True. Did you forget to call "
+                "super().__init__(manual_distributed_sharding=True, manual_multiprocess_sharding=True) "
                 "in your constructor?"
             )
 
@@ -350,10 +350,10 @@ class DatasetReader(Registrable):
                 else:
                     max_instances = max_instances // self._worker_info.num_workers
 
-            if not self.manual_multi_process_sharding:
+            if not self.manual_multiprocess_sharding:
                 warnings.warn(
                     "Using multi-process data loading without setting "
-                    "DatasetReader.manual_multi_process_sharding to True.\n"
+                    "DatasetReader.manual_multiprocess_sharding to True.\n"
                     "Did you forget to set this?\n"
                     "If you're not handling the multi-process sharding logic within your "
                     "_read() method, there is probably no benefit to using more than one "

--- a/allennlp/data/dataset_readers/sequence_tagging.py
+++ b/allennlp/data/dataset_readers/sequence_tagging.py
@@ -50,7 +50,7 @@ class SequenceTaggingDatasetReader(DatasetReader):
         **kwargs,
     ) -> None:
         super().__init__(
-            manual_distributed_sharding=True, manual_multi_process_sharding=True, **kwargs
+            manual_distributed_sharding=True, manual_multiprocess_sharding=True, **kwargs
         )
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._word_tag_delimiter = word_tag_delimiter

--- a/allennlp/data/dataset_readers/sharded_dataset_reader.py
+++ b/allennlp/data/dataset_readers/sharded_dataset_reader.py
@@ -38,7 +38,7 @@ class ShardedDatasetReader(DatasetReader):
 
     def __init__(self, base_reader: DatasetReader, **kwargs) -> None:
         super().__init__(
-            manual_distributed_sharding=True, manual_multi_process_sharding=True, **kwargs
+            manual_distributed_sharding=True, manual_multiprocess_sharding=True, **kwargs
         )
         self.reader = base_reader
         # We have to make the base reader think that it's the only worker so that it doesn't

--- a/allennlp/data/dataset_readers/text_classification_json.py
+++ b/allennlp/data/dataset_readers/text_classification_json.py
@@ -56,7 +56,7 @@ class TextClassificationJsonReader(DatasetReader):
         **kwargs,
     ) -> None:
         super().__init__(
-            manual_distributed_sharding=True, manual_multi_process_sharding=True, **kwargs
+            manual_distributed_sharding=True, manual_multiprocess_sharding=True, **kwargs
         )
         self._tokenizer = tokenizer or SpacyTokenizer()
         self._segment_sentences = segment_sentences

--- a/allennlp/data/dataset_readers/vision_reader.py
+++ b/allennlp/data/dataset_readers/vision_reader.py
@@ -100,7 +100,7 @@ class VisionReader(DatasetReader):
         super().__init__(
             max_instances=max_instances,
             manual_distributed_sharding=True,
-            manual_multi_process_sharding=True,
+            manual_multiprocess_sharding=True,
         )
 
         # tokenizers and indexers

--- a/tests/data/data_loaders/multi_process_data_loader_test.py
+++ b/tests/data/data_loaders/multi_process_data_loader_test.py
@@ -29,7 +29,7 @@ class MockDatasetReader(DatasetReader):
 
     def __init__(self, model: str = "epwalsh/bert-xsmall-dummy", **kwargs) -> None:
         super().__init__(
-            manual_distributed_sharding=True, manual_multi_process_sharding=True, **kwargs
+            manual_distributed_sharding=True, manual_multiprocess_sharding=True, **kwargs
         )
         self.tokenizer = PretrainedTransformerTokenizer(model)
         self.token_indexers = {"tokens": PretrainedTransformerIndexer(model)}
@@ -111,7 +111,7 @@ def test_error_raised_when_text_fields_contain_token_indexers(max_instances_in_m
     ],
     ids=str,
 )
-def test_multi_process_data_loader(options):
+def test_multiprocess_data_loader(options):
     reader = MockDatasetReader()
     data_path = "this doesn't matter"
 

--- a/tests/data/dataset_readers/dataset_reader_test.py
+++ b/tests/data/dataset_readers/dataset_reader_test.py
@@ -31,7 +31,7 @@ class MockMmpsDatasetReader(DatasetReader):
     """
 
     def __init__(self, **kwargs) -> None:
-        super().__init__(manual_multi_process_sharding=True, **kwargs)
+        super().__init__(manual_multiprocess_sharding=True, **kwargs)
 
     def _read(self, file_path):
         start_index = 0
@@ -75,7 +75,7 @@ class MockMmpdsDatasetReader(DatasetReader):
 
     def __init__(self, **kwargs) -> None:
         super().__init__(
-            manual_distributed_sharding=True, manual_multi_process_sharding=True, **kwargs
+            manual_distributed_sharding=True, manual_multiprocess_sharding=True, **kwargs
         )
 
     def _read(self, file_path):


### PR DESCRIPTION
<!-- Please reference the issue number here -->
See #4904.

```
find ./ -type f -exec sed -i '' 's/multi_process/multiprocess/g' {} \;
```

Requires a small change in `allennlp-models` for CI to pass.