### PR TITLE
fix mkdocs config

### DIFF
--- a/mkdocs-skeleton.yml
+++ b/mkdocs-skeleton.yml
@@ -37,8 +37,7 @@ nav:
 markdown_extensions:
 - toc:
     permalink: '#'
-- markdown.extensions.codehilite:
-    guess_lang: true
 - admonition
-- codehilite
 - extra
+- pymdownx.highlight
+- pymdownx.superfences


### PR DESCRIPTION
Syntax highlighting had quietly disappeared. This fixes that.