### PR TITLE
Fix ShouldValidateCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed a spurious error message "'torch.cuda' has no attribute '_check_driver'" that would be appear in the logs
   when a `ConfigurationError` for missing GPU was raised.
 - Load model on CPU post training to save GPU memory.
+- Fixed a bug in `ShouldValidateCallback` that leads to valuation occuring after the first epoch regardless of `validation_start` value.
+- Fixed a bug in `ShouldValidateCallback` that leads to valuation occuring every `validation_interval + 1` epochs, instead of every `validation_interval` epochs.
 
 ### Removed
 

--- a/allennlp/training/callbacks/should_validate.py
+++ b/allennlp/training/callbacks/should_validate.py
@@ -25,6 +25,11 @@ class ShouldValidateCallback(TrainerCallback):
         self._validation_start = validation_start
         self._validation_interval = validation_interval
 
+    def on_start(
+        self, trainer: "GradientDescentTrainer", is_primary: bool = True, **kwargs
+    ) -> None:
+        trainer._should_validate_this_epoch = self._should_validate(epoch=0)
+
     def on_epoch(
         self,
         trainer: "GradientDescentTrainer",
@@ -33,9 +38,12 @@ class ShouldValidateCallback(TrainerCallback):
         is_primary: bool = True,
         **kwargs,
     ) -> None:
+        trainer._should_validate_this_epoch = self._should_validate(epoch=epoch + 1)
+
+    def _should_validate(self, epoch: int) -> bool:
+        should_validate = True
         if self._validation_start is not None and epoch < self._validation_start:
-            trainer._should_validate_this_epoch = False
+            should_validate = False
         elif self._validation_interval is not None and epoch % self._validation_interval != 0:
-            trainer._should_validate_this_epoch = False
-        else:
-            trainer._should_validate_this_epoch = True
+            should_validate = False
+        return should_validate

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -1361,16 +1361,20 @@ class TestTrainer(TrainerTestBase):
         )
         trainer.train()
 
-        # Doesn't satisfy 'validation_start' or 'validation_interval'
+        # Shouldn't validate on the first epoch as it's before the 'validation_start'
+        callback.on_start(trainer)
+        assert not trainer._should_validate_this_epoch
+
+        # Satisfies 'validation_interval' but not 'validation_start'
         callback.on_epoch(trainer, metrics={}, epoch=1)
         assert not trainer._should_validate_this_epoch
 
-        # Satisfies 'validation_start' but not 'validation_interval'
+        # Doesn't satisfy 'validation_start' or 'validation_interval'
         callback.on_epoch(trainer, metrics={}, epoch=2)
         assert not trainer._should_validate_this_epoch
 
         # Satisfies both 'validation_start' and 'validation_interval'
-        callback.on_epoch(trainer, metrics={}, epoch=4)
+        callback.on_epoch(trainer, metrics={}, epoch=5)
         assert trainer._should_validate_this_epoch
 
 


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Addresses a bug in #5534.

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->

There were two subtle bugs in `ShouldValidateCallback` merged in #5534. One caused validation to always happen after the first epoch regardless of `validation_start`. The other caused validation to happen every `validation_interval + 1` epochs instead of every `validation_interval` epochs. Fixed both with the following changes:

- Add `on_start` method to `ShouldValidateCallback` that correctly sets `_should_validate_this_epoch` when training begins.
- Because `on_epoch` is called at the _end_ of every epoch, it needs to consider `epoch + 1` (instead of `epoch`) when setting `_should_validate_this_epoch`.
- Update `TrainerTest.test_should_validate_callback` so that it fails without these fixes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [x] All GitHub Actions jobs for my pull request have passed.
- [x] **`codecov/patch`** reports high test coverage (at least 90%).
    You can find this under the "Actions" tab of the pull request once the other checks have finished.
