### PR TITLE
Add ListField example to apply token indexers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ModelUsage` to `ModelCard` class.
 - Added a way to specify extra parameters to the predictor in an `allennlp predict` call.
 - Added a way to initialize a `Vocabulary` from transformers models.
+- Added an example for fields of type `ListField[TextField]` to `apply_token_indexers` API docs.
 
 ### Fixed
 

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -233,6 +233,14 @@ class DatasetReader(Registrable):
         """
         If `Instance`s created by this reader contain `TextField`s without `token_indexers`,
         this method can be overriden to set the `token_indexers` of those fields.
+
+        If your `TextField`s are wrapped in a `ListField`, you can access them via `field_list`.
+        E.g. if you had a `"source"` field of `ListField[TextField]` objects, you could:
+
+        ```python
+        for text_field in instance["source"].field_list:
+            text_field.token_indexers = self._token_indexers
+        ```
         """
         pass
 

--- a/allennlp/data/dataset_readers/dataset_reader.py
+++ b/allennlp/data/dataset_readers/dataset_reader.py
@@ -234,6 +234,13 @@ class DatasetReader(Registrable):
         If `Instance`s created by this reader contain `TextField`s without `token_indexers`,
         this method can be overriden to set the `token_indexers` of those fields.
 
+        E.g. if you have you have `"source"` `TextField`, you could implement this method like this:
+
+        ```python
+        def apply_token_indexers(self, instance: Instance) -> None:
+            instance["source"].token_indexers = self._token_indexers
+        ```
+
         If your `TextField`s are wrapped in a `ListField`, you can access them via `field_list`.
         E.g. if you had a `"source"` field of `ListField[TextField]` objects, you could:
 


### PR DESCRIPTION
<!-- Please reference the issue number here -->

Addresses a [comment in the migration guide](https://github.com/allenai/allennlp/discussions/4933#discussioncomment-371349).

Changes proposed in this pull request:

- Added an example for fields of type `ListField[TextField]` to `apply_token_indexers` API docs.

The documentation for `apply_token_indexers` now reads like this:

![image](https://user-images.githubusercontent.com/8917831/108075629-937f3900-7038-11eb-871a-5ad91dc6389a.png)

Let me know if there's anything you would like me to change! @epwalsh 

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
