### PR TITLE
allow TransformerTextField to take input directly from HF tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a mispelling: the parameter `contructor_extras` in `Lazy()` is now correctly called `constructor_extras`.
 - Fixed broken links in `allennlp.nn.initializers` docs.
+- `TransformerTextField` can now take tensors of shape `(1, n)` like the tensors produced from a HuggingFace tokenizer.
 
 ### Changed
 

--- a/allennlp/data/fields/transformer_text_field.py
+++ b/allennlp/data/fields/transformer_text_field.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List, Any
+from typing import Dict, Optional, List, Any, Union
 
 from overrides import overrides
 import torch
@@ -6,6 +6,12 @@ import torch.nn.functional
 
 from allennlp.data.fields.field import Field
 from allennlp.nn import util
+
+
+def _tensorize(x: Union[torch.Tensor, List[int]]) -> torch.Tensor:
+    if not isinstance(x, torch.Tensor):
+        return torch.tensor(x)
+    return x
 
 
 class TransformerTextField(Field[torch.Tensor]):
@@ -28,19 +34,21 @@ class TransformerTextField(Field[torch.Tensor]):
 
     def __init__(
         self,
-        input_ids: torch.Tensor,
+        input_ids: Union[torch.Tensor, List[int]],
         # I wish input_ids were called `token_ids` for clarity, but we want to be compatible with huggingface.
-        token_type_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        special_tokens_mask: Optional[torch.Tensor] = None,
-        offsets_mapping: Optional[torch.Tensor] = None,
+        token_type_ids: Optional[Union[torch.Tensor, List[int]]] = None,
+        attention_mask: Optional[Union[torch.Tensor, List[int]]] = None,
+        special_tokens_mask: Optional[Union[torch.Tensor, List[int]]] = None,
+        offsets_mapping: Optional[Union[torch.Tensor, List[int]]] = None,
         padding_token_id: int = 0,
     ) -> None:
-        self.input_ids = input_ids
-        self.token_type_ids = token_type_ids
-        self.attention_mask = attention_mask
-        self.special_tokens_mask = special_tokens_mask
-        self.offsets_mapping = offsets_mapping
+        self.input_ids = _tensorize(input_ids)
+        self.token_type_ids = None if token_type_ids is None else _tensorize(token_type_ids)
+        self.attention_mask = None if attention_mask is None else _tensorize(attention_mask)
+        self.special_tokens_mask = (
+            None if special_tokens_mask is None else _tensorize(special_tokens_mask)
+        )
+        self.offsets_mapping = None if offsets_mapping is None else _tensorize(offsets_mapping)
         self.padding_token_id = padding_token_id
 
     @overrides

--- a/tests/data/fields/transformer_text_field_test.py
+++ b/tests/data/fields/transformer_text_field_test.py
@@ -1,4 +1,5 @@
 import torch
+import pytest
 
 from allennlp.common.cached_transformers import get_tokenizer
 from allennlp.data import Batch, Instance
@@ -41,11 +42,15 @@ def test_transformer_text_field_batching():
     assert torch.all(tensors["text"]["attention_mask"][-1] == torch.tensor([False]))
 
 
-def test_transformer_text_field_from_huggingface():
+@pytest.mark.parametrize("return_tensors", ["pt", None])
+def test_transformer_text_field_from_huggingface(return_tensors):
     tokenizer = get_tokenizer("bert-base-cased")
+
     batch = Batch(
         [
-            Instance({"text": TransformerTextField(**tokenizer(text, return_tensors="pt"))})
+            Instance(
+                {"text": TransformerTextField(**tokenizer(text, return_tensors=return_tensors))}
+            )
             for text in [
                 "Hello, World!",
                 "The fox jumped over the fence",


### PR DESCRIPTION
Currently you can't do

```python
TransformerTextField(**tokenizer("Hello, World!", return_tensors="pt"))
```

because the tensors returned from the tokenizer have a batch dimension. This fixes that.