### PR TITLE
raise on HTTP errors in cached_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   brings that functionality back.
 - Fixed a bug where the `MultiProcessDataLoading` would crash when `num_workers > 0`, `start_method = "spawn"`, `max_instances_in_memory not None`, and `batches_per_epoch not None`.
 - Fixed documentation and validation checks for `FBetaMultiLabelMetric`.
+- Fixed handling of HTTP errors when fetching remote resources with `cached_path()`. Previously the content would be cached even when
+  certain errors - like 404s - occurred. Now an `HTTPError` will be raised whenever the HTTP response is not OK.
 
 
 ## [v2.0.1](https://github.com/allenai/allennlp/releases/tag/v2.0.1) - 2021-01-29

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -448,6 +448,7 @@ def _http_etag(url: str) -> Optional[str]:
 def _http_get(url: str, temp_file: IO) -> None:
     with _session_with_backoff() as session:
         req = session.get(url, stream=True)
+        req.raise_for_status()
         content_length = req.headers.get("Content-Length")
         total = int(content_length) if content_length is not None else None
         progress = Tqdm.tqdm(unit="B", total=total, desc="downloading")

--- a/tests/common/file_utils_test.py
+++ b/tests/common/file_utils_test.py
@@ -9,7 +9,7 @@ from filelock import Timeout
 import pytest
 import responses
 import torch
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, HTTPError
 
 from allennlp.common import file_utils
 from allennlp.common.file_utils import (
@@ -305,6 +305,22 @@ class TestFileUtils(AllenNlpTestCase):
         )
         with open(filename, "r") as f:
             assert f.read().startswith("I mean, ")
+
+    @responses.activate
+    def test_cached_path_http_err_handling(self):
+        url_404 = "http://fake.datastore.com/does-not-exist"
+        byt = b"Does not exist"
+        for method in (responses.GET, responses.HEAD):
+            responses.add(
+                method,
+                url_404,
+                body=byt,
+                status=404,
+                headers={"Content-Length": str(len(byt))},
+            )
+
+        with pytest.raises(HTTPError):
+            cached_path(url_404, cache_dir=self.TEST_DIR)
 
     def test_extract_with_external_symlink(self):
         dangerous_file = self.FIXTURES_ROOT / "common" / "external_symlink.tar.gz"


### PR DESCRIPTION
<!-- Please reference the issue number here -->
Fixes #4978.

Changes proposed in this pull request:

- When the HTTP response we get from remote resources has an error code, we raise an `HTTPError` now by simply calling `.raise_for_status()` on the response object.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
