### PR TITLE
Registrable to params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added in a default behavior to the `_to_params` method of `Registrable` so that in the case it is not implemented by the child class, it will still produce _a parameter dictionary_.   
+- Added in `_to_params` implementations to all tokenizers.
 - Added support to evaluate mutiple datasets and produce corresponding output files in the `evaluate` command.
 - Added more documentation to the learning rate schedulers to include a sample config object for how to use it.
 - Moved the pytorch learning rate schedulers wrappers to their own file called `pytorch_lr_schedulers.py` so that they will have their own documentation page.

--- a/allennlp/common/registrable.py
+++ b/allennlp/common/registrable.py
@@ -232,6 +232,20 @@ class Registrable(FromParams):
             return [default] + [k for k in keys if k != default]
 
     def _to_params(self) -> Dict[str, Any]:
+        """
+        Default behavior to get a params dictionary from a registrable class
+        that does NOT have a _to_params implementation. It is NOT recommended to
+         use this method. Rather this method is a minial implementation that
+         exists so that calling `_to_params` does not break.
+
+        # Returns
+
+        parameter_dict: `Dict[str, Any]`
+            A minimal parameter dictionary for a given registrable class. Will
+            get the registered name and return that as well as any positional
+            arguments it can find the value of.
+
+        """
         logger.warning(
             f"'{self.__class__.__name__}' does not implement '_to_params`. Will"
             f" use Registrable's `_to_params`."

--- a/allennlp/common/registrable.py
+++ b/allennlp/common/registrable.py
@@ -7,8 +7,19 @@ import importlib
 import logging
 import inspect
 from collections import defaultdict
-from typing import Callable, ClassVar, DefaultDict, Dict, List, Optional, Tuple, Type, TypeVar, \
-    cast, Any
+from typing import (
+    Callable,
+    ClassVar,
+    DefaultDict,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    cast,
+    Any,
+)
 
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.from_params import FromParams
@@ -49,7 +60,7 @@ class Registrable(FromParams):
 
     @classmethod
     def register(
-            cls, name: str, constructor: Optional[str] = None, exist_ok: bool = False
+        cls, name: str, constructor: Optional[str] = None, exist_ok: bool = False
     ) -> Callable[[Type[_T]], Type[_T]]:
         """
         Register a class under a particular name.
@@ -150,7 +161,7 @@ class Registrable(FromParams):
 
     @classmethod
     def resolve_class_name(
-            cls: Type[_RegistrableT], name: str
+        cls: Type[_RegistrableT], name: str
     ) -> Tuple[Type[_RegistrableT], Optional[str]]:
         """
         Returns the subclass that corresponds to the given `name`, along with the name of the
@@ -195,16 +206,16 @@ class Registrable(FromParams):
             suggestion = _get_suggestion(name, available)
             raise ConfigurationError(
                 (
-                        f"'{name}' is not a registered name for '{cls.__name__}'"
-                        + (". " if not suggestion else f", did you mean '{suggestion}'? ")
+                    f"'{name}' is not a registered name for '{cls.__name__}'"
+                    + (". " if not suggestion else f", did you mean '{suggestion}'? ")
                 )
                 + "If your registered class comes from custom code, you'll need to import "
-                  "the corresponding modules. If you're using AllenNLP from the command-line, "
-                  "this is done by using the '--include-package' flag, or by specifying your imports "
-                  "in a '.allennlp_plugins' file. "
-                  "Alternatively, you can specify your choices "
-                  """using fully-qualified paths, e.g. {"model": "my_module.models.MyModel"} """
-                  "in which case they will be automatically imported correctly."
+                "the corresponding modules. If you're using AllenNLP from the command-line, "
+                "this is done by using the '--include-package' flag, or by specifying your imports "
+                "in a '.allennlp_plugins' file. "
+                "Alternatively, you can specify your choices "
+                """using fully-qualified paths, e.g. {"model": "my_module.models.MyModel"} """
+                "in which case they will be automatically imported correctly."
             )
 
     @classmethod

--- a/allennlp/data/tokenizers/character_tokenizer.py
+++ b/allennlp/data/tokenizers/character_tokenizer.py
@@ -40,11 +40,11 @@ class CharacterTokenizer(Tokenizer):
     """
 
     def __init__(
-            self,
-            byte_encoding: str = None,
-            lowercase_characters: bool = False,
-            start_tokens: List[Union[str, int]] = None,
-            end_tokens: List[Union[str, int]] = None,
+        self,
+        byte_encoding: str = None,
+        lowercase_characters: bool = False,
+        start_tokens: List[Union[str, int]] = None,
+        end_tokens: List[Union[str, int]] = None,
     ) -> None:
         # TODO(brendanr): Add length truncation.
         self._byte_encoding = byte_encoding
@@ -86,9 +86,9 @@ class CharacterTokenizer(Tokenizer):
 
     def _to_params(self) -> Dict[str, Any]:
         return {
-            "type"                : "character",
-            "byte_encoding"       : self._byte_encoding,
+            "type": "character",
+            "byte_encoding": self._byte_encoding,
             "lowercase_characters": self._lowercase_characters,
-            "start_tokens"        : self._start_tokens,
-            "end_tokens"          : self._end_tokens
+            "start_tokens": self._start_tokens,
+            "end_tokens": self._end_tokens,
         }

--- a/allennlp/data/tokenizers/character_tokenizer.py
+++ b/allennlp/data/tokenizers/character_tokenizer.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Union, Dict, Any
 
 from overrides import overrides
 
@@ -40,11 +40,11 @@ class CharacterTokenizer(Tokenizer):
     """
 
     def __init__(
-        self,
-        byte_encoding: str = None,
-        lowercase_characters: bool = False,
-        start_tokens: List[Union[str, int]] = None,
-        end_tokens: List[Union[str, int]] = None,
+            self,
+            byte_encoding: str = None,
+            lowercase_characters: bool = False,
+            start_tokens: List[Union[str, int]] = None,
+            end_tokens: List[Union[str, int]] = None,
     ) -> None:
         # TODO(brendanr): Add length truncation.
         self._byte_encoding = byte_encoding
@@ -83,3 +83,12 @@ class CharacterTokenizer(Tokenizer):
         if isinstance(self, other.__class__):
             return self.__dict__ == other.__dict__
         return NotImplemented
+
+    def _to_params(self) -> Dict[str, Any]:
+        return {
+            "type"                : "character",
+            "byte_encoding"       : self._byte_encoding,
+            "lowercase_characters": self._lowercase_characters,
+            "start_tokens"        : self._start_tokens,
+            "end_tokens"          : self._end_tokens
+        }

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -48,11 +48,11 @@ class PretrainedTransformerTokenizer(Tokenizer):
     """  # noqa: E501
 
     def __init__(
-            self,
-            model_name: str,
-            add_special_tokens: bool = True,
-            max_length: Optional[int] = None,
-            tokenizer_kwargs: Optional[Dict[str, Any]] = None,
+        self,
+        model_name: str,
+        add_special_tokens: bool = True,
+        max_length: Optional[int] = None,
+        tokenizer_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         if tokenizer_kwargs is None:
             tokenizer_kwargs = {}
@@ -83,11 +83,11 @@ class PretrainedTransformerTokenizer(Tokenizer):
             self._reverse_engineer_special_tokens("1", "2", model_name, tokenizer_kwargs)
 
     def _reverse_engineer_special_tokens(
-            self,
-            token_a: str,
-            token_b: str,
-            model_name: str,
-            tokenizer_kwargs: Optional[Dict[str, Any]],
+        self,
+        token_a: str,
+        token_b: str,
+        model_name: str,
+        tokenizer_kwargs: Optional[Dict[str, Any]],
     ):
         # storing the special tokens
         self.sequence_pair_start_tokens = []
@@ -131,15 +131,15 @@ class PretrainedTransformerTokenizer(Tokenizer):
         seen_dummy_a = False
         seen_dummy_b = False
         for token_id, token_type_id in zip(
-                dummy_output["input_ids"], dummy_output["token_type_ids"]
+            dummy_output["input_ids"], dummy_output["token_type_ids"]
         ):
             if token_id == dummy_a:
                 if seen_dummy_a or seen_dummy_b:  # seeing a twice or b before a
                     raise ValueError("Cannot auto-determine the number of special tokens added.")
                 seen_dummy_a = True
                 assert (
-                        self.sequence_pair_first_token_type_id is None
-                        or self.sequence_pair_first_token_type_id == token_type_id
+                    self.sequence_pair_first_token_type_id is None
+                    or self.sequence_pair_first_token_type_id == token_type_id
                 ), "multiple different token type ids found for the first sequence"
                 self.sequence_pair_first_token_type_id = token_type_id
                 continue
@@ -149,8 +149,8 @@ class PretrainedTransformerTokenizer(Tokenizer):
                     raise ValueError("Cannot auto-determine the number of special tokens added.")
                 seen_dummy_b = True
                 assert (
-                        self.sequence_pair_second_token_type_id is None
-                        or self.sequence_pair_second_token_type_id == token_type_id
+                    self.sequence_pair_second_token_type_id is None
+                    or self.sequence_pair_second_token_type_id == token_type_id
                 ), "multiple different token type ids found for the second sequence"
                 self.sequence_pair_second_token_type_id = token_type_id
                 continue
@@ -168,10 +168,10 @@ class PretrainedTransformerTokenizer(Tokenizer):
                 self.sequence_pair_end_tokens.append(token)
 
         assert (
-                       len(self.sequence_pair_start_tokens)
-                       + len(self.sequence_pair_mid_tokens)
-                       + len(self.sequence_pair_end_tokens)
-               ) == self.tokenizer.num_special_tokens_to_add(pair=True)
+            len(self.sequence_pair_start_tokens)
+            + len(self.sequence_pair_mid_tokens)
+            + len(self.sequence_pair_end_tokens)
+        ) == self.tokenizer.num_special_tokens_to_add(pair=True)
 
         # Reverse-engineer the tokenizer for one sequence
         dummy_output = tokenizer_with_special_tokens.encode_plus(
@@ -188,15 +188,15 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         seen_dummy_a = False
         for token_id, token_type_id in zip(
-                dummy_output["input_ids"], dummy_output["token_type_ids"]
+            dummy_output["input_ids"], dummy_output["token_type_ids"]
         ):
             if token_id == dummy_a:
                 if seen_dummy_a:
                     raise ValueError("Cannot auto-determine the number of special tokens added.")
                 seen_dummy_a = True
                 assert (
-                        self.single_sequence_token_type_id is None
-                        or self.single_sequence_token_type_id == token_type_id
+                    self.single_sequence_token_type_id is None
+                    or self.single_sequence_token_type_id == token_type_id
                 ), "multiple different token type ids found for the sequence"
                 self.single_sequence_token_type_id = token_type_id
                 continue
@@ -212,8 +212,8 @@ class PretrainedTransformerTokenizer(Tokenizer):
                 self.single_sequence_end_tokens.append(token)
 
         assert (
-                       len(self.single_sequence_start_tokens) + len(self.single_sequence_end_tokens)
-               ) == self.tokenizer.num_special_tokens_to_add(pair=False)
+            len(self.single_sequence_start_tokens) + len(self.single_sequence_end_tokens)
+        ) == self.tokenizer.num_special_tokens_to_add(pair=False)
 
     @staticmethod
     def tokenizer_lowercases(tokenizer: PreTrainedTokenizer) -> bool:
@@ -259,7 +259,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         tokens = []
         for token_id, token_type_id, special_token_mask, offsets in zip(
-                token_ids, token_type_ids, special_tokens_mask, token_offsets
+            token_ids, token_type_ids, special_tokens_mask, token_offsets
         ):
             # In `special_tokens_mask`, 1s indicate special tokens and 0s indicate regular tokens.
             # NOTE: in transformers v3.4.0 (and probably older versions) the docstring
@@ -287,7 +287,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         return tokens
 
     def _estimate_character_indices(
-            self, text: str, token_ids: List[int]
+        self, text: str, token_ids: List[int]
     ) -> List[Optional[Tuple[int, int]]]:
         """
         The huggingface tokenizers produce tokens that may or may not be slices from the
@@ -349,7 +349,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         return token_offsets
 
     def _intra_word_tokenize(
-            self, string_tokens: List[str]
+        self, string_tokens: List[str]
     ) -> Tuple[List[Token], List[Optional[Tuple[int, int]]]]:
         tokens: List[Token] = []
         offsets: List[Optional[Tuple[int, int]]] = []
@@ -375,7 +375,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
     @staticmethod
     def _increment_offsets(
-            offsets: Iterable[Optional[Tuple[int, int]]], increment: int
+        offsets: Iterable[Optional[Tuple[int, int]]], increment: int
     ) -> List[Optional[Tuple[int, int]]]:
         return [
             None if offset is None else (offset[0] + increment, offset[1] + increment)
@@ -383,7 +383,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         ]
 
     def intra_word_tokenize(
-            self, string_tokens: List[str]
+        self, string_tokens: List[str]
     ) -> Tuple[List[Token], List[Optional[Tuple[int, int]]]]:
         """
         Tokenizes each word into wordpieces separately and returns the wordpiece IDs.
@@ -398,7 +398,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         return tokens, offsets
 
     def intra_word_tokenize_sentence_pair(
-            self, string_tokens_a: List[str], string_tokens_b: List[str]
+        self, string_tokens_a: List[str], string_tokens_b: List[str]
     ) -> Tuple[List[Token], List[Optional[Tuple[int, int]]], List[Optional[Tuple[int, int]]]]:
         """
         Tokenizes each word into wordpieces separately and returns the wordpiece IDs.
@@ -412,9 +412,9 @@ class PretrainedTransformerTokenizer(Tokenizer):
         offsets_b = self._increment_offsets(
             offsets_b,
             (
-                    len(self.sequence_pair_start_tokens)
-                    + len(tokens_a)
-                    + len(self.sequence_pair_mid_tokens)
+                len(self.sequence_pair_start_tokens)
+                + len(tokens_a)
+                + len(self.sequence_pair_mid_tokens)
             ),
         )
         tokens_a = self.add_special_tokens(tokens_a, tokens_b)
@@ -423,7 +423,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         return tokens_a, offsets_a, offsets_b
 
     def add_special_tokens(
-            self, tokens1: List[Token], tokens2: Optional[List[Token]] = None
+        self, tokens1: List[Token], tokens2: Optional[List[Token]] = None
     ) -> List[Token]:
         def with_new_type_id(tokens: List[Token], type_id: int) -> List[Token]:
             return [dataclasses.replace(t, type_id=type_id) for t in tokens]
@@ -433,19 +433,17 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         if tokens2 is None:
             return (
-                    self.single_sequence_start_tokens
-                    + with_new_type_id(tokens1, self.single_sequence_token_type_id)  # type: ignore
-                    + self.single_sequence_end_tokens
+                self.single_sequence_start_tokens
+                + with_new_type_id(tokens1, self.single_sequence_token_type_id)  # type: ignore
+                + self.single_sequence_end_tokens
             )
         else:
             return (
-                    self.sequence_pair_start_tokens
-                    + with_new_type_id(tokens1,
-                                       self.sequence_pair_first_token_type_id)  # type: ignore
-                    + self.sequence_pair_mid_tokens
-                    + with_new_type_id(tokens2,
-                                       self.sequence_pair_second_token_type_id)  # type: ignore
-                    + self.sequence_pair_end_tokens
+                self.sequence_pair_start_tokens
+                + with_new_type_id(tokens1, self.sequence_pair_first_token_type_id)  # type: ignore
+                + self.sequence_pair_mid_tokens
+                + with_new_type_id(tokens2, self.sequence_pair_second_token_type_id)  # type: ignore
+                + self.sequence_pair_end_tokens
             )
 
     def num_special_tokens_for_sequence(self) -> int:
@@ -453,16 +451,16 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
     def num_special_tokens_for_pair(self) -> int:
         return (
-                len(self.sequence_pair_start_tokens)
-                + len(self.sequence_pair_mid_tokens)
-                + len(self.sequence_pair_end_tokens)
+            len(self.sequence_pair_start_tokens)
+            + len(self.sequence_pair_mid_tokens)
+            + len(self.sequence_pair_end_tokens)
         )
 
     def _to_params(self) -> Dict[str, Any]:
         return {
-            "type"              : "pretrained_transformer",
-            "model_name"        : self._model_name,
+            "type": "pretrained_transformer",
+            "model_name": self._model_name,
             "add_special_tokens": self._add_special_tokens,
-            "max_length"        : self._max_length,
-            "tokenizer_kwargs"  : self._tokenizer_kwargs
+            "max_length": self._max_length,
+            "tokenizer_kwargs": self._tokenizer_kwargs,
         }

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -48,23 +48,26 @@ class PretrainedTransformerTokenizer(Tokenizer):
     """  # noqa: E501
 
     def __init__(
-        self,
-        model_name: str,
-        add_special_tokens: bool = True,
-        max_length: Optional[int] = None,
-        tokenizer_kwargs: Optional[Dict[str, Any]] = None,
+            self,
+            model_name: str,
+            add_special_tokens: bool = True,
+            max_length: Optional[int] = None,
+            tokenizer_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         if tokenizer_kwargs is None:
             tokenizer_kwargs = {}
         else:
             tokenizer_kwargs = tokenizer_kwargs.copy()
-        tokenizer_kwargs.setdefault("use_fast", True)
         # Note: Just because we request a fast tokenizer doesn't mean we get one.
+        tokenizer_kwargs.setdefault("use_fast", True)
+
+        self._tokenizer_kwargs = tokenizer_kwargs
+        self._model_name = model_name
 
         from allennlp.common import cached_transformers
 
         self.tokenizer = cached_transformers.get_tokenizer(
-            model_name, add_special_tokens=False, **tokenizer_kwargs
+            self._model_name, add_special_tokens=False, **self._tokenizer_kwargs
         )
 
         self._add_special_tokens = add_special_tokens
@@ -80,11 +83,11 @@ class PretrainedTransformerTokenizer(Tokenizer):
             self._reverse_engineer_special_tokens("1", "2", model_name, tokenizer_kwargs)
 
     def _reverse_engineer_special_tokens(
-        self,
-        token_a: str,
-        token_b: str,
-        model_name: str,
-        tokenizer_kwargs: Optional[Dict[str, Any]],
+            self,
+            token_a: str,
+            token_b: str,
+            model_name: str,
+            tokenizer_kwargs: Optional[Dict[str, Any]],
     ):
         # storing the special tokens
         self.sequence_pair_start_tokens = []
@@ -128,15 +131,15 @@ class PretrainedTransformerTokenizer(Tokenizer):
         seen_dummy_a = False
         seen_dummy_b = False
         for token_id, token_type_id in zip(
-            dummy_output["input_ids"], dummy_output["token_type_ids"]
+                dummy_output["input_ids"], dummy_output["token_type_ids"]
         ):
             if token_id == dummy_a:
                 if seen_dummy_a or seen_dummy_b:  # seeing a twice or b before a
                     raise ValueError("Cannot auto-determine the number of special tokens added.")
                 seen_dummy_a = True
                 assert (
-                    self.sequence_pair_first_token_type_id is None
-                    or self.sequence_pair_first_token_type_id == token_type_id
+                        self.sequence_pair_first_token_type_id is None
+                        or self.sequence_pair_first_token_type_id == token_type_id
                 ), "multiple different token type ids found for the first sequence"
                 self.sequence_pair_first_token_type_id = token_type_id
                 continue
@@ -146,8 +149,8 @@ class PretrainedTransformerTokenizer(Tokenizer):
                     raise ValueError("Cannot auto-determine the number of special tokens added.")
                 seen_dummy_b = True
                 assert (
-                    self.sequence_pair_second_token_type_id is None
-                    or self.sequence_pair_second_token_type_id == token_type_id
+                        self.sequence_pair_second_token_type_id is None
+                        or self.sequence_pair_second_token_type_id == token_type_id
                 ), "multiple different token type ids found for the second sequence"
                 self.sequence_pair_second_token_type_id = token_type_id
                 continue
@@ -165,10 +168,10 @@ class PretrainedTransformerTokenizer(Tokenizer):
                 self.sequence_pair_end_tokens.append(token)
 
         assert (
-            len(self.sequence_pair_start_tokens)
-            + len(self.sequence_pair_mid_tokens)
-            + len(self.sequence_pair_end_tokens)
-        ) == self.tokenizer.num_special_tokens_to_add(pair=True)
+                       len(self.sequence_pair_start_tokens)
+                       + len(self.sequence_pair_mid_tokens)
+                       + len(self.sequence_pair_end_tokens)
+               ) == self.tokenizer.num_special_tokens_to_add(pair=True)
 
         # Reverse-engineer the tokenizer for one sequence
         dummy_output = tokenizer_with_special_tokens.encode_plus(
@@ -185,15 +188,15 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         seen_dummy_a = False
         for token_id, token_type_id in zip(
-            dummy_output["input_ids"], dummy_output["token_type_ids"]
+                dummy_output["input_ids"], dummy_output["token_type_ids"]
         ):
             if token_id == dummy_a:
                 if seen_dummy_a:
                     raise ValueError("Cannot auto-determine the number of special tokens added.")
                 seen_dummy_a = True
                 assert (
-                    self.single_sequence_token_type_id is None
-                    or self.single_sequence_token_type_id == token_type_id
+                        self.single_sequence_token_type_id is None
+                        or self.single_sequence_token_type_id == token_type_id
                 ), "multiple different token type ids found for the sequence"
                 self.single_sequence_token_type_id = token_type_id
                 continue
@@ -209,8 +212,8 @@ class PretrainedTransformerTokenizer(Tokenizer):
                 self.single_sequence_end_tokens.append(token)
 
         assert (
-            len(self.single_sequence_start_tokens) + len(self.single_sequence_end_tokens)
-        ) == self.tokenizer.num_special_tokens_to_add(pair=False)
+                       len(self.single_sequence_start_tokens) + len(self.single_sequence_end_tokens)
+               ) == self.tokenizer.num_special_tokens_to_add(pair=False)
 
     @staticmethod
     def tokenizer_lowercases(tokenizer: PreTrainedTokenizer) -> bool:
@@ -256,7 +259,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         tokens = []
         for token_id, token_type_id, special_token_mask, offsets in zip(
-            token_ids, token_type_ids, special_tokens_mask, token_offsets
+                token_ids, token_type_ids, special_tokens_mask, token_offsets
         ):
             # In `special_tokens_mask`, 1s indicate special tokens and 0s indicate regular tokens.
             # NOTE: in transformers v3.4.0 (and probably older versions) the docstring
@@ -284,7 +287,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         return tokens
 
     def _estimate_character_indices(
-        self, text: str, token_ids: List[int]
+            self, text: str, token_ids: List[int]
     ) -> List[Optional[Tuple[int, int]]]:
         """
         The huggingface tokenizers produce tokens that may or may not be slices from the
@@ -346,7 +349,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         return token_offsets
 
     def _intra_word_tokenize(
-        self, string_tokens: List[str]
+            self, string_tokens: List[str]
     ) -> Tuple[List[Token], List[Optional[Tuple[int, int]]]]:
         tokens: List[Token] = []
         offsets: List[Optional[Tuple[int, int]]] = []
@@ -372,7 +375,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
     @staticmethod
     def _increment_offsets(
-        offsets: Iterable[Optional[Tuple[int, int]]], increment: int
+            offsets: Iterable[Optional[Tuple[int, int]]], increment: int
     ) -> List[Optional[Tuple[int, int]]]:
         return [
             None if offset is None else (offset[0] + increment, offset[1] + increment)
@@ -380,7 +383,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         ]
 
     def intra_word_tokenize(
-        self, string_tokens: List[str]
+            self, string_tokens: List[str]
     ) -> Tuple[List[Token], List[Optional[Tuple[int, int]]]]:
         """
         Tokenizes each word into wordpieces separately and returns the wordpiece IDs.
@@ -395,7 +398,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         return tokens, offsets
 
     def intra_word_tokenize_sentence_pair(
-        self, string_tokens_a: List[str], string_tokens_b: List[str]
+            self, string_tokens_a: List[str], string_tokens_b: List[str]
     ) -> Tuple[List[Token], List[Optional[Tuple[int, int]]], List[Optional[Tuple[int, int]]]]:
         """
         Tokenizes each word into wordpieces separately and returns the wordpiece IDs.
@@ -409,9 +412,9 @@ class PretrainedTransformerTokenizer(Tokenizer):
         offsets_b = self._increment_offsets(
             offsets_b,
             (
-                len(self.sequence_pair_start_tokens)
-                + len(tokens_a)
-                + len(self.sequence_pair_mid_tokens)
+                    len(self.sequence_pair_start_tokens)
+                    + len(tokens_a)
+                    + len(self.sequence_pair_mid_tokens)
             ),
         )
         tokens_a = self.add_special_tokens(tokens_a, tokens_b)
@@ -420,7 +423,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         return tokens_a, offsets_a, offsets_b
 
     def add_special_tokens(
-        self, tokens1: List[Token], tokens2: Optional[List[Token]] = None
+            self, tokens1: List[Token], tokens2: Optional[List[Token]] = None
     ) -> List[Token]:
         def with_new_type_id(tokens: List[Token], type_id: int) -> List[Token]:
             return [dataclasses.replace(t, type_id=type_id) for t in tokens]
@@ -430,17 +433,19 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         if tokens2 is None:
             return (
-                self.single_sequence_start_tokens
-                + with_new_type_id(tokens1, self.single_sequence_token_type_id)  # type: ignore
-                + self.single_sequence_end_tokens
+                    self.single_sequence_start_tokens
+                    + with_new_type_id(tokens1, self.single_sequence_token_type_id)  # type: ignore
+                    + self.single_sequence_end_tokens
             )
         else:
             return (
-                self.sequence_pair_start_tokens
-                + with_new_type_id(tokens1, self.sequence_pair_first_token_type_id)  # type: ignore
-                + self.sequence_pair_mid_tokens
-                + with_new_type_id(tokens2, self.sequence_pair_second_token_type_id)  # type: ignore
-                + self.sequence_pair_end_tokens
+                    self.sequence_pair_start_tokens
+                    + with_new_type_id(tokens1,
+                                       self.sequence_pair_first_token_type_id)  # type: ignore
+                    + self.sequence_pair_mid_tokens
+                    + with_new_type_id(tokens2,
+                                       self.sequence_pair_second_token_type_id)  # type: ignore
+                    + self.sequence_pair_end_tokens
             )
 
     def num_special_tokens_for_sequence(self) -> int:
@@ -448,7 +453,16 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
     def num_special_tokens_for_pair(self) -> int:
         return (
-            len(self.sequence_pair_start_tokens)
-            + len(self.sequence_pair_mid_tokens)
-            + len(self.sequence_pair_end_tokens)
+                len(self.sequence_pair_start_tokens)
+                + len(self.sequence_pair_mid_tokens)
+                + len(self.sequence_pair_end_tokens)
         )
+
+    def _to_params(self) -> Dict[str, Any]:
+        return {
+            "type"              : "pretrained_transformer",
+            "model_name"        : self._model_name,
+            "add_special_tokens": self._add_special_tokens,
+            "max_length"        : self._max_length,
+            "tokenizer_kwargs"  : self._tokenizer_kwargs
+        }

--- a/allennlp/data/tokenizers/sentence_splitter.py
+++ b/allennlp/data/tokenizers/sentence_splitter.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict, Any
 from overrides import overrides
 
 import spacy
@@ -44,8 +44,11 @@ class SpacySentenceSplitter(SentenceSplitter):
     """
 
     def __init__(self, language: str = "en_core_web_sm", rule_based: bool = False) -> None:
+        self._language = language
+        self._rule_based = rule_based
+
         # we need spacy's dependency parser if we're not using rule-based sentence boundary detection.
-        self.spacy = get_spacy_model(language, parse=not rule_based, ner=False)
+        self.spacy = get_spacy_model(self._language, parse=not self._rule_based, ner=False)
         self._is_version_3 = spacy.__version__ >= "3.0"
         if rule_based:
             # we use `sentencizer`, a built-in spacy module for rule-based sentence boundary detection.
@@ -77,3 +80,10 @@ class SpacySentenceSplitter(SentenceSplitter):
         return [
             [sentence.string.strip() for sentence in doc.sents] for doc in self.spacy.pipe(texts)
         ]
+
+    def _to_params(self) -> Dict[str, Any]:
+        return {
+            "type"      : "spacy",
+            "language"  : self._language,
+            "rule_based": self._rule_based
+        }

--- a/allennlp/data/tokenizers/sentence_splitter.py
+++ b/allennlp/data/tokenizers/sentence_splitter.py
@@ -82,8 +82,4 @@ class SpacySentenceSplitter(SentenceSplitter):
         ]
 
     def _to_params(self) -> Dict[str, Any]:
-        return {
-            "type"      : "spacy",
-            "language"  : self._language,
-            "rule_based": self._rule_based
-        }
+        return {"type": "spacy", "language": self._language, "rule_based": self._rule_based}

--- a/allennlp/data/tokenizers/spacy_tokenizer.py
+++ b/allennlp/data/tokenizers/spacy_tokenizer.py
@@ -50,18 +50,31 @@ class SpacyTokenizer(Tokenizer):
     """
 
     def __init__(
-        self,
-        language: str = "en_core_web_sm",
-        pos_tags: bool = True,
-        parse: bool = False,
-        ner: bool = False,
-        keep_spacy_tokens: bool = False,
-        split_on_spaces: bool = False,
-        start_tokens: Optional[List[str]] = None,
-        end_tokens: Optional[List[str]] = None,
+            self,
+            language: str = "en_core_web_sm",
+            pos_tags: bool = True,
+            parse: bool = False,
+            ner: bool = False,
+            keep_spacy_tokens: bool = False,
+            split_on_spaces: bool = False,
+            start_tokens: Optional[List[str]] = None,
+            end_tokens: Optional[List[str]] = None,
     ) -> None:
-        self.spacy = get_spacy_model(language, pos_tags, parse, ner)
-        if split_on_spaces:
+        # Save these for use later in the _to_params method
+        self._language = language
+        self._pos_tags = pos_tags
+        self._parse = parse
+        self._ner = ner
+        self._split_on_spaces = split_on_spaces
+
+        self.spacy = get_spacy_model(
+            self._language,
+            self._pos_tags,
+            self._parse,
+            self._ner
+        )
+
+        if self._split_on_spaces:
             self.spacy.tokenizer = _WhitespaceSpacyTokenizer(self.spacy.vocab)
 
         self._keep_spacy_tokens = keep_spacy_tokens
@@ -115,6 +128,19 @@ class SpacyTokenizer(Tokenizer):
         # This works because our Token class matches spacy's.
         return self._sanitize(_remove_spaces(self.spacy(text)))
 
+    def _to_params(self):
+        return {
+            "type"             : "spacy",
+            "language"         : self._language,
+            "pos_tags"         : self._pos_tags,
+            "parse"            : self._parse,
+            "ner"              : self._ner,
+            "keep_spacy_tokens": self._keep_spacy_tokens,
+            "split_on_spaces"  : self._split_on_spaces,
+            "start_tokens"     : self._start_tokens,
+            "end_tokens"       : self._end_tokens,
+
+        }
 
 class _WhitespaceSpacyTokenizer:
     """
@@ -135,7 +161,6 @@ class _WhitespaceSpacyTokenizer:
         words = text.split(" ")
         spaces = [True] * len(words)
         return Doc(self.vocab, words=words, spaces=spaces)
-
 
 def _remove_spaces(tokens: List[spacy.tokens.Token]) -> List[spacy.tokens.Token]:
     return [token for token in tokens if not token.is_space]

--- a/allennlp/data/tokenizers/spacy_tokenizer.py
+++ b/allennlp/data/tokenizers/spacy_tokenizer.py
@@ -50,15 +50,15 @@ class SpacyTokenizer(Tokenizer):
     """
 
     def __init__(
-            self,
-            language: str = "en_core_web_sm",
-            pos_tags: bool = True,
-            parse: bool = False,
-            ner: bool = False,
-            keep_spacy_tokens: bool = False,
-            split_on_spaces: bool = False,
-            start_tokens: Optional[List[str]] = None,
-            end_tokens: Optional[List[str]] = None,
+        self,
+        language: str = "en_core_web_sm",
+        pos_tags: bool = True,
+        parse: bool = False,
+        ner: bool = False,
+        keep_spacy_tokens: bool = False,
+        split_on_spaces: bool = False,
+        start_tokens: Optional[List[str]] = None,
+        end_tokens: Optional[List[str]] = None,
     ) -> None:
         # Save these for use later in the _to_params method
         self._language = language
@@ -67,12 +67,7 @@ class SpacyTokenizer(Tokenizer):
         self._ner = ner
         self._split_on_spaces = split_on_spaces
 
-        self.spacy = get_spacy_model(
-            self._language,
-            self._pos_tags,
-            self._parse,
-            self._ner
-        )
+        self.spacy = get_spacy_model(self._language, self._pos_tags, self._parse, self._ner)
 
         if self._split_on_spaces:
             self.spacy.tokenizer = _WhitespaceSpacyTokenizer(self.spacy.vocab)
@@ -130,17 +125,17 @@ class SpacyTokenizer(Tokenizer):
 
     def _to_params(self):
         return {
-            "type"             : "spacy",
-            "language"         : self._language,
-            "pos_tags"         : self._pos_tags,
-            "parse"            : self._parse,
-            "ner"              : self._ner,
+            "type": "spacy",
+            "language": self._language,
+            "pos_tags": self._pos_tags,
+            "parse": self._parse,
+            "ner": self._ner,
             "keep_spacy_tokens": self._keep_spacy_tokens,
-            "split_on_spaces"  : self._split_on_spaces,
-            "start_tokens"     : self._start_tokens,
-            "end_tokens"       : self._end_tokens,
-
+            "split_on_spaces": self._split_on_spaces,
+            "start_tokens": self._start_tokens,
+            "end_tokens": self._end_tokens,
         }
+
 
 class _WhitespaceSpacyTokenizer:
     """
@@ -161,6 +156,7 @@ class _WhitespaceSpacyTokenizer:
         words = text.split(" ")
         spaces = [True] * len(words)
         return Doc(self.vocab, words=words, spaces=spaces)
+
 
 def _remove_spaces(tokens: List[spacy.tokens.Token]) -> List[spacy.tokens.Token]:
     return [token for token in tokens if not token.is_space]

--- a/allennlp/data/tokenizers/whitespace_tokenizer.py
+++ b/allennlp/data/tokenizers/whitespace_tokenizer.py
@@ -25,6 +25,4 @@ class WhitespaceTokenizer(Tokenizer):
         return [Token(t) for t in text.split()]
 
     def _to_params(self) -> Dict[str, Any]:
-        return {
-            "type": "whitespace"
-        }
+        return {"type": "whitespace"}

--- a/allennlp/data/tokenizers/whitespace_tokenizer.py
+++ b/allennlp/data/tokenizers/whitespace_tokenizer.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict, Any
 
 from overrides import overrides
 
@@ -23,3 +23,8 @@ class WhitespaceTokenizer(Tokenizer):
     @overrides
     def tokenize(self, text: str) -> List[Token]:
         return [Token(t) for t in text.split()]
+
+    def _to_params(self) -> Dict[str, Any]:
+        return {
+            "type": "whitespace"
+        }

--- a/tests/common/registrable_test.py
+++ b/tests/common/registrable_test.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+from typing import List
 
 import pytest
 
@@ -15,7 +16,16 @@ from allennlp.modules.token_embedders.token_embedder import TokenEmbedder
 from allennlp.nn.regularizers.regularizer import Regularizer
 
 
+@pytest.fixture()
+def empty_registrable():
+    class EmptyRegistrable(Registrable):
+        pass
+
+    yield EmptyRegistrable
+
+
 class TestRegistrable(AllenNlpTestCase):
+
     def test_registrable_functionality_works(self):
         # This function tests the basic `Registrable` functionality:
         #
@@ -33,7 +43,6 @@ class TestRegistrable(AllenNlpTestCase):
 
         @base_class.register("fake")
         class Fake(base_class):
-
             pass
 
         assert base_class.by_name("fake") == Fake
@@ -52,17 +61,14 @@ class TestRegistrable(AllenNlpTestCase):
         # Verify that registering under a name that already exists
         # causes a ConfigurationError.
         with pytest.raises(ConfigurationError):
-
             @base_class.register("fake")
             class FakeAlternate(base_class):
-
                 pass
 
         # Registering under a name that already exists should overwrite
         # if exist_ok=True.
         @base_class.register("fake", exist_ok=True)  # noqa
         class FakeAlternate2(base_class):
-
             pass
 
         assert base_class.by_name("fake") == FakeAlternate2
@@ -130,6 +136,73 @@ class TestRegistrable(AllenNlpTestCase):
                 "testpackage.reader.TextClassificationJsonReader"
             )
             assert duplicate_reader.__name__ == "TextClassificationJsonReader"
+
+    def test_to_params_no_arguments(self, empty_registrable):
+        # Test how registrable disambiguates the class based on if there is no
+        # init function nor arguments.
+        @empty_registrable.register("no-args")
+        class NoArguments(empty_registrable):
+            pass
+
+        obj = NoArguments()
+        assert obj.to_params().params == {
+            "type": "no-args"
+        }
+
+    def test_to_params_no_pos_arguments(self, empty_registrable):
+        # Test how registrable disambiguates the _to_params when there is an
+        # init function but no positional arguments.
+        @empty_registrable.register("no-pos-args")
+        class NoPosArguments(empty_registrable):
+            def __init__(self, A: bool = None):
+                self.A = A
+
+        obj = NoPosArguments()
+        assert obj.to_params().params == {
+            "type": "no-pos-args"
+        }
+
+    def test_to_params_pos_arguments(self, empty_registrable):
+        # Test how registrable disambiguates the _to_params when there is an
+        # init function and positional arguments.
+        @empty_registrable.register("pos-args")
+        class PosArguments(empty_registrable):
+            def __init__(self, A: bool, B: int, C: List):
+                self.A = A
+                self._B = B
+                self._msg = C
+
+        obj = PosArguments(False, 5, [])
+        assert obj.to_params().params == {
+            "type": "pos-args",
+            "A"   : False,
+            "B"   : 5
+        }
+
+    def test_to_params_not_registered(self, empty_registrable):
+        # Test that Registrable raises an exception when the class called is
+        # not registered.
+        class NotRegistered(empty_registrable):
+            pass
+
+        obj = NotRegistered()
+        with pytest.raises(KeyError):
+            obj.to_params()
+
+    def test_to_params_nested(self, empty_registrable):
+        # Test how registrable disambiguates the _to_params when there is nested
+        # registrables.
+        class NestedBase(empty_registrable):
+            pass
+
+        @NestedBase.register("nested")
+        class NestedClass(NestedBase):
+            pass
+
+        obj = NestedClass()
+        assert obj.to_params().params == {
+            "type": "nested"
+        }
 
 
 @pytest.mark.parametrize(

--- a/tests/common/registrable_test.py
+++ b/tests/common/registrable_test.py
@@ -25,7 +25,6 @@ def empty_registrable():
 
 
 class TestRegistrable(AllenNlpTestCase):
-
     def test_registrable_functionality_works(self):
         # This function tests the basic `Registrable` functionality:
         #
@@ -61,6 +60,7 @@ class TestRegistrable(AllenNlpTestCase):
         # Verify that registering under a name that already exists
         # causes a ConfigurationError.
         with pytest.raises(ConfigurationError):
+
             @base_class.register("fake")
             class FakeAlternate(base_class):
                 pass
@@ -145,9 +145,7 @@ class TestRegistrable(AllenNlpTestCase):
             pass
 
         obj = NoArguments()
-        assert obj.to_params().params == {
-            "type": "no-args"
-        }
+        assert obj.to_params().params == {"type": "no-args"}
 
     def test_to_params_no_pos_arguments(self, empty_registrable):
         # Test how registrable disambiguates the _to_params when there is an
@@ -158,9 +156,7 @@ class TestRegistrable(AllenNlpTestCase):
                 self.A = A
 
         obj = NoPosArguments()
-        assert obj.to_params().params == {
-            "type": "no-pos-args"
-        }
+        assert obj.to_params().params == {"type": "no-pos-args"}
 
     def test_to_params_pos_arguments(self, empty_registrable):
         # Test how registrable disambiguates the _to_params when there is an
@@ -173,11 +169,7 @@ class TestRegistrable(AllenNlpTestCase):
                 self._msg = C
 
         obj = PosArguments(False, 5, [])
-        assert obj.to_params().params == {
-            "type": "pos-args",
-            "A"   : False,
-            "B"   : 5
-        }
+        assert obj.to_params().params == {"type": "pos-args", "A": False, "B": 5}
 
     def test_to_params_not_registered(self, empty_registrable):
         # Test that Registrable raises an exception when the class called is
@@ -200,9 +192,7 @@ class TestRegistrable(AllenNlpTestCase):
             pass
 
         obj = NestedClass()
-        assert obj.to_params().params == {
-            "type": "nested"
-        }
+        assert obj.to_params().params == {"type": "nested"}
 
 
 @pytest.mark.parametrize(

--- a/tests/data/tokenizers/character_tokenizer_test.py
+++ b/tests/data/tokenizers/character_tokenizer_test.py
@@ -1,3 +1,4 @@
+from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data.tokenizers import CharacterTokenizer
 
@@ -55,3 +56,15 @@ class TestCharacterTokenizer(AllenNlpTestCase):
         # Note that we've added one to the utf-8 encoded bytes, to account for masking.
         expected_tokens = [259, 196, 166, 196, 185, 196, 163, 196, 162, 98, 99, 102, 260]
         assert tokens == expected_tokens
+
+    def test_to_params(self):
+        tokenizer = CharacterTokenizer(byte_encoding="utf-8", start_tokens=[259], end_tokens=[260])
+        params = tokenizer.to_params()
+        assert isinstance(params, Params)
+        assert params.params == {
+            "type"                : "character",
+            "byte_encoding"       : "utf-8",
+            "end_tokens"          : [259],
+            "start_tokens"        : [260],
+            "lowercase_characters": False
+        }

--- a/tests/data/tokenizers/character_tokenizer_test.py
+++ b/tests/data/tokenizers/character_tokenizer_test.py
@@ -62,9 +62,9 @@ class TestCharacterTokenizer(AllenNlpTestCase):
         params = tokenizer.to_params()
         assert isinstance(params, Params)
         assert params.params == {
-            "type"                : "character",
-            "byte_encoding"       : "utf-8",
-            "end_tokens"          : [259],
-            "start_tokens"        : [260],
-            "lowercase_characters": False
+            "type": "character",
+            "byte_encoding": "utf-8",
+            "end_tokens": [259],
+            "start_tokens": [260],
+            "lowercase_characters": False,
         }

--- a/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -327,3 +327,17 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
         PretrainedTransformerTokenizer.from_params(
             Params({"model_name": "bert-base-uncased", "tokenizer_kwargs": {"max_len": 10}})
         )
+
+    def test_to_params(self):
+        tokenizer = PretrainedTransformerTokenizer.from_params(
+            Params({"model_name": "bert-base-uncased", "tokenizer_kwargs": {"max_len": 10}})
+        )
+        params = tokenizer.to_params()
+        assert isinstance(params, Params)
+        assert params.params == {
+            "type"              : "pretrained_transformer",
+            "model_name"        : "bert-base-uncased",
+            "add_special_tokens": True,
+            "max_length"        : None,
+            "tokenizer_kwargs"  : {"max_len": 10, 'use_fast': True}
+        }

--- a/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -335,9 +335,9 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
         params = tokenizer.to_params()
         assert isinstance(params, Params)
         assert params.params == {
-            "type"              : "pretrained_transformer",
-            "model_name"        : "bert-base-uncased",
+            "type": "pretrained_transformer",
+            "model_name": "bert-base-uncased",
             "add_special_tokens": True,
-            "max_length"        : None,
-            "tokenizer_kwargs"  : {"max_len": 10, 'use_fast': True}
+            "max_length": None,
+            "tokenizer_kwargs": {"max_len": 10, "use_fast": True},
         }

--- a/tests/data/tokenizers/sentence_splitter_test.py
+++ b/tests/data/tokenizers/sentence_splitter_test.py
@@ -1,3 +1,4 @@
+from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data.tokenizers.sentence_splitter import SpacySentenceSplitter
 
@@ -47,7 +48,9 @@ class TestSentenceSplitter(AllenNlpTestCase):
                 assert batch_sentence == separate_sentence
 
     def test_to_params(self):
-        assert self.dep_parse_splitter.to_params() == {
+        params = self.dep_parse_splitter.to_params()
+        assert isinstance(params, Params)
+        assert params.params == {
             "type"      : "spacy",
             "language"  : self.dep_parse_splitter._language,
             "rule_based": self.dep_parse_splitter._rule_based

--- a/tests/data/tokenizers/sentence_splitter_test.py
+++ b/tests/data/tokenizers/sentence_splitter_test.py
@@ -45,3 +45,10 @@ class TestSentenceSplitter(AllenNlpTestCase):
             assert len(batch_doc) == len(separate_doc)
             for batch_sentence, separate_sentence in zip(batch_doc, separate_doc):
                 assert batch_sentence == separate_sentence
+
+    def test_to_params(self):
+        assert self.dep_parse_splitter.to_params() == {
+            "type"      : "spacy",
+            "language"  : self.dep_parse_splitter._language,
+            "rule_based": self.dep_parse_splitter._rule_based
+        }

--- a/tests/data/tokenizers/sentence_splitter_test.py
+++ b/tests/data/tokenizers/sentence_splitter_test.py
@@ -51,7 +51,7 @@ class TestSentenceSplitter(AllenNlpTestCase):
         params = self.dep_parse_splitter.to_params()
         assert isinstance(params, Params)
         assert params.params == {
-            "type"      : "spacy",
-            "language"  : self.dep_parse_splitter._language,
-            "rule_based": self.dep_parse_splitter._rule_based
+            "type": "spacy",
+            "language": self.dep_parse_splitter._language,
+            "rule_based": self.dep_parse_splitter._rule_based,
         }

--- a/tests/data/tokenizers/spacy_tokenizer_test.py
+++ b/tests/data/tokenizers/spacy_tokenizer_test.py
@@ -1,5 +1,6 @@
 import spacy
 
+from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data.tokenizers import Token, SpacyTokenizer
 
@@ -121,7 +122,9 @@ class TestSpacyTokenizer(AllenNlpTestCase):
 
     def test_to_params(self):
         tokenizer = SpacyTokenizer()
-        assert tokenizer.to_params() == {
+        params = tokenizer.to_params()
+        assert isinstance(params, Params)
+        assert params == {
             "type"             : "spacy",
             "language"         : tokenizer._language,
             "pos_tags"         : tokenizer._pos_tags,

--- a/tests/data/tokenizers/spacy_tokenizer_test.py
+++ b/tests/data/tokenizers/spacy_tokenizer_test.py
@@ -124,7 +124,7 @@ class TestSpacyTokenizer(AllenNlpTestCase):
         tokenizer = SpacyTokenizer()
         params = tokenizer.to_params()
         assert isinstance(params, Params)
-        assert params == {
+        assert params.params == {
             "type"             : "spacy",
             "language"         : tokenizer._language,
             "pos_tags"         : tokenizer._pos_tags,

--- a/tests/data/tokenizers/spacy_tokenizer_test.py
+++ b/tests/data/tokenizers/spacy_tokenizer_test.py
@@ -118,3 +118,17 @@ class TestSpacyTokenizer(AllenNlpTestCase):
         tokens = word_tokenizer.tokenize(sentence)
         assert tokens
         assert all(isinstance(token, spacy.tokens.Token) for token in tokens)
+
+    def test_to_params(self):
+        tokenizer = SpacyTokenizer()
+        assert tokenizer.to_params() == {
+            "type"             : "spacy",
+            "language"         : tokenizer._language,
+            "pos_tags"         : tokenizer._pos_tags,
+            "parse"            : tokenizer._parse,
+            "ner"              : tokenizer._ner,
+            "keep_spacy_tokens": tokenizer._keep_spacy_tokens,
+            "split_on_spaces"  : tokenizer._split_on_spaces,
+            "start_tokens"     : tokenizer._start_tokens,
+            "end_tokens"       : tokenizer._end_tokens,
+        }

--- a/tests/data/tokenizers/spacy_tokenizer_test.py
+++ b/tests/data/tokenizers/spacy_tokenizer_test.py
@@ -125,13 +125,13 @@ class TestSpacyTokenizer(AllenNlpTestCase):
         params = tokenizer.to_params()
         assert isinstance(params, Params)
         assert params.params == {
-            "type"             : "spacy",
-            "language"         : tokenizer._language,
-            "pos_tags"         : tokenizer._pos_tags,
-            "parse"            : tokenizer._parse,
-            "ner"              : tokenizer._ner,
+            "type": "spacy",
+            "language": tokenizer._language,
+            "pos_tags": tokenizer._pos_tags,
+            "parse": tokenizer._parse,
+            "ner": tokenizer._ner,
             "keep_spacy_tokens": tokenizer._keep_spacy_tokens,
-            "split_on_spaces"  : tokenizer._split_on_spaces,
-            "start_tokens"     : tokenizer._start_tokens,
-            "end_tokens"       : tokenizer._end_tokens,
+            "split_on_spaces": tokenizer._split_on_spaces,
+            "start_tokens": tokenizer._start_tokens,
+            "end_tokens": tokenizer._end_tokens,
         }


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #5367 .

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Added in a default behavior to the `_to_params` method of `Registrable` so that in the case it is not implemented by the child class, it will still produce _a parameter dictionary_.   
- Added in `_to_params` implementations to all tokenizers.

The motivation for this PR is that currently, almost every Registrable does not have an implementation of `_to_params` and thus will raise a `NotImplementedError` when trying to populate a config with parameters. Thus, adding minimal functionality to the Registrable class avoids this error.

It is not the cleanest solution and implementing the `_to_params` method for all classes would be better, but also time-consuming. 

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.

- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
- [ ] **`codecov/patch`** reports high test coverage (at least 90%).
    You can find this under the "Actions" tab of the pull request once the other checks have finished.
