### PR TITLE
Adds Huggingface Dataset Reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Print the first batch to the console by default.
 
 ### Added
-
+- Added `HuggingfaceDatasetReader` for using huggingface datasets in AllenNLP
 - Added `TaskSuite` base class and command line functionality for running [`checklist`](https://github.com/marcotcr/checklist) test suites, along with implementations for `SentimentAnalysisSuite`, `QuestionAnsweringSuite`, and `TextualEntailmentSuite`. These can be found in the `allennlp.sanity_checks.task_checklists` module.
 - Added `allennlp diff` command to compute a diff on model checkpoints, analogous to what `git diff` does on two files.
 - Added `allennlp.nn.util.load_state_dict` helper function.

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,13 @@ test-with-cov :
 			--cov=$(SRC) \
 			--cov-report=xml
 
+.PHONY : test-with-cov-html
+test-with-cov-html :
+	pytest --color=yes -rf --durations=40 \
+			--cov-config=.coveragerc \
+			--cov=$(SRC) \
+			--cov-report=html
+
 .PHONY : gpu-test
 gpu-test : check-for-cuda
 	pytest --color=yes -v -rf -m gpu

--- a/allennlp/data/dataset_readers/huggingface_datasets_reader.py
+++ b/allennlp/data/dataset_readers/huggingface_datasets_reader.py
@@ -1,0 +1,269 @@
+from allennlp.data import DatasetReader, Token, Field, Tokenizer
+from allennlp.data.fields import TextField, LabelField, ListField
+from allennlp.data.instance import Instance
+from datasets import load_dataset, DatasetDict, Split, list_datasets
+from datasets.features import (
+    ClassLabel,
+    Sequence,
+    Translation,
+    TranslationVariableLanguages,
+    Value,
+    FeatureType,
+)
+from typing import Iterable, Optional, Dict, List, Union
+
+
+@DatasetReader.register("huggingface-datasets")
+class HuggingfaceDatasetReader(DatasetReader):
+    """
+    Reads instances from the given huggingface supported dataset
+
+    This reader implementation wraps the huggingface datasets package
+
+    Registered as a `DatasetReader` with name `huggingface-datasets`
+
+    # Parameters
+    dataset_name : `str`
+        Name of the dataset from huggingface datasets the reader will be used for.
+    config_name : `str`, optional (default=`None`)
+        Configuration(mandatory for some datasets) of the dataset.
+    tokenizer : `Tokenizer`, optional (default=`None`)
+        If specified is used for tokenization of string and text fields from the dataset.
+        This is useful since text in allennlp is dealt with as a series of tokens.
+    """
+
+    SUPPORTED_SPLITS = [Split.TRAIN, Split.TEST, Split.VALIDATION]
+
+    def __init__(
+        self,
+        dataset_name: str = None,
+        config_name: Optional[str] = None,
+        tokenizer: Optional[Tokenizer] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            manual_distributed_sharding=True,
+            manual_multiprocess_sharding=True,
+            **kwargs,
+        )
+
+        # It would be cleaner to create a separate reader object for diferent dataset
+        if dataset_name not in list_datasets():
+            raise ValueError(f"Dataset {dataset_name} not available in huggingface datasets")
+        self.dataset: DatasetDict = DatasetDict()
+        self.dataset_name = dataset_name
+        self.config_name = config_name
+        self.tokenizer = tokenizer
+
+    def load_dataset_split(self, split: str):
+        # TODO add support for datasets.split.NamedSplit
+        if split in self.SUPPORTED_SPLITS:
+            if self.config_name is not None:
+                self.dataset[split] = load_dataset(self.dataset_name, self.config_name, split=split)
+            else:
+                self.dataset[split] = load_dataset(self.dataset_name, split=split)
+        else:
+            raise ValueError(
+                f"Only default splits:{self.SUPPORTED_SPLITS} are currently supported."
+            )
+
+    def _read(self, file_path: str) -> Iterable[Instance]:
+        """
+        Reads the dataset and converts the entry to AllenNLP friendly instance
+        """
+        if file_path is None:
+            raise ValueError("parameter split cannot be None")
+
+        # If split is not loaded, load the specific split
+        if file_path not in self.dataset:
+            self.load_dataset_split(file_path)
+
+        # TODO see if use of Dataset.select() is better
+        dataset_split = self.dataset[file_path]
+        for index in self.shard_iterable(range(len(dataset_split))):
+            yield self.text_to_instance(file_path, dataset_split[index])
+
+    def raise_feature_not_supported_value_error(value):
+        raise ValueError(f"Datasets feature type {type(value)} is not supported yet.")
+
+    def text_to_instance(self, *inputs) -> Instance:
+        """
+        Takes care of converting dataset entry into AllenNLP friendly instance
+
+        Currently this is how datasets.features types are mapped to AllenNLP Fields
+
+        dataset.feature type           allennlp.data.fields
+        `ClassLabel`                   `LabelField` in feature name namespace
+        `Value.string`                 `TextField` with value as Token
+        `Value.*`                      `LabelField` with value being label in feature name namespace
+        `Translation`                  `ListField` of 2 ListField (ClassLabel and TextField)
+        `TranslationVariableLanguages` `ListField` of 2 ListField (ClassLabel and TextField)
+        `Sequence`                     `ListField` of sub-types
+        """
+
+        # features indicate the different information available in each entry from dataset
+        # feature types decide what type of information they are
+        # e.g. In a Sentiment dataset an entry could have one feature (of type text/string) indicating the text
+        # and another indicate the sentiment (of typeint32/ClassLabel)
+
+        split = inputs[0]
+        features: Dict[str, FeatureType] = self.dataset[split].features
+        fields: Dict[str, Field] = dict()
+
+        # TODO we need to support all different datasets features described
+        # in https://huggingface.co/docs/datasets/features.html
+        for feature in features:
+            fields_to_be_added: Dict[str, Field] = dict()
+            item_field: Field
+            field_list: list
+            value = features[feature]
+
+            fields_to_be_added = map_Feature(feature, inputs[1], value, self.tokenizer)
+            for field_key in fields_to_be_added:
+                fields[field_key] = fields_to_be_added[field_key]
+
+        return Instance(fields)
+
+
+# Feature Mappers - These functions map a FeatureType into Fields
+def map_Feature(
+    feature: str, entry: Dict, value, tokenizer: Optional[Tokenizer]
+) -> Dict[str, Field]:
+    fields_to_be_added: Dict[str, Field] = dict()
+    if isinstance(value, ClassLabel):
+        fields_to_be_added[feature] = map_ClassLabel(feature, entry[feature])
+    # datasets Value can be of different types
+    elif isinstance(value, Value):
+        fields_to_be_added[feature] = map_Value(feature, entry[feature], value, tokenizer)
+
+    elif isinstance(value, Sequence):
+        fields_to_be_added = map_Sequence(feature, entry, value, tokenizer)
+
+    elif isinstance(value, Translation):
+        fields_to_be_added = map_Translation(feature, entry, value, tokenizer)
+
+    elif isinstance(value, TranslationVariableLanguages):
+        fields_to_be_added = map_TranslationVariableLanguages(feature, entry, value, tokenizer)
+
+    else:
+        raise ValueError(f"Datasets feature type {type(value)} is not supported yet.")
+    return fields_to_be_added
+
+
+def map_ClassLabel(feature: str, entry: Dict) -> Field:
+    field: Field = map_to_Label(feature, entry, skip_indexing=True)
+    return field
+
+
+def map_Value(
+    feature: str, item: Value, value, tokenizer: Optional[Tokenizer]
+) -> Union[TextField, LabelField]:
+    field: Union[TextField, LabelField]
+    if value.dtype == "string":
+        # datasets.Value[string] maps to TextField
+        # If tokenizer is provided we will use it to split it to tokens
+        # Else put whole text as a single token
+        field = map_String(feature, item, None, tokenizer)
+
+    else:
+        field = LabelField(item, label_namespace=feature, skip_indexing=True)
+    return field
+
+
+def map_Sequence(
+    feature: str, entry: Dict, value, tokenizer: Optional[Tokenizer]
+) -> Dict[str, Field]:
+    item_field: Union[LabelField, TextField]
+    field_list: List[Union[TextField, LabelField]] = list()
+    fields: Dict[str, Field] = dict()
+    if isinstance(value.feature, Value):
+        for item in entry[feature]:
+            # If tokenizer is provided we will use it to split it to tokens
+            # Else put whole text as a single token
+            item_field = map_Value(feature, item, value.feature, tokenizer)
+            field_list.append(item_field)
+        if len(field_list) > 0:
+            fields[feature] = ListField(field_list)
+
+    # datasets Sequence of strings to ListField of LabelField
+    elif isinstance(value.feature, ClassLabel):
+        for item in entry[feature]:
+            item_field = map_to_Label(feature, item, skip_indexing=True)
+            field_list.append(item_field)
+
+        if len(field_list) > 0:
+            fields[feature] = ListField(field_list)
+
+    else:
+        HuggingfaceDatasetReader.raise_feature_not_supported_value_error(value)
+
+    return fields
+
+
+def map_Translation(
+    feature: str, entry: Dict, value, tokenizer: Optional[Tokenizer]
+) -> Dict[str, Field]:
+    fields: Dict[str, Field] = dict()
+    if value.dtype == "dict":
+        input_dict = entry[feature]
+        langs = list(input_dict.keys())
+        texts = list()
+        for lang in langs:
+            if tokenizer is not None:
+                tokens = tokenizer.tokenize(input_dict[lang])
+
+            else:
+                tokens = [Token(input_dict[lang])]
+            texts.append(TextField(tokens))
+
+        fields[feature + "-languages"] = ListField(
+            [map_to_Label(feature + "-languages", lang, skip_indexing=False) for lang in langs]
+        )
+        fields[feature + "-texts"] = ListField(texts)
+
+    else:
+        raise ValueError(f"Datasets feature type {type(value)} is not supported yet.")
+
+    return fields
+
+
+def map_TranslationVariableLanguages(
+    feature: str, entry: Dict, value, tokenizer: Optional[Tokenizer]
+) -> Dict[str, Field]:
+    fields: Dict[str, Field] = dict()
+    if value.dtype == "dict":
+        input_dict = entry[feature]
+        fields[feature + "-language"] = ListField(
+            [
+                map_to_Label(feature + "-languages", lang, skip_indexing=False)
+                for lang in input_dict["language"]
+            ]
+        )
+
+        if tokenizer is not None:
+            fields[feature + "-translation"] = ListField(
+                [TextField(tokenizer.tokenize(text)) for text in input_dict["translation"]]
+            )
+        else:
+            fields[feature + "-translation"] = ListField(
+                [TextField([Token(text)]) for text in input_dict["translation"]]
+            )
+
+    else:
+        raise ValueError(f"Datasets feature type {type(value)} is not supported yet.")
+
+    return fields
+
+
+# Value mapper - Maps a single Value
+def map_String(feature: str, text: str, value, tokenizer: Optional[Tokenizer]) -> TextField:
+    field: TextField
+    if tokenizer is not None:
+        field = TextField(tokenizer.tokenize(text))
+    else:
+        field = TextField([Token(text)])
+    return field
+
+
+def map_to_Label(namespace, item, skip_indexing=True) -> LabelField:
+    return LabelField(label=item, label_namespace=namespace, skip_indexing=skip_indexing)

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         "wandb>=0.10.0,<0.11.0",
         "huggingface_hub>=0.0.8",
         "google-cloud-storage>=1.38.0,<1.39.0",
+        "datasets>=1.5.0,<1.6.0",
     ],
     entry_points={"console_scripts": ["allennlp=allennlp.__main__:run"]},
     include_package_data=True,

--- a/tests/data/dataset_readers/huggingface_datasets_reader_test.py
+++ b/tests/data/dataset_readers/huggingface_datasets_reader_test.py
@@ -1,0 +1,163 @@
+import pytest
+from allennlp.data import Tokenizer
+
+from allennlp.data.dataset_readers.huggingface_datasets_reader import HuggingfaceDatasetReader
+from allennlp.data.tokenizers import WhitespaceTokenizer
+
+
+# TODO Add test where we compare huggingface wrapped reader with an explicitly coded dataset
+# TODO pab-vmware/Abhishek-P Add test where we load conll2003 and test it
+#  the way tested for conll2003 specific reader
+class HuggingfaceDatasetReaderTest:
+
+    """
+    Test read for some lightweight datasets
+    """
+
+    @pytest.mark.parametrize(
+        "dataset, config, split",
+        (("glue", "cola", "train"), ("glue", "cola", "test")),
+    )
+    def test_read(self, dataset, config, split):
+        huggingface_reader = HuggingfaceDatasetReader(dataset_name=dataset, config_name=config)
+        instances = list(huggingface_reader.read(split))
+        # Confirm instance were made for all rows
+        assert len(instances) == len(huggingface_reader.dataset[split])
+
+        entry = huggingface_reader.dataset[split][0]
+        instance = instances[0]
+
+        # Confirm all features were mapped
+        assert len(instance.fields) == len(entry)
+
+    def test_read_sequence_nesting(self):
+        dataset = "diplomacy_detection"
+        split = "train"
+        huggingface_reader = HuggingfaceDatasetReader(dataset_name=dataset)
+        instances = list(huggingface_reader.read(split))
+        assert len(instances) == len(huggingface_reader.dataset[split])
+
+    def test_read_with_tokenizer(self):
+        dataset = "glue"
+        config = "cola"
+        split = "train"
+        tokenizer: Tokenizer = WhitespaceTokenizer()
+        huggingface_reader = HuggingfaceDatasetReader(
+            dataset_name=dataset, config_name=config, tokenizer=tokenizer
+        )
+        instances = list(huggingface_reader.read(split))
+        # Confirm instance were made for all rows
+        assert len(instances) == len(huggingface_reader.dataset[split])
+
+        entry = huggingface_reader.dataset[split][0]
+        instance = instances[0]
+
+        # Confirm all features were mapped
+        assert len(instance.fields) == len(entry)
+
+        # Confirm it was tokenized
+        assert len(instance["sentence"]) > 1
+
+    def test_read_without_config(self):
+        dataset = "urdu_fake_news"
+        split = "train"
+        huggingface_reader = HuggingfaceDatasetReader(dataset_name=dataset)
+        instances = list(huggingface_reader.read(split))
+        # Confirm instance were made for all rows
+        assert len(instances) == len(huggingface_reader.dataset[split])
+
+        entry = huggingface_reader.dataset[split][0]
+        instance = instances[0]
+
+        # Confirm all features were mapped
+        assert len(instance.fields) == len(entry)
+
+    """
+    Test mapping of the datasets.feature.Translation and datasets.feature.TranslationVariableLanguages
+    """
+
+    def test_read_xnli_all_languages(self):
+        dataset = "xnli"
+        config = "all_languages"
+        split = "validation"
+        huggingface_reader = HuggingfaceDatasetReader(dataset_name=dataset, config_name=config)
+        instances = list(huggingface_reader.read(split))
+        # Confirm instance were made for all rows
+        assert len(instances) == len(huggingface_reader.dataset[split])
+        instance = instances[0]
+        # We are splitting datasets.features.Translation and
+        # datasets.features.TranslationVariableLanguages into two fields each
+        # For XNLI that means 3 fields become 5
+        assert len(instance.fields) == 5
+
+    def test_non_supported_feature(self):
+        dataset = "pubmed_qa"
+        config = "pqa_labeled"
+        split = "train"
+        with pytest.raises(ValueError):
+            next(HuggingfaceDatasetReader(dataset_name=dataset, config_name=config).read(split))
+
+    def test_non_available_dataset(self):
+        with pytest.raises(ValueError):
+            HuggingfaceDatasetReader(dataset_name="surely-such-a-dataset-does-not-exist")
+
+    @pytest.mark.parametrize("split", (None, "surely-such-a-split-does-not-exist"))
+    def test_read_with_invalid_split(self, split):
+        with pytest.raises(ValueError):
+            next(HuggingfaceDatasetReader(dataset_name="glue", config_name="cola").read(split))
+
+    """
+    Test to help validate for the known supported datasets
+    Skipped by default, enable when required
+    """
+
+    @pytest.mark.skip()
+    @pytest.mark.parametrize(
+        "dataset, config, split",
+        (
+            ("xnli", "ar", "train"),
+            ("xnli", "en", "train"),
+            ("xnli", "de", "train"),
+            ("glue", "mrpc", "train"),
+            ("glue", "sst2", "train"),
+            ("glue", "qqp", "train"),
+            ("glue", "mnli", "train"),
+            ("glue", "mnli_matched", "validation"),
+            ("universal_dependencies", "en_lines", "train"),
+            ("universal_dependencies", "ko_kaist", "train"),
+            ("universal_dependencies", "af_afribooms", "train"),
+        ),
+    )
+    def test_read_known_supported_datasets_with_config(self, dataset, config, split):
+        huggingface_reader = HuggingfaceDatasetReader(dataset_name=dataset, config_name=config)
+        instances = list(huggingface_reader.read(split))
+        # Confirm instance were made for all rows
+        assert len(instances) == len(huggingface_reader.dataset[split])
+
+        entry = huggingface_reader.dataset[split][0]
+        instance = instances[0]
+
+        # Confirm all features were mapped
+        assert len(instance.fields) == len(entry)
+
+    """
+        Test to help validate for the known supported datasets without config
+        Skipped by default, enable when required
+    """
+
+    @pytest.mark.skip()
+    @pytest.mark.parametrize(
+        "dataset", (("swahili"), ("conll2003"), ("dbpedia_14"), ("trec"), ("emotion"))
+    )
+    def test_read_known_supported_datasets_without_config(self, dataset):
+        split = "train"
+        huggingface_reader = HuggingfaceDatasetReader(dataset_name=dataset)
+        instances = list(huggingface_reader.read(split))
+        # Confirm instance were made for all rows
+        assert len(instances) == len(huggingface_reader.dataset[split])
+
+        entry = huggingface_reader.dataset[split][0]
+        instance = instances[0]
+
+        # Confirm all features were mapped
+        assert len(instance.fields) == len(entry)


### PR DESCRIPTION
Moved over from #5095.


Added a new reader to allow for reading huggingface datasets as instance
Mapped limited `datasets.features` to `allenlp.data.fields`

Verified for selective dataset and/or dataset configurations for training split, mentioned in the documentation comments of the reader.

datasets==1.5.0

Joint work with @divijbajaj @annajung @prajaktakini-vmware @agururajvais

Signed-off-by: Abhishek P (VMware) <pab@vmware.com>

<!-- Please reference the issue number here -->
Fixes #4962

Changes proposed in this pull request:
Introduce a new reader that wraps huggingface datasets to provide instances for a split of the dataset with configuration if required

<!-- To ensure we can review your pull request promptly please ensure ALL GitHub Actions workflows pass -->
