### PR TITLE
fix bug with MultiProcessDataLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a bug where the `MultiProcessDataLoading` would crash when `num_workers > 0`, `start_method = "spawn"`, `max_instances_in_memory not None`, and `batches_per_epoch not None`.
+
+
 ## [v2.0.1](https://github.com/allenai/allennlp/releases/tag/v2.0.1) - 2021-01-29
 
 ### Added


### PR DESCRIPTION
<!-- Please reference the issue number here -->
Fixes a bug in `MultiProcessDataLoader` that causes a crash when using lazy loader with workers when `start_method = "spawn"` and `batches_per_epoch` is set.

The bug happens because generator objects cannot be pickled. And with those settings in the `MultiProcessDataLoader`, a generator would be created and assigned to `self._batch_generator` before spawning workers, and since spawning uses pickle, this would fail.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
