### PR TITLE
add kwargs to Predictor.from_path()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `on_backward` training callback which allows for control over backpropagation and gradient manipulation.
 - Added `AdversarialBiasMitigator`, a Model wrapper to adversarially mitigate biases in predictions produced by a pretrained model for a downstream task.
 - Added `which_loss` parameter to `ensure_model_can_train_save_and_load` in `ModelTestCase` to specify which loss to test.
+- Added `**kwargs` to `Predictor.from_path()`. These key-word argument will be passed on to the `Predictor`'s constructor.
 
 ### Fixed
 

--- a/allennlp/predictors/predictor.py
+++ b/allennlp/predictors/predictor.py
@@ -321,6 +321,7 @@ class Predictor(Registrable):
         frozen: bool = True,
         import_plugins: bool = True,
         overrides: Union[str, Dict[str, Any]] = "",
+        **kwargs,
     ) -> "Predictor":
         """
         Instantiate a `Predictor` from an archive path.
@@ -350,6 +351,9 @@ class Predictor(Registrable):
             can be found by `allennlp.common.plugins.import_plugins()`.
         overrides : `Union[str, Dict[str, Any]]`, optional (default = `""`)
             JSON overrides to apply to the unarchived `Params` object.
+        **kwargs : `Any`
+            Additional key-word arguments that will be passed to the `Predictor`'s
+            `__init__()` method.
 
         # Returns
 
@@ -363,6 +367,7 @@ class Predictor(Registrable):
             predictor_name,
             dataset_reader_to_load=dataset_reader_to_load,
             frozen=frozen,
+            extra_args=kwargs,
         )
 
     @classmethod


### PR DESCRIPTION
Adds `**kwargs` to `Predictor.from_path()`. This was requested here: https://stackoverflow.com/q/68011338/4151392.