### PR TITLE
Added new parameter 'sub_token_mode' to 'pretrained_transformer_mismatched_embedder' class to support first sub-token embedding (#4363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ported the following Huggingface `LambdaLR`-based schedulers: `ConstantLearningRateScheduler`, `ConstantWithWarmupLearningRateScheduler`, `CosineWithWarmupLearningRateScheduler`, `CosineHardRestartsWithWarmupLearningRateScheduler`.
+- Added new `sub_token_mode` parameter to `pretrained_transformer_mismatched_embedder` class to support first sub-token embedding
 
 ### Changed
 
@@ -28,9 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where some `Activation` implementations could not be pickled due to involving a lambda function.
 
-### Added
-
-- Added new `sub_token_mode` parameter to `pretrained_transformer_mismatched_embedder` class to support first sub-token embedding
 
 ## [v2.2.0](https://github.com/allenai/allennlp/releases/tag/v2.2.0) - 2021-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where some `Activation` implementations could not be pickled due to involving a lambda function.
 
+### Added
+
+- Added new `sub_token_mode` parameter to `pretrained_transformer_mismatched_embedder` class to support first sub-token embedding
 
 ## [v2.2.0](https://github.com/allenai/allennlp/releases/tag/v2.2.0) - 2021-03-26
 

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -11,7 +11,7 @@ from allennlp.nn import util
 class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
     """
     Use this embedder to embed wordpieces given by `PretrainedTransformerMismatchedIndexer`
-    and to pool the resulting vectors to get word-level representations.
+    and to get word-level representations.
 
     Registered as a `TokenEmbedder` with name "pretrained_transformer_mismatched".
 
@@ -41,6 +41,12 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         Dictionary with
         [additional arguments](https://github.com/huggingface/transformers/blob/155c782a2ccd103cf63ad48a2becd7c76a7d2115/transformers/modeling_utils.py#L253)
         for `AutoModel.from_pretrained`.
+    sub_token_mode: `Optional[str]`, optional (default= `avg`)
+        If `sub_token_mode` is set to `first`, return first sub-token representation as word-level representation
+        If `sub_token_mode` is set to `avg`, return average of all the sub-tokens representation as word-level representation
+        If `sub_token_mode` is not specified it defaults to `avg`
+        If invalid `sub_token_mode` is provided, throw `ValueError`
+
     """  # noqa: E501
 
     def __init__(
@@ -52,6 +58,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         gradient_checkpointing: Optional[bool] = None,
         tokenizer_kwargs: Optional[Dict[str, Any]] = None,
         transformer_kwargs: Optional[Dict[str, Any]] = None,
+        sub_token_mode: Optional[str] = "avg",
     ) -> None:
         super().__init__()
         # The matched version v.s. mismatched
@@ -64,6 +71,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
             tokenizer_kwargs=tokenizer_kwargs,
             transformer_kwargs=transformer_kwargs,
         )
+        self.sub_token_mode = sub_token_mode
 
     @overrides
     def get_output_dim(self):
@@ -111,15 +119,53 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         # span_embeddings: (batch_size, num_orig_tokens, max_span_length, embedding_size)
         # span_mask: (batch_size, num_orig_tokens, max_span_length)
         span_embeddings, span_mask = util.batched_span_select(embeddings.contiguous(), offsets)
-        span_mask = span_mask.unsqueeze(-1)
-        span_embeddings *= span_mask  # zero out paddings
 
-        span_embeddings_sum = span_embeddings.sum(2)
-        span_embeddings_len = span_mask.sum(2)
-        # Shape: (batch_size, num_orig_tokens, embedding_size)
-        orig_embeddings = span_embeddings_sum / torch.clamp_min(span_embeddings_len, 1)
+        # int: maximum number of sub-tokens a batch has
+        max_span_length = span_mask.shape[-1]
 
-        # All the places where the span length is zero, write in zeros.
-        orig_embeddings[(span_embeddings_len == 0).expand(orig_embeddings.shape)] = 0
+        # If "sub_token_mode" is set to "first", return the first sub-token embedding
+        if self.sub_token_mode == "first":
+            # Shape: (batch_size, num_orig_tokens, max_span_length)
+            span_mask_bool = torch.zeros(span_mask.shape, dtype=torch.bool)
+
+            # Shape: 1-dimensional tensor
+            max_span_range_indices = torch.arange(max_span_length, dtype=torch.long).view(1, 1, -1)
+
+            # Shape (batch_size, num_orig_tokens, max_span_length)
+            span_mask = max_span_range_indices <= span_mask_bool
+            span_mask = span_mask.unsqueeze(-1)
+
+            # Shape: (batch_size, num_orig_tokens, max_span_length, embedding_size)
+            span_embeddings *= span_mask
+
+            # Sum over embeddings of all sub-tokens of a word where except first sub-token,
+            # rest all sub-token's embeddings is zero padded
+            # Shape: (batch_size, num_orig_tokens, embedding_size)
+            orig_embeddings = span_embeddings.sum(2)
+
+        # If "sub_token_mode" is set to "avg", return the average of embeddings of all sub-tokens of a word
+        elif self.sub_token_mode == "avg":
+            span_mask = span_mask.unsqueeze(-1)
+
+            # Shape: (batch_size, num_orig_tokens, max_span_length, embedding_size)
+            span_embeddings *= span_mask  # zero out paddings
+
+            # Sum over embeddings of all sub-tokens of a word
+            # Shape: (batch_size, num_orig_tokens, embedding_size)
+            span_embeddings_sum = span_embeddings.sum(2)
+
+            # Shape (batch_size, num_orig_tokens)
+            span_embeddings_len = span_mask.sum(2)
+
+            # Find the average of sub-tokens embeddings by dividing `span_embedding_sum` by `span_embedding_len`
+            # Shape: (batch_size, num_orig_tokens, embedding_size)
+            orig_embeddings = span_embeddings_sum / torch.clamp_min(span_embeddings_len, 1)
+
+            # All the places where the span length is zero, write in zeros.
+            orig_embeddings[(span_embeddings_len == 0).expand(orig_embeddings.shape)] = 0
+
+        # If invalid "sub_token_mode" is provided, throw error
+        else:
+            raise ValueError("Do not recognise 'sub_token_mode' {}".format(self.sub_token_mode))
 
         return orig_embeddings

--- a/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
+++ b/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
@@ -177,3 +177,92 @@ class TestPretrainedTransformerMismatchedEmbedder(AllenNlpTestCase):
         for name, param in token_embedder.named_parameters():
             grad = param.grad
             assert (grad is None) or (not torch.any(torch.isnan(grad)).item())
+
+    @pytest.mark.parametrize("sub_token_mode", ("first", "avg"))
+    def test_end_to_end_for_first_sub_token_embedding(self, sub_token_mode: str):
+        token_indexer = PretrainedTransformerMismatchedIndexer("bert-base-uncased")
+
+        sentence1 = ["A", ",", "AllenNLP", "sentence", "."]
+        sentence2 = ["AllenNLP", "is", "open", "source", "NLP", "library"]
+
+        tokens1 = [Token(word) for word in sentence1]
+        tokens2 = [Token(word) for word in sentence2]
+
+        vocab = Vocabulary()
+
+        params = Params(
+            {
+                "token_embedders": {
+                    "bert": {
+                        "type": "pretrained_transformer_mismatched",
+                        "model_name": "bert-base-uncased",
+                        "sub_token_mode": sub_token_mode,
+                    }
+                }
+            }
+        )
+        token_embedder = BasicTextFieldEmbedder.from_params(vocab=vocab, params=params)
+
+        instance1 = Instance({"tokens": TextField(tokens1, {"bert": token_indexer})})
+        instance2 = Instance({"tokens": TextField(tokens2, {"bert": token_indexer})})
+
+        batch = Batch([instance1, instance2])
+        batch.index_instances(vocab)
+
+        padding_lengths = batch.get_padding_lengths()
+        tensor_dict = batch.as_tensor_dict(padding_lengths)
+        tokens = tensor_dict["tokens"]
+
+        assert tokens["bert"]["mask"].tolist() == [
+            [True, True, True, True, True, False],
+            [True, True, True, True, True, True],
+        ]
+
+        assert tokens["bert"]["offsets"].tolist() == [
+            [[1, 1], [2, 2], [3, 5], [6, 6], [7, 7], [0, 0]],
+            [[1, 3], [4, 4], [5, 5], [6, 6], [7, 8], [9, 9]],
+        ]
+
+        # Attention mask
+        bert_vectors = token_embedder(tokens)
+
+        assert bert_vectors.size() == (2, max(len(sentence1), len(sentence2)), 768)
+        assert not torch.isnan(bert_vectors).any()
+
+    @pytest.mark.parametrize("sub_token_mode", ["last"])
+    def test_throws_error_on_incorrect_sub_token_mode(self, sub_token_mode: str):
+        token_indexer = PretrainedTransformerMismatchedIndexer("bert-base-uncased")
+
+        sentence1 = ["A", ",", "AllenNLP", "sentence", "."]
+        sentence2 = ["AllenNLP", "is", "open", "source", "NLP", "library"]
+
+        tokens1 = [Token(word) for word in sentence1]
+        tokens2 = [Token(word) for word in sentence2]
+
+        vocab = Vocabulary()
+
+        params = Params(
+            {
+                "token_embedders": {
+                    "bert": {
+                        "type": "pretrained_transformer_mismatched",
+                        "model_name": "bert-base-uncased",
+                        "sub_token_mode": sub_token_mode,
+                    }
+                }
+            }
+        )
+        token_embedder = BasicTextFieldEmbedder.from_params(vocab=vocab, params=params)
+
+        instance1 = Instance({"tokens": TextField(tokens1, {"bert": token_indexer})})
+        instance2 = Instance({"tokens": TextField(tokens2, {"bert": token_indexer})})
+
+        batch = Batch([instance1, instance2])
+        batch.index_instances(vocab)
+
+        padding_lengths = batch.get_padding_lengths()
+        tensor_dict = batch.as_tensor_dict(padding_lengths)
+        tokens = tensor_dict["tokens"]
+
+        with pytest.raises(ValueError):
+            token_embedder(tokens)

--- a/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
+++ b/tests/modules/token_embedders/pretrained_transformer_mismatched_embedder_test.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from allennlp.common import Params
+from allennlp.common.checks import ConfigurationError
 from allennlp.data import Token, Vocabulary
 from allennlp.data.batch import Batch
 from allennlp.data.fields import TextField
@@ -264,5 +265,5 @@ class TestPretrainedTransformerMismatchedEmbedder(AllenNlpTestCase):
         tensor_dict = batch.as_tensor_dict(padding_lengths)
         tokens = tensor_dict["tokens"]
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ConfigurationError):
             token_embedder(tokens)


### PR DESCRIPTION
<!-- Please reference the issue number here -->
Fixes #4363 .

Changes proposed in this pull request:
Currently 'PretrainedTransformerMismatchedEmbedder' in allennlp only allows to return average of embeddings of all
sub-tokens of a word whereas Original BERT Model suggests to take first/last sub-token embedding.
Added the flexibility to choose first subtoken embedding based on a parameter `sub_token_mode`

- If 'sub_token_mode' is set to 'first', return first sub-token representation as word-level representation
- If 'sub_token_mode' is set to 'avg', return average of all the sub-tokens representation as word-level representation
- If 'sub_token_mode' is not specified it defaults to 'avg'
- If invalid 'sub_token_mode' is provided, throw 'ConfigurationError'

Acknowledgement of support by  @pab-vmware, @annajung, @agururajvais, @divijbajaj 

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
