### PR TITLE
Add scaling to tqdm bar when downloading files

### DIFF
--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -539,7 +539,7 @@ def _http_get(url: str, temp_file: IO) -> None:
         req.raise_for_status()
         content_length = req.headers.get("Content-Length")
         total = int(content_length) if content_length is not None else None
-        progress = Tqdm.tqdm(unit="B", total=total, desc="downloading")
+        progress = Tqdm.tqdm(unit="B", unit_scale=True, total=total, desc="downloading")
         for chunk in req.iter_content(chunk_size=1024):
             if chunk:  # filter out keep-alive new chunks
                 progress.update(len(chunk))


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Adds unit scaling to Tqdm bar when it is used to track file downloading progress

### Rationale:
Seeing million-like numbers in the tqdm bar when downloading large files is quite non-informative. I think that scaled units will be way more useful, as we see them daily while downloading files in the browser of checking connectivity speed on speedtest. Fortunately, tqdm has scaling features that convert numbers to their scaled variants like 12304556B -> 12,3MB. 

That is used in other libraries, which deal with pretrained models, for example [huggingface/transformers](https://github.com/huggingface/transformers/blob/35236b870ee4102fb82f7a1d4713dc83af78a00a/src/transformers/file_utils.py#L1520).

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
- [ ] **`codecov/patch`** reports high test coverage (at least 90%).
    You can find this under the "Actions" tab of the pull request once the other checks have finished.
