### PR TITLE
Avoid from_pretrained download of model weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If you use the `min_count` parameter of the Vocabulary, but you specify a namespace that does not exist, the vocabulary creation will raise a `ConfigurationError`.
 - Documentation updates made to SoftmaxLoss regarding padding and the expected shapes of the input and output tensors of `forward`.
 - Moved the data preparation script for coref into allennlp-models.
+- If a transformer is not in cache but has override weights, the transformer's pretrained weights are no longer downloaded, that is, only its `config.json` file is downloaded.
 
 ### Fixed
 

--- a/allennlp/common/cached_transformers.py
+++ b/allennlp/common/cached_transformers.py
@@ -81,7 +81,10 @@ def get(
                     **kwargs,
                 )
             )
-            # Only load the model itself if we are using distributed training
+            # When DistributedDataParallel or DataParallel is used, the state dict of the
+            # DistributedDataParallel/DataParallel wrapper prepends "module." to all parameters of the actual model,
+            # since the actual model is stored within the module field.
+            # This accounts for if a pretained model was saved without removing the DistributedDataParallel/DataParallel wrapper.
             if hasattr(transformer, "module"):
                 transformer.module.load_state_dict(override_weights)
             else:

--- a/allennlp/common/cached_transformers.py
+++ b/allennlp/common/cached_transformers.py
@@ -1,7 +1,7 @@
 import logging
 from typing import NamedTuple, Optional, Dict, Tuple
 import transformers
-from transformers import AutoModel
+from transformers import AutoModel, AutoConfig
 
 
 logger = logging.getLogger(__name__)
@@ -75,10 +75,12 @@ def get(
                     )
                 override_weights = {strip_prefix(k): override_weights[k] for k in valid_keys}
 
-            transformer = AutoModel.from_pretrained(
-                model_name,
-                state_dict=override_weights,
-                **kwargs,
+            transformer = AutoModel.from_config(
+                AutoConfig.from_pretrained(
+                    model_name,
+                    state_dict=override_weights,
+                    **kwargs,
+                )
             )
         else:
             transformer = AutoModel.from_pretrained(

--- a/allennlp/common/cached_transformers.py
+++ b/allennlp/common/cached_transformers.py
@@ -82,9 +82,10 @@ def get(
                 )
             )
             # When DistributedDataParallel or DataParallel is used, the state dict of the
-            # DistributedDataParallel/DataParallel wrapper prepends "module." to all parameters of the actual model,
-            # since the actual model is stored within the module field.
-            # This accounts for if a pretained model was saved without removing the DistributedDataParallel/DataParallel wrapper.
+            # DistributedDataParallel/DataParallel wrapper prepends "module." to all parameters
+            # of the actual model, since the actual model is stored within the module field.
+            # This accounts for if a pretained model was saved without removing the
+            # DistributedDataParallel/DataParallel wrapper.
             if hasattr(transformer, "module"):
                 transformer.module.load_state_dict(override_weights)
             else:

--- a/allennlp/common/cached_transformers.py
+++ b/allennlp/common/cached_transformers.py
@@ -78,10 +78,14 @@ def get(
             transformer = AutoModel.from_config(
                 AutoConfig.from_pretrained(
                     model_name,
-                    state_dict=override_weights,
                     **kwargs,
                 )
             )
+            # Only load the model itself if we are using distributed training
+            if hasattr(transformer, "module"):
+                transformer.module.load_state_dict(override_weights)
+            else:
+                transformer.load_state_dict(override_weights)
         else:
             transformer = AutoModel.from_pretrained(
                 model_name,

--- a/tests/common/cached_transformers_test.py
+++ b/tests/common/cached_transformers_test.py
@@ -22,7 +22,7 @@ class TestCachedTransformers(AllenNlpTestCase):
     def test_from_pretrained_avoids_weights_download_if_override_weights(self):
         # only download config because downloading pretrained weights in addition takes too long
         transformer = AutoModel.from_config(
-            AutoConfig.from_pretrained("bert-base-uncased", cache_dir=self.TEST_DIR)
+            AutoConfig.from_pretrained("epwalsh/bert-xsmall-dummy", cache_dir=self.TEST_DIR)
         )
         # clear cache directory
         for f in os.listdir(str(self.TEST_DIR)):

--- a/tests/common/cached_transformers_test.py
+++ b/tests/common/cached_transformers_test.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import os
+import json
 
 from allennlp.common import cached_transformers
 from allennlp.common.testing import AllenNlpTestCase
@@ -11,7 +12,7 @@ from transformers import AutoModel, AutoConfig
 class TestCachedTransformers(AllenNlpTestCase):
     def test_get_missing_from_cache_local_files_only(self):
         with pytest.raises((OSError, ValueError)):
-            transformer = cached_transformers.get(
+            cached_transformers.get(
                 "bert-base-uncased",
                 True,
                 cache_dir=self.TEST_DIR,
@@ -31,19 +32,26 @@ class TestCachedTransformers(AllenNlpTestCase):
         save_weights_path = str(self.TEST_DIR) + "/bert_weights.pth"
         torch.save(transformer.state_dict(), save_weights_path)
 
-        pre_download_num_files = len(os.listdir(str(self.TEST_DIR)))
         override_transformer = cached_transformers.get(
             "bert-base-uncased",
             False,
             override_weights_file=save_weights_path,
             cache_dir=self.TEST_DIR,
         )
-        post_download_num_files = len(os.listdir(str(self.TEST_DIR)))
-        # check that only three files were downloaded (.json, .[etag], .lock), for config.json
+        # check that only three files were downloaded (filename.json, filename, filename.lock), for config.json
         # if more than three files were downloaded, then model weights were also (incorrectly) downloaded
         # NOTE: downloaded files are not explicitly detailed in Huggingface's public API,
         # so this assertion could fail in the future
-        assert post_download_num_files - pre_download_num_files == 3
+        json_fnames = [fname for fname in os.listdir(str(self.TEST_DIR)) if fname.endswith(".json")]
+        assert len(json_fnames) == 1
+        json_data = json.load(open(str(self.TEST_DIR) + "/" + json_fnames[0]))
+        assert (
+            json_data["url"] == "https://huggingface.co/bert-base-uncased/resolve/main/config.json"
+        )
+        resource_id = os.path.splitext(json_fnames[0])[0]
+        assert set(os.listdir(str(self.TEST_DIR))) == set(
+            [json_fnames[0], resource_id, resource_id + ".lock", "bert_weights.pth"]
+        )
 
         # check that override weights were loaded correctly
         for p1, p2 in zip(transformer.parameters(), override_transformer.parameters()):

--- a/tests/common/cached_transformers_test.py
+++ b/tests/common/cached_transformers_test.py
@@ -16,7 +16,9 @@ class TestCachedTransformers(AllenNlpTestCase):
                 local_files_only=True,
             )
             assert os.path.isfile(self.TEST_DIR + "/" + "bert-base-uncased.bin")
+            assert os.path.isfile(self.TEST_DIR + "/" + "config.json")
             os.remove(self.TEST_DIR + "/" + "bert-base-uncased.bin")
+            os.remove(self.TEST_DIR + "/" + "config.json")
 
             torch.save(transformer.module.state_dict(), self.TEST_DIR + "/" + "bert_weights.pth")
             cached_transformers.get(
@@ -27,6 +29,7 @@ class TestCachedTransformers(AllenNlpTestCase):
                 local_files_only=True,
             )
             assert not os.path.isfile(self.TEST_DIR + "/" + "bert-base-uncased.bin")
+            assert os.path.isfile(self.TEST_DIR + "/" + "config.json")
 
     def test_get_tokenizer_missing_from_cache_local_files_only(self):
         with pytest.raises((OSError, ValueError)):

--- a/tests/common/cached_transformers_test.py
+++ b/tests/common/cached_transformers_test.py
@@ -5,6 +5,8 @@ import os
 from allennlp.common import cached_transformers
 from allennlp.common.testing import AllenNlpTestCase
 
+from transformers import AutoModel, AutoConfig
+
 
 class TestCachedTransformers(AllenNlpTestCase):
     def test_get_missing_from_cache_local_files_only(self):
@@ -15,21 +17,37 @@ class TestCachedTransformers(AllenNlpTestCase):
                 cache_dir=self.TEST_DIR,
                 local_files_only=True,
             )
-            assert os.path.isfile(self.TEST_DIR + "/" + "bert-base-uncased.bin")
-            assert os.path.isfile(self.TEST_DIR + "/" + "config.json")
-            os.remove(self.TEST_DIR + "/" + "bert-base-uncased.bin")
-            os.remove(self.TEST_DIR + "/" + "config.json")
 
-            torch.save(transformer.module.state_dict(), self.TEST_DIR + "/" + "bert_weights.pth")
-            cached_transformers.get(
-                "bert-base-uncased",
-                True,
-                override_weights_file=self.TEST_DIR + "/" + "bert_weights.pth",
-                cache_dir=self.TEST_DIR,
-                local_files_only=True,
-            )
-            assert not os.path.isfile(self.TEST_DIR + "/" + "bert-base-uncased.bin")
-            assert os.path.isfile(self.TEST_DIR + "/" + "config.json")
+    def test_from_pretrained_avoids_weights_download_if_override_weights(self):
+        # only download config because downloading pretrained weights in addition takes too long
+        transformer = AutoModel.from_config(
+            AutoConfig.from_pretrained("bert-base-uncased", cache_dir=self.TEST_DIR)
+        )
+        # clear cache directory
+        for f in os.listdir(str(self.TEST_DIR)):
+            os.remove(str(self.TEST_DIR) + "/" + f)
+        assert len(os.listdir(str(self.TEST_DIR))) == 0
+
+        save_weights_path = str(self.TEST_DIR) + "/bert_weights.pth"
+        torch.save(transformer.state_dict(), save_weights_path)
+
+        pre_download_num_files = len(os.listdir(str(self.TEST_DIR)))
+        override_transformer = cached_transformers.get(
+            "bert-base-uncased",
+            False,
+            override_weights_file=save_weights_path,
+            cache_dir=self.TEST_DIR,
+        )
+        post_download_num_files = len(os.listdir(str(self.TEST_DIR)))
+        # check that only three files were downloaded (.json, .[etag], .lock), for config.json
+        # if more than three files were downloaded, then model weights were also (incorrectly) downloaded
+        # NOTE: downloaded files are not explicitly detailed in Huggingface's public API,
+        # so this assertion could fail in the future
+        assert post_download_num_files - pre_download_num_files == 3
+
+        # check that override weights were loaded correctly
+        for p1, p2 in zip(transformer.parameters(), override_transformer.parameters()):
+            assert p1.data.ne(p2.data).sum() == 0
 
     def test_get_tokenizer_missing_from_cache_local_files_only(self):
         with pytest.raises((OSError, ValueError)):

--- a/tests/common/cached_transformers_test.py
+++ b/tests/common/cached_transformers_test.py
@@ -1,4 +1,6 @@
 import pytest
+import torch
+import os
 
 from allennlp.common import cached_transformers
 from allennlp.common.testing import AllenNlpTestCase
@@ -7,12 +9,24 @@ from allennlp.common.testing import AllenNlpTestCase
 class TestCachedTransformers(AllenNlpTestCase):
     def test_get_missing_from_cache_local_files_only(self):
         with pytest.raises((OSError, ValueError)):
-            cached_transformers.get(
+            transformer = cached_transformers.get(
                 "bert-base-uncased",
                 True,
                 cache_dir=self.TEST_DIR,
                 local_files_only=True,
             )
+            assert os.path.isfile(self.TEST_DIR + "/" + "bert-base-uncased.bin")
+            os.remove(self.TEST_DIR + "/" + "bert-base-uncased.bin")
+
+            torch.save(transformer.module.state_dict(), self.TEST_DIR + "/" + "bert_weights.pth")
+            cached_transformers.get(
+                "bert-base-uncased",
+                True,
+                override_weights_file=self.TEST_DIR + "/" + "bert_weights.pth",
+                cache_dir=self.TEST_DIR,
+                local_files_only=True,
+            )
+            assert not os.path.isfile(self.TEST_DIR + "/" + "bert-base-uncased.bin")
 
     def test_get_tokenizer_missing_from_cache_local_files_only(self):
         with pytest.raises((OSError, ValueError)):

--- a/tests/common/cached_transformers_test.py
+++ b/tests/common/cached_transformers_test.py
@@ -33,7 +33,7 @@ class TestCachedTransformers(AllenNlpTestCase):
         torch.save(transformer.state_dict(), save_weights_path)
 
         override_transformer = cached_transformers.get(
-            "bert-base-uncased",
+            "epwalsh/bert-xsmall-dummy",
             False,
             override_weights_file=save_weights_path,
             cache_dir=self.TEST_DIR,
@@ -46,7 +46,8 @@ class TestCachedTransformers(AllenNlpTestCase):
         assert len(json_fnames) == 1
         json_data = json.load(open(str(self.TEST_DIR) + "/" + json_fnames[0]))
         assert (
-            json_data["url"] == "https://huggingface.co/bert-base-uncased/resolve/main/config.json"
+            json_data["url"]
+            == "https://huggingface.co/epwalsh/bert-xsmall-dummy/resolve/main/config.json"
         )
         resource_id = os.path.splitext(json_fnames[0])[0]
         assert set(os.listdir(str(self.TEST_DIR))) == set(


### PR DESCRIPTION
<!-- Please reference the issue number here -->
Related to #4599 .

Changes proposed in this pull request:

- If a transformer is not in cache but has override weights, the transformer's pretrained weights are no longer downloaded, that is, only its `config.json` file is downloaded.
- Does not completely fix this issue, as model architecture download still occurs.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
