### PR TITLE
fix pickle bug for Lazy FromParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Makes sure tensors that are stored in `TensorCache` always live on CPUs
+- Fixed a bug where `FromParams` objects wrapped in `Lazy()` couldn't be pickled.
 
 
 ## [v2.1.0](https://github.com/allenai/allennlp/releases/tag/v2.1.0) - 2021-02-24

--- a/allennlp/common/from_params.py
+++ b/allennlp/common/from_params.py
@@ -458,18 +458,7 @@ def construct_arg(
 
         value_cls = args[0]
         subextras = create_extras(value_cls, extras)
-
-        def constructor(**kwargs):
-            # If there are duplicate keys between subextras and kwargs, this will overwrite the ones
-            # in subextras with what's in kwargs.  If an argument shows up twice, we should take it
-            # from what's passed to Lazy.construct() instead of what we got from create_extras().
-            # Almost certainly these will be identical objects, anyway.
-            # We do this by constructing a new dictionary, instead of mutating subextras, just in
-            # case this constructor is called multiple times.
-            constructor_extras = {**subextras, **kwargs}
-            return value_cls.from_params(params=deepcopy(popped_params), **constructor_extras)
-
-        return Lazy(constructor)  # type: ignore
+        return Lazy(value_cls, params=deepcopy(popped_params), contructor_extras=subextras)  # type: ignore
 
     # For any other kind of iterable, we will just assume that a list is good enough, and treat
     # it the same as List. This condition needs to be at the end, so we don't catch other kinds

--- a/tests/common/from_params_test.py
+++ b/tests/common/from_params_test.py
@@ -12,12 +12,6 @@ from allennlp.models.archival import load_archive
 from allennlp.common.checks import ConfigurationError
 
 
-class MyClass(FromParams):
-    def __init__(self, my_int: int, my_bool: bool = False) -> None:
-        self.my_int = my_int
-        self.my_bool = my_bool
-
-
 class TestFromParams(AllenNlpTestCase):
     def test_takes_arg(self):
         def bare_function(some_input: int) -> int:
@@ -739,6 +733,13 @@ class TestFromParams(AllenNlpTestCase):
 
         Testing.from_params(Params({"lazy_object": {"string": test_string}}))
 
+    def test_lazy_and_from_params_can_be_pickled(self):
+
+        import pickle
+
+        baz = Baz.from_params(Params({"bar": {"foo": {"a": 2}}}))
+        pickle.dumps(baz)
+
     def test_optional_vs_required_lazy_objects(self):
         class ConstructedObject(FromParams):
             def __init__(self, a: int):
@@ -1042,3 +1043,28 @@ class TestFromParams(AllenNlpTestCase):
 
         foo = Foo.from_params(Params({"a": 2}))
         assert foo.a == 2
+
+
+class MyClass(FromParams):
+    def __init__(self, my_int: int, my_bool: bool = False) -> None:
+        self.my_int = my_int
+        self.my_bool = my_bool
+
+
+class Foo(FromParams):
+    def __init__(self, a: int = 1) -> None:
+        self.a = a
+
+
+class Bar(FromParams):
+    def __init__(self, foo: Foo) -> None:
+        self.foo = foo
+
+
+class Baz(FromParams):
+    def __init__(self, bar: Lazy[Bar]) -> None:
+        self._bar = bar
+
+    @property
+    def bar(self):
+        return self._bar.construct()


### PR DESCRIPTION
From https://github.com/allenai/allennlp/issues/5030#issuecomment-795765426. This should ensure the `VisionReader` is pickleable, which is needed in order to use the "spawn" start method with multi-process data loading.