### PR TITLE
add SanityCheckError class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If you use the `min_count` parameter of the Vocabulary, but you specify a namespace that does not exist, the vocabulary creation will raise a `ConfigurationError`.
 - Documentation updates made to SoftmaxLoss regarding padding and the expected shapes of the input and output tensors of `forward`.
 - Moved the data preparation script for coref into allennlp-models.
+- `SanityChecksCallback` now raises `SanityCheckError` instead of `AssertionError` when a check fails.
 
 ### Fixed
 

--- a/allennlp/sanity_checks/verification_base.py
+++ b/allennlp/sanity_checks/verification_base.py
@@ -66,9 +66,3 @@ class VerificationBase:
         if isinstance(inputs, dict):
             return self.model(**inputs)
         return self.model(inputs)
-
-
-class VerificationError(Exception):
-    """
-    The error type raised when a sanity check fails.
-    """

--- a/allennlp/sanity_checks/verification_base.py
+++ b/allennlp/sanity_checks/verification_base.py
@@ -66,3 +66,9 @@ class VerificationBase:
         if isinstance(inputs, dict):
             return self.model(**inputs)
         return self.model(inputs)
+
+
+class VerificationError(Exception):
+    """
+    The error type raised when a sanity check fails.
+    """

--- a/allennlp/training/callbacks/sanity_checks.py
+++ b/allennlp/training/callbacks/sanity_checks.py
@@ -53,6 +53,19 @@ class SanityChecksCallback(TrainerCallback):
         if epoch == 0 and batch_number == 1 and is_training:
             self._verification.destroy_hooks()
             detected_pairs = self._verification.collect_detections()
-            assert (
-                len(detected_pairs) == 0
-            ), "The NormalizationBiasVerification check failed. See logs for more details."
+            if len(detected_pairs) > 0:
+                raise SanityCheckError(
+                    "The NormalizationBiasVerification check failed. See logs for more details."
+                )
+
+
+class SanityCheckError(Exception):
+    """
+    The error type raised when a sanity check fails.
+    """
+
+    def __init__(self, message) -> None:
+        super().__init__(
+            message
+            + "\nYou can disable these checks by setting the trainer parameter `run_sanity_checks` to `False`."
+        )

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -32,6 +32,7 @@ from allennlp.training.callbacks import (
     SanityChecksCallback,
     ConsoleLoggerCallback,
 )
+from allennlp.training.callbacks.sanity_checks import SanityCheckError
 from allennlp.training.learning_rate_schedulers import CosineWithRestarts
 from allennlp.training.learning_rate_schedulers import ExponentialLearningRateScheduler
 from allennlp.training.momentum_schedulers import MomentumScheduler
@@ -826,7 +827,7 @@ class TestTrainer(TrainerTestBase):
             serialization_dir=self.TEST_DIR,
             callbacks=[SanityChecksCallback(serialization_dir=self.TEST_DIR)],
         )
-        with pytest.raises(AssertionError):
+        with pytest.raises(SanityCheckError):
             trainer.train()
 
     def test_sanity_check_default(self):
@@ -839,7 +840,7 @@ class TestTrainer(TrainerTestBase):
             data_loader=data_loader,
             num_epochs=1,
         )
-        with pytest.raises(AssertionError):
+        with pytest.raises(SanityCheckError):
             trainer.train()
 
         trainer = GradientDescentTrainer.from_partial_objects(


### PR DESCRIPTION
<!-- Please reference the issue number here -->

Changes proposed in this pull request:

- The sanity checks callback will raise a `SanityCheckError` instead of an `AssertionError` when a check fails.
- The error message explicitly says how to turn off sanity checks.

I think it's good to have a custom error class for this type of thing so that users can easily detect and/or handle these errors in particular.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
