### PR TITLE
[WIP] Introduce Optuna related logics to `allennlp.commands.train` for supporting pruning in distributed situation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `self.ddp_accelerator` during distributed training. This is useful when, for example, instantiating submodules in your
   model's `__init__()` method by wrapping them with `self.ddp_accelerator.wrap_module()`. See the `allennlp.modules.transformer.t5`
   for an example.
+- Introduce [`Optuna`](https://github.com/optuna/optuna) related logic to `allennlp.commands.train`.
 
 ### Fixed
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -232,9 +232,12 @@ def train_model(
     return_model : `Optional[bool]`, optional (default = `None`)
         Whether or not to return the final model. If not specified, this defaults to `False` for
         distributed training and `True` otherwise.
-    trial : :class:`~optuna.trial.Trial`, optional (default=`None`)
-        A :class:`~optuna.trial.Trial` corresponding to the current evaluation of the
-        objective function.
+    trial : `Trial`, optional (default=`None`)
+        A [Trial](
+        https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial)
+        corresponding to the current evaluation of the objective function.
+        It is used by [Optuna](https://github.com/optuna/optuna) or
+        [allennlp-optuna](https://github.com/himkt/allennlp-optuna) and not expected used by users directly.
 
     # Returns
 
@@ -439,9 +442,12 @@ def _train_worker(
         Paths relative to `serialization_dir` that should be archived in addition to the default ones.
     distributed_params : `Optional[Params]`, optional
         Additional distributed params.
-    trial : :class:`~optuna.trial.Trial`, optional (default=`None`)
-        A :class:`~optuna.trial.Trial` corresponding to the current evaluation of the
-        objective function.
+    trial : `Trial`, optional (default=`None`)
+        A [Trial](
+        https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial)
+        corresponding to the current evaluation of the objective function.
+        It is used by [Optuna](https://github.com/optuna/optuna) or
+        [allennlp-optuna](https://github.com/himkt/allennlp-optuna) and not expected used by users directly.
 
     # Returns
 

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -361,6 +361,7 @@ def train_model(
                     file_friendly_logging,
                     include_in_archive,
                     Params(distributed_params),
+                    trial,
                 ),
                 nprocs=num_procs,
             )

--- a/allennlp/commands/train.py
+++ b/allennlp/commands/train.py
@@ -15,6 +15,9 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 from overrides import overrides
+from optuna import Trial
+from optuna import TrialPruned
+from optuna.storages import _CachedStorage
 
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common import Params, Registrable, Lazy
@@ -359,7 +362,7 @@ def train_model(
                 nprocs=num_procs,
             )
 
-        except Exception as e
+        except Exception as e:
             # NOTE `mp.spawn` raises `torch.multiprocessing.spawn.ProcessRaisedException` when
             # some error occurs in a worker. This exception propagates to Optuna and `study.optimize()`
             # terminates without pruning. To make pruning work, we check a traceback and raise
@@ -369,7 +372,6 @@ def train_model(
 
             # Re-raise the original exception if `TrialPruned` is not raised.
             raise e
-
 
     if not dry_run:
         archive_model(serialization_dir, include_in_archive=include_in_archive)

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         "wandb>=0.10.0,<0.12.0",
         "huggingface_hub>=0.0.8",
         "google-cloud-storage>=1.38.0,<1.42.0",
+        "optuna",
     ],
     entry_points={"console_scripts": ["allennlp=allennlp.__main__:run"]},
     include_package_data=True,

--- a/test_fixtures/optuna/classifier.jsonnet
+++ b/test_fixtures/optuna/classifier.jsonnet
@@ -1,0 +1,65 @@
+local DROPOUT = std.parseJson(std.extVar('DROPOUT'));
+
+
+{
+  dataset_reader: {
+    type: 'sequence_tagging',
+    word_tag_delimiter: '/',
+    token_indexers: {
+      tokens: {
+        type: 'single_id',
+        lowercase_tokens: true,
+      },
+      token_characters: {
+        type: 'characters',
+      },
+    },
+  },
+  train_data_path: 'test_fixtures/optuna/train.sents',
+  validation_data_path: 'test_fixtures/optuna/valid.sents',
+  model: {
+    type: 'simple_tagger',
+    text_field_embedder: {
+      token_embedders: {
+        tokens: {
+          type: 'embedding',
+          embedding_dim: 5,
+        },
+        token_characters: {
+          type: 'character_encoding',
+          embedding: {
+            embedding_dim: 4,
+          },
+          encoder: {
+            type: 'cnn',
+            embedding_dim: 4,
+            num_filters: 5,
+            ngram_filter_sizes: [3],
+          },
+          dropout: DROPOUT,
+        },
+      },
+    },
+    encoder: {
+      type: 'lstm',
+      input_size: 10,
+      hidden_size: 10,
+      num_layers: 2,
+      dropout: 0,
+      bidirectional: true,
+    },
+  },
+  data_loader: {
+    batch_size: 32,
+  },
+  trainer: {
+    optimizer: 'adam',
+    num_epochs: 1,
+    patience: 10,
+    callbacks: [
+      {
+        type: 'optuna_pruner',
+      }
+    ],
+  },
+}

--- a/test_fixtures/optuna/classifier_distributed.jsonnet
+++ b/test_fixtures/optuna/classifier_distributed.jsonnet
@@ -1,0 +1,69 @@
+local DROPOUT = std.parseJson(std.extVar('DROPOUT'));
+
+
+{
+  dataset_reader: {
+    type: 'sequence_tagging',
+    word_tag_delimiter: '/',
+    token_indexers: {
+      tokens: {
+        type: 'single_id',
+        lowercase_tokens: true,
+      },
+      token_characters: {
+        type: 'characters',
+      },
+    },
+  },
+  train_data_path: 'test_fixtures/optuna/train.sents',
+  validation_data_path: 'test_fixtures/optuna/valid.sents',
+  model: {
+    type: 'simple_tagger',
+    text_field_embedder: {
+      token_embedders: {
+        tokens: {
+          type: 'embedding',
+          embedding_dim: 5,
+        },
+        token_characters: {
+          type: 'character_encoding',
+          embedding: {
+            embedding_dim: 4,
+          },
+          encoder: {
+            type: 'cnn',
+            embedding_dim: 4,
+            num_filters: 5,
+            ngram_filter_sizes: [3],
+          },
+          dropout: DROPOUT,
+        },
+      },
+    },
+    encoder: {
+      type: 'lstm',
+      input_size: 10,
+      hidden_size: 10,
+      num_layers: 2,
+      dropout: 0,
+      bidirectional: true,
+    },
+  },
+  data_loader: {
+    batch_size: 32,
+  },
+  trainer: {
+    optimizer: 'adam',
+    num_epochs: 1,
+    patience: 10,
+    cuda_device: -1,
+    callbacks: [
+      {
+        type: 'optuna_pruner',
+      }
+    ],
+  },
+  distributed: {
+    cuda_devices: std.parseJson(std.extVar("CUDA_DEVICES")),
+  },
+}

--- a/test_fixtures/optuna/train.sents
+++ b/test_fixtures/optuna/train.sents
@@ -1,0 +1,3 @@
+Optuna/NNP is/VBZ an/DT automatic/JJ hyperparameter/NN optimization/NN software/NN framework/NN ,/, particularly/RB designed/VBN for/IN machine/NN learning/NN ./.
+It/PRP features/VBZ an/DT imperative/JJ ,/, define/VB -/HYPH by/IN -/HYPH run/NN style/NN user/NN API/NN ./.
+Thanks/NNS to/IN our/PRP$ define/NN -/HYPH by/IN -/HYPH run/NN API/NNP ,/, the/DT code/NN written/VBN with/IN Optuna/NNP enjoys/VBZ high/JJ modularity/NN ,/, and/CC the/DT user/NN of/IN Optuna/NNP can/MD dynamically/RB construct/VB the/DT search/NN spaces/NNS for/IN the/DT hyperparameters/NNS ./.

--- a/test_fixtures/optuna/valid.sents
+++ b/test_fixtures/optuna/valid.sents
@@ -1,0 +1,3 @@
+Optuna/NNP is/VBZ an/DT hyperparameter/JJ optimization/NN software/NN framework/NN ,/, designed/VBN for/IN machine/NN learning/NN ./.
+It/PRP features/VBZ an/DT imperative/JJ ,/, define/VB -/HYPH by/IN -/HYPH run/NN style/NN user/NN API/NN ./.
+Thanks/NNS to/IN our/PRP$ define/NN -/HYPH by/IN -/HYPH run/NN API/NNP ,/, the/DT code/NN written/VBN with/IN Optuna/NNP enjoys/VBZ high/JJ modularity/NN ./.


### PR DESCRIPTION
🚧  Under construction 🚧 

<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Related to #5338. See also optuna/optuna#2796.
Other backrgound information can be seen in optuna/optuna#1990 and himkt/allennlp-optuna#20.

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Introduce `trial` as an optional argument for `train_model` and `_train_worker`

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
- [ ] **`codecov/patch`** reports high test coverage (at least 90%).
    You can find this under the "Actions" tab of the pull request once the other checks have finished.

## Reference

- https://guide.allennlp.org/hyperparameter-optimization for understanding the basic architecture of Optuna integration
  - I think it would help to understand how to prune a AllenNLP training procedure in Optuna
