### PR TITLE
Resize transformers word embeddings layer for additional_special_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `tokenizer_kwargs` and `transformer_kwargs` arguments to `PretrainedTransformerBackbone`
+- Resize transformers word embeddings layer for `additional_special_tokens`
 
 ### Changed
 

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -106,12 +106,16 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
         )
 
         try:
-            if self.transformer_model.get_input_embeddings().num_embeddings != len(tokenizer.tokenizer):
+            if self.transformer_model.get_input_embeddings().num_embeddings != len(
+                tokenizer.tokenizer
+            ):
                 self.transformer_model.resize_token_embeddings(len(tokenizer.tokenizer))
         except NotImplementedError:
             # Can't resize for transformers models that don't implement base_model.get_input_embeddings()
-            logger.warning("Could not resize the token embedding matrix of the transformer model. "
-                           "This model does not support resizing.")
+            logger.warning(
+                "Could not resize the token embedding matrix of the transformer model. "
+                "This model does not support resizing."
+            )
 
         self._num_added_start_tokens = len(tokenizer.single_sequence_start_tokens)
         self._num_added_end_tokens = len(tokenizer.single_sequence_end_tokens)

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -102,7 +102,11 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             tokenizer_kwargs=tokenizer_kwargs,
         )
 
-        self.transformer_model.resize_token_embeddings(len(tokenizer.tokenizer))
+        try:
+            self.transformer_model.resize_token_embeddings(len(tokenizer.tokenizer))
+        except NotImplementedError:
+            # Can't resize for transformers models that don't implement base_model.get_input_embeddings()
+            pass
 
         self._num_added_start_tokens = len(tokenizer.single_sequence_start_tokens)
         self._num_added_end_tokens = len(tokenizer.single_sequence_end_tokens)

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -101,6 +101,9 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             model_name,
             tokenizer_kwargs=tokenizer_kwargs,
         )
+
+        self.transformer_model.resize_token_embeddings(len(tokenizer.tokenizer))
+
         self._num_added_start_tokens = len(tokenizer.single_sequence_start_tokens)
         self._num_added_end_tokens = len(tokenizer.single_sequence_end_tokens)
         self._num_added_tokens = self._num_added_start_tokens + self._num_added_end_tokens

--- a/allennlp/training/metric_tracker.py
+++ b/allennlp/training/metric_tracker.py
@@ -99,7 +99,7 @@ class MetricTracker:
         except KeyError as e:
             raise ConfigurationError(
                 f"You configured the trainer to use the {e.args[0]}"
-                "metric for early stopping, but the model did not produce that metric."
+                " metric for early stopping, but the model did not produce that metric."
             )
 
         new_best = (self._best_so_far is None) or (combined_score > self._best_so_far)

--- a/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -315,3 +315,10 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
         token_ids = torch.LongTensor([[1, 2, 3], [2, 3, 4]])
         mask = torch.ones_like(token_ids).bool()
         token_embedder(token_ids, mask)
+
+    def test_embeddings_resize(self):
+        regular_token_embedder = PretrainedTransformerEmbedder("bert-base-cased")
+        assert regular_token_embedder.transformer_model.embeddings.word_embeddings.num_embeddings == 28996
+        tokenizer_kwargs = {"additional_special_tokens": ['<NEW_TOKEN>']}
+        enhanced_token_embedder = PretrainedTransformerEmbedder("bert-base-cased", tokenizer_kwargs=tokenizer_kwargs)
+        assert enhanced_token_embedder.transformer_model.embeddings.word_embeddings.num_embeddings == 28997

--- a/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
+++ b/tests/modules/token_embedders/pretrained_transformer_embedder_test.py
@@ -318,7 +318,15 @@ class TestPretrainedTransformerEmbedder(AllenNlpTestCase):
 
     def test_embeddings_resize(self):
         regular_token_embedder = PretrainedTransformerEmbedder("bert-base-cased")
-        assert regular_token_embedder.transformer_model.embeddings.word_embeddings.num_embeddings == 28996
-        tokenizer_kwargs = {"additional_special_tokens": ['<NEW_TOKEN>']}
-        enhanced_token_embedder = PretrainedTransformerEmbedder("bert-base-cased", tokenizer_kwargs=tokenizer_kwargs)
-        assert enhanced_token_embedder.transformer_model.embeddings.word_embeddings.num_embeddings == 28997
+        assert (
+            regular_token_embedder.transformer_model.embeddings.word_embeddings.num_embeddings
+            == 28996
+        )
+        tokenizer_kwargs = {"additional_special_tokens": ["<NEW_TOKEN>"]}
+        enhanced_token_embedder = PretrainedTransformerEmbedder(
+            "bert-base-cased", tokenizer_kwargs=tokenizer_kwargs
+        )
+        assert (
+            enhanced_token_embedder.transformer_model.embeddings.word_embeddings.num_embeddings
+            == 28997
+        )


### PR DESCRIPTION
<!-- Please reference the issue number here -->
Fixes part of #4690 

Changes proposed in this pull request:
- I opened issue #4690 a while ago for AllenNLP to provide `additional_special_tokens` parameter for transformers models. @dirkgr already provided a fix for the parameter to be added and worked very well, but we were missing some way for the model to adapt it's word embeddings layer to the additional tokens provided. I'm not sure if this is the best way to do it, but this PR seems to solve this.