### PR TITLE
Use HF Transformers output types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `histogram_interval` parameter is now deprecated in `TensorboardWriter`, please use `distribution_interval` instead.
 - Memory usage is not logged in tensorboard during training now. `ConsoleLoggerCallback` should be used instead.
+- Use attributes of `ModelOutputs` object in `PretrainedTransformerEmbedder` instead of indexing.
 
 ### Added
 

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -200,12 +200,7 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
 
         transformer_output = self.transformer_model(**parameters)
         if self._scalar_mix is not None:
-            # As far as I can tell, the hidden states will always be the last element
-            # in the output tuple as long as the model is not also configured to return
-            # attention scores.
-            # See, for example, the return value description for BERT:
-            # https://huggingface.co/transformers/model_doc/bert.html#transformers.BertModel.forward
-            # These hidden states will also include the embedding layer, which we don't
+            # The hidden states will also include the embedding layer, which we don't
             # include in the scalar mix. Hence the `[1:]` slicing.
             hidden_states = transformer_output.hidden_states[1:]
             embeddings = self._scalar_mix(hidden_states)

--- a/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_embedder.py
@@ -207,10 +207,10 @@ class PretrainedTransformerEmbedder(TokenEmbedder):
             # https://huggingface.co/transformers/model_doc/bert.html#transformers.BertModel.forward
             # These hidden states will also include the embedding layer, which we don't
             # include in the scalar mix. Hence the `[1:]` slicing.
-            hidden_states = transformer_output[-1][1:]
+            hidden_states = transformer_output.hidden_states[1:]
             embeddings = self._scalar_mix(hidden_states)
         else:
-            embeddings = transformer_output[0]
+            embeddings = transformer_output.last_hidden_state
 
         if fold_long_sequences:
             embeddings = self._unfold_long_sequences(


### PR DESCRIPTION
<!-- Please reference the issue number here -->
Fixes # . (no open issue for this)

Changes proposed in this pull request:

Uses the [`ModelOutput`](https://huggingface.co/transformers/main_classes/output.html) attributes of the `transformers` library in place of indexing. E.g., instead of

```python
hidden_states = transformer_output[-1][1:]
# OR
embeddings = transformer_output[0]
```

does

```python
hidden_states = transformer_output.hidden_states[1:]
# OR
embeddings = transformer_output.last_hidden_state
```

IMO this is more readable and (probably?) less likely to break with new versions of `transformers`.

I didn't open an issue or give the maintainers any heads up (sorry!) so please feel free to close the PR if this change is not welcome.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
