### PR TITLE
Always keep Spacy PoS tagger on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Makes sure tensors that are stored in `TensorCache` always live on CPUs
 - Fixed a bug where `FromParams` objects wrapped in `Lazy()` couldn't be pickled.
 - Fixed a bug where the `ROUGE` metric couldn't be picked.
-- Fixed a bug in issue 5036. We keeps our spacy POS tagger on.
+- Fixed a bug reported by https://github.com/allenai/allennlp/issues/5036 . We keeps our spacy POS tagger on.
 
 
 ## [v2.1.0](https://github.com/allenai/allennlp/releases/tag/v2.1.0) - 2021-02-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Makes sure tensors that are stored in `TensorCache` always live on CPUs
 - Fixed a bug where `FromParams` objects wrapped in `Lazy()` couldn't be pickled.
 - Fixed a bug where the `ROUGE` metric couldn't be picked.
+- Fixed a bug in issue 5036. We keeps our spacy POS tagger on.
 
 
 ## [v2.1.0](https://github.com/allenai/allennlp/releases/tag/v2.1.0) - 2021-02-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Makes sure tensors that are stored in `TensorCache` always live on CPUs
 - Fixed a bug where `FromParams` objects wrapped in `Lazy()` couldn't be pickled.
 - Fixed a bug where the `ROUGE` metric couldn't be picked.
-- Fixed a bug reported by https://github.com/allenai/allennlp/issues/5036 . We keeps our spacy POS tagger on.
+- Fixed a bug reported by https://github.com/allenai/allennlp/issues/5036. We keeps our spacy POS tagger on.
 
 
 ## [v2.1.0](https://github.com/allenai/allennlp/releases/tag/v2.1.0) - 2021-02-24

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -255,9 +255,7 @@ def prepare_environment(params: Params):
 LOADED_SPACY_MODELS: Dict[Tuple[str, bool, bool], SpacyModelType] = {}
 
 
-def get_spacy_model(
-    spacy_model_name: str, parse: bool, ner: bool
-) -> SpacyModelType:
+def get_spacy_model(spacy_model_name: str, parse: bool, ner: bool) -> SpacyModelType:
     """
     In order to avoid loading spacy models a whole bunch of times, we'll save references to them,
     keyed by the options we used to create the spacy model, so any particular configuration only

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -256,7 +256,7 @@ LOADED_SPACY_MODELS: Dict[Tuple[str, bool, bool, bool], SpacyModelType] = {}
 
 
 def get_spacy_model(
-    spacy_model_name: str, parse: bool, ner: bool, pos_tags: bool = True
+    spacy_model_name: str, pos_tags: bool = True, parse: bool = False, ner: bool = False
 ) -> SpacyModelType:
     """
     In order to avoid loading spacy models a whole bunch of times, we'll save references to them,

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -255,7 +255,9 @@ def prepare_environment(params: Params):
 LOADED_SPACY_MODELS: Dict[Tuple[str, bool, bool, bool], SpacyModelType] = {}
 
 
-def get_spacy_model(spacy_model_name: str, parse: bool, ner: bool, pos_tags: bool = True) -> SpacyModelType:
+def get_spacy_model(
+    spacy_model_name: str, parse: bool, ner: bool, pos_tags: bool = True
+) -> SpacyModelType:
     """
     In order to avoid loading spacy models a whole bunch of times, we'll save references to them,
     keyed by the options we used to create the spacy model, so any particular configuration only

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -252,19 +252,21 @@ def prepare_environment(params: Params):
     log_pytorch_version_info()
 
 
-LOADED_SPACY_MODELS: Dict[Tuple[str, bool, bool], SpacyModelType] = {}
+LOADED_SPACY_MODELS: Dict[Tuple[str, bool, bool, bool], SpacyModelType] = {}
 
 
-def get_spacy_model(spacy_model_name: str, parse: bool, ner: bool) -> SpacyModelType:
+def get_spacy_model(spacy_model_name: str, parse: bool, ner: bool, pos_tags: bool = True) -> SpacyModelType:
     """
     In order to avoid loading spacy models a whole bunch of times, we'll save references to them,
     keyed by the options we used to create the spacy model, so any particular configuration only
     gets loaded once.
     """
 
-    options = (spacy_model_name, parse, ner)
+    options = (spacy_model_name, pos_tags, parse, ner)
     if options not in LOADED_SPACY_MODELS:
         disable = ["vectors", "textcat"]
+        if not pos_tags:
+            disable.append("tagger")
         if not parse:
             disable.append("parser")
         if not ner:

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -252,11 +252,11 @@ def prepare_environment(params: Params):
     log_pytorch_version_info()
 
 
-LOADED_SPACY_MODELS: Dict[Tuple[str, bool, bool, bool], SpacyModelType] = {}
+LOADED_SPACY_MODELS: Dict[Tuple[str, bool, bool], SpacyModelType] = {}
 
 
 def get_spacy_model(
-    spacy_model_name: str, pos_tags: bool, parse: bool, ner: bool
+    spacy_model_name: str, parse: bool, ner: bool
 ) -> SpacyModelType:
     """
     In order to avoid loading spacy models a whole bunch of times, we'll save references to them,
@@ -264,11 +264,9 @@ def get_spacy_model(
     gets loaded once.
     """
 
-    options = (spacy_model_name, pos_tags, parse, ner)
+    options = (spacy_model_name, parse, ner)
     if options not in LOADED_SPACY_MODELS:
         disable = ["vectors", "textcat"]
-        if not pos_tags:
-            disable.append("tagger")
         if not parse:
             disable.append("parser")
         if not ner:

--- a/allennlp/data/tokenizers/sentence_splitter.py
+++ b/allennlp/data/tokenizers/sentence_splitter.py
@@ -45,7 +45,7 @@ class SpacySentenceSplitter(SentenceSplitter):
 
     def __init__(self, language: str = "en_core_web_sm", rule_based: bool = False) -> None:
         # we need spacy's dependency parser if we're not using rule-based sentence boundary detection.
-        self.spacy = get_spacy_model(language, parse=not rule_based, ner=False, pos_tags=False)
+        self.spacy = get_spacy_model(language, parse=not rule_based, ner=False)
         self._is_version_3 = spacy.__version__ >= "3.0"
         if rule_based:
             # we use `sentencizer`, a built-in spacy module for rule-based sentence boundary detection.

--- a/allennlp/data/tokenizers/spacy_tokenizer.py
+++ b/allennlp/data/tokenizers/spacy_tokenizer.py
@@ -52,7 +52,6 @@ class SpacyTokenizer(Tokenizer):
     def __init__(
         self,
         language: str = "en_core_web_sm",
-        pos_tags: bool = False,
         parse: bool = False,
         ner: bool = False,
         keep_spacy_tokens: bool = False,
@@ -60,7 +59,7 @@ class SpacyTokenizer(Tokenizer):
         start_tokens: Optional[List[str]] = None,
         end_tokens: Optional[List[str]] = None,
     ) -> None:
-        self.spacy = get_spacy_model(language, pos_tags, parse, ner)
+        self.spacy = get_spacy_model(language, parse, ner)
         if split_on_spaces:
             self.spacy.tokenizer = _WhitespaceSpacyTokenizer(self.spacy.vocab)
 

--- a/allennlp/data/tokenizers/spacy_tokenizer.py
+++ b/allennlp/data/tokenizers/spacy_tokenizer.py
@@ -52,6 +52,7 @@ class SpacyTokenizer(Tokenizer):
     def __init__(
         self,
         language: str = "en_core_web_sm",
+        pos_tags: bool = True,
         parse: bool = False,
         ner: bool = False,
         keep_spacy_tokens: bool = False,
@@ -59,7 +60,7 @@ class SpacyTokenizer(Tokenizer):
         start_tokens: Optional[List[str]] = None,
         end_tokens: Optional[List[str]] = None,
     ) -> None:
-        self.spacy = get_spacy_model(language, parse, ner)
+        self.spacy = get_spacy_model(language, parse, ner, pos_tags=pos_tags)
         if split_on_spaces:
             self.spacy.tokenizer = _WhitespaceSpacyTokenizer(self.spacy.vocab)
 

--- a/allennlp/data/tokenizers/spacy_tokenizer.py
+++ b/allennlp/data/tokenizers/spacy_tokenizer.py
@@ -60,7 +60,7 @@ class SpacyTokenizer(Tokenizer):
         start_tokens: Optional[List[str]] = None,
         end_tokens: Optional[List[str]] = None,
     ) -> None:
-        self.spacy = get_spacy_model(language, parse, ner, pos_tags=pos_tags)
+        self.spacy = get_spacy_model(language, pos_tags, parse, ner)
         if split_on_spaces:
             self.spacy.tokenizer = _WhitespaceSpacyTokenizer(self.spacy.vocab)
 

--- a/allennlp/predictors/sentence_tagger.py
+++ b/allennlp/predictors/sentence_tagger.py
@@ -26,7 +26,7 @@ class SentenceTaggerPredictor(Predictor):
         self, model: Model, dataset_reader: DatasetReader, language: str = "en_core_web_sm"
     ) -> None:
         super().__init__(model, dataset_reader)
-        self._tokenizer = SpacyTokenizer(language=language, pos_tags=True)
+        self._tokenizer = SpacyTokenizer(language=language)
 
     def predict(self, sentence: str) -> JsonDict:
         return self.predict_json({"sentence": sentence})

--- a/tests/data/dataset_readers/dataset_utils/span_utils_test.py
+++ b/tests/data/dataset_readers/dataset_utils/span_utils_test.py
@@ -129,7 +129,7 @@ class SpanUtilsTest(AllenNlpTestCase):
         }
 
     def test_enumerate_spans_enumerates_all_spans(self):
-        tokenizer = SpacyTokenizer(pos_tags=True)
+        tokenizer = SpacyTokenizer()
         sentence = tokenizer.tokenize("This is a sentence.")
 
         spans = span_utils.enumerate_spans(sentence)

--- a/tests/data/dataset_readers/text_classification_json_test.py
+++ b/tests/data/dataset_readers/text_classification_json_test.py
@@ -278,7 +278,7 @@ class TestTextClassificationJsonReader:
         instances = list(reader.read(ag_path))
 
         splitter = SpacySentenceSplitter()
-        spacy_tokenizer = get_spacy_model("en_core_web_sm", False, False)
+        spacy_tokenizer = get_spacy_model("en_core_web_sm", parse=False, ner=False)
 
         text1 = (
             "Memphis Rout Still Stings for No. 14 Louisville; Coach "

--- a/tests/data/dataset_readers/text_classification_json_test.py
+++ b/tests/data/dataset_readers/text_classification_json_test.py
@@ -278,7 +278,7 @@ class TestTextClassificationJsonReader:
         instances = list(reader.read(ag_path))
 
         splitter = SpacySentenceSplitter()
-        spacy_tokenizer = get_spacy_model("en_core_web_sm", False, False, False)
+        spacy_tokenizer = get_spacy_model("en_core_web_sm", False, False)
 
         text1 = (
             "Memphis Rout Still Stings for No. 14 Louisville; Coach "

--- a/tests/data/token_indexers/spacy_indexer_test.py
+++ b/tests/data/token_indexers/spacy_indexer_test.py
@@ -8,7 +8,7 @@ from allennlp.data.vocabulary import Vocabulary
 class TestSpacyTokenIndexer(AllenNlpTestCase):
     def test_as_array_produces_token_array(self):
         indexer = SpacyTokenIndexer()
-        nlp = get_spacy_model("en_core_web_sm", pos_tags=True, parse=False, ner=False)
+        nlp = get_spacy_model("en_core_web_sm", parse=False, ner=False)
         tokens = [t for t in nlp("This is a sentence.")]
         field = TextField(tokens, token_indexers={"spacy": indexer})
 


### PR DESCRIPTION
<!-- Please reference the issue number here -->
Fixes #5036  .

Changes proposed in this pull request:

- We always keep our spacy model's PoS tagger on, since the additional computation seems small and fix the behavioral issue of upgrading to SpaCy 3.0
-

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
