### PR TITLE
Ensure all relevant allennlp submodules are imported with `import_plugins()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed Broken link in `allennlp.fairness.fairness_metrics.Separation` docs
-- `allennlp` is now treated as a default plugin itself to ensure that `allennlp.common.plugins.import_plugins()`
-  imports all submodules of `allennlp`.
+- Ensured all `allennlp` submodules are imported with `allennlp.common.plugins.import_plugins()`.
 
 
 ## [v2.5.0](https://github.com/allenai/allennlp/releases/tag/v2.5.0) - 2021-06-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed Broken link in `allennlp.fairness.fairness_metrics.Separation` docs
+- `allennlp` is now treated as a default plugin itself to ensure that `allennlp.common.plugins.import_plugins()`
+  imports all submodules of `allennlp`.
 
 
 ## [v2.5.0](https://github.com/allenai/allennlp/releases/tag/v2.5.0) - 2021-06-03

--- a/allennlp/common/plugins.py
+++ b/allennlp/common/plugins.py
@@ -33,7 +33,7 @@ GLOBAL_PLUGINS_FILENAME = str(Path.home() / ".allennlp" / "plugins")
 The global plugins file will be found here.
 """
 
-DEFAULT_PLUGINS = ("allennlp_models", "allennlp_semparse", "allennlp_server")
+DEFAULT_PLUGINS = ("allennlp", "allennlp_models", "allennlp_semparse", "allennlp_server")
 """
 Default plugins do not need to be declared in a plugins file. They will always
 be imported when they are installed in the current Python environment.

--- a/allennlp/common/plugins.py
+++ b/allennlp/common/plugins.py
@@ -78,10 +78,10 @@ def import_plugins() -> None:
     # Ensure all relevant submodules of AllenNLP are imported.
     import_module_and_submodules(
         "allennlp",
-        exclude=[
+        exclude={
             "allennlp.sanity_checks",  # deprecated
             "allennlp.tools",  # things in here are usually run as commands themselves
-        ],
+        },
     )
 
     # Workaround for a presumed Python issue where spawned processes can't find modules in the current directory.

--- a/allennlp/common/plugins.py
+++ b/allennlp/common/plugins.py
@@ -33,7 +33,7 @@ GLOBAL_PLUGINS_FILENAME = str(Path.home() / ".allennlp" / "plugins")
 The global plugins file will be found here.
 """
 
-DEFAULT_PLUGINS = ("allennlp", "allennlp_models", "allennlp_semparse", "allennlp_server")
+DEFAULT_PLUGINS = ("allennlp_models", "allennlp_semparse", "allennlp_server")
 """
 Default plugins do not need to be declared in a plugins file. They will always
 be imported when they are installed in the current Python environment.
@@ -75,6 +75,14 @@ def import_plugins() -> None:
     """
     Imports the plugins found with `discover_plugins()`.
     """
+    # Ensure all relevant submodules of AllenNLP are imported.
+    import_module_and_submodules(
+        "allennlp",
+        exclude=[
+            "allennlp.sanity_checks",  # deprecated
+            "allennlp.tools",  # things in here are usually run as commands themselves
+        ],
+    )
 
     # Workaround for a presumed Python issue where spawned processes can't find modules in the current directory.
     cwd = os.getcwd()

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -328,7 +328,7 @@ def push_python_path(path: PathType) -> ContextManagerFunctionReturnType[None]:
         sys.path.remove(path)
 
 
-def import_module_and_submodules(package_name: str) -> None:
+def import_module_and_submodules(package_name: str, exclude: Optional[List[str]] = None) -> None:
     """
     Import all submodules under the given package.
     Primarily useful so that people using AllenNLP as a library
@@ -342,7 +342,8 @@ def import_module_and_submodules(package_name: str) -> None:
     # the end won't hurt anything.
     with push_python_path("."):
         # Import at top level
-        module = importlib.import_module(package_name)
+        if not exclude or package_name not in exlude:
+            module = importlib.import_module(package_name)
         path = getattr(module, "__path__", [])
         path_string = "" if not path else path[0]
 
@@ -353,7 +354,7 @@ def import_module_and_submodules(package_name: str) -> None:
             if path_string and module_finder.path != path_string:  # type: ignore[union-attr]
                 continue
             subpackage = f"{package_name}.{name}"
-            import_module_and_submodules(subpackage)
+            import_module_and_submodules(subpackage, exclude=exclude)
 
 
 def peak_cpu_memory() -> Dict[int, int]:

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -28,6 +28,7 @@ from typing import (
     TypeVar,
     Union,
     Sequence,
+    Set,
 )
 
 import numpy
@@ -328,7 +329,7 @@ def push_python_path(path: PathType) -> ContextManagerFunctionReturnType[None]:
         sys.path.remove(path)
 
 
-def import_module_and_submodules(package_name: str, exclude: Optional[List[str]] = None) -> None:
+def import_module_and_submodules(package_name: str, exclude: Optional[Set[str]] = None) -> None:
     """
     Import all submodules under the given package.
     Primarily useful so that people using AllenNLP as a library

--- a/allennlp/common/util.py
+++ b/allennlp/common/util.py
@@ -335,6 +335,9 @@ def import_module_and_submodules(package_name: str, exclude: Optional[List[str]]
     can specify their own custom packages and have their custom
     classes get loaded and registered.
     """
+    if exclude and package_name in exclude:
+        return
+
     importlib.invalidate_caches()
 
     # For some reason, python doesn't always add this by default to your path, but you pretty much
@@ -342,8 +345,7 @@ def import_module_and_submodules(package_name: str, exclude: Optional[List[str]]
     # the end won't hurt anything.
     with push_python_path("."):
         # Import at top level
-        if not exclude or package_name not in exlude:
-            module = importlib.import_module(package_name)
+        module = importlib.import_module(package_name)
         path = getattr(module, "__path__", [])
         path_string = "" if not path else path[0]
 

--- a/allennlp/tools/archive_surgery.py
+++ b/allennlp/tools/archive_surgery.py
@@ -78,5 +78,5 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.setLevel(logging.ERROR)
+    logging.basicConfig(level=logging.ERROR)
     main()

--- a/allennlp/tools/archive_surgery.py
+++ b/allennlp/tools/archive_surgery.py
@@ -22,8 +22,7 @@ import tarfile
 from allennlp.common.file_utils import cached_path
 from allennlp.models.archival import CONFIG_NAME
 
-logger = logging.getLogger()
-logger.setLevel(logging.ERROR)
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -79,4 +78,5 @@ def main():
 
 
 if __name__ == "__main__":
+    logging.setLevel(logging.ERROR)
     main()


### PR DESCRIPTION
I was wondering why "bias_mitigator_applicator" wasn't showing up as a registered model name. This fixes that.