### PR TITLE
only run CHANGELOG check when source files are modified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,12 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: Check if source files have changed
+      run: |
+        git diff --name-only $(git merge-base origin/main HEAD) | grep '^allennlp/.*\.py$' && echo "source_files_changed=true" >> $GITHUB_ENV || echo "source_files_changed=false" >> $GITHUB_ENV
+
     - name: Check that CHANGELOG has been updated
+      if: env.source_files_changed == 'true'
       run: |
         # If this step fails, this means you haven't updated the CHANGELOG.md
         # file with notes on your contribution.


### PR DESCRIPTION
This PR makes it so the "Check that CHANGELOG has been updated" CI step will only run when source files (files matching `allennlp/*.py`) have been modified. This should result in a cleaner looking CI history for pull requests.