### PR TITLE
Update mean_absolute_error.py

### DIFF
--- a/allennlp/training/metrics/mean_absolute_error.py
+++ b/allennlp/training/metrics/mean_absolute_error.py
@@ -66,7 +66,7 @@ class MeanAbsoluteError(Metric):
         mean_absolute_error = self._absolute_error / self._total_count
         if reset:
             self.reset()
-        return {"mae": mean_absolute_error}
+        return {"mae": float(mean_absolute_error)}
 
     @overrides
     def reset(self):


### PR DESCRIPTION
I had a `TypeError`stating that `torch.Tensor` objects are not JSON-serializable, which seems perfectly reasonable. The culprit was `MeanAbsoluteError.get_metric(...)` because it was returning a tensor and not a float.

<!-- Please reference the issue number here -->
No issue is currently open because it was a quick edit. I can open one if you like.

Changes proposed in this pull request:
- Explicitly return a `float` in `MeanAbsoluteError.get_metric`

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
