### PR TITLE
Introduce `convert_to_coding_scheme` and make `coding_scheme` deprecated in CoNLL2003DatasetReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Introduce `convert_to_coding_scheme` and make `coding_scheme` deprecated in `Conll2003DatasetReader`.
+
 ### Added
 
 - Added `ModelUsage` to `ModelCard` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Introduce `convert_to_coding_scheme` and make `coding_scheme` deprecated in `Conll2003DatasetReader`.
+### Changed
+
+- `coding_scheme` parameter is now deprecated in `Conll2003DatasetReader`, please use `convert_to_coding_scheme` instead.
 
 ### Added
 

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -98,8 +98,7 @@ class Conll2003DatasetReader(DatasetReader):
 
         if "coding_scheme" in kwargs:
             warnings.warn("`coding_scheme` is deprecated.", DeprecationWarning)
-            coding_scheme = kwargs["coding_scheme"]
-            kwargs.pop("coding_scheme")
+            coding_scheme = kwargs.pop("coding_scheme")
 
             if coding_scheme not in ("IOB1", "BIOUL"):
                 raise ConfigurationError("unknown coding_scheme: {}".format(coding_scheme))

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -74,6 +74,11 @@ class Conll2003DatasetReader(DatasetReader):
         In the IOB1 scheme, I is a token inside a span, O is a token outside
         a span and B is the beginning of span immediately following another
         span of the same type.
+    coding_scheme : `str`, optional (default=`IOB1`)
+        This parameter is deprecated. If you specify `coding_scheme` to
+        `IOB1`, consider simply removing it or specifying `convert_to_coding_scheme`
+        to `None`. If you want to specify `BIOUL` for `coding_scheme`,
+        replace it with `convert_to_coding_scheme`.
     label_namespace : `str`, optional (default=`labels`)
         Specifies the namespace for the chosen `tag_label`.
     """

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -1,6 +1,7 @@
-from typing import Dict, List, Sequence, Iterable
+from typing import Dict, List, Optional, Sequence, Iterable
 import itertools
 import logging
+import warnings
 
 from overrides import overrides
 
@@ -66,9 +67,9 @@ class Conll2003DatasetReader(DatasetReader):
         Each will have its own namespace : `pos_tags`, `chunk_tags`, `ner_tags`.
         If you want to use one of the tags as a `feature` in your model, it should be
         specified here.
-    coding_scheme : `str`, optional (default=`IOB1`)
+    convert_to_coding_scheme : `str`, optional (default=`None`)
         Specifies the coding scheme for `ner_labels` and `chunk_labels`.
-        Valid options are `IOB1` and `BIOUL`.  The `IOB1` default maintains
+        Valid options are `None` and `BIOUL`.  The `None` default maintains
         the original IOB1 scheme in the CoNLL 2003 NER data.
         In the IOB1 scheme, I is a token inside a span, O is a token outside
         a span and B is the beginning of span immediately following another
@@ -84,10 +85,24 @@ class Conll2003DatasetReader(DatasetReader):
         token_indexers: Dict[str, TokenIndexer] = None,
         tag_label: str = "ner",
         feature_labels: Sequence[str] = (),
-        coding_scheme: str = "IOB1",
+        convert_to_coding_scheme: Optional[str] = None,
         label_namespace: str = "labels",
         **kwargs,
     ) -> None:
+
+        if "coding_scheme" in kwargs:
+            warnings.warn("`coding_scheme` is deprecated.", DeprecationWarning)
+            coding_scheme = kwargs["coding_scheme"]
+            kwargs.pop("coding_scheme")
+
+            if coding_scheme not in ("IOB1", "BIOUL"):
+                raise ConfigurationError("unknown coding_scheme: {}".format(coding_scheme))
+
+            if coding_scheme == "IOB1":
+                convert_to_coding_scheme = None
+            else:
+                convert_to_coding_scheme = coding_scheme
+
         super().__init__(
             manual_distributed_sharding=True, manual_multiprocess_sharding=True, **kwargs
         )
@@ -97,12 +112,14 @@ class Conll2003DatasetReader(DatasetReader):
         for label in feature_labels:
             if label not in self._VALID_LABELS:
                 raise ConfigurationError("unknown feature label type: {}".format(label))
-        if coding_scheme not in ("IOB1", "BIOUL"):
-            raise ConfigurationError("unknown coding_scheme: {}".format(coding_scheme))
+        if convert_to_coding_scheme not in (None, "BIOUL"):
+            raise ConfigurationError(
+                "unknown convert_to_coding_scheme: {}".format(convert_to_coding_scheme)
+            )
 
         self.tag_label = tag_label
         self.feature_labels = set(feature_labels)
-        self.coding_scheme = coding_scheme
+        self.convert_to_coding_scheme = convert_to_coding_scheme
         self.label_namespace = label_namespace
         self._original_coding_scheme = "IOB1"
 
@@ -148,7 +165,7 @@ class Conll2003DatasetReader(DatasetReader):
         instance_fields["metadata"] = MetadataField({"words": [x.text for x in tokens]})
 
         # Recode the labels if necessary.
-        if self.coding_scheme == "BIOUL":
+        if self.convert_to_coding_scheme == "BIOUL":
             coded_chunks = (
                 to_bioul(chunk_tags, encoding=self._original_coding_scheme)
                 if chunk_tags is not None

--- a/allennlp/data/dataset_readers/conll2003.py
+++ b/allennlp/data/dataset_readers/conll2003.py
@@ -69,6 +69,7 @@ class Conll2003DatasetReader(DatasetReader):
         specified here.
     convert_to_coding_scheme : `str`, optional (default=`None`)
         Specifies the coding scheme for `ner_labels` and `chunk_labels`.
+        `Conll2003DatasetReader` assumes a coding scheme of input data is `IOB1`.
         Valid options are `None` and `BIOUL`.  The `None` default maintains
         the original IOB1 scheme in the CoNLL 2003 NER data.
         In the IOB1 scheme, I is a token inside a span, O is a token outside

--- a/tests/data/dataset_readers/conll2003_test.py
+++ b/tests/data/dataset_readers/conll2003_test.py
@@ -30,7 +30,6 @@ class TestConll2003Reader:
         assert tokens == ["AI2", "engineer", "Joel", "lives", "in", "Seattle", "."]
         assert fields["tags"].labels == expected_labels
 
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     @pytest.mark.parametrize("convert_to_coding_scheme", (None, "BIOUL"))
     def test_read_from_file(self, convert_to_coding_scheme):
         conll_reader = Conll2003DatasetReader(convert_to_coding_scheme=convert_to_coding_scheme)

--- a/tests/data/dataset_readers/conll2003_test.py
+++ b/tests/data/dataset_readers/conll2003_test.py
@@ -1,0 +1,59 @@
+import pytest
+
+from allennlp.data.dataset_readers.conll2003 import Conll2003DatasetReader
+from allennlp.common.checks import ConfigurationError
+from allennlp.common.util import ensure_list
+from allennlp.common.testing import AllenNlpTestCase
+
+
+class TestConll2003Reader:
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    @pytest.mark.parametrize("coding_scheme", ("IOB1", "BIOUL"))
+    def test_read_from_file_with_deprecated_parameter(self, coding_scheme):
+        conll_reader = Conll2003DatasetReader(coding_scheme=coding_scheme)
+        instances = ensure_list(
+            conll_reader.read(AllenNlpTestCase.FIXTURES_ROOT / "data" / "conll2003.txt")
+        )
+
+        if coding_scheme == "IOB1":
+            expected_labels = ["I-ORG", "O", "I-PER", "O", "O", "I-LOC", "O"]
+        else:
+            expected_labels = ["U-ORG", "O", "U-PER", "O", "O", "U-LOC", "O"]
+
+        fields = instances[0].fields
+        tokens = [t.text for t in fields["tokens"].tokens]
+        assert tokens == ["U.N.", "official", "Ekeus", "heads", "for", "Baghdad", "."]
+        assert fields["tags"].labels == expected_labels
+
+        fields = instances[1].fields
+        tokens = [t.text for t in fields["tokens"].tokens]
+        assert tokens == ["AI2", "engineer", "Joel", "lives", "in", "Seattle", "."]
+        assert fields["tags"].labels == expected_labels
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    @pytest.mark.parametrize("convert_to_coding_scheme", (None, "BIOUL"))
+    def test_read_from_file(self, convert_to_coding_scheme):
+        conll_reader = Conll2003DatasetReader(convert_to_coding_scheme=convert_to_coding_scheme)
+        instances = ensure_list(
+            conll_reader.read(AllenNlpTestCase.FIXTURES_ROOT / "data" / "conll2003.txt")
+        )
+
+        if convert_to_coding_scheme is None:
+            expected_labels = ["I-ORG", "O", "I-PER", "O", "O", "I-LOC", "O"]
+        else:
+            expected_labels = ["U-ORG", "O", "U-PER", "O", "O", "U-LOC", "O"]
+
+        fields = instances[0].fields
+        tokens = [t.text for t in fields["tokens"].tokens]
+        assert tokens == ["U.N.", "official", "Ekeus", "heads", "for", "Baghdad", "."]
+        assert fields["tags"].labels == expected_labels
+
+        fields = instances[1].fields
+        tokens = [t.text for t in fields["tokens"].tokens]
+        assert tokens == ["AI2", "engineer", "Joel", "lives", "in", "Seattle", "."]
+        assert fields["tags"].labels == expected_labels
+
+    def test_read_data_from_with_unsupported_coding_scheme(self):
+        with pytest.raises(ConfigurationError):
+            # `IOB1` is not supported in `convert_to_coding_scheme`.
+            Conll2003DatasetReader(convert_to_coding_scheme="IOB1")


### PR DESCRIPTION
Fixes #1941 and retry of #4924.

This PR introduces `convert_to_coding_scheme` to `Conll2003DatasetReader` based on the [suggestion](https://github.com/allenai/allennlp/pull/4924#discussion_r566309610) by @epwalsh.