### PR TITLE
small fixes for tango

### DIFF
--- a/allennlp/__main__.py
+++ b/allennlp/__main__.py
@@ -2,6 +2,8 @@
 import logging
 import os
 import sys
+import warnings
+
 
 if os.environ.get("ALLENNLP_DEBUG"):
     LEVEL = logging.DEBUG
@@ -27,10 +29,16 @@ def _transformers_log_filter(record):
 
 logging.getLogger("transformers.file_utils").addFilter(_transformers_log_filter)
 
-from allennlp.commands import main  # noqa
-
 
 def run():
+    # We issue a seperate warning from the tango command and ignore this one so that
+    # users won't see a Tango warning when they're not using the Tango command.
+    warnings.filterwarnings(
+        "ignore", category=UserWarning, message="AllenNLP Tango", module="allennlp\.tango"
+    )
+
+    from allennlp.commands import main  # noqa
+
     main(prog="allennlp")
 
 

--- a/allennlp/__main__.py
+++ b/allennlp/__main__.py
@@ -34,7 +34,7 @@ def run():
     # We issue a seperate warning from the tango command and ignore this one so that
     # users won't see a Tango warning when they're not using the Tango command.
     warnings.filterwarnings(
-        "ignore", category=UserWarning, message="AllenNLP Tango", module="allennlp\.tango"
+        "ignore", category=UserWarning, message="AllenNLP Tango", module=r"allennlp\.tango"
     )
 
     from allennlp.commands import main  # noqa

--- a/allennlp/commands/tango.py
+++ b/allennlp/commands/tango.py
@@ -8,6 +8,7 @@ import os
 from os import PathLike
 from pathlib import Path
 from typing import Union, Dict, Any, List, Optional
+import warnings
 
 from overrides import overrides
 
@@ -69,6 +70,10 @@ class Tango(Subcommand):
 
 
 def run_tango_from_args(args: argparse.Namespace):
+    warnings.warn(
+        "AllenNLP Tango is an experimental API and parts of it might change or disappear "
+        "every time we release a new version."
+    )
     run_tango_from_file(
         tango_filename=args.config_path,
         serialization_dir=args.serialization_dir,

--- a/allennlp/tango/evaluation.py
+++ b/allennlp/tango/evaluation.py
@@ -9,7 +9,6 @@ from typing import Dict, Any, List, Optional
 import torch
 
 from allennlp.common import Lazy, Tqdm
-from allennlp.common.checks import check_for_gpu
 from allennlp.common.util import sanitize
 from allennlp.models import Model
 from allennlp.nn.util import move_to_device
@@ -58,10 +57,10 @@ class EvaluationStep(Step):
             concrete_data_loader = data_loader.construct(instances=dataset.splits[split])
 
         if torch.cuda.device_count() > 0:
+            model = model.cuda()
             cuda_device = torch.device(0)
         else:
             cuda_device = torch.device("cpu")
-        check_for_gpu(cuda_device)
 
         generator_tqdm = Tqdm.tqdm(iter(concrete_data_loader))
 

--- a/allennlp/tango/step.py
+++ b/allennlp/tango/step.py
@@ -454,6 +454,8 @@ class Step(Registrable, Generic[T]):
         if self.work_dir_for_run is not None:
             raise ValueError("You can only run a Step's run() method once at a time.")
 
+        logger.info("Starting run for step %s of type %s", self.name, self.__class__)
+
         if self.DETERMINISTIC:
             random.seed(784507111)
 


### PR DESCRIPTION
- Only issue an "AllenNLP Tango is experimental..." warning when the `tango` command is run instead of issuing this warning when ANY command is run.
- Fixes the evaluation step to put the model on the right device.
- Adds a log message that says when a step run is starting (without it the logs are really hard to segment by step).