### PR TITLE
Makes sure serialized tensors live on CPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LogWriter` class. `TensorBoardWriter` now inherits from `LogWriter`.
 - Added `LogCallback` and `ConsoleLoggerCallback` classes. `TensorBoardCallback` inherits from `LogCallback`. 
 
+### Fixed
+
+- Makes sure tensors that are stored in `TensorCache` always live on CPUs
+
+
 ## [v2.1.0](https://github.com/allenai/allennlp/releases/tag/v2.1.0) - 2021-02-24
 
 ### Changed

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -603,6 +603,7 @@ class TensorCache(MutableMapping[str, Tensor], ABC):
         if self.read_only:
             raise ValueError("cannot write to a read-only cache")
 
+        tensor = tensor.cpu()
         encoded_key = key.encode()
         buffer = io.BytesIO()
         if tensor.storage().size() != np.prod(tensor.size()):


### PR DESCRIPTION
Fixes https://github.com/allenai/allennlp/issues/5014.

I am not sure why this is necessary, but @aleSuglia ran into a problem with this, and this is a simple and fast way to make sure it doesn't happen again.