### PR TITLE
make W&B callback resumable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the docs for `PytorchTransformerWrapper`
 - Fixed recovering training jobs with models that expect `get_metrics()` to not be called until they have seen at least one batch.
 - Made the Transformer Toolkit compatible with transformers that don't start their positional embeddings at 0.
+- Weights & Biases training callback ("wandb") now works when resuming training jobs.
 
 ### Changed
 


### PR DESCRIPTION
Ensures the Weights & Biases callback will resume logging to the same run on `allennlp train --resume ...`. See https://docs.wandb.ai/guides/track/advanced/resuming for reference. Here's an example run that was stopped and then restarted: https://wandb.ai/allenai-team1/allennlp-testing/runs/2gf9ug4m/overview.