### PR TITLE
Transformer heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a way for AllenNLP Tango to read and write datasets lazily.
 - Added a way to remix datasets flexibly
 - Added `from_pretrained_transformer_and_instances` constructor to `Vocabulary`
+- Added a Transformer Toolkit equivalent for masked language modeling
 - `TransformerTextField` now supports `__len__`.
 
 ### Fixed

--- a/allennlp/modules/transformer/__init__.py
+++ b/allennlp/modules/transformer/__init__.py
@@ -137,6 +137,7 @@ from allennlp.modules.transformer.transformer_layer import AttentionLayer, Trans
 from allennlp.modules.transformer.transformer_stack import TransformerStack
 from allennlp.modules.transformer.transformer_pooler import TransformerPooler
 from allennlp.modules.transformer.output_layer import OutputLayer
+from allennlp.modules.transformer.masked_lm_head import MaskedLMHead
 
 from allennlp.modules.transformer.bimodal_attention import BiModalAttention
 from allennlp.modules.transformer.bimodal_encoder import BiModalEncoder

--- a/allennlp/modules/transformer/masked_lm_head.py
+++ b/allennlp/modules/transformer/masked_lm_head.py
@@ -1,0 +1,48 @@
+from typing import Union
+
+import torch
+from allennlp.common import FromParams
+from allennlp.modules.transformer import TransformerModule
+from transformers import PretrainedConfig
+from transformers.activations import ACT2FN
+
+
+class MaskedLMHead(TransformerModule, FromParams):
+    _pretrained_mapping = {"LayerNorm": "layer_norm"}
+    _pretrained_relevant_module = ["encoder", "bert.encoder", "roberta.encoder"]
+
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        *,
+        activation: Union[str, torch.nn.Module] = "gelu",
+        layer_norm_eps: float = 1e-5,
+    ):
+        super().__init__()
+
+        self.dense = torch.nn.Linear(hidden_size, hidden_size)
+        if isinstance(activation, str):
+            self.act_fn = ACT2FN[activation]
+        else:
+            self.act_fn = activation
+        self.layer_norm = torch.nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.decoder = torch.nn.Linear(hidden_size, vocab_size, bias=False)
+        self.bias = torch.nn.Parameter(torch.zeros(vocab_size))
+        self.decoder.bias = self.bias
+
+    def forward(self, features: torch.Tensor):
+        x = self.dense(features)
+        x = self.act_fn(x)
+        x = self.layer_norm(x)
+        x = self.decoder(x)
+        return x
+
+    @classmethod
+    def _from_config(cls, config: PretrainedConfig, **kwargs) -> "MaskedLMHead":
+        final_kwargs = {}
+        final_kwargs["vocab_size"] = config.vocab_size
+        final_kwargs["hidden_size"] = config.hidden_size
+        final_kwargs["layer_norm_eps"] = config.layer_norm_eps
+        final_kwargs.update(**kwargs)
+        return cls(**final_kwargs)


### PR DESCRIPTION
@AkshitaB, this is the MaskedLM head we talked about earlier. It does not load right. The way we load the state dict from huggingface, we don't even have the parameters we need for the heads.

This is how I tried to call it in allennlp-models:
```Python
class MaskedLMTT(Model):
    def __init__(
        self,
        vocab: Vocabulary,
        transformer_model: str = "roberta-large",
        override_weights_file: Optional[str] = None,
        **kwargs,
    ) -> None:
        super().__init__(vocab, **kwargs)
        transformer_kwargs = {
            "model_name": transformer_model,
            "weights_path": override_weights_file,
        }
        self.embeddings = TransformerEmbeddings.from_pretrained_module(**transformer_kwargs)
        self.transformer_stack = TransformerStack.from_pretrained_module(**transformer_kwargs)
        self.lm_head = MaskedLMHead.from_pretrained_module(**transformer_kwargs)
```