### PR TITLE
improve error message from Registrable class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If a transformer is not in cache but has override weights, the transformer's pretrained weights are no longer downloaded, that is, only its `config.json` file is downloaded.
 - `SanityChecksCallback` now raises `SanityCheckError` instead of `AssertionError` when a check fails.
 - `jsonpickle` removed from dependencies.
+- Improved the error message from `Registrable.by_name()` when the name passed does not match any registered subclassess.
+  The error message will include a suggestion if there is a close match between the name passed and a registered name.
 
 ### Fixed
 

--- a/tests/common/registrable_test.py
+++ b/tests/common/registrable_test.py
@@ -130,3 +130,16 @@ class TestRegistrable(AllenNlpTestCase):
                 "testpackage.reader.TextClassificationJsonReader"
             )
             assert duplicate_reader.__name__ == "TextClassificationJsonReader"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "sequence-tagging",  # using '-' instead of '_'
+        "sequence-taggign",  # transposition of 'ng'
+    ],
+)
+def test_suggestions_when_name_not_found(name):
+    with pytest.raises(ConfigurationError) as exc:
+        DatasetReader.by_name(name)
+        assert "did you mean 'sequence_tagging'?" in str(exc.value)


### PR DESCRIPTION
From a discussion @AkshitaB and I had.

- Improves the error message when the name passed to `Registrable.by_name()` doesn't match the name of an available subclass.
- The error message will also include a suggestion if there is a close match between the given name and the name of an available subclass.

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
