### PR TITLE
Make `--overrides` more flexible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
           torch_platform: cpu
           run: |
             cd allennlp-models
+            git checkout test-fixes
             make test-with-cov COV=allennlp
             mv coverage.xml ../
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,6 @@ jobs:
           torch_platform: cpu
           run: |
             cd allennlp-models
-            git checkout test-fixes
             make test-with-cov COV=allennlp
             mv coverage.xml ../
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The behavior of `--overrides` has changed. Previously the final configuration params were simply taken as the union over the original params and the `--overrides` params.
+  But now you can use `--overrides` to completely replace any part of the original config. For example, passing `--overrides '{"model":{"type":"foo"}}'` will completely
+  replace the "model" part of the original config. However, when you just want to change a single field in the JSON structure without removing / replacing adjacent fields,
+  you can still use the "dot" syntax. For example, `--overrides '{"model.num_layers":3}'` will only change the `num_layers` parameter to the "model" part of the config, leaving
+  everything else unchanged.
+
 
 ## [v2.7.0](https://github.com/allenai/allennlp/releases/tag/v2.7.0) - 2021-09-01
 

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -1,4 +1,5 @@
 import copy
+from itertools import chain
 import json
 import logging
 import os
@@ -104,7 +105,9 @@ def with_overrides(original: T, overrides_dict: Dict[str, Any], prefix: str = ""
         keys = range(len(original))
     elif isinstance(original, dict):
         merged = {}
-        keys = original.keys()
+        keys = chain(
+            original.keys(), (k for k in overrides_dict if "." not in k and k not in original)
+        )
     else:
         if prefix:
             raise ValueError(

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -402,7 +402,7 @@ class Params(MutableMapping):
         if key in self.params:
             return self._check_is_dict(key, self.params[key])
         else:
-            raise KeyError
+            raise KeyError(str(key))
 
     def __setitem__(self, key, value):
         self.params[key] = value

--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -6,7 +6,7 @@ import zlib
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from os import PathLike
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Dict, List, Union, Optional, TypeVar, Iterable, Set
 
 from overrides import overrides
 
@@ -93,87 +93,59 @@ def _environment_variables() -> Dict[str, str]:
     return {key: value for key, value in os.environ.items() if _is_encodable(value)}
 
 
-def unflatten(flat_dict: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Given a "flattened" dict with compound keys, e.g.
-        {"a.b": 0}
-    unflatten it:
-        {"a": {"b": 0}}
-    """
-    unflat: Dict[str, Any] = {}
-
-    for compound_key, value in flat_dict.items():
-        curr_dict = unflat
-        parts = compound_key.split(".")
-        for key in parts[:-1]:
-            curr_value = curr_dict.get(key)
-            if key not in curr_dict:
-                curr_dict[key] = {}
-                curr_dict = curr_dict[key]
-            elif isinstance(curr_value, dict):
-                curr_dict = curr_value
-            else:
-                raise ConfigurationError("flattened dictionary is invalid")
-        if not isinstance(curr_dict, dict) or parts[-1] in curr_dict:
-            raise ConfigurationError("flattened dictionary is invalid")
-        curr_dict[parts[-1]] = value
-
-    return unflat
+T = TypeVar("T", dict, list)
 
 
-def with_fallback(preferred: Dict[str, Any], fallback: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Deep merge two dicts, preferring values from `preferred`.
-    """
-
-    def merge(preferred_value: Any, fallback_value: Any) -> Any:
-        if isinstance(preferred_value, dict) and isinstance(fallback_value, dict):
-            return with_fallback(preferred_value, fallback_value)
-        elif isinstance(preferred_value, dict) and isinstance(fallback_value, list):
-            # treat preferred_value as a sparse list, where each key is an index to be overridden
-            merged_list = fallback_value
-            for elem_key, preferred_element in preferred_value.items():
-                try:
-                    index = int(elem_key)
-                    merged_list[index] = merge(preferred_element, fallback_value[index])
-                except ValueError:
-                    raise ConfigurationError(
-                        "could not merge dicts - the preferred dict contains "
-                        f"invalid keys (key {elem_key} is not a valid list index)"
-                    )
-                except IndexError:
-                    raise ConfigurationError(
-                        "could not merge dicts - the preferred dict contains "
-                        f"invalid keys (key {index} is out of bounds)"
-                    )
-            return merged_list
+def with_overrides(original: T, overrides_dict: Dict[str, Any], prefix: str = "") -> T:
+    merged: T
+    keys: Union[Iterable[str], Iterable[int]]
+    if isinstance(original, list):
+        merged = [None] * len(original)
+        keys = range(len(original))
+    elif isinstance(original, dict):
+        merged = {}
+        keys = original.keys()
+    else:
+        if prefix:
+            raise ValueError(
+                f"overrides for '{prefix[:-1]}.*' expected list or dict in original, "
+                f"found {type(original)} instead"
+            )
         else:
-            return copy.deepcopy(preferred_value)
+            raise ValueError(f"expected list or dict, found {type(original)} instead")
 
-    preferred_keys = set(preferred.keys())
-    fallback_keys = set(fallback.keys())
-    common_keys = preferred_keys & fallback_keys
+    used_override_keys: Set[str] = set()
+    for key in keys:
+        if str(key) in overrides_dict:
+            merged[key] = copy.deepcopy(overrides_dict[str(key)])
+            used_override_keys.add(str(key))
+        else:
+            overrides_subdict = {}
+            for o_key in overrides_dict:
+                if o_key.startswith(f"{key}."):
+                    overrides_subdict[o_key[len(f"{key}.") :]] = overrides_dict[o_key]
+                    used_override_keys.add(o_key)
+            if overrides_subdict:
+                merged[key] = with_overrides(
+                    original[key], overrides_subdict, prefix=prefix + f"{key}."
+                )
+            else:
+                merged[key] = copy.deepcopy(original[key])
 
-    merged: Dict[str, Any] = {}
+    unused_override_keys = [prefix + key for key in set(overrides_dict.keys()) - used_override_keys]
+    if unused_override_keys:
+        raise ValueError(f"overrides dict contains unused keys: {unused_override_keys}")
 
-    for key in preferred_keys - fallback_keys:
-        merged[key] = copy.deepcopy(preferred[key])
-    for key in fallback_keys - preferred_keys:
-        merged[key] = copy.deepcopy(fallback[key])
-
-    for key in common_keys:
-        preferred_value = preferred[key]
-        fallback_value = fallback[key]
-
-        merged[key] = merge(preferred_value, fallback_value)
     return merged
 
 
-def parse_overrides(serialized_overrides: str) -> Dict[str, Any]:
+def parse_overrides(
+    serialized_overrides: str, ext_vars: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     if serialized_overrides:
-        ext_vars = _environment_variables()
+        ext_vars = {**_environment_variables(), **(ext_vars or {})}
 
-        return unflatten(json.loads(evaluate_snippet("", serialized_overrides, ext_vars=ext_vars)))
+        return json.loads(evaluate_snippet("", serialized_overrides, ext_vars=ext_vars))
     else:
         return {}
 
@@ -468,7 +440,9 @@ class Params(MutableMapping):
         params_overrides: `Union[str, Dict[str, Any]]`, optional (default = `""`)
 
             A dict of overrides that can be applied to final object.
-            e.g. {"model.embedding_dim": 10}
+            e.g. `{"model.embedding_dim": 10}` will change the value of "embedding_dim"
+            within the "model" object of the config to 10. If you wanted to override the entire
+            "model" object of the config, you could do `{"model": {"type": "other_type", ...}}`.
 
         ext_vars: `dict`, optional
 
@@ -489,8 +463,12 @@ class Params(MutableMapping):
 
         if isinstance(params_overrides, dict):
             params_overrides = json.dumps(params_overrides)
-        overrides_dict = parse_overrides(params_overrides)
-        param_dict = with_fallback(preferred=overrides_dict, fallback=file_dict)
+        overrides_dict = parse_overrides(params_overrides, ext_vars=ext_vars)
+
+        if overrides_dict:
+            param_dict = with_overrides(file_dict, overrides_dict)
+        else:
+            param_dict = file_dict
 
         return cls(param_dict)
 

--- a/tests/common/params_test.py
+++ b/tests/common/params_test.py
@@ -49,11 +49,13 @@ class TestParams(AllenNlpTestCase):
             "bar.0": "d",
             "baz.bar": 1,
             "baz.x": [0, 0],
+            "z": 2,
         }
         assert with_overrides(original, overrides) == {
             "foo": {"bar": {"z": 2}, "x": 0},
             "bar": ["d", "b", "c"],
             "baz": {"bar": 1, "y": 3, "x": [0, 0]},
+            "z": 2,
         }
 
     def test_bad_overrides(self):


### PR DESCRIPTION
This proposed change impacts the behavior of `--overrides` in a potentially breaking way ⚠️

## Overview

Previously the final configuration params read from a file were simply taken as the union over the original params in the file and the params specified in `--overrides`. With this, you can now use `--overrides` to completely replace any part of the original config.

For example, passing `--overrides '{"model":{"type":"foo"}}'` will completely replace the "model" part of the original config. However, when you just want to change a single field in the JSON structure without removing / replacing adjacent fields, you can still use the "dot" syntax. For example, `--overrides '{"model.num_layers":3}'` will only change the `num_layers` parameter to the "model" part of the config, leaving everything else unchanged.

## Why is this useful?

With the old behavior it is impossible to remove any fields from the a config via `--overrides`. This becomes an issue when, for example, you want to change the type of your `dataset_reader` or `model` to a different type that takes completely different arguments.

cc @yakazimir 