### PR TITLE
Explicitly pass serialization directory and local rank to trainer in train command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - When `PretrainedTransformerIndexer` folds long sequences, it no longer loses the information from token type ids.
-- Fixed a bug where `local_rank` wasn't passed to the trainer during distributed trainer.
 
 
 ## [v2.4.0](https://github.com/allenai/allennlp/releases/tag/v2.4.0) - 2021-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See [PR #5172](https://github.com/allenai/allennlp/pull/5172) for more details.
 - Added `SpanExtractorWithSpanWidthEmbedding`, putting specific span embedding computations into the `_embed_spans` method and leaving the common code in `SpanExtractorWithSpanWidthEmbedding` to unify the arguments, and modified `BidirectionalEndpointSpanExtractor`, `EndpointSpanExtractor` and `SelfAttentiveSpanExtractor` accordingly. Now, `SelfAttentiveSpanExtractor` can also embed span widths.
 
-
 ### Fixed
 
 - When `PretrainedTransformerIndexer` folds long sequences, it no longer loses the information from token type ids.
+- Fixed a bug where `local_rank` wasn't passed to the trainer during distributed trainer.
 
 
 ## [v2.4.0](https://github.com/allenai/allennlp/releases/tag/v2.4.0) - 2021-04-22

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -426,7 +426,6 @@ def _train_worker(
 
         # Till now, "cuda_device" might not be set in the trainer params.
         # But a worker trainer needs to only know about its specific GPU id.
-        params["trainer"]["local_rank"] = process_rank
         params["trainer"]["cuda_device"] = gpu_id
         params["trainer"]["world_size"] = world_size
         params["trainer"]["distributed"] = True
@@ -724,13 +723,12 @@ class TrainModel(Registrable):
         for data_loader_ in data_loaders.values():
             data_loader_.index_with(model_.vocab)
 
-        # We don't need to pass serialization_dir and local_rank here, because they will have been
-        # passed through the trainer by from_params already, because they were keyword arguments to
-        # construct this class in the first place.
         trainer_ = trainer.construct(
+            serialization_dir=serialization_dir,
             model=model_,
             data_loader=data_loaders["train"],
             validation_data_loader=data_loaders.get("validation"),
+            local_rank=local_rank,
         )
         assert trainer_ is not None
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -426,6 +426,7 @@ def _train_worker(
 
         # Till now, "cuda_device" might not be set in the trainer params.
         # But a worker trainer needs to only know about its specific GPU id.
+        params["trainer"]["local_rank"] = process_rank
         params["trainer"]["cuda_device"] = gpu_id
         params["trainer"]["world_size"] = world_size
         params["trainer"]["distributed"] = True

--- a/allennlp/training/trainer.py
+++ b/allennlp/training/trainer.py
@@ -286,7 +286,13 @@ class GradientDescentTrainer(Trainer):
         enable_default_callbacks: bool = True,
         run_sanity_checks: bool = True,
     ) -> None:
-        super().__init__(serialization_dir, cuda_device, distributed, local_rank, world_size)
+        super().__init__(
+            serialization_dir=serialization_dir,
+            cuda_device=cuda_device,
+            distributed=distributed,
+            local_rank=local_rank,
+            world_size=world_size,
+        )
 
         # I am not calling move_to_gpu here, because if the model is
         # not already on the GPU then the optimizer is going to be wrong.


### PR DESCRIPTION
<!-- Please reference the issue number here -->

~~The `local_rank` was never actually passed to the trainer.~~

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
