### PR TITLE
fix dataclasses import

### DIFF
--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -1,4 +1,5 @@
 import copy
+import dataclasses
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Iterable
 
@@ -426,9 +427,6 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         # Make sure we don't change the input parameters
         tokens2 = copy.deepcopy(tokens2)
-
-        # We add special tokens and also set token type ids.
-        import dataclasses
 
         if tokens2 is None:
             return (


### PR DESCRIPTION
We are importing `dataclasses` within a method in the `PretrainedTransformerTokenizer` class, instead of at the top level of the module. There's no good reason to do that, because `dataclasses` is imported elsewhere anyway, and there is probably a performance penalty with having to call this import statement every time the method is called. I usually don't worry about that when the method is only meant to be called once, but this particular method is likely to be called many times by the user (for example, on each tokenized sentence read from a dataset reader).
