### PR TITLE
Bring back `run_sanity_checks` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Sanity checks in the `GradientDescentTrainer` can now be turned off by setting the `run_sanity_checks` parameter to `False`.
 - Allow the order of examples in the task cards to be specified explicitly
 - `histogram_interval` parameter is now deprecated in `TensorboardWriter`, please use `distribution_interval` instead.
 - Memory usage is not logged in tensorboard during training now. `ConsoleLoggerCallback` should be used instead.

--- a/allennlp/sanity_checks/normalization_bias_verification.py
+++ b/allennlp/sanity_checks/normalization_bias_verification.py
@@ -1,6 +1,7 @@
 """
-Code based almost entirely on
-https://github.com/awaelchli/pytorch-lightning-snippets/commit/7db53f774715d635c59ef56f21a17634d246b2c5
+Code based almost entirely from the [pytorch-lightning-snippets]
+(https://github.com/awaelchli/pytorch-lightning-snippets/commit/7db53f774715d635c59ef56f21a17634d246b2c5)
+repository.
 """
 
 import torch

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -6,7 +6,7 @@ import re
 import time
 import traceback
 from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, Type
 
 from allennlp.common.util import int_to_device
 
@@ -336,7 +336,7 @@ class GradientDescentTrainer(Trainer):
                 if callback.__class__ == callback_cls:
                     break
             else:
-                self._callbacks.append(callback_cls(serialization_dir))
+                self._callbacks.append(callback_cls(self._serialization_dir))
 
         self._batch_num_total = 0
         self._last_log = 0.0  # time of last logging
@@ -1087,7 +1087,7 @@ class GradientDescentTrainer(Trainer):
         )
 
 
-DEFAULT_CALLBACKS = (ConsoleLoggerCallback,)
+DEFAULT_CALLBACKS: Tuple[Type[TrainerCallback]] = (ConsoleLoggerCallback,)
 """
 The default callbacks used by `GradientDescentTrainer`.
 """

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -990,6 +990,8 @@ class GradientDescentTrainer(Trainer):
         moving_average: Lazy[MovingAverage] = None,
         checkpointer: Lazy[Checkpointer] = Lazy(Checkpointer),
         callbacks: List[Lazy[TrainerCallback]] = None,
+        enable_default_callbacks: bool = True,
+        run_sanity_checks: bool = True,
     ) -> "Trainer":
         """
         This method exists so that we can have a documented method to construct this class using
@@ -1080,6 +1082,8 @@ class GradientDescentTrainer(Trainer):
             world_size=world_size,
             num_gradient_accumulation_steps=num_gradient_accumulation_steps,
             use_amp=use_amp,
+            enable_default_callbacks=enable_default_callbacks,
+            run_sanity_checks=run_sanity_checks,
         )
 
 

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -847,7 +847,7 @@ class TestTrainer(TrainerTestBase):
             serialization_dir=self.TEST_DIR,
             data_loader=data_loader,
             num_epochs=1,
-            enable_default_callbacks=False,
+            run_sanity_checks=False,
         )
 
         # Check is not run, so no failure.


### PR DESCRIPTION
<!-- Please reference the issue number here -->
From the discussion [here](https://github.com/allenai/allennlp/discussions/5053#discussioncomment-544325).

Changes proposed in this pull request:

- Adds (back) a `run_sanity_checks` parameter.
- `SanityChecksCallback` no longer a `DEFAULT_CALLBACK`.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
