### PR TITLE
Remove spurious error message "'torch.cuda' has no attribute '_check_driver'"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FBetaMultiLabelMeasure` now works with multiple dimensions
 - Support for inferior operating systems when making hardlinks
 - Use `,` as a separator for filenames in the `evaluate` command, thus allowing for URLs (eg. `gs://...`) as input files.
+- Removed a spurious error message "torch.cuda has no attribute '_check_driver'" that would be appear in the logs
+  when a `ConfigurationError` for missing GPU was raised.
 
 ### Removed
 

--- a/allennlp/common/checks.py
+++ b/allennlp/common/checks.py
@@ -5,7 +5,7 @@ AllenNLP and its models are configured correctly.
 import logging
 import re
 import subprocess
-from typing import List, Union, Tuple, Any
+from typing import Any, List, Tuple, Union
 
 import torch
 from torch import cuda
@@ -114,22 +114,10 @@ def check_for_gpu(device: Union[int, torch.device, List[Union[int, torch.device]
         if device != torch.device("cpu"):
             num_devices_available = cuda.device_count()
             if num_devices_available == 0:
-                # Torch will give a more informative exception than ours, so we want to include
-                # that context as well if it's available.  For example, if you try to run torch 1.5
-                # on a machine with CUDA10.1 you'll get the following:
-                #
-                #     The NVIDIA driver on your system is too old (found version 10010).
-                #
-                torch_gpu_error = ""
-                try:
-                    cuda._check_driver()
-                except Exception as e:
-                    torch_gpu_error = "\n{0}".format(e)
-
                 raise ConfigurationError(
                     "Experiment specified a GPU but none is available;"
                     " if you want to run on CPU use the override"
-                    " 'trainer.cuda_device=-1' in the json config file." + torch_gpu_error
+                    " 'trainer.cuda_device=-1' in the json config file."
                 )
             elif device.index >= num_devices_available:
                 raise ConfigurationError(


### PR DESCRIPTION
It seems the `_check_driver` function was removed or renamed at some point. Let's not rely on PyTorch internal functions in the future.

This came up in https://github.com/allenai/beaker-service/issues/1837.