### PR TITLE
Don't orphan checkpoints when we run out of patience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- The `GradientDescentTrainer` no longer leaves stray model checkpoints around when it runs out of patience.
+
 
 ## [v2.3.1](https://github.com/allenai/allennlp/releases/tag/v2.3.1) - 2021-04-20
 

--- a/allennlp/training/checkpointer.py
+++ b/allennlp/training/checkpointer.py
@@ -1,9 +1,9 @@
+import glob
 from typing import Union, Dict, Any, List, Tuple, Optional
 
 import logging
 import os
 import re
-import shutil
 import time
 
 import torch
@@ -85,66 +85,94 @@ class Checkpointer(Registrable):
         epoch_str = f"{epoch}.{training_util.time_to_str(int(self._last_save_time))}"
         self.save_checkpoint(epoch_str, trainer)
 
+    def shelve_model(self, epoch: Union[int, str], trainer: "allennlp.training.trainer.Trainer"):
+        if self._serialization_dir is None:
+            return
+
+        # back up the model
+        with trainer.get_checkpoint_state() as state:
+            model_state, _ = state
+            model_backup_path = os.path.join(
+                self._serialization_dir, "model_state_backup_epoch_{}.th".format(epoch)
+            )
+            torch.save(model_state, model_backup_path)
+
+    def remove_shelved_models(self):
+        if self._serialization_dir is None:
+            return
+
+        for old_model_backup_path in glob.glob(
+            os.path.join(self._serialization_dir, "model_state_backup_epoch_*.th")
+        ):
+            os.remove(old_model_backup_path)
+
     def save_checkpoint(
         self,
         epoch: Union[int, str],
         trainer: "allennlp.training.trainer.Trainer",
         is_best_so_far: bool = False,
-        save_model_only=False,
     ) -> None:
-        if self._serialization_dir is not None:
-            with trainer.get_checkpoint_state() as state:
-                model_state, training_states = state
-                model_path = os.path.join(
-                    self._serialization_dir, "model_state_epoch_{}.th".format(epoch)
+        if self._serialization_dir is None:
+            return
+
+        with trainer.get_checkpoint_state() as state:
+            model_state, training_states = state
+            model_path = os.path.join(
+                self._serialization_dir, "model_state_epoch_{}.th".format(epoch)
+            )
+            if not os.path.isfile(model_path):
+                model_backup_path = os.path.join(
+                    self._serialization_dir, "model_state_backup_epoch_{}.th".format(epoch)
                 )
-                if not os.path.isfile(model_path):
+                if os.path.isfile(model_backup_path):
+                    os.rename(model_backup_path, model_path)
+                else:
                     torch.save(model_state, model_path)
-                if save_model_only:
-                    return
 
-                training_path = os.path.join(
-                    self._serialization_dir, "training_state_epoch_{}.th".format(epoch)
-                )
-                if not os.path.isfile(training_path):
-                    torch.save({**training_states, "epoch": epoch}, training_path)
+            training_path = os.path.join(
+                self._serialization_dir, "training_state_epoch_{}.th".format(epoch)
+            )
+            if not os.path.isfile(training_path):
+                torch.save({**training_states, "epoch": epoch}, training_path)
 
-            # The main checkpointing logic is now done, this is just shuffling files around, to keep
-            # track of best weights, and to remove old checkpoints, if desired.
-            if is_best_so_far:
-                logger.info(
-                    "Best validation performance so far. Copying weights to '%s/best.th'.",
-                    self._serialization_dir,
-                )
-                shutil.copyfile(model_path, os.path.join(self._serialization_dir, "best.th"))
+        # The main checkpointing logic is now done, this is just shuffling files around, to keep
+        # track of best weights, and to remove old checkpoints, if desired.
+        self.remove_shelved_models()
 
-            if (
-                self._num_serialized_models_to_keep is not None
-                and self._num_serialized_models_to_keep >= 0
-            ):
-                self._serialized_paths.append((time.time(), model_path, training_path))
-                if len(self._serialized_paths) > self._num_serialized_models_to_keep:
-                    paths_to_remove = self._serialized_paths.pop(0)
-                    # Check to see if we should keep this checkpoint, if it has been longer
-                    # then self._keep_serialized_model_every_num_seconds since the last
-                    # kept checkpoint.
-                    remove_path = True
-                    if self._keep_serialized_model_every_num_seconds is not None:
-                        save_time = paths_to_remove[0]
-                        time_since_checkpoint_kept = (
-                            save_time - self._last_permanent_saved_checkpoint_time
-                        )
-                        if (
-                            time_since_checkpoint_kept
-                            > self._keep_serialized_model_every_num_seconds
-                        ):
-                            # We want to keep this checkpoint.
-                            remove_path = False
-                            self._last_permanent_saved_checkpoint_time = save_time
-                    if remove_path:
-                        for fname in paths_to_remove[1:]:
-                            if os.path.isfile(fname):
-                                os.remove(fname)
+        if is_best_so_far:
+            logger.info(
+                "Best validation performance so far. Copying weights to '%s/best.th'.",
+                self._serialization_dir,
+            )
+            dest_path = os.path.join(self._serialization_dir, "best.th")
+            if os.path.exists(dest_path):
+                os.remove(dest_path)
+            os.link(model_path, dest_path)
+
+        if (
+            self._num_serialized_models_to_keep is not None
+            and self._num_serialized_models_to_keep >= 0
+        ):
+            self._serialized_paths.append((time.time(), model_path, training_path))
+            if len(self._serialized_paths) > self._num_serialized_models_to_keep:
+                paths_to_remove = self._serialized_paths.pop(0)
+                # Check to see if we should keep this checkpoint, if it has been longer
+                # then self._keep_serialized_model_every_num_seconds since the last
+                # kept checkpoint.
+                remove_path = True
+                if self._keep_serialized_model_every_num_seconds is not None:
+                    save_time = paths_to_remove[0]
+                    time_since_checkpoint_kept = (
+                        save_time - self._last_permanent_saved_checkpoint_time
+                    )
+                    if time_since_checkpoint_kept > self._keep_serialized_model_every_num_seconds:
+                        # We want to keep this checkpoint.
+                        remove_path = False
+                        self._last_permanent_saved_checkpoint_time = save_time
+                if remove_path:
+                    for fname in paths_to_remove[1:]:
+                        if os.path.isfile(fname):
+                            os.remove(fname)
 
     def find_latest_checkpoint(self) -> Optional[Tuple[str, str]]:
         """


### PR DESCRIPTION
This is supposed to fix #5076, and supersede #5077.

Fixes #5067.

I don't understand how we ever got away with bailing so early when we're out of patience. We didn't update metrics, write outputs for the last epoch, nothing, just bailed as soon as we saw we didn't improve.