### PR TITLE
Update torch requirement from <1.8.0,>=1.6.0 to >=1.6.0,<1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
         elif [[ $CUDA == '10.2' ]]; then
             echo "DOCKER_TORCH_VERSION='torch==1.8.0'" >> $GITHUB_ENV;
         elif [[ $CUDA == '11.1' ]]; then
-            echo "DOCKER_TORCH_VERSION='torch==1.8.0+cu111 torchvision==0.8.0+cu111 -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV;
+            echo "DOCKER_TORCH_VERSION='torch==1.8.0+cu111 torchvision==0.9.0+cu111 -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV;
         else
             echo "Unhandled CUDA version $CUDA";
             exit 1;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,11 +257,6 @@ jobs:
     - name: Install core package
       run: |
         pip install $(ls dist/*.whl)
-        # TODO(epwalsh): In PyTorch 1.7, dataclasses is an unconditional dependency, when it should
-        # only be a conditional dependency for Python < 3.7.
-        # This has been fixed on PyTorch main branch, so we should be able to
-        # remove this check with the next PyTorch release.
-        pip uninstall -y dataclasses
 
     - name: Pip freeze
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
     runs-on: [self-hosted, GPU]
     strategy:
       matrix:
-        cuda: ['10.1', '10.2', '11.0']
+        cuda: ['10.1', '10.2', '11.1']
 
     steps:
     - uses: actions/checkout@v2
@@ -284,11 +284,11 @@ jobs:
       run: |
         # Check the install instructions on https://pytorch.org/ to keep these up-to-date.
         if [[ $CUDA == '10.1' ]]; then
-            echo "DOCKER_TORCH_VERSION='torch==1.7.1+cu101 torchvision==0.8.2+cu101 -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV;
+            echo "DOCKER_TORCH_VERSION='torch==1.8.0+cu101 torchvision==0.9.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV;
         elif [[ $CUDA == '10.2' ]]; then
-            echo "DOCKER_TORCH_VERSION='torch==1.7.1'" >> $GITHUB_ENV;
-        elif [[ $CUDA == '11.0' ]]; then
-            echo "DOCKER_TORCH_VERSION='torch==1.7.1+cu110 torchvision==0.8.2+cu110 -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV;
+            echo "DOCKER_TORCH_VERSION='torch==1.8.0'" >> $GITHUB_ENV;
+        elif [[ $CUDA == '11.1' ]]; then
+            echo "DOCKER_TORCH_VERSION='torch==1.8.0+cu111 torchvision==0.8.0+cu111 -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV;
         else
             echo "Unhandled CUDA version $CUDA";
             exit 1;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `histogram_interval` parameter is now deprecated in `TensorboardWriter`, please use `distribution_interval` instead.
 - Memory usage is not logged in tensorboard during training now. `ConsoleLoggerCallback` should be used instead.
 - Use attributes of `ModelOutputs` object in `PretrainedTransformerEmbedder` instead of indexing.
+- Added support for PyTorch version 1.8.
 
 ### Added
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         ]
     ),
     install_requires=[
-        "torch>=1.6.0,<1.8.0",
+        "torch>=1.6.0,<1.9.0",
         "torchvision>=0.8.1,<0.9.0",
         "jsonnet>=0.10.0 ; sys.platform != 'win32'",
         "overrides==3.1.0",


### PR DESCRIPTION
Playing dependabot for the day.

Updates the requirements on [torch](https://github.com/pytorch/pytorch) to permit the latest version.

Release Notes: https://github.com/pytorch/pytorch/releases/tag/v1.8.0
