### PR TITLE
Adding missing transformer_kwargs arg that was recently added to PretrainedTransformerEmbedder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `transformer_kwargs` argument to `PretrainedTransformerBackbone`
 
 ## [v2.0.0](https://github.com/allenai/allennlp/releases/tag/v2.0.0) - 2021-01-27
 
 ### Added
 
-- Added `transformer_kwargs` argument to `PretrainedTransformerBackbone`
 - The `TrainerCallback` constructor accepts `serialization_dir` provided by `Trainer`. This can be useful for `Logger` callbacks those need to store files in the run directory.
 - The `TrainerCallback.on_start()` is fired at the start of the training.
 - The `TrainerCallback` event methods now accept `**kwargs`. This may be useful to maintain backwards-compability of callbacks easier in the future. E.g. we may decide to pass the exception/traceback object in case of failure to `on_end()` and this older callbacks may simply ignore the argument instead of raising a `TypeError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `transformer_kwargs` argument to `PretrainedTransformerBackbone`
 - The `TrainerCallback` constructor accepts `serialization_dir` provided by `Trainer`. This can be useful for `Logger` callbacks those need to store files in the run directory.
 - The `TrainerCallback.on_start()` is fired at the start of the training.
 - The `TrainerCallback` event methods now accept `**kwargs`. This may be useful to maintain backwards-compability of callbacks easier in the future. E.g. we may decide to pass the exception/traceback object in case of failure to `on_end()` and this older callbacks may simply ignore the argument instead of raising a `TypeError`.

--- a/allennlp/modules/backbones/pretrained_transformer_backbone.py
+++ b/allennlp/modules/backbones/pretrained_transformer_backbone.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 from overrides import overrides
 import torch
@@ -47,6 +47,10 @@ class PretrainedTransformerBackbone(Backbone):
         When `True` (the default), only the final layer of the pretrained transformer is taken
         for the embeddings. But if set to `False`, a scalar mix of all of the layers
         is used.
+    transformer_kwargs: `Dict[str, Any]`, optional (default = `None`)
+        Dictionary with
+        [additional arguments](https://github.com/huggingface/transformers/blob/155c782a2ccd103cf63ad48a2becd7c76a7d2115/transformers/modeling_utils.py#L253)
+        for `AutoModel.from_pretrained`.
     output_token_strings : `bool`, optional (default = `True`)
         If `True`, we will add the input token ids to the output dictionary in `forward` (with key
         "token_ids"), and convert them to strings in `make_output_human_readable` (with key
@@ -55,7 +59,7 @@ class PretrainedTransformerBackbone(Backbone):
     vocab_namespace : `str`, optional (default = `"tags"`)
         The namespace to use in conjunction with the `Vocabulary` above.  We use a somewhat
         confusing default of "tags" here, to match what is done in `PretrainedTransformerIndexer`.
-    """
+    """  # noqa: E501
 
     def __init__(
         self,
@@ -68,6 +72,7 @@ class PretrainedTransformerBackbone(Backbone):
         last_layer_only: bool = True,
         override_weights_file: Optional[str] = None,
         override_weights_strip_prefix: Optional[str] = None,
+        transformer_kwargs: Optional[Dict[str, Any]] = None,
         output_token_strings: bool = True,
         vocab_namespace: str = "tags",
     ) -> None:
@@ -82,6 +87,7 @@ class PretrainedTransformerBackbone(Backbone):
             last_layer_only=last_layer_only,
             override_weights_file=override_weights_file,
             override_weights_strip_prefix=override_weights_strip_prefix,
+            transformer_kwargs=transformer_kwargs,
         )
         self._output_token_strings = output_token_strings
 


### PR DESCRIPTION
<!-- Please reference the issue number here -->
Changes proposed in this pull request:
- Just adding a missing `transformer_kwargs` arg to `PretrainedTransformerBackbone` constructor, that was recently added to `PretrainedTransformerEmbedder`.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
