### PR TITLE
ensure torch always up-to-date in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,11 @@ jobs:
         which python
         pip freeze
 
+    - name: Ensure torch up-to-date
+      run: |
+        . .venv/bin/activate
+        python scripts/check_torch_version.py
+
     - name: ${{ matrix.task.name }}
       run: |
         . .venv/bin/activate

--- a/scripts/check_torch_version.py
+++ b/scripts/check_torch_version.py
@@ -1,0 +1,60 @@
+"""
+Ensures currently installed torch version is the newest allowed.
+"""
+
+from typing import Tuple, cast
+
+
+def get_current_installed_torch_version() -> Tuple[str, str, str]:
+    import torch
+
+    version = tuple(torch.version.__version__.split("."))
+    assert len(version) == 3, f"Bad parsed version '{version}'"
+    return cast(Tuple[str, str, str], version)
+
+
+def get_latest_torch_version() -> Tuple[str, str, str]:
+    import requests
+
+    r = requests.get("https://api.github.com/repos/pytorch/pytorch/tags")
+    assert r.ok
+    for tag_data in r.json():
+        tag = tag_data["name"]
+        if tag.startswith("v") and "-rc" not in tag:
+            # Tag should look like "vX.Y.Z"
+            version = tuple(tag[1:].split("."))
+            assert len(version) == 3, f"Bad parsed version '{version}'"
+            break
+    else:
+        raise RuntimeError("could not find latest stable release tag")
+    return cast(Tuple[str, str, str], version)
+
+
+def get_torch_version_upper_limit() -> Tuple[str, str, str]:
+    with open("setup.py") as f:
+        for line in f:
+            # The torch version line should look like:
+            #   "torch>=X.Y.Z,<X.V.0",
+            if '"torch>=' in line:
+                version = tuple(line.split('"')[1].split("<")[1].strip().split("."))
+                assert len(version) == 3, f"Bad parsed version '{version}'"
+                break
+        else:
+            raise RuntimeError("could not find torch version spec in setup.py")
+    return cast(Tuple[str, str, str], version)
+
+
+def main():
+    current_torch_version = get_current_installed_torch_version()
+    latest_torch_version = get_latest_torch_version()
+    torch_version_upper_limit = get_torch_version_upper_limit()
+    if current_torch_version < latest_torch_version < torch_version_upper_limit:
+        raise RuntimeError(
+            f"current torch version {current_torch_version} is behind "
+            f"latest allowed torch version {latest_torch_version}"
+        )
+    print("All good!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_torch_version.py
+++ b/scripts/check_torch_version.py
@@ -5,7 +5,21 @@ Ensures currently installed torch version is the newest allowed.
 from typing import Tuple, cast
 
 
-def get_current_installed_torch_version() -> Tuple[str, str, str]:
+def main():
+    current_torch_version = _get_current_installed_torch_version()
+    latest_torch_version = _get_latest_torch_version()
+    torch_version_upper_limit = _get_torch_version_upper_limit()
+
+    if current_torch_version < latest_torch_version < torch_version_upper_limit:
+        raise RuntimeError(
+            f"current torch version {current_torch_version} is behind "
+            f"latest allowed torch version {latest_torch_version}"
+        )
+
+    print("All good!")
+
+
+def _get_current_installed_torch_version() -> Tuple[str, str, str]:
     import torch
 
     version = tuple(torch.version.__version__.split("."))
@@ -13,7 +27,7 @@ def get_current_installed_torch_version() -> Tuple[str, str, str]:
     return cast(Tuple[str, str, str], version)
 
 
-def get_latest_torch_version() -> Tuple[str, str, str]:
+def _get_latest_torch_version() -> Tuple[str, str, str]:
     import requests
 
     r = requests.get("https://api.github.com/repos/pytorch/pytorch/tags")
@@ -30,7 +44,7 @@ def get_latest_torch_version() -> Tuple[str, str, str]:
     return cast(Tuple[str, str, str], version)
 
 
-def get_torch_version_upper_limit() -> Tuple[str, str, str]:
+def _get_torch_version_upper_limit() -> Tuple[str, str, str]:
     with open("setup.py") as f:
         for line in f:
             # The torch version line should look like:
@@ -42,18 +56,6 @@ def get_torch_version_upper_limit() -> Tuple[str, str, str]:
         else:
             raise RuntimeError("could not find torch version spec in setup.py")
     return cast(Tuple[str, str, str], version)
-
-
-def main():
-    current_torch_version = get_current_installed_torch_version()
-    latest_torch_version = get_latest_torch_version()
-    torch_version_upper_limit = get_torch_version_upper_limit()
-    if current_torch_version < latest_torch_version < torch_version_upper_limit:
-        raise RuntimeError(
-            f"current torch version {current_torch_version} is behind "
-            f"latest allowed torch version {latest_torch_version}"
-        )
-    print("All good!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a step in CI that will ensure the current installed version of PyTorch is the most recent allowed version PyTorch according to our dependency specification in `setup.py`.

This is needed because we have to hard-code the torch installation steps in some places, so dependabot updates don't necessarily change the version of PyTorch used in CI.