### PR TITLE
Results on validation set fixed in GradientDescentTrainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+## 2021-03-29
+
+
+### Changed
+
+- Results on validation set during training with GradientDescentTrainer are made deterministic
+
+
 ### Changed
 
 - Allow the order of examples in the task cards to be specified explicitly

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -762,6 +762,8 @@ class GradientDescentTrainer(Trainer):
             this_epoch_val_metric: float = 0.0
             if self._validation_data_loader is not None:
                 with torch.no_grad():
+                    # Make results deterministic on the validation set
+                    self.model.eval()
                     # We have a validation set, so compute all the metrics on it.
                     val_loss, val_reg_loss, num_batches = self._validation_loss(epoch)
 


### PR DESCRIPTION
Results on validation set during training in `GradientDescentTrainer` are made deterministic to prevent weird metrics values. 