### PR TITLE
Implementing abstraction to score final sequences in `BeamSearch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   You can do this by setting the parameter `load_weights` to `False`.
   See [PR #5172](https://github.com/allenai/allennlp/pull/5172) for more details.
 - Added `SpanExtractorWithSpanWidthEmbedding`, putting specific span embedding computations into the `_embed_spans` method and leaving the common code in `SpanExtractorWithSpanWidthEmbedding` to unify the arguments, and modified `BidirectionalEndpointSpanExtractor`, `EndpointSpanExtractor` and `SelfAttentiveSpanExtractor` accordingly. Now, `SelfAttentiveSpanExtractor` can also embed span widths.
+- Added the `FinalSequenceScorer` abstraction to calculate the final scores of the generated sequences in `BeamSearch`. 
 
 ### Fixed
 

--- a/allennlp/nn/beam_search.py
+++ b/allennlp/nn/beam_search.py
@@ -454,7 +454,7 @@ class FinalSequenceScorer(Registrable):
         predictions : `torch.Tensor`
             A tensor containing the initial predictions with shape `(batch_size, beam_size, max_steps)`.
 
-        log_probabilities : `StateType`
+        log_probabilities : `torch.Tensor`
             A tensor containing the log probabilities of the sequence, defined as the sum
             of the log probabilities per token, with shape `(batch_size, beam_size)`.
 
@@ -481,9 +481,8 @@ class SequenceLogProbabilityScorer(FinalSequenceScorer):
         self, predictions: torch.Tensor, log_probabilities: torch.Tensor, end_index: int
     ) -> torch.Tensor:
         # The sum of the sequence log probabilities is the input parameter, so just
-        # return it. The tensor is cloned so it does not use the same storage as the input
-        # tensor, as is the case with `LengthNormalizedSequenceLogProbabilityScorer`.
-        return log_probabilities.clone()
+        # return it.
+        return log_probabilities
 
 
 @FinalSequenceScorer.register("length-normalized-sequence-log-prob")
@@ -492,7 +491,7 @@ class LengthNormalizedSequenceLogProbabilityScorer(FinalSequenceScorer):
     A `FinalSequenceScorer` which scores the sequences by the average log probability of the
     tokens in the sequence. It optionally includes a length penalty which promotes
     or demotes sequences based on their lengths. The final score for a sequence will
-    be (sequence_log_probability) / (sequence_length ** length_penalty). The sequence length
+    be `(sequence_log_probability) / (sequence_length ** length_penalty)`. The sequence length
     here includes the end token.
 
     # Parameters

--- a/tests/nn/beam_search_test.py
+++ b/tests/nn/beam_search_test.py
@@ -476,6 +476,19 @@ class BeamSearchTest(AllenNlpTestCase):
         expected_scores = expected_log_probs / length_normalization
         self._check_results(expected_log_probs=expected_scores)
 
+        # Pick a length penalty so extreme that the order of the sequences is reversed
+        length_penalty = -2.0
+        self.beam_search.final_sequence_scorer = LengthNormalizedSequenceLogProbabilityScorer(
+            length_penalty=length_penalty
+        )
+        expected_top_k = np.array([[3, 4, 5, 5, 5], [2, 3, 4, 5, 5], [1, 2, 3, 4, 5]])
+        expected_log_probs = np.log(np.array([0.2, 0.3, 0.4]))
+        length_normalization = np.array(
+            [3 ** length_penalty, 4 ** length_penalty, 5 ** length_penalty]
+        )
+        expected_scores = expected_log_probs / length_normalization
+        self._check_results(expected_top_k=expected_top_k, expected_log_probs=expected_scores)
+
         # Here, we set the max_steps = 4. This prevents the first sequence from finishing,
         # so its length does not include the end token, whereas the other sequences do.
         length_penalty = 2.0

--- a/tests/nn/beam_search_test.py
+++ b/tests/nn/beam_search_test.py
@@ -489,7 +489,4 @@ class BeamSearchTest(AllenNlpTestCase):
             [4 ** length_penalty, 4 ** length_penalty, 3 ** length_penalty]
         )
         expected_scores = expected_log_probs / length_normalization
-        self._check_results(
-            expected_top_k=expected_top_k,
-            expected_log_probs=expected_scores
-        )
+        self._check_results(expected_top_k=expected_top_k, expected_log_probs=expected_scores)


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Implements feature requests 2 and 3 from #5205 and closes #5113.

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Other libraries, such as `transformers` or `fairseq` pick the top outputs from beam search by taking the sequence with the highest **average** log probability per token. See [here](https://huggingface.co/transformers/_modules/transformers/generation_beam_search.html) for the `transformers` implementation. The AllenNLP implementation takes the sequence with the best **total** log probability of the sequence. This change adds an abstraction called `FinalSequenceScorer` to decide how the final sequences will be scored. The default is `SequenceLogProbabilityScorer`, which assigns a score equal to sum of the log probabilities per token (i.e., the current implementation). This PR also includes `LengthNormalizedSequenceLogProbabilityScorer` which assigns a score equal to the average log probability per token.
- The `LengthNormalizedSequenceLogProbabilityScorer` also has a `length_penalty` parameter, which will increase or decrease sequence scores based on their length. This is also included in the `transformers` beam search.

## Notes
- This change does not break the code, but it does change the semantics of the second tensor returned by the `search` method in `BeamSearch`. Previously it was the log probabilities of the sequences, but now it is the score that is returned by the `FinalSequenceScorer` class. The new default is to return what is currently returned, so this should not break any models.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
- [ ] **`codecov/patch`** reports high test coverage (at least 90%).
    You can find this under the "Actions" tab of the pull request once the other checks have finished.
