### PR TITLE
Sanitize set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `transformer_kwargs` argument to `PretrainedTransformerBackbone`
 
+### Fixed
+
+- `common.util.sanitize` now handles sets.
+
+
 ## [v2.0.0](https://github.com/allenai/allennlp/releases/tag/v2.0.0) - 2021-01-27
 
 ### Added

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -93,8 +93,8 @@ def sanitize(x: Any) -> Any:
     elif isinstance(x, (spacy.tokens.Token, Token)):
         # Tokens get sanitized to just their text.
         return x.text
-    elif isinstance(x, (list, tuple)):
-        # Lists and Tuples need their values sanitized
+    elif isinstance(x, (list, tuple, set)):
+        # Lists, tuples, and sets need their values sanitized
         return [sanitize(x_i) for x_i in x]
     elif x is None:
         return "None"

--- a/tests/common/util_test.py
+++ b/tests/common/util_test.py
@@ -57,6 +57,10 @@ class TestCommonUtils(AllenNlpTestCase):
 
         assert util.sanitize(Sanitizable()) == {"sanitizable": True}
 
+        x = util.sanitize({1, 2, 3})
+        assert isinstance(x, list)
+        assert len(x) == 3
+
     def test_import_submodules(self):
         (self.TEST_DIR / "mymodule").mkdir()
         (self.TEST_DIR / "mymodule" / "__init__.py").touch()


### PR DESCRIPTION
<!-- Please reference the issue number here -->

Changes proposed in this pull request:

- `common.util.sanitize()` didn't handle `set` objects before. Now it will.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
