### PR TITLE
cancel redundant GH Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,22 +85,22 @@ jobs:
         pip freeze
 
     - name: Format
-      if: always()
+      if: '! cancelled()'
       run: |
         make format
 
     - name: Lint
-      if: always()
+      if: '! cancelled()'
       run: |
         make lint
 
     - name: Type check
-      if: always()
+      if: '! cancelled()'
       run: |
         make typecheck
 
     - name: Run tests
-      if: always()
+      if: '! cancelled()'
       run: |
         make test-with-cov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,8 @@ jobs:
   docker:
     name: Docker (CUDA ${{ matrix.cuda }})
     if: github.repository == 'allenai/allennlp'
-    runs-on: [self-hosted, GPU]
+    # Run on self-hosted to utilize layer caching.
+    runs-on: [self-hosted]
     strategy:
       matrix:
         cuda: ['10.1', '10.2', '11.1']
@@ -314,7 +315,7 @@ jobs:
 
     - name: Test image
       run: |
-        make docker-run DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME ARGS='test-install'
+        make docker-run DOCKER_GPUS='' DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME ARGS='test-install'
 
     - name: Authenticate to Docker Hub
       if: github.event_name == 'release' || github.event_name == 'push'

--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,11 @@ docker-image :
 		--build-arg TORCH=$(DOCKER_TORCH_VERSION) \
 		-t $(DOCKER_IMAGE_NAME) .
 
+DOCKER_GPUS = --gpus all
+
 .PHONY : docker-run
 docker-run :
-	$(DOCKER_RUN_CMD) --gpus all $(DOCKER_IMAGE_NAME) $(ARGS)
+	$(DOCKER_RUN_CMD) $(DOCKER_GPUS) $(DOCKER_IMAGE_NAME) $(ARGS)
 
 .PHONY : docker-test-image
 docker-test-image :
@@ -161,4 +163,4 @@ docker-test-image :
 
 .PHONY : docker-test-run
 docker-test-run :
-	$(DOCKER_RUN_CMD) --gpus all $(DOCKER_TEST_IMAGE_NAME) $(ARGS)
+	$(DOCKER_RUN_CMD) $(DOCKER_GPUS) $(DOCKER_TEST_IMAGE_NAME) $(ARGS)


### PR DESCRIPTION
Uses the [`concurrency`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency) feature to cancel redundant workflows associated with the same `ref`.