### PR TITLE
for torch.distributed.is_available()==False

### DIFF
--- a/allennlp/nn/util.py
+++ b/allennlp/nn/util.py
@@ -12,7 +12,12 @@ import math
 import numpy
 import torch
 import torch.distributed as dist
-from torch.distributed import ReduceOp
+
+if dist.is_available():
+    from torch.distributed import ReduceOp
+else:
+    class ReduceOp(object):
+        SUM = None
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.util import int_to_device, is_distributed


### PR DESCRIPTION
`import allennlp.nn.util` always fails when `torch.distributed.is_available()==False`. See [here](https://pytorch.org/docs/stable/distributed.html#torch.distributed.is_available) details.

Changes proposed in this pull request:

- check `torch.distributed.is_available()` before `import ReduceOp`
- if unavailable, dummy `ReduceOp` created

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
