### PR TITLE
update Python environment setup in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ on:
 
 env:
   # NOTE: Need to update `TORCH_VERSION` and `TORCH_VISION_VERSION` for new torch releases.
-  _TORCH_VERSION: 1.9.0
-  _TORCH_VISION_VERSION: 0.10.0
+  TORCH_VERSION: 1.9.0
+  TORCH_VISION_VERSION: 0.10.0
   # Change this to invalidate existing cache.
   CACHE_PREFIX: v1
   # Disable tokenizers parallelism because this doesn't help, and can cause issues in distributed tests.
@@ -138,7 +138,7 @@ jobs:
       run: |
         test -d .venv || virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
-        make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
+        make install TORCH_VERSION="torch==${TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Setup virtual environment (cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit == 'true'
@@ -266,7 +266,7 @@ jobs:
       run: |
         test -d .venv || virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
-        make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
+        make install TORCH_VERSION="torch==${TORCH_VERSION}+cpu torchvision==${TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Setup virtual environment (cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit == 'true'
@@ -485,7 +485,7 @@ jobs:
       run: |
         test -d .venv || virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
-        make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
+        make install TORCH_VERSION="torch==${TORCH_VERSION}+cpu torchvision==${TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Setup virtual environment (cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,11 +385,13 @@ jobs:
       run: |
         # Check the install instructions on https://pytorch.org/ to keep these up-to-date.
         if [[ $CUDA == '10.1' ]]; then
+            # NOTE: We need to use an older version of torch to support CUDA 10.1
             echo "DOCKER_TORCH_VERSION='torch==1.8.0+cu101 torchvision==0.9.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV;
         elif [[ $CUDA == '10.2' ]]; then
-            echo "DOCKER_TORCH_VERSION='torch==1.9.0 torchvision==0.10.0'" >> $GITHUB_ENV;
+            # NOTE: 10.2 is still the default but that could change in the next release.
+            echo "DOCKER_TORCH_VERSION='torch==${{ env.TORCH_VERSION }} torchvision==${{ env.TORCH_VISION_VERSION }}'" >> $GITHUB_ENV;
         elif [[ $CUDA == '11.1' ]]; then
-            echo "DOCKER_TORCH_VERSION='torch==1.9.0+cu111 torchvision==0.10.0+cu111 -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV;
+            echo "DOCKER_TORCH_VERSION='torch==${{ env.TORCH_VERSION }}+cu111 torchvision==${{ env.TORCH_VISION_VERSION }}+cu111 -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV;
         else
             echo "Unhandled CUDA version $CUDA";
             exit 1;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
       run: |
         . .venv/bin/activate
         pip install --no-deps -e .
+        make download-extras
 
     - name: Pull and install models repo
       if: matrix.task.name == 'Model Tests'
@@ -276,6 +277,7 @@ jobs:
       run: |
         . .venv/bin/activate
         pip install --no-deps -e .
+        make download-extras
 
     - name: Debug info
       run: |
@@ -498,6 +500,7 @@ jobs:
       run: |
         . .venv/bin/activate
         pip install --no-deps -e .
+        make download-extras
 
     - name: Debug info
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,11 +130,13 @@ jobs:
       with:
         path: .venv
         key: ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        restore-keys: |
+          ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-
 
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
-        virtualenv -p $(which python) --copies --reset-app-data .venv
+        test -d .venv || virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
 
@@ -143,11 +145,6 @@ jobs:
       run: |
         . .venv/bin/activate
         pip install --no-deps -e .
-
-    # - name: Install requirements
-    #   run: |
-    #     . .venv/bin/activate
-    #     make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Pull and install models repo
       if: matrix.task.name == 'Model Tests'
@@ -261,11 +258,13 @@ jobs:
       with:
         path: .venv
         key: ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        restore-keys: |
+          ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-
 
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
-        virtualenv -p $(which python) --copies --reset-app-data .venv
+        test -d .venv || virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
@@ -274,11 +273,6 @@ jobs:
       run: |
         . .venv/bin/activate
         pip install --no-deps -e .
-
-    # - name: Install requirements
-    #   run: |
-    #     . .venv/bin/activate
-    #     make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Debug info
       run: |
@@ -483,11 +477,13 @@ jobs:
       with:
         path: .venv
         key: ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        restore-keys: |
+          ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-
 
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
-        virtualenv -p $(which python) --copies --reset-app-data .venv
+        test -d .venv || virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
@@ -496,11 +492,6 @@ jobs:
       run: |
         . .venv/bin/activate
         pip install --no-deps -e .
-
-    # - name: Install requirements
-    #   run: |
-    #     . .venv/bin/activate
-    #     make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Debug info
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   TORCH_VERSION: 1.9.0
   TORCH_VISION_VERSION: 0.10.0
   # Change this to invalidate existing cache.
-  CACHE_PREFIX: v1
+  CACHE_PREFIX: v0
   # Disable tokenizers parallelism because this doesn't help, and can cause issues in distributed tests.
   TOKENIZERS_PARALLELISM: 'false'
   # Disable multithreading with OMP because this can lead to dead-locks in distributed tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
     timeout-minutes: 5
     if: github.repository == 'allenai/allennlp' && (github.event_name == 'push' || github.event_name == 'pull_request')
     runs-on: ubuntu-latest
-    needs: [cpu_tests, gpu_tests, model_tests]
+    needs: [checks]
 
     steps:
       # Need to checkout code to get the coverage config.
@@ -593,7 +593,7 @@ jobs:
   publish:
     name: PyPI
     timeout-minutes: 10
-    needs: [style, lint, cpu_tests, gpu_tests, model_tests, build_package, test_package, docker, docs]
+    needs: [style, checks, build_package, test_package, docker, docs]
     # Only publish to PyPI on releases and nightly builds to "allenai/allennlp" (not forks).
     if: github.repository == 'allenai/allennlp' && (github.event_name == 'release' || github.event_name == 'schedule')
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,11 @@ jobs:
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
 
+    - name: Install AllenNLP as editable
+      if: steps.virtualenv-cache.outputs.cache-hit == 'true'
+      run: |
+        pip install --no-deps -e .
+
     # - name: Install requirements
     #   run: |
     #     . .venv/bin/activate
@@ -259,6 +264,11 @@ jobs:
         virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
+
+    - name: Install AllenNLP as editable
+      if: steps.virtualenv-cache.outputs.cache-hit == 'true'
+      run: |
+        pip install --no-deps -e .
 
     # - name: Install requirements
     #   run: |
@@ -475,6 +485,11 @@ jobs:
         virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
+
+    - name: Install AllenNLP as editable
+      if: steps.virtualenv-cache.outputs.cache-hit == 'true'
+      run: |
+        pip install --no-deps -e .
 
     # - name: Install requirements
     #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,15 @@ on:
   schedule:
   - cron: '37 11 * * 1,2,3,4,5'  # early morning (11:37 UTC / 4:37 AM PDT) Monday - Friday
 
+env:
+  # NOTE: Need to update `TORCH_VERSION` and `TORCH_VISION_VERSION` for new torch releases.
+  _TORCH_VERSION: 1.9.0
+  _TORCH_VISION_VERSION: 0.10.0
+  # Disable tokenizers parallelism because this doesn't help, and can cause issues in distributed tests.
+  TOKENIZERS_PARALLELISM: 'false'
+  # Disable multithreading with OMP because this can lead to dead-locks in distributed tests.
+  OMP_NUM_THREADS: '1'
+
 jobs:
   changelog:
     name: CHANGELOG
@@ -39,7 +48,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
@@ -55,54 +64,42 @@ jobs:
       run: |
         black --check .
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
+  checks:
+    name: ${{ matrix.task.name }}
+    runs-on: ${{ matrix.task.runs_on }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        task:
+        - name: Lint
+          runs_on: ubuntu-latest
+          coverage_report: false
+          torch_platform: cpu
+          run: |
+            make flake8
+            make typecheck
 
-    steps:
-    - uses: actions/checkout@v2
+        - name: CPU Tests
+          runs_on: ubuntu-latest
+          coverage_report: true
+          torch_platform: cpu
+          run: make test
 
-    - name: Setup Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
+        - name: GPU Tests
+          runs_on: [self-hosted, GPU]
+          coverage_report: true
+          torch_platform: cu111  # Our self-hosted GPU runners currently support CUDA 11.*
+          run: make gpu-tests
 
-    - uses: actions/cache@v2
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
-
-    - name: Install requirements
-      run: |
-        make install
-
-    - name: Debug info
-      run: |
-        pip freeze
-
-    - name: Run flake8
-      run: |
-        flake8 .
-
-    - name: Run mypy
-      if: '! cancelled()'  # run this step even if the last step failed.
-      run: |
-        mypy . --cache-dir=/dev/null
-
-  gpu_tests:
-    name: GPU Tests
-    if: github.repository == 'allenai/allennlp'  # self-hosted runner only available on main repo
-    timeout-minutes: 15
-    runs-on: [self-hosted, GPU]
-    env:
-      # Required to use the setup-python action.
-      AGENT_TOOLSDIRECTORY: '/opt/hostedtoolcache'
-      # Our self-hosted runner currently is currently compatible with CUDA 11.*.
-      TORCH_VERSION: 'torch==1.9.0+cu111 torchvision==0.10.0+cu111 -f https://download.pytorch.org/whl/torch_stable.html'
-      # Disable tokenizers parallelism because this doesn't help.
-      TOKENIZERS_PARALLELISM: 'false'
-      # Disable multithreading with OMP because this can lead to dead-locks in distributed training.
-      OMP_NUM_THREADS: '1'
+        - name: Model Tests
+          runs_on: ubuntu-latest
+          coverage_report: true
+          torch_platform: cpu
+          run: |
+            cd allennlp-models
+            make test-with-cov COV=allennlp
+            mv coverage.xml ../
 
     steps:
     - uses: actions/checkout@v2
@@ -115,157 +112,78 @@ jobs:
       with:
         python-version: 3.8
 
+    - name: Install prerequisites
+      run: |
+        pip install --upgrade pip setuptools wheel virtualenv
+
+    - name: Set build variables
+      shell: bash
+      run: |
+        echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
+        echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
+        echo "TORCH_VERSION='torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV
+
     - uses: actions/cache@v2
+      id: virtualenv-cache
       with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ env.TORCH_VERSION }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        path: .venv
+        key: v2-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
+    - name: Setup virtual environment
+      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+      run: |
+        virtualenv -p $(which python) --copies --reset-app-data .venv
 
     - name: Install requirements
       run: |
+        . .venv/bin/activate
         make install
-
-    - name: Debug info
-      run: |
-        which python
-        python --version
-        pip freeze
-
-    - name: Run tests
-      run: |
-        make gpu-test
-        mkdir coverage
-        mv coverage.xml coverage/
-
-    - name: Save coverage report
-      if: github.repository == 'allenai/allennlp' && (github.event_name == 'push' || github.event_name == 'pull_request')
-      uses: actions/upload-artifact@v1
-      with:
-        name: gpu-tests-coverage
-        path: ./coverage
-
-    - name: Clean up
-      if: always()
-      run: |
-        # Could run into issues with the cache if we don't uninstall the editable.
-        # See https://github.com/pypa/pip/issues/4537.
-        pip uninstall --yes allennlp
-
-  cpu_tests:
-    name: CPU Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      matrix:
-        python: ['3.7', '3.8']
-    env:
-      # Disable tokenizers parallelism because this doesn't help.
-      TOKENIZERS_PARALLELISM: 'false'
-      # Disable multithreading with OMP because this can lead to dead-locks in distributed training.
-      OMP_NUM_THREADS: '1'
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Setup Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python }}
-
-    - uses: actions/cache@v2
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
-
-    - name: Install requirements
-      run: |
-        make install
-
-    - name: Debug info
-      run: |
-        pip freeze
-
-    - name: Run tests
-      if: '! cancelled()'
-      run: |
-        make test
-        mkdir coverage
-        mv coverage.xml coverage/
-
-    - name: Save coverage report
-      if: matrix.python == '3.7' && github.repository == 'allenai/allennlp' && (github.event_name == 'push' || github.event_name == 'pull_request')
-      uses: actions/upload-artifact@v1
-      with:
-        name: cpu-tests-coverage
-        path: ./coverage
-
-    - name: Clean up
-      if: always()
-      run: |
-        # Could run into issues with the cache if we don't uninstall the editable.
-        # See https://github.com/pypa/pip/issues/4537.
-        pip uninstall --yes allennlp
-
-  model_tests:
-    name: Model Tests
-    timeout-minutes: 18
-    runs-on: ubuntu-latest
-    env:
-      # Disable tokenizers parallelism because this doesn't help.
-      TOKENIZERS_PARALLELISM: 'false'
-      # Disable multithreading with OMP because this can lead to dead-locks in distributed training.
-      OMP_NUM_THREADS: '1'
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Setup Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-
-    - uses: actions/cache@v2
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
-
-    - name: Install requirements
-      run: |
-        make install
-
-    - name: Debug info
-      run: |
-        pip freeze
 
     - name: Pull and install models repo
+      if: ${{ matrix.task.name }} == 'Model Tests'
       env:
         ALLENNLP_VERSION_OVERRIDE: ""  # Don't replace the core library.
       run: |
+        . .venv/bin/activate
         git clone https://github.com/allenai/allennlp-models.git
         cd allennlp-models
         pip install --upgrade --upgrade-strategy eager -e . -r dev-requirements.txt
 
-    - name: Run tests
+    - name: Debug info
       run: |
-        cd allennlp-models
-        make test-with-cov COV=allennlp
+        . .venv/bin/activate
+        which python
+        pip freeze
+
+    - name: ${{ matrix.task.name }}
+      run: |
+        . .venv/bin/activate
+        ${{ matrix.task.run }}
+
+    - name: Prepare coverage report
+      if: ${{ matrix.task.coverage_report }}
+      run: |
         mkdir coverage
         mv coverage.xml coverage/
 
     - name: Save coverage report
-      if: github.repository == 'allenai/allennlp' && (github.event_name == 'push' || github.event_name == 'pull_request')
+      if: ${{ matrix.task.coverage_report }}
       uses: actions/upload-artifact@v1
       with:
-        name: model-tests-coverage
-        path: allennlp-models/coverage
+        name: ${{ matrix.task.name }}-coverage
+        path: ./coverage
 
     - name: Clean up
       if: always()
       run: |
+        # Could run into issues with the cache if we don't uninstall the editable.
+        # See https://github.com/pypa/pip/issues/4537.
+        . .venv/bin/activate
         pip uninstall --yes allennlp allennlp-models
 
   upload_coverage:
     name: Upload Coverage Report
-    timeout-minutes: 18
+    timeout-minutes: 5
     if: github.repository == 'allenai/allennlp' && (github.event_name == 'push' || github.event_name == 'pull_request')
     runs-on: ubuntu-latest
     needs: [cpu_tests, gpu_tests, model_tests]
@@ -277,19 +195,19 @@ jobs:
     - name: Download coverage report from CPU tests
       uses: actions/download-artifact@v1
       with:
-        name: cpu-tests-coverage
+        name: CPU Tests-coverage
         path: coverage/cpu_tests
 
     - name: Download coverage report from GPU Tests
       uses: actions/download-artifact@v1
       with:
-        name: gpu-tests-coverage
+        name: GPU Tests-coverage
         path: coverage/gpu_tests
 
     - name: Download coverage report from model tests
       uses: actions/download-artifact@v1
       with:
-        name: model-tests-coverage
+        name: Model Tests-coverage
         path: coverage/model_tests
 
     - name: Upload coverage to Codecov
@@ -307,28 +225,55 @@ jobs:
     name: Build Package
     timeout-minutes: 18
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
+      env:
+        # Log useful debugging information.
+        ACTIONS_STEP_DEBUG: 'true'
       with:
-        python-version: 3.7
+        python-version: 3.8
+
+    - name: Install prerequisites
+      run: |
+        pip install --upgrade pip setuptools wheel virtualenv
+
+    - name: Set build variables
+      shell: bash
+      run: |
+        echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
+        echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
+        echo "TORCH_VERSION='torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV
 
     - uses: actions/cache@v2
+      id: virtualenv-cache
       with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        path: .venv
+        key: v2-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
+    - name: Setup virtual environment
+      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+      run: |
+        virtualenv -p $(which python) --copies --reset-app-data .venv
 
     - name: Install requirements
       run: |
+        . .venv/bin/activate
         make install
+
+    - name: Debug info
+      run: |
+        . .venv/bin/activate
+        which python
+        pip freeze
 
     - name: Check and set nightly version
       if: github.event_name == 'schedule'
       run: |
         # Verify that current version is ahead of the last release.
+        . .venv/bin/activate
         LATEST=$(scripts/get_version.py latest)
         CURRENT=$(scripts/get_version.py current)
         if [ "$CURRENT" == "$LATEST" ]; then
@@ -344,6 +289,7 @@ jobs:
       if: github.event_name == 'release'
       run: |
         # Remove 'refs/tags/' to get the actual tag from the release.
+        . .venv/bin/activate
         TAG=${GITHUB_REF#refs/tags/};
         VERSION=$(scripts/get_version.py current)
         if [ "$TAG" != "$VERSION" ]; then
@@ -353,8 +299,8 @@ jobs:
 
     - name: Build core package
       run: |
-        echo "Building packages for core release"
         # Just print out the version for debugging.
+        . .venv/bin/activate
         make version
         python setup.py bdist_wheel sdist
 
@@ -367,12 +313,13 @@ jobs:
     - name: Clean up
       if: always()
       run: |
+        . .venv/bin/activate
         pip uninstall --yes allennlp
 
   # Tests installing from the distribution files.
   test_package:
     name: Test Package
-    timeout-minutes: 18
+    timeout-minutes: 10
     needs: [build_package]  # needs the package artifact created from 'build_package' job.
     runs-on: ubuntu-latest
     strategy:
@@ -413,7 +360,7 @@ jobs:
     timeout-minutes: 18
     if: github.repository == 'allenai/allennlp'
     # Run on self-hosted to utilize layer caching.
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, Docker-enabled]
     strategy:
       matrix:
         cuda: ['10.1', '10.2', '11.1']
@@ -483,11 +430,10 @@ jobs:
   # allennlp-docs repo.
   docs:
     name: Docs
-    timeout-minutes: 18
+    timeout-minutes: 15
     # Don't run for forks.
     if: github.repository == 'allenai/allennlp'
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
 
@@ -498,21 +444,44 @@ jobs:
         ssh-private-key: ${{ secrets.DOCS_DEPLOY_KEY }}
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
+      env:
+        # Log useful debugging information.
+        ACTIONS_STEP_DEBUG: 'true'
       with:
-        python-version: 3.7
+        python-version: 3.8
+
+    - name: Install prerequisites
+      run: |
+        pip install --upgrade pip setuptools wheel virtualenv
+
+    - name: Set build variables
+      shell: bash
+      run: |
+        echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
+        echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
+        echo "TORCH_VERSION='torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV
 
     - uses: actions/cache@v2
+      id: virtualenv-cache
       with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ runner.os }}-pydeps-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        path: .venv
+        key: v2-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
+    - name: Setup virtual environment
+      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+      run: |
+        virtualenv -p $(which python) --copies --reset-app-data .venv
 
     - name: Install requirements
       run: |
+        . .venv/bin/activate
         make install
 
     - name: Debug info
       run: |
+        . .venv/bin/activate
+        which python
         pip freeze
 
     - name: Prepare environment
@@ -527,6 +496,7 @@ jobs:
 
     - name: Build docs
       run: |
+        . .venv/bin/activate
         ./scripts/build_docs.sh
 
     - name: Print the ref
@@ -558,6 +528,7 @@ jobs:
       run: |
         # Fail immediately if any step fails.
         set -e
+        . .venv/bin/activate
 
         LATEST=$(./scripts/get_version.py latest)
         STABLE=$(./scripts/get_version.py stable)
@@ -615,12 +586,13 @@ jobs:
     - name: Clean up
       if: always()
       run: |
+        . .venv/bin/activate
         pip uninstall --yes allennlp
 
   # Publish the core distribution files to PyPI.
   publish:
     name: PyPI
-    timeout-minutes: 18
+    timeout-minutes: 10
     needs: [style, lint, cpu_tests, gpu_tests, model_tests, build_package, test_package, docker, docs]
     # Only publish to PyPI on releases and nightly builds to "allenai/allennlp" (not forks).
     if: github.repository == 'allenai/allennlp' && (github.event_name == 'release' || github.event_name == 'schedule')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Install requirements
       run: |
         . .venv/bin/activate
-        TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html" make install
+        make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Pull and install models repo
       if: ${{ matrix.task.name }} == 'Model Tests'
@@ -259,7 +259,7 @@ jobs:
     - name: Install requirements
       run: |
         . .venv/bin/activate
-        TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html" make install
+        make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Debug info
       run: |
@@ -473,7 +473,7 @@ jobs:
     - name: Install requirements
       run: |
         . .venv/bin/activate
-        TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html" make install
+        make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Debug info
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ env:
   # NOTE: Need to update `TORCH_VERSION` and `TORCH_VISION_VERSION` for new torch releases.
   _TORCH_VERSION: 1.9.0
   _TORCH_VISION_VERSION: 0.10.0
+  # Change this to invalidate existing cache.
+  CACHE_PREFIX: v1
   # Disable tokenizers parallelism because this doesn't help, and can cause issues in distributed tests.
   TOKENIZERS_PARALLELISM: 'false'
   # Disable multithreading with OMP because this can lead to dead-locks in distributed tests.
@@ -119,6 +121,7 @@ jobs:
     - name: Set build variables
       shell: bash
       run: |
+        # Get the exact Python version to use in the cache key.
         echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
         echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
 
@@ -126,7 +129,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -257,7 +260,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -479,7 +482,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Pull and install models repo
-      if: ${{ matrix.task.name }} == 'Model Tests'
+      if: matrix.task.name == 'Model Tests'
       env:
         ALLENNLP_VERSION_OVERRIDE: ""  # Don't replace the core library.
       run: |
@@ -160,13 +160,13 @@ jobs:
         ${{ matrix.task.run }}
 
     - name: Prepare coverage report
-      if: ${{ matrix.task.coverage_report }}
+      if: matrix.task.coverage_report
       run: |
         mkdir coverage
         mv coverage.xml coverage/
 
     - name: Save coverage report
-      if: ${{ matrix.task.coverage_report }}
+      if: matrix.task.coverage_report
       uses: actions/upload-artifact@v1
       with:
         name: ${{ matrix.task.name }}-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
     - name: Install AllenNLP as editable
       if: steps.virtualenv-cache.outputs.cache-hit == 'true'
       run: |
+        . .venv/bin/activate
         pip install --no-deps -e .
 
     # - name: Install requirements
@@ -268,6 +269,7 @@ jobs:
     - name: Install AllenNLP as editable
       if: steps.virtualenv-cache.outputs.cache-hit == 'true'
       run: |
+        . .venv/bin/activate
         pip install --no-deps -e .
 
     # - name: Install requirements
@@ -489,6 +491,7 @@ jobs:
     - name: Install AllenNLP as editable
       if: steps.virtualenv-cache.outputs.cache-hit == 'true'
       run: |
+        . .venv/bin/activate
         pip install --no-deps -e .
 
     # - name: Install requirements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,13 +121,12 @@ jobs:
       run: |
         echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
         echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
-        echo "TORCH_VERSION='torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV
 
     - uses: actions/cache@v2
       id: virtualenv-cache
       with:
         path: .venv
-        key: v2-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: v0-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -137,7 +136,7 @@ jobs:
     - name: Install requirements
       run: |
         . .venv/bin/activate
-        make install
+        TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html" make install
 
     - name: Pull and install models repo
       if: ${{ matrix.task.name }} == 'Model Tests'
@@ -245,13 +244,12 @@ jobs:
       run: |
         echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
         echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
-        echo "TORCH_VERSION='torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV
 
     - uses: actions/cache@v2
       id: virtualenv-cache
       with:
         path: .venv
-        key: v2-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: v0-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -261,7 +259,7 @@ jobs:
     - name: Install requirements
       run: |
         . .venv/bin/activate
-        make install
+        TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html" make install
 
     - name: Debug info
       run: |
@@ -460,13 +458,12 @@ jobs:
       run: |
         echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
         echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
-        echo "TORCH_VERSION='torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html'" >> $GITHUB_ENV
 
     - uses: actions/cache@v2
       id: virtualenv-cache
       with:
         path: .venv
-        key: v2-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: v0-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -476,7 +473,7 @@ jobs:
     - name: Install requirements
       run: |
         . .venv/bin/activate
-        make install
+        TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html" make install
 
     - name: Debug info
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,14 +124,16 @@ jobs:
         # Get the exact Python version to use in the cache key.
         echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
         echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
+        # Use week number in cache key so we can refresh the cache weekly.
+        echo "WEEK_NUMBER=$(date +%V)" >> $GITHUB_ENV
 
     - uses: actions/cache@v2
       id: virtualenv-cache
       with:
         path: .venv
-        key: ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: ${{ env.CACHE_PREFIX }}-${{ env.WEEK_NUMBER }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
         restore-keys: |
-          ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-
+          ${{ env.CACHE_PREFIX }}-${{ env.WEEK_NUMBER }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-
 
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -252,14 +254,15 @@ jobs:
       run: |
         echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
         echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
+        echo "WEEK_NUMBER=$(date +%V)" >> $GITHUB_ENV
 
     - uses: actions/cache@v2
       id: virtualenv-cache
       with:
         path: .venv
-        key: ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: ${{ env.CACHE_PREFIX }}-${{ env.WEEK_NUMBER }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
         restore-keys: |
-          ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-
+          ${{ env.CACHE_PREFIX }}-${{ env.WEEK_NUMBER }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-
 
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -473,14 +476,15 @@ jobs:
       run: |
         echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
         echo "RUNNER_ARCH=$(uname -m)" >> $GITHUB_ENV
+        echo "WEEK_NUMBER=$(date +%V)" >> $GITHUB_ENV
 
     - uses: actions/cache@v2
       id: virtualenv-cache
       with:
         path: .venv
-        key: ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: ${{ env.CACHE_PREFIX }}-${{ env.WEEK_NUMBER }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
         restore-keys: |
-          ${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-
+          ${{ env.CACHE_PREFIX }}-${{ env.WEEK_NUMBER }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-
 
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,11 +132,13 @@ jobs:
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
         virtualenv -p $(which python) --copies --reset-app-data .venv
-
-    - name: Install requirements
-      run: |
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
+
+    # - name: Install requirements
+    #   run: |
+    #     . .venv/bin/activate
+    #     make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Pull and install models repo
       if: matrix.task.name == 'Model Tests'
@@ -255,11 +257,13 @@ jobs:
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
         virtualenv -p $(which python) --copies --reset-app-data .venv
-
-    - name: Install requirements
-      run: |
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
+
+    # - name: Install requirements
+    #   run: |
+    #     . .venv/bin/activate
+    #     make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Debug info
       run: |
@@ -469,11 +473,13 @@ jobs:
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
         virtualenv -p $(which python) --copies --reset-app-data .venv
-
-    - name: Install requirements
-      run: |
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
+
+    # - name: Install requirements
+    #   run: |
+    #     . .venv/bin/activate
+    #     make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Debug info
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -259,7 +259,7 @@ jobs:
     - name: Install requirements
       run: |
         . .venv/bin/activate
-        make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
+        make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Debug info
       run: |
@@ -463,7 +463,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -473,7 +473,7 @@ jobs:
     - name: Install requirements
       run: |
         . .venv/bin/activate
-        make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
+        make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
     - name: Debug info
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: v0-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -249,7 +249,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: v0-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -463,7 +463,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: v0-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+        key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
     - name: Setup virtual environment
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,14 +128,14 @@ jobs:
         path: .venv
         key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ matrix.task.torch_platform }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
-    - name: Setup virtual environment
+    - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
         virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+${{ matrix.task.torch_platform }} torchvision==${_TORCH_VISION_VERSION}+${{ matrix.task.torch_platform }} -f https://download.pytorch.org/whl/torch_stable.html"
 
-    - name: Install AllenNLP as editable
+    - name: Setup virtual environment (cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit == 'true'
       run: |
         . .venv/bin/activate
@@ -259,14 +259,14 @@ jobs:
         path: .venv
         key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
-    - name: Setup virtual environment
+    - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
         virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
-    - name: Install AllenNLP as editable
+    - name: Setup virtual environment (cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit == 'true'
       run: |
         . .venv/bin/activate
@@ -481,14 +481,14 @@ jobs:
         path: .venv
         key: v1-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-cpu-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
-    - name: Setup virtual environment
+    - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
         virtualenv -p $(which python) --copies --reset-app-data .venv
         . .venv/bin/activate
         make install TORCH_VERSION="torch==${_TORCH_VERSION}+cpu torchvision==${_TORCH_VISION_VERSION}+cpu -f https://download.pytorch.org/whl/torch_stable.html"
 
-    - name: Install AllenNLP as editable
+    - name: Setup virtual environment (cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit == 'true'
       run: |
         . .venv/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -44,17 +44,17 @@ check-for-cuda :
 # Testing helpers.
 #
 
-.PHONY : lint
-lint :
-	flake8 .
+.PHONY : flake8
+flake8 :
+	flake8 allennlp tests scripts 
 
 .PHONY : format
 format :
-	black --check .
+	black --check allennlp tests scripts 
 
 .PHONY : typecheck
 typecheck :
-	mypy . --cache-dir=/dev/null
+	mypy allennlp tests scripts --cache-dir=/dev/null
 
 .PHONY : test
 test :
@@ -63,8 +63,8 @@ test :
 			--cov=$(SRC) \
 			--cov-report=xml
 
-.PHONY : gpu-test
-gpu-test : check-for-cuda
+.PHONY : gpu-tests
+gpu-tests : check-for-cuda
 	pytest --color=yes -v -rf --durations=20 \
 			--cov-config=.coveragerc \
 			--cov=$(SRC) \

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ install :
 	pip install --upgrade pip setuptools wheel
 	# Due to a weird thing with pip, we may need egg-info before running `pip install -e`.
 	# See https://github.com/pypa/pip/issues/4537.
-	python setup.py install_egg_info
+	# python setup.py install_egg_info
 	# Install torch ecosystem first.
 	pip install $(TORCH_VERSION)
 	pip install --upgrade --upgrade-strategy eager -e . -r dev-requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ DOCKER_RUN_CMD = docker run --rm \
 		-v $$HOME/.cache/huggingface:/root/.cache/huggingface \
 		-v $$HOME/nltk_data:/root/nltk_data
 
+# These nltk packages are used by the 'checklist' module. They are downloaded automatically
+# if not found when `checklist` is imported, but it's good to download the ahead of time
+# to avoid potential race conditions.
+NLTK_DOWNLOAD_CMD = python -c 'import nltk; [nltk.download(p) for p in ("wordnet", "wordnet_ic", "sentiwordnet")]'
+
 ifeq ($(shell uname),Darwin)
 ifeq ($(shell which gsed),)
 $(error Please install GNU sed with 'brew install gnu-sed')
@@ -79,6 +84,10 @@ benchmarks :
 # Setup helpers
 #
 
+.PHONY : download-extras
+download-extras :
+	$(NLTK_DOWNLOAD_CMD)
+
 .PHONY : install
 install :
 	# Ensure pip, setuptools, and wheel are up-to-date.
@@ -90,7 +99,7 @@ install :
 	pip install $(TORCH_VERSION)
 	pip install --upgrade --upgrade-strategy eager -e . -r dev-requirements.txt
 	# These nltk packages are used by the 'checklist' module.
-	python -c 'import nltk; [nltk.download(p) for p in ("wordnet", "wordnet_ic", "sentiwordnet")]'
+	$(NLTK_DOWNLOAD_CMD)
 #
 # Documention helpers.
 #


### PR DESCRIPTION
This PR makes some improvements to how we cache and initialize the Python environment within GitHub Actions jobs. In particular, we now
- Create, use, and cache a virtualenv instead of the Python installation created by the `setup-python` action to avoid messing with system-wide files. Messing with system-wide files is okay for GitHub-hosted runners, but not for self-hosted runners.
- Consolidates where the PyTorch/Torchvision versions are defined. They still have to be hard-coded in the GH Actions config for now, but just in a single spot (an environment variable at the top of the file).
- Completely reset all caches weekly to keep them fresh.
- Use a secondary cache restore key based on the torch installation to speed up builds when a non-torch requirement changes.

Another notable change proposed here is that we only run the "CPU Tests" job on the latest supported Python version. We still test to make sure we can properly install AllenNLP on all officially supported versions, but I don't think it's worth running all of our tests on different Python versions because it seems redundant and takes up build time and cache space. The only issues we've had between Python versions have had to do with either how the package is built or syntax, both of which are still checked by our "Test Install" job that runs on all supported Python versions. Cache space is limited to 5GiB I think, and any cache that includes a torch version with CUDA support takes up a sizeable portion of that (2.2GiB).