### PR TITLE
Mean absolute error returns float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Ensured that `MeanAbsoluteError` always returns a `float` metric value instead of a `Tensor`.
+
 ### Changed
 
 - `coding_scheme` parameter is now deprecated in `Conll2003DatasetReader`, please use `convert_to_coding_scheme` instead.
@@ -23,8 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   brings that functionality back.
 - Fixed a bug where the `MultiProcessDataLoading` would crash when `num_workers > 0`, `start_method = "spawn"`, `max_instances_in_memory not None`, and `batches_per_epoch not None`.
 - Fixed documentation and validation checks for `FBetaMultiLabelMetric`.
-- Ensured that `MeanAbsoluteError` always returns a `float` metric value instead of a `Tensor`.
-
 
 ## [v2.0.1](https://github.com/allenai/allennlp/releases/tag/v2.0.1) - 2021-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   brings that functionality back.
 - Fixed a bug where the `MultiProcessDataLoading` would crash when `num_workers > 0`, `start_method = "spawn"`, `max_instances_in_memory not None`, and `batches_per_epoch not None`.
 - Fixed documentation and validation checks for `FBetaMultiLabelMetric`.
+- Ensured that `MeanAbsoluteError` always returns a `float` metric value instead of a `Tensor`.
 
 
 ## [v2.0.1](https://github.com/allenai/allennlp/releases/tag/v2.0.1) - 2021-01-29

--- a/allennlp/training/metrics/mean_absolute_error.py
+++ b/allennlp/training/metrics/mean_absolute_error.py
@@ -66,7 +66,6 @@ class MeanAbsoluteError(Metric):
         mean_absolute_error = self._absolute_error / self._total_count
         if reset:
             self.reset()
-        assert isinstance(mean_absolute_error, float)
         return {"mae": mean_absolute_error}
 
     @overrides

--- a/allennlp/training/metrics/mean_absolute_error.py
+++ b/allennlp/training/metrics/mean_absolute_error.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from overrides import overrides
 import torch
@@ -23,7 +23,7 @@ class MeanAbsoluteError(Metric):
         predictions: torch.Tensor,
         gold_labels: torch.Tensor,
         mask: Optional[torch.BoolTensor] = None,
-    ):
+    ) -> None:
         """
         # Parameters
 
@@ -54,10 +54,10 @@ class MeanAbsoluteError(Metric):
             _absolute_error = absolute_error.item()
             _total_count = total_count.item()
 
-        self._absolute_error += _absolute_error
-        self._total_count += _total_count
+        self._absolute_error += float(_absolute_error)
+        self._total_count += int(_total_count)
 
-    def get_metric(self, reset: bool = False):
+    def get_metric(self, reset: bool = False) -> Dict[str, float]:
         """
         # Returns
 
@@ -66,9 +66,10 @@ class MeanAbsoluteError(Metric):
         mean_absolute_error = self._absolute_error / self._total_count
         if reset:
             self.reset()
+        assert isinstance(mean_absolute_error, float)
         return {"mae": mean_absolute_error}
 
     @overrides
-    def reset(self):
+    def reset(self) -> None:
         self._absolute_error = 0.0
         self._total_count = 0.0

--- a/tests/training/metrics/mean_absolute_error_test.py
+++ b/tests/training/metrics/mean_absolute_error_test.py
@@ -1,10 +1,12 @@
 from typing import Any, Dict, List, Tuple, Union
+
+import pytest
 import torch
 
 from allennlp.common.testing import (
     AllenNlpTestCase,
-    multi_device,
     global_distributed_metric,
+    multi_device,
     run_distributed_test,
 )
 from allennlp.training.metrics import MeanAbsoluteError
@@ -15,39 +17,90 @@ class MeanAbsoluteErrorTest(AllenNlpTestCase):
     def test_mean_absolute_error_computation(self, device: str):
         mae = MeanAbsoluteError()
         predictions = torch.tensor(
-            [[1.0, 1.5, 1.0], [2.0, 3.0, 3.5], [4.0, 5.0, 5.5], [6.0, 7.0, 7.5]], device=device
+            [
+                [1.0, 1.5, 1.0],
+                [2.0, 3.0, 3.5],
+                [4.0, 5.0, 5.5],
+                [6.0, 7.0, 7.5],
+            ],
+            device=device,
         )
         targets = torch.tensor(
-            [[0.0, 1.0, 0.0], [2.0, 2.0, 0.0], [4.0, 5.0, 0.0], [7.0, 7.0, 0.0]], device=device
+            [
+                [0.0, 1.0, 0.0],
+                [2.0, 2.0, 0.0],
+                [4.0, 5.0, 0.0],
+                [7.0, 7.0, 0.0],
+            ],
+            device=device,
         )
         mae(predictions, targets)
-        assert mae.get_metric()["mae"] == 21.0 / 12.0
+        actual_mae_value = mae.get_metric()["mae"]
+        assert isinstance(actual_mae_value, float)
+        assert actual_mae_value == 21.0 / 12.0
 
         mask = torch.tensor(
-            [[True, True, False], [True, True, False], [True, True, False], [True, True, False]],
+            [
+                [True, True, False],
+                [True, True, False],
+                [True, True, False],
+                [True, True, False],
+            ],
             device=device,
         )
         mae(predictions, targets, mask)
-        assert mae.get_metric()["mae"] == (21.0 + 3.5) / (12.0 + 8.0)
+        actual_mae_value = mae.get_metric()["mae"]
+        assert isinstance(actual_mae_value, float)
+        assert actual_mae_value == (21.0 + 3.5) / (12.0 + 8.0)
 
         new_targets = torch.tensor(
-            [[2.0, 2.0, 0.0], [0.0, 1.0, 0.0], [7.0, 7.0, 0.0], [4.0, 5.0, 0.0]], device=device
+            [
+                [2.0, 2.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [7.0, 7.0, 0.0],
+                [4.0, 5.0, 0.0],
+            ],
+            device=device,
         )
         mae(predictions, new_targets)
-        assert mae.get_metric()["mae"] == (21.0 + 3.5 + 32.0) / (12.0 + 8.0 + 12.0)
+        actual_mae_value = mae.get_metric()["mae"]
+        assert isinstance(actual_mae_value, float)
+        assert actual_mae_value == (21.0 + 3.5 + 32.0) / (12.0 + 8.0 + 12.0)
 
         mae.reset()
         mae(predictions, new_targets)
-        assert mae.get_metric()["mae"] == 32.0 / 12.0
+        actual_mae_value = mae.get_metric()["mae"]
+        assert isinstance(actual_mae_value, float)
+        assert actual_mae_value == 32.0 / 12.0
 
     def test_distributed_accuracy(self):
         predictions = [
-            torch.tensor([[1.0, 1.5, 1.0], [2.0, 3.0, 3.5]]),
-            torch.tensor([[4.0, 5.0, 5.5], [6.0, 7.0, 7.5]]),
+            torch.tensor(
+                [
+                    [1.0, 1.5, 1.0],
+                    [2.0, 3.0, 3.5],
+                ]
+            ),
+            torch.tensor(
+                [
+                    [4.0, 5.0, 5.5],
+                    [6.0, 7.0, 7.5],
+                ]
+            ),
         ]
         targets = [
-            torch.tensor([[0.0, 1.0, 0.0], [2.0, 2.0, 0.0]]),
-            torch.tensor([[4.0, 5.0, 0.0], [7.0, 7.0, 0.0]]),
+            torch.tensor(
+                [
+                    [0.0, 1.0, 0.0],
+                    [2.0, 2.0, 0.0],
+                ]
+            ),
+            torch.tensor(
+                [
+                    [4.0, 5.0, 0.0],
+                    [7.0, 7.0, 0.0],
+                ]
+            ),
         ]
         metric_kwargs = {"predictions": predictions, "gold_labels": targets}
         desired_values = {"mae": 21.0 / 12.0}
@@ -62,12 +115,32 @@ class MeanAbsoluteErrorTest(AllenNlpTestCase):
 
     def test_multiple_distributed_runs(self):
         predictions = [
-            torch.tensor([[1.0, 1.5, 1.0], [2.0, 3.0, 3.5]]),
-            torch.tensor([[4.0, 5.0, 5.5], [6.0, 7.0, 7.5]]),
+            torch.tensor(
+                [
+                    [1.0, 1.5, 1.0],
+                    [2.0, 3.0, 3.5],
+                ]
+            ),
+            torch.tensor(
+                [
+                    [4.0, 5.0, 5.5],
+                    [6.0, 7.0, 7.5],
+                ]
+            ),
         ]
         targets = [
-            torch.tensor([[0.0, 1.0, 0.0], [2.0, 2.0, 0.0]]),
-            torch.tensor([[4.0, 5.0, 0.0], [7.0, 7.0, 0.0]]),
+            torch.tensor(
+                [
+                    [0.0, 1.0, 0.0],
+                    [2.0, 2.0, 0.0],
+                ]
+            ),
+            torch.tensor(
+                [
+                    [4.0, 5.0, 0.0],
+                    [7.0, 7.0, 0.0],
+                ]
+            ),
         ]
         metric_kwargs = {"predictions": predictions, "gold_labels": targets}
         desired_values = {"mae": 21.0 / 12.0}

--- a/tests/training/metrics/mean_absolute_error_test.py
+++ b/tests/training/metrics/mean_absolute_error_test.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, List, Tuple, Union
 
-import pytest
 import torch
 
 from allennlp.common.testing import (


### PR DESCRIPTION
<!-- Please reference the issue number here -->
Fixes #4961

Changes proposed in this pull request:

- Ensure that `MeanAbsoluteError.get_metric(...)` returns a float, not a tensor.
- Update tests accordingly.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
