### PR TITLE
vocab fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where some `Activation` implementations could not be pickled due to involving a lambda function.
 - Fixed `__str__()` method on `ModelCardInfo` class.
+- Fixed an issue where using the `from_pretrained_transformer` `Vocabulary` constructor in distributed training via the `allennlp train` command
+  would result in the data being iterated through unnecessarily.
 
 
 ## [v2.2.0](https://github.com/allenai/allennlp/releases/tag/v2.2.0) - 2021-03-26

--- a/allennlp/training/util.py
+++ b/allennlp/training/util.py
@@ -452,7 +452,11 @@ def make_vocab_from_params(
     )
     # Do a quick sanity check here. There's no need to load any datasets if the vocab
     # type is "empty" or "from_files".
-    if datasets_for_vocab_creation is None and vocab_params.get("type") in {"empty", "from_files"}:
+    if datasets_for_vocab_creation is None and vocab_params.get("type") in {
+        "empty",
+        "from_files",
+        "from_pretrained_transformer",
+    }:
         datasets_for_vocab_creation = []
 
     data_loaders: Dict[str, DataLoader]


### PR DESCRIPTION
@pdasigi brought this up.

When using the `from_pretrained_transformer` vocab constructor, we shouldn't need to iterate through the data.