### PR TITLE
remove jsonpickle from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved the data preparation script for coref into allennlp-models.
 - If a transformer is not in cache but has override weights, the transformer's pretrained weights are no longer downloaded, that is, only its `config.json` file is downloaded.
 - `SanityChecksCallback` now raises `SanityCheckError` instead of `AssertionError` when a check fails.
+- `jsonpickle` removed from dependencies.
 
 ### Fixed
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
         "pytest",
         "transformers>=4.1,<4.6",
         "sentencepiece",
-        "jsonpickle",
         "dataclasses;python_version<'3.7'",
         "filelock>=3.0,<3.1",
         "lmdb",


### PR DESCRIPTION
We don't use jsonpickle anymore.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
