### PR TITLE
Improved Documentation For Learning Rate Schedulers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-
+- Added more documentation to the learning rate schedulers to include a sample config object for how to use it.
+- Moved the pytorch learning rate schedulers wrappers to their own file called `pytorch_lr_schedulers.py` so that they will have their own documentation page.
 - Added a module `allennlp.nn.parallel` with a new base class, `DdpAccelerator`, which generalizes
   PyTorch's `DistributedDataParallel` wrapper to support other implementations. Two implementations of
   this class are provided. The default is `TorchDdpAccelerator` (registered at "torch"), which is just a thin wrapper around

--- a/allennlp/training/learning_rate_schedulers/__init__.py
+++ b/allennlp/training/learning_rate_schedulers/__init__.py
@@ -20,13 +20,13 @@ from allennlp.training.learning_rate_schedulers.learning_rate_scheduler import (
     ConstantLearningRateScheduler,
     ConstantWithWarmupLearningRateScheduler,
     CosineWithWarmupLearningRateScheduler,
-    CosineHardRestartsWithWarmupLearningRateScheduler
+    CosineHardRestartsWithWarmupLearningRateScheduler,
 )
 from allennlp.training.learning_rate_schedulers.pytorch_lr_schedulers import (
     StepLearningRateScheduler,
     MultiStepLearningRateScheduler,
     ExponentialLearningRateScheduler,
-    ReduceOnPlateauLearningRateScheduler
+    ReduceOnPlateauLearningRateScheduler,
 )
 from allennlp.training.learning_rate_schedulers.combined import CombinedLearningRateScheduler
 from allennlp.training.learning_rate_schedulers.cosine import CosineWithRestarts

--- a/allennlp/training/learning_rate_schedulers/__init__.py
+++ b/allennlp/training/learning_rate_schedulers/__init__.py
@@ -17,10 +17,16 @@ a Noam schedule, and a slanted triangular schedule, which are registered as
 
 from allennlp.training.learning_rate_schedulers.learning_rate_scheduler import (
     LearningRateScheduler,
+    ConstantLearningRateScheduler,
+    ConstantWithWarmupLearningRateScheduler,
+    CosineWithWarmupLearningRateScheduler,
+    CosineHardRestartsWithWarmupLearningRateScheduler
+)
+from allennlp.training.learning_rate_schedulers.pytorch_lr_schedulers import (
     StepLearningRateScheduler,
     MultiStepLearningRateScheduler,
     ExponentialLearningRateScheduler,
-    ReduceOnPlateauLearningRateScheduler,
+    ReduceOnPlateauLearningRateScheduler
 )
 from allennlp.training.learning_rate_schedulers.combined import CombinedLearningRateScheduler
 from allennlp.training.learning_rate_schedulers.cosine import CosineWithRestarts

--- a/allennlp/training/learning_rate_schedulers/combined.py
+++ b/allennlp/training/learning_rate_schedulers/combined.py
@@ -34,8 +34,12 @@ class CombinedLearningRateScheduler(LearningRateScheduler):
     Config for using the `CombinedLearningRateScheduler` Learning Rate Scheduler
     with the following arguments:
 
-    * Use [`PolynomialDecay`](https://docs.allennlp.org/main/api/training/learning_rate_schedulers/polynomial_decay/) for the first `15` epochs.
-    * Use [`NoamLR`](https://docs.allennlp.org/main/api/training/learning_rate_schedulers/noam/) for the next `15` epochs.
+    * Use [`PolynomialDecay`](
+    https://docs.allennlp.org/main/api/training/learning_rate_schedulers/polynomial_decay/
+    ) for the first `15` epochs.
+    * Use [`NoamLR`](
+    https://docs.allennlp.org/main/api/training/learning_rate_schedulers/noam/
+    ) for the next `15` epochs.
     * Use a constant LR for the remaining epochs.
 
     ```json

--- a/allennlp/training/learning_rate_schedulers/combined.py
+++ b/allennlp/training/learning_rate_schedulers/combined.py
@@ -13,10 +13,10 @@ class CombinedLearningRateScheduler(LearningRateScheduler):
     This `LearningRateScheduler` can be used to apply an arbitrary number of other schedulers
     one after the other.
 
-    These schedulers are defined though the `schedulers` parameter, which takes a list
-    of `Tuple[int, Lazy[LearningRateScheduler]]`. The first field of the tuple, the `int`,
-    specifies how many epochs the corresponding scheduler will be used before the next
-    scheduler takes its place.
+    These schedulers are defined though the `schedulers` parameter, which takes
+    a list of `Tuple[int, Lazy[LearningRateScheduler]]`. The first field of the
+    tuple, the `int`, specifies how many epochs the corresponding scheduler will
+     be used before the next scheduler takes its place.
 
     While it usually makes sense for the sum
 
@@ -25,8 +25,50 @@ class CombinedLearningRateScheduler(LearningRateScheduler):
     ```
 
     to equal the total number of training epochs, it is not a requirement.
-    If training continues beyond the last defined scheduler, both `step()` and `step_batch()`
-    will be a no-op.
+    If training continues beyond the last defined scheduler, both `step()` and
+    `step_batch()` will be a no-op. In effect, this causes the learning rate to
+    stay constant.
+
+    # Example
+
+    Config for using the `CombinedLearningRateScheduler` Learning Rate Scheduler
+    with the following arguments:
+
+    * Use [`PolynomialDecay`](https://docs.allennlp.org/main/api/training/learning_rate_schedulers/polynomial_decay/) for the first `15` epochs.
+    * Use [`NoamLR`](https://docs.allennlp.org/main/api/training/learning_rate_schedulers/noam/) for the next `15` epochs.
+    * Use a constant LR for the remaining epochs.
+
+    ```json
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "combined",
+                "schedulers": [
+                    [
+                        15, {
+                            "type": "polynomial_decay",
+                            "power": 2,
+                            "warmup_steps": 50,
+                            "end_learning_rate": 1e-10
+                        }
+                    ],
+                    [
+                        15, {
+                            "type": "noam",
+                            "warmup_steps": 1,
+                            "model_size": 128,
+                            "factor": 0.5
+                        }
+                    ]
+                ]
+            },
+            ...
+       }
+    }
+    ```
+    Note that you do NOT pass a `optimizer` key to the Learning rate scheduler.
     """
 
     def __init__(

--- a/allennlp/training/learning_rate_schedulers/cosine.py
+++ b/allennlp/training/learning_rate_schedulers/cosine.py
@@ -49,7 +49,7 @@ class CosineWithRestarts(LearningRateScheduler):
     * `eta_mul` set to `0.8`
     * `last_epoch` set to `10`
 
-    ```
+    ```json
     {
         ...
        "trainer":{

--- a/allennlp/training/learning_rate_schedulers/cosine.py
+++ b/allennlp/training/learning_rate_schedulers/cosine.py
@@ -15,15 +15,16 @@ class CosineWithRestarts(LearningRateScheduler):
     """
     Cosine annealing with restarts.
 
-    This is described in the paper https://arxiv.org/abs/1608.03983. Note that early
-    stopping should typically be avoided when using this schedule.
+    This is described in the paper https://arxiv.org/abs/1608.03983. Note that
+    early stopping should typically be avoided when using this schedule.
 
     Registered as a `LearningRateScheduler` with name "cosine".
 
     # Parameters
 
     optimizer : `torch.optim.Optimizer`
-        This argument does not get an entry in a configuration file for the object.
+        This argument does not get an entry in a configuration file for the
+        object.
     t_initial : `int`
         The number of iterations (epochs) within the first cycle.
     t_mul : `float`, optional (default=`1`)
@@ -32,10 +33,41 @@ class CosineWithRestarts(LearningRateScheduler):
     eta_min : `float`, optional (default=`0`)
         The minimum learning rate.
     eta_mul : `float`, optional (default=`1`)
-        Determines the initial learning rate for the i-th decay cycle, which is the
-        last initial learning rate multiplied by `m_mul`.
+        Determines the initial learning rate for the i-th decay cycle, which is
+        the last initial learning rate multiplied by `m_mul`.
     last_epoch : `int`, optional (default=`-1`)
         The index of the last epoch. This is used when restarting.
+
+    # Example
+
+    Config for using the `CosineWithRestarts` Learning Rate Scheduler with the
+    following arguments:
+
+    * `t_initial` set to `5`
+    * `t_mul` set to `0.9`
+    * `eta_min` set to `1e-12`
+    * `eta_mul` set to `0.8`
+    * `last_epoch` set to `10`
+
+    ```
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "cosine",
+                "t_initial": 5,
+                "t_mul": 0.9,
+                "eta_min": 1e-12
+                "eta_mul": 0.8
+                "last_epoch": 10
+            },
+            ...
+       }
+    }
+    ```
+    Note that you do NOT pass a `optimizer` key to the Learning rate scheduler.
+
     """
 
     def __init__(

--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -14,6 +14,7 @@ from transformers.optimization import (
     get_cosine_with_hard_restarts_schedule_with_warmup,
 )
 
+
 class LearningRateScheduler(Scheduler, Registrable):
     def __init__(self, optimizer: torch.optim.Optimizer, last_epoch: int = -1) -> None:
         super().__init__(optimizer, "lr", last_epoch)
@@ -160,12 +161,12 @@ class CosineWithWarmupLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper
     """
 
     def __init__(
-            self,
-            optimizer: Optimizer,
-            num_warmup_steps: int,
-            num_training_steps: int,
-            num_cycles: float = 0.5,
-            last_epoch: int = -1,
+        self,
+        optimizer: Optimizer,
+        num_warmup_steps: int,
+        num_training_steps: int,
+        num_cycles: float = 0.5,
+        last_epoch: int = -1,
     ) -> None:
         lr_scheduler = get_cosine_schedule_with_warmup(
             optimizer=optimizer,
@@ -204,12 +205,12 @@ class CosineHardRestartsWithWarmupLearningRateScheduler(_PyTorchLearningRateSche
     """
 
     def __init__(
-            self,
-            optimizer: Optimizer,
-            num_warmup_steps: int,
-            num_training_steps: int,
-            num_cycles: int = 1,
-            last_epoch: int = -1,
+        self,
+        optimizer: Optimizer,
+        num_warmup_steps: int,
+        num_training_steps: int,
+        num_cycles: int = 1,
+        last_epoch: int = -1,
     ) -> None:
         lr_scheduler = get_cosine_with_hard_restarts_schedule_with_warmup(
             optimizer=optimizer,

--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict
 from overrides import overrides
 import torch
 

--- a/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
+++ b/allennlp/training/learning_rate_schedulers/learning_rate_scheduler.py
@@ -1,12 +1,11 @@
 from typing import Any, Dict, List, Union
-
 from overrides import overrides
 import torch
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.registrable import Registrable
-from allennlp.training.scheduler import Scheduler
 from allennlp.training.optimizers import Optimizer
+from allennlp.training.scheduler import Scheduler
 
 from transformers.optimization import (
     get_constant_schedule,
@@ -14,7 +13,6 @@ from transformers.optimization import (
     get_cosine_schedule_with_warmup,
     get_cosine_with_hard_restarts_schedule_with_warmup,
 )
-
 
 class LearningRateScheduler(Scheduler, Registrable):
     def __init__(self, optimizer: torch.optim.Optimizer, last_epoch: int = -1) -> None:
@@ -57,92 +55,29 @@ class _PyTorchLearningRateSchedulerWithMetricsWrapper(_PyTorchLearningRateSchedu
         self.lr_scheduler.step(metric)
 
 
-@LearningRateScheduler.register("step")
-class StepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
-    """
-    Registered as a `LearningRateScheduler` with name "step".  The "optimizer" argument does not get
-    an entry in a configuration file for the object.
-    """
-
-    def __init__(
-        self, optimizer: Optimizer, step_size: int, gamma: float = 0.1, last_epoch: int = -1
-    ) -> None:
-        lr_scheduler = torch.optim.lr_scheduler.StepLR(
-            optimizer=optimizer, step_size=step_size, gamma=gamma, last_epoch=last_epoch
-        )
-        super().__init__(lr_scheduler)
-
-
-@LearningRateScheduler.register("multi_step")
-class MultiStepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
-    """
-    Registered as a `LearningRateScheduler` with name "multi_step".  The "optimizer" argument does
-    not get an entry in a configuration file for the object.
-    """
-
-    def __init__(
-        self, optimizer: Optimizer, milestones: List[int], gamma: float = 0.1, last_epoch: int = -1
-    ) -> None:
-        lr_scheduler = torch.optim.lr_scheduler.MultiStepLR(
-            optimizer=optimizer, milestones=milestones, gamma=gamma, last_epoch=last_epoch
-        )
-        super().__init__(lr_scheduler)
-
-
-@LearningRateScheduler.register("exponential")
-class ExponentialLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
-    """
-    Registered as a `LearningRateScheduler` with name "exponential".  The "optimizer" argument does
-    not get an entry in a configuration file for the object.
-    """
-
-    def __init__(self, optimizer: Optimizer, gamma: float = 0.1, last_epoch: int = -1) -> None:
-        lr_scheduler = torch.optim.lr_scheduler.ExponentialLR(
-            optimizer=optimizer, gamma=gamma, last_epoch=last_epoch
-        )
-        super().__init__(lr_scheduler)
-
-
-@LearningRateScheduler.register("reduce_on_plateau")
-class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetricsWrapper):
-    """
-    Registered as a `LearningRateScheduler` with name "reduce_on_plateau".  The "optimizer" argument
-    does not get an entry in a configuration file for the object.
-    """
-
-    def __init__(
-        self,
-        optimizer: Optimizer,
-        mode: str = "min",
-        factor: float = 0.1,
-        patience: int = 10,
-        verbose: bool = False,
-        threshold_mode: str = "rel",
-        threshold: float = 1e-4,
-        cooldown: int = 0,
-        min_lr: Union[float, List[float]] = 0,
-        eps: float = 1e-8,
-    ) -> None:
-        lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-            optimizer=optimizer,
-            mode=mode,
-            factor=factor,
-            patience=patience,
-            verbose=verbose,
-            threshold_mode=threshold_mode,
-            threshold=threshold,
-            cooldown=cooldown,
-            min_lr=min_lr,
-            eps=eps,
-        )
-        super().__init__(lr_scheduler)
-
-
 @LearningRateScheduler.register("constant")
 class ConstantLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
-    Registered as a `LearningRateScheduler` with name "constant".  The "optimizer" argument does
-    not get an entry in a configuration file for the object.
+    Registered as a `LearningRateScheduler` with name "constant".  The
+    "optimizer" argument does not get an entry in a configuration file for the
+    object.
+
+    # Example
+
+    Config for using the `ConstantLearningRateScheduler` Learning Rate
+    Scheduler.
+
+    ```json
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": "constant",
+            ...
+       }
+    }
+    ```
+    Note that you do NOT pass a `optimizer` key to the Learning rate scheduler.
     """
 
     def __init__(self, optimizer: Optimizer, last_epoch: int = -1) -> None:
@@ -153,8 +88,35 @@ class ConstantLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
 @LearningRateScheduler.register("constant_with_warmup")
 class ConstantWithWarmupLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
-    Registered as a `LearningRateScheduler` with name "constant_with_warmup".  The "optimizer" argument does
-    not get an entry in a configuration file for the object.
+    Registered as a `LearningRateScheduler` with name "constant_with_warmup".
+    The "optimizer" argument does not get an entry in a configuration file for
+    the object.
+
+    # Parameters
+
+    optimizer : `torch.optim.Optimizer`
+        This argument does not get an entry in a configuration file for the
+        object.
+    num_warmup_steps : `int`, required
+        The number of steps to linearly increase the learning rate.
+
+    # Example
+
+    Config for using the `ConstantWithWarmupLearningRateScheduler` Learning Rate
+     Scheduler with `num_warmup_steps` set `100`.
+
+    ```json
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "constant_with_warmup",
+                "num_warmup_steps": 100
+            },
+            ...
+       }
+    }
     """
 
     def __init__(self, optimizer: Optimizer, num_warmup_steps: int, last_epoch: int = -1) -> None:
@@ -169,15 +131,41 @@ class CosineWithWarmupLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper
     """
     Registered as a `LearningRateScheduler` with name "cosine_with_warmup".  The "optimizer" argument does
     not get an entry in a configuration file for the object.
+
+    # Parameters
+
+    optimizer : `torch.optim.Optimizer`
+        This argument does not get an entry in a configuration file for the
+        object.
+    num_warmup_steps : `int`, required
+        The number of steps to linearly increase the learning rate.
+
+    # Example
+
+    Config for using the `CosineWithWarmupLearningRateScheduler` Learning Rate
+     Scheduler with `num_warmup_steps` set `100`.
+
+    ```json
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "cosine_with_warmup",
+                "num_warmup_steps": 100
+            },
+            ...
+       }
+    }
     """
 
     def __init__(
-        self,
-        optimizer: Optimizer,
-        num_warmup_steps: int,
-        num_training_steps: int,
-        num_cycles: float = 0.5,
-        last_epoch: int = -1,
+            self,
+            optimizer: Optimizer,
+            num_warmup_steps: int,
+            num_training_steps: int,
+            num_cycles: float = 0.5,
+            last_epoch: int = -1,
     ) -> None:
         lr_scheduler = get_cosine_schedule_with_warmup(
             optimizer=optimizer,
@@ -192,17 +180,36 @@ class CosineWithWarmupLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper
 @LearningRateScheduler.register("cosine_hard_restarts_with_warmup")
 class CosineHardRestartsWithWarmupLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
-    Registered as a `LearningRateScheduler` with name "cosine_hard_restarts_with_warmup".
-    The "optimizer" argument does not get an entry in a configuration file for the object.
+    Registered as a `LearningRateScheduler` with name
+    "cosine_hard_restarts_with_warmup". The "optimizer" argument does not get an
+     entry in a configuration file for the object.
+
+    # Example
+
+    Config for using the `CosineHardRestartsWithWarmupLearningRateScheduler`
+    Learning Rate Scheduler with `num_warmup_steps` set `100`.
+
+    ```json
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "cosine_hard_restarts_with_warmup",
+                "num_warmup_steps": 100
+            },
+            ...
+       }
+    }
     """
 
     def __init__(
-        self,
-        optimizer: Optimizer,
-        num_warmup_steps: int,
-        num_training_steps: int,
-        num_cycles: int = 1,
-        last_epoch: int = -1,
+            self,
+            optimizer: Optimizer,
+            num_warmup_steps: int,
+            num_training_steps: int,
+            num_cycles: int = 1,
+            last_epoch: int = -1,
     ) -> None:
         lr_scheduler = get_cosine_with_hard_restarts_schedule_with_warmup(
             optimizer=optimizer,

--- a/allennlp/training/learning_rate_schedulers/linear_with_warmup.py
+++ b/allennlp/training/learning_rate_schedulers/linear_with_warmup.py
@@ -11,7 +11,9 @@ class LinearWithWarmup(PolynomialDecay):
     `lr` during the first `warmup_steps` steps, and then decreases it to zero
     over the rest of the training steps.
 
-    In practice, this is a wrapper of [`PolynomialDecay`](https://docs.allennlp.org/main/api/training/learning_rate_schedulers/polynomial_decay/)
+    In practice, this is a wrapper of [`PolynomialDecay`](
+    https://docs.allennlp.org/main/api/training/
+    learning_rate_schedulers/polynomial_decay/)
     with `power=1` and `end_learning_rate=0`.
 
 

--- a/allennlp/training/learning_rate_schedulers/linear_with_warmup.py
+++ b/allennlp/training/learning_rate_schedulers/linear_with_warmup.py
@@ -51,12 +51,12 @@ class LinearWithWarmup(PolynomialDecay):
     """
 
     def __init__(
-            self,
-            optimizer: torch.optim.Optimizer,
-            num_epochs: int,
-            num_steps_per_epoch: int,
-            warmup_steps: int = 100,
-            last_epoch: int = -1,
+        self,
+        optimizer: torch.optim.Optimizer,
+        num_epochs: int,
+        num_steps_per_epoch: int,
+        warmup_steps: int = 100,
+        last_epoch: int = -1,
     ) -> None:
         super().__init__(
             optimizer,

--- a/allennlp/training/learning_rate_schedulers/linear_with_warmup.py
+++ b/allennlp/training/learning_rate_schedulers/linear_with_warmup.py
@@ -7,17 +7,56 @@ from allennlp.training.learning_rate_schedulers.learning_rate_scheduler import L
 @LearningRateScheduler.register("linear_with_warmup")
 class LinearWithWarmup(PolynomialDecay):
     """
-    Implements a learning rate scheduler that increases the learning rate to `lr` during the first
-    `warmup_steps` steps, and then decreases it to zero over the rest of the training steps.
+    Implements a learning rate scheduler that increases the learning rate to
+    `lr` during the first `warmup_steps` steps, and then decreases it to zero
+    over the rest of the training steps.
+
+    In practice, this is a wrapper of [`PolynomialDecay`](https://docs.allennlp.org/main/api/training/learning_rate_schedulers/polynomial_decay/)
+    with `power=1` and `end_learning_rate=0`.
+
+
+    # Parameters
+    optimizer : `torch.optim.Optimizer`
+        This argument does not get an entry in a configuration file for the
+        object.
+    num_epochs: `int`
+        The number of epochs in the experiment. this does *NOT* get an entry in
+        the config.
+    num_steps_per_epoch: `int`
+        The number of steps per epoch. this does *NOT* get an entry in the
+        config.
+    warmup_steps : `int`, required
+        The number of steps to linearly increase the learning rate.
+
+    # Example
+
+    Config for using the `LinearWithWarmup` Learning Rate Scheduler with
+    `warmup_steps` set `100`.
+
+    ```json
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "linear_with_warmup",
+                "warmup_steps":100
+            },
+            ...
+       }
+    }
+    ```
+    Note that you do NOT pass a `optimizer`, `num_epochs`, nor
+    `num_steps_per_epoch` key to the Learning rate scheduler.
     """
 
     def __init__(
-        self,
-        optimizer: torch.optim.Optimizer,
-        num_epochs: int,
-        num_steps_per_epoch: int,
-        warmup_steps: int = 100,
-        last_epoch: int = -1,
+            self,
+            optimizer: torch.optim.Optimizer,
+            num_epochs: int,
+            num_steps_per_epoch: int,
+            warmup_steps: int = 100,
+            last_epoch: int = -1,
     ) -> None:
         super().__init__(
             optimizer,

--- a/allennlp/training/learning_rate_schedulers/noam.py
+++ b/allennlp/training/learning_rate_schedulers/noam.py
@@ -55,7 +55,7 @@ class NoamLR(LearningRateScheduler):
        }
     }
     ```
-    Note that you do NOT pass an optimizer key to the Learning rate scheduler.
+    Note that you do NOT pass an `optimizer` key to the Learning rate scheduler.
     """
 
     def __init__(

--- a/allennlp/training/learning_rate_schedulers/noam.py
+++ b/allennlp/training/learning_rate_schedulers/noam.py
@@ -15,9 +15,9 @@ class NoamLR(LearningRateScheduler):
 
     The formula for learning rate when using `NoamLR` is:
 
-    `lr`= `factor` \* (
-        `model_size` \*\* (`-0.5`)
-        \* min(`step` \*\* (`-0.5`), `step` \* `warmup_steps` \*\* (`-1.5`))
+    `lr`= `factor *` (
+        `model_size **` (`-0.5`)
+        `*` min(`step**` (`-0.5`), `step * warmup_steps **` (`-1.5`))
     )
 
     Registered as a `LearningRateScheduler` with name "noam".

--- a/allennlp/training/learning_rate_schedulers/noam.py
+++ b/allennlp/training/learning_rate_schedulers/noam.py
@@ -40,7 +40,7 @@ class NoamLR(LearningRateScheduler):
     Config for using `NoamLR` with a model size of `1024`, warmup steps
     of `5`, and `factor` of `.25`.
 
-    ```
+    ```json
     {
         ...
        "trainer":{

--- a/allennlp/training/learning_rate_schedulers/noam.py
+++ b/allennlp/training/learning_rate_schedulers/noam.py
@@ -7,23 +7,55 @@ from allennlp.training.learning_rate_schedulers.learning_rate_scheduler import L
 @LearningRateScheduler.register("noam")
 class NoamLR(LearningRateScheduler):
     """
-    Implements the Noam Learning rate schedule. This corresponds to increasing the learning rate
-    linearly for the first `warmup_steps` training steps, and decreasing it thereafter proportionally
-    to the inverse square root of the step number, scaled by the inverse square root of the
-    dimensionality of the model. Time will tell if this is just madness or it's actually important.
+    Implements the Noam Learning rate schedule. This corresponds to increasing
+    the learning rate linearly for the first `warmup_steps` training steps, and
+    decreasing it thereafter proportionally to the inverse square root of the
+    step number, scaled by the inverse square root of the dimensionality of the
+    model. Time will tell if this is just madness or it's actually important.
+
+    The formula for learning rate when using `NoamLR` is:
+
+    `lr`= `factor` \* (
+        `model_size` \*\* (`-0.5`)
+        \* min(`step` \*\* (`-0.5`), `step` \* `warmup_steps` \*\* (`-1.5`))
+    )
 
     Registered as a `LearningRateScheduler` with name "noam".
 
     # Parameters
 
     optimizer : `torch.optim.Optimizer`
-        This argument does not get an entry in a configuration file for the object.
+        This argument does not get an entry in a configuration file for the
+        object.
     model_size : `int`, required.
-        The hidden size parameter which dominates the number of parameters in your model.
+        The hidden size parameter which dominates the number of parameters in
+        your model.
     warmup_steps : `int`, required.
         The number of steps to linearly increase the learning rate.
     factor : `float`, optional (default = `1.0`).
         The overall scale factor for the learning rate decay.
+
+    # Example
+
+    Config for using `NoamLR` with a model size of `1024`, warmup steps
+    of `5`, and `factor` of `.25`.
+
+    ```
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "noam",
+                "model_size": 1024,
+                "warmup_steps":5,
+                "factor":0.25
+            },
+            ...
+       }
+    }
+    ```
+    Note that you do NOT pass an optimizer key to the Learning rate scheduler.
     """
 
     def __init__(

--- a/allennlp/training/learning_rate_schedulers/polynomial_decay.py
+++ b/allennlp/training/learning_rate_schedulers/polynomial_decay.py
@@ -42,7 +42,7 @@ class PolynomialDecay(LearningRateScheduler):
     `warmup_steps` set `100`, `power` set to `2`, and `end_learning_rate` set
     to `1e-10`.
 
-    ```
+    ```json
     {
         ...
        "trainer":{

--- a/allennlp/training/learning_rate_schedulers/polynomial_decay.py
+++ b/allennlp/training/learning_rate_schedulers/polynomial_decay.py
@@ -8,10 +8,10 @@ from allennlp.training.learning_rate_schedulers.learning_rate_scheduler import L
 @LearningRateScheduler.register("polynomial_decay")
 class PolynomialDecay(LearningRateScheduler):
     """
-    Implements polynomial decay Learning rate scheduling. The learning rate is first
-    linearly increased for the first `warmup_steps` training steps. Then it is decayed for
-    `total_steps` - `warmup_steps` from the initial learning rate to `end_learning_rate` using a polynomial
-    of degree `power`.
+    Implements polynomial decay Learning rate scheduling. The learning rate is
+    first linearly increased for the first `warmup_steps` training steps. Then
+    it is decayed for `total_steps` - `warmup_steps` from the initial learning
+    rate to `end_learning_rate` using a polynomial of degree `power`.
 
     Formally,
 
@@ -20,25 +20,56 @@ class PolynomialDecay(LearningRateScheduler):
 
     # Parameters
 
-    total_steps: `int`, required
-        The total number of steps to adjust the learning rate for.
+    optimizer : `torch.optim.Optimizer`
+        This argument does not get an entry in a configuration file for the
+        object.
+    num_epochs: `int`
+        The number of epochs in the experiment. this does *NOT* get an entry in
+        the config.
+    num_steps_per_epoch: `int`
+        The number of steps per epoch. this does *NOT* get an entry in the
+        config.
     warmup_steps : `int`, required
         The number of steps to linearly increase the learning rate.
     power : `float`, optional (default = `1.0`)
         The power of the polynomial used for decaying.
     end_learning_rate : `float`, optional (default = `0.0`)
         Final learning rate to decay towards.
+
+    # Example
+
+    Config for using the `PolynomialDecay` Learning Rate Scheduler with
+    `warmup_steps` set `100`, `power` set to `2`, and `end_learning_rate` set
+    to `1e-10`.
+
+    ```
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "polynomial_decay",
+                "power": 2,
+                "warmup_steps": 100,
+                "end_learning_rate": 1e-10
+            },
+            ...
+       }
+    }
+    ```
+    Note that you do NOT pass a `optimizer`, `num_epochs`, nor
+    `num_steps_per_epoch` key to the Learning rate scheduler.
     """
 
     def __init__(
-        self,
-        optimizer: torch.optim.Optimizer,
-        num_epochs: int,
-        num_steps_per_epoch: int,
-        power=1.0,
-        warmup_steps=0,
-        end_learning_rate=0.0,
-        last_epoch: int = -1,
+            self,
+            optimizer: torch.optim.Optimizer,
+            num_epochs: int,
+            num_steps_per_epoch: int,
+            power=1.0,
+            warmup_steps=0,
+            end_learning_rate=0.0,
+            last_epoch: int = -1,
     ):
         super().__init__(optimizer, last_epoch)
 

--- a/allennlp/training/learning_rate_schedulers/polynomial_decay.py
+++ b/allennlp/training/learning_rate_schedulers/polynomial_decay.py
@@ -62,14 +62,14 @@ class PolynomialDecay(LearningRateScheduler):
     """
 
     def __init__(
-            self,
-            optimizer: torch.optim.Optimizer,
-            num_epochs: int,
-            num_steps_per_epoch: int,
-            power=1.0,
-            warmup_steps=0,
-            end_learning_rate=0.0,
-            last_epoch: int = -1,
+        self,
+        optimizer: torch.optim.Optimizer,
+        num_epochs: int,
+        num_steps_per_epoch: int,
+        power=1.0,
+        warmup_steps=0,
+        end_learning_rate=0.0,
+        last_epoch: int = -1,
     ):
         super().__init__(optimizer, last_epoch)
 

--- a/allennlp/training/learning_rate_schedulers/pytorch_lr_schedulers.py
+++ b/allennlp/training/learning_rate_schedulers/pytorch_lr_schedulers.py
@@ -15,7 +15,10 @@ from allennlp.training.learning_rate_schedulers.learning_rate_scheduler import (
 @LearningRateScheduler.register("step")
 class StepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
-    Wrapper for [PyTorch's `StepLR`](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.StepLR.html#torch.optim.lr_scheduler.StepLR).
+    Wrapper for [PyTorch's `StepLR`](
+    https://pytorch.org/docs/stable/generated/
+    torch.optim.lr_scheduler.StepLR.html#torch.optim.lr_scheduler.StepLR
+    ).
 
     Registered as a `LearningRateScheduler` with name "step".  The "optimizer"
     argument does not get an entry in a configuration file for the object.
@@ -73,7 +76,10 @@ class StepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
 @LearningRateScheduler.register("multi_step")
 class MultiStepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
-    Wrapper for [PyTorch's `MultiStepLR`](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.MultiStepLR.html#torch.optim.lr_scheduler.MultiStepLR).
+    Wrapper for [PyTorch's `MultiStepLR`](
+    https://pytorch.org/docs/stable/
+    generated/torch.optim.lr_scheduler.MultiStepLR.html#torch.optim.lr_scheduler.MultiStepLR
+    ).
 
     Registered as a `LearningRateScheduler` with name "multi_step".  The "optimizer" argument does
     not get an entry in a configuration file for the object.
@@ -112,7 +118,9 @@ class MultiStepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
 @LearningRateScheduler.register("exponential")
 class ExponentialLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
-    Wrapper for [PyTorch's `ExponentialLR`](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ExponentialLR.html#torch.optim.lr_scheduler.ExponentialLR).
+    Wrapper for [PyTorch's `ExponentialLR`](
+    https://pytorch.org/docs/stable/generated/
+    torch.optim.lr_scheduler.ExponentialLR.html#torch.optim.lr_scheduler.ExponentialLR).
 
     Registered as a `LearningRateScheduler` with name "exponential".  The "optimizer" argument does
     not get an entry in a configuration file for the object.
@@ -148,7 +156,8 @@ class ExponentialLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
 @LearningRateScheduler.register("reduce_on_plateau")
 class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetricsWrapper):
     """
-    Wrapper for [PyTorch's `ReduceLROnPlateau`](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html#torch.optim.lr_scheduler.ReduceLROnPlateau).
+    Wrapper for [PyTorch's `ReduceLROnPlateau`](https://pytorch.org/docs/stable/generated/
+    torch.optim.lr_scheduler.ReduceLROnPlateau.html#torch.optim.lr_scheduler.ReduceLROnPlateau).
 
     Registered as a `LearningRateScheduler` with name "reduce_on_plateau".  The
     "optimizer" argument does not get an entry in a configuration file for the

--- a/allennlp/training/learning_rate_schedulers/pytorch_lr_schedulers.py
+++ b/allennlp/training/learning_rate_schedulers/pytorch_lr_schedulers.py
@@ -1,0 +1,225 @@
+"""
+Wrappers for PyTorch's Learning Rate Schedulers so that they work with AllenNLP
+"""
+from typing import List, Union
+
+import torch
+from allennlp.training.optimizers import Optimizer
+from allennlp.training.learning_rate_schedulers.learning_rate_scheduler import (
+    LearningRateScheduler,
+    _PyTorchLearningRateSchedulerWrapper,
+    _PyTorchLearningRateSchedulerWithMetricsWrapper
+)
+
+
+
+@LearningRateScheduler.register("step")
+class StepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
+    """
+    Wrapper for [PyTorch's `StepLR`](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.StepLR.html#torch.optim.lr_scheduler.StepLR).
+
+    Registered as a `LearningRateScheduler` with name "step".  The "optimizer"
+    argument does not get an entry in a configuration file for the object.
+
+    # Parameters
+    optimizer : `torch.optim.Optimizer`
+        This argument does not get an entry in a configuration file for the
+        object.
+    step_size : `int`
+        Period of learning rate decay.
+    gamma: `float`, optional (default = `0.1`)
+        Multiplicative factor of learning rate decay.
+    last_epoch : `int`, optional (default=`-1`)
+        The index of the last epoch. This is used when restarting.
+
+
+    # Example
+
+    Config for using the `StepLearningRateScheduler` Learning Rate Scheduler
+    with `step_size` of `100` and `gamma` set `0.2`.
+
+    ```json
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "step",
+                "step_size": 100,
+                "gamma": 0.2
+            },
+            ...
+       }
+    }
+    ```
+    Note that you do NOT pass a `optimizer` key to the Learning rate scheduler.
+
+    """
+
+    def __init__(
+            self,
+            optimizer: Optimizer,
+            step_size: int,
+            gamma: float = 0.1,
+            last_epoch: int = -1
+    ) -> None:
+        """
+
+        Args:
+
+        """
+
+        lr_scheduler = torch.optim.lr_scheduler.StepLR(
+            optimizer=optimizer, step_size=step_size, gamma=gamma, last_epoch=last_epoch
+        )
+        super().__init__(lr_scheduler)
+
+
+@LearningRateScheduler.register("multi_step")
+class MultiStepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
+    """
+    Wrapper for [PyTorch's `MultiStepLR`](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.MultiStepLR.html#torch.optim.lr_scheduler.MultiStepLR).
+
+    Registered as a `LearningRateScheduler` with name "multi_step".  The "optimizer" argument does
+    not get an entry in a configuration file for the object.
+
+    # Example
+
+    Config for using the `MultiStepLearningRateScheduler` Learning Rate
+    Scheduler with `milestones` of `[10,20,40]` and `gamma` set `0.2`.
+
+    ```json
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "multi_step",
+                "milestones": [10,20,40],
+                "gamma": 0.2
+            },
+            ...
+       }
+    }
+    ```
+    Note that you do NOT pass a `optimizer` key to the Learning rate scheduler.
+    """
+
+    def __init__(
+            self, optimizer: Optimizer, milestones: List[int], gamma: float = 0.1,
+            last_epoch: int = -1
+    ) -> None:
+        lr_scheduler = torch.optim.lr_scheduler.MultiStepLR(
+            optimizer=optimizer, milestones=milestones, gamma=gamma, last_epoch=last_epoch
+        )
+        super().__init__(lr_scheduler)
+
+
+@LearningRateScheduler.register("exponential")
+class ExponentialLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
+    """
+    Wrapper for [PyTorch's `ExponentialLR`](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ExponentialLR.html#torch.optim.lr_scheduler.ExponentialLR).
+
+    Registered as a `LearningRateScheduler` with name "exponential".  The "optimizer" argument does
+    not get an entry in a configuration file for the object.
+
+    # Example
+
+    Config for using the `ExponentialLearningRateScheduler` Learning Rate
+    Scheduler with `gamma` set `0.2`.
+
+    ```json
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "exponential",
+                "gamma": 0.2
+            },
+            ...
+       }
+    }
+    ```
+    Note that you do NOT pass a `optimizer` key to the Learning rate scheduler.
+    """
+
+    def __init__(self, optimizer: Optimizer, gamma: float = 0.1, last_epoch: int = -1) -> None:
+        lr_scheduler = torch.optim.lr_scheduler.ExponentialLR(
+            optimizer=optimizer, gamma=gamma, last_epoch=last_epoch
+        )
+        super().__init__(lr_scheduler)
+
+
+@LearningRateScheduler.register("reduce_on_plateau")
+class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetricsWrapper):
+    """
+    Wrapper for [PyTorch's `ReduceLROnPlateau`](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html#torch.optim.lr_scheduler.ReduceLROnPlateau).
+
+    Registered as a `LearningRateScheduler` with name "reduce_on_plateau".  The
+    "optimizer" argument does not get an entry in a configuration file for the
+    object.
+
+     # Example
+
+    Config for using the `ReduceOnPlateauLearningRateScheduler` Learning Rate
+    Scheduler with the following `init` arguments:
+    
+    * `mode="max"`
+    * `factor=0.2`
+    * `patience=5`
+    * `threshold=5e-3`
+    * `threshold_mode="abs"`
+    * `cooldown=2`
+    * `min_lr=1e-12`
+    * `eps=1e-10`
+
+    ```json
+    {
+        ...
+       "trainer":{
+            ...
+            "learning_rate_scheduler": {
+                "type": "reduce_on_plateau",
+                "mode": "max",
+                "factor": 0.2,
+                "patience": 5,
+                "threshold": 5e-3,
+                "threshold_mode": "abs",
+                "cooldown": 2,
+                "min_lr": 1e-12,
+                "eps": 1e-10
+            },
+            ...
+       }
+    }
+    ```
+    Note that you do NOT pass a `optimizer` key to the Learning rate scheduler.
+    """
+
+    def __init__(
+            self,
+            optimizer: Optimizer,
+            mode: str = "min",
+            factor: float = 0.1,
+            patience: int = 10,
+            verbose: bool = False,
+            threshold_mode: str = "rel",
+            threshold: float = 1e-4,
+            cooldown: int = 0,
+            min_lr: Union[float, List[float]] = 0,
+            eps: float = 1e-8,
+    ) -> None:
+        lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+            optimizer=optimizer,
+            mode=mode,
+            factor=factor,
+            patience=patience,
+            verbose=verbose,
+            threshold_mode=threshold_mode,
+            threshold=threshold,
+            cooldown=cooldown,
+            min_lr=min_lr,
+            eps=eps,
+        )
+        super().__init__(lr_scheduler)

--- a/allennlp/training/learning_rate_schedulers/pytorch_lr_schedulers.py
+++ b/allennlp/training/learning_rate_schedulers/pytorch_lr_schedulers.py
@@ -8,9 +8,8 @@ from allennlp.training.optimizers import Optimizer
 from allennlp.training.learning_rate_schedulers.learning_rate_scheduler import (
     LearningRateScheduler,
     _PyTorchLearningRateSchedulerWrapper,
-    _PyTorchLearningRateSchedulerWithMetricsWrapper
+    _PyTorchLearningRateSchedulerWithMetricsWrapper,
 )
-
 
 
 @LearningRateScheduler.register("step")
@@ -57,11 +56,7 @@ class StepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
 
     def __init__(
-            self,
-            optimizer: Optimizer,
-            step_size: int,
-            gamma: float = 0.1,
-            last_epoch: int = -1
+        self, optimizer: Optimizer, step_size: int, gamma: float = 0.1, last_epoch: int = -1
     ) -> None:
         """
 
@@ -106,8 +101,7 @@ class MultiStepLearningRateScheduler(_PyTorchLearningRateSchedulerWrapper):
     """
 
     def __init__(
-            self, optimizer: Optimizer, milestones: List[int], gamma: float = 0.1,
-            last_epoch: int = -1
+        self, optimizer: Optimizer, milestones: List[int], gamma: float = 0.1, last_epoch: int = -1
     ) -> None:
         lr_scheduler = torch.optim.lr_scheduler.MultiStepLR(
             optimizer=optimizer, milestones=milestones, gamma=gamma, last_epoch=last_epoch
@@ -164,7 +158,7 @@ class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetr
 
     Config for using the `ReduceOnPlateauLearningRateScheduler` Learning Rate
     Scheduler with the following `init` arguments:
-    
+
     * `mode="max"`
     * `factor=0.2`
     * `patience=5`
@@ -198,17 +192,17 @@ class ReduceOnPlateauLearningRateScheduler(_PyTorchLearningRateSchedulerWithMetr
     """
 
     def __init__(
-            self,
-            optimizer: Optimizer,
-            mode: str = "min",
-            factor: float = 0.1,
-            patience: int = 10,
-            verbose: bool = False,
-            threshold_mode: str = "rel",
-            threshold: float = 1e-4,
-            cooldown: int = 0,
-            min_lr: Union[float, List[float]] = 0,
-            eps: float = 1e-8,
+        self,
+        optimizer: Optimizer,
+        mode: str = "min",
+        factor: float = 0.1,
+        patience: int = 10,
+        verbose: bool = False,
+        threshold_mode: str = "rel",
+        threshold: float = 1e-4,
+        cooldown: int = 0,
+        min_lr: Union[float, List[float]] = 0,
+        eps: float = 1e-8,
     ) -> None:
         lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
             optimizer=optimizer,


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Partially addresses #4835.

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Improved documentation and a basic config snippet example for the learning rate schedulers
- Moved the Pytorch wrapped learning rates into their own file `pytorch_lr_schedulers.py` so that they have their own docs page
- Added links to the original PyTorch LRSchedulers so that people can read their docs as well. 
- Added formula for Noam to its docs page.
- The only LR scheduler without an example is `slanted_triangular.py` as I have not used it before and do not know of a valid config for it.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [x] All GitHub Actions jobs for my pull request have passed.
- [x] **`codecov/patch`** reports high test coverage (at least 90%).
    You can find this under the "Actions" tab of the pull request once the other checks have finished.
