### PR TITLE
Fix should validate callback train end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed a spurious error message "'torch.cuda' has no attribute '_check_driver'" that would be appear in the logs
   when a `ConfigurationError` for missing GPU was raised.
 - Load model on CPU post training to save GPU memory.
-- Fixed a bug in `ShouldValidateCallback` that leads to valuation occuring after the first epoch regardless of `validation_start` value.
-- Fixed a bug in `ShouldValidateCallback` that leads to valuation occuring every `validation_interval + 1` epochs, instead of every `validation_interval` epochs.
+- Fixed a bug in `ShouldValidateCallback` that leads to validation occuring after the first epoch regardless of `validation_start` value.
+- Fixed a bug in `ShouldValidateCallback` that leads to validation occuring every `validation_interval + 1` epochs, instead of every `validation_interval` epochs.
+- Fixed a bug in `ShouldValidateCallback` that leads to validation never occuring at the end of training.
 
 ### Removed
 

--- a/allennlp/training/callbacks/should_validate.py
+++ b/allennlp/training/callbacks/should_validate.py
@@ -48,7 +48,8 @@ class ShouldValidateCallback(TrainerCallback):
         is_primary: bool = True,
         **kwargs,
     ) -> None:
-        trainer._should_validate_this_epoch = self._should_validate(epoch=trainer._epochs_completed)
+        epoch = epoch + 1 if epoch is not None else trainer._epochs_completed
+        trainer._should_validate_this_epoch = self._should_validate(epoch=epoch)
 
     def _should_validate(self, epoch: int) -> bool:
         should_validate = True

--- a/allennlp/training/callbacks/should_validate.py
+++ b/allennlp/training/callbacks/should_validate.py
@@ -40,6 +40,16 @@ class ShouldValidateCallback(TrainerCallback):
     ) -> None:
         trainer._should_validate_this_epoch = self._should_validate(epoch=epoch + 1)
 
+    def on_end(
+        self,
+        trainer: "GradientDescentTrainer",
+        metrics: Dict[str, Any] = None,
+        epoch: int = None,
+        is_primary: bool = True,
+        **kwargs,
+    ) -> None:
+        trainer._should_validate_this_epoch = self._should_validate(epoch=trainer._epochs_completed)
+
     def _should_validate(self, epoch: int) -> bool:
         should_validate = True
         if self._validation_start is not None and epoch < self._validation_start:

--- a/tests/training/trainer_test.py
+++ b/tests/training/trainer_test.py
@@ -1374,7 +1374,11 @@ class TestTrainer(TrainerTestBase):
         assert not trainer._should_validate_this_epoch
 
         # Satisfies both 'validation_start' and 'validation_interval'
-        callback.on_epoch(trainer, metrics={}, epoch=5)
+        callback.on_epoch(trainer, metrics={}, epoch=3)
+        assert trainer._should_validate_this_epoch
+
+        # Check that final validation happens on the last epoch
+        callback.on_end(trainer)
         assert trainer._should_validate_this_epoch
 
 


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Addresses another bug in #5534. Sorry my original PR had so many bugs in it!

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->

The `ShouldValidateCallback` merged in #5534 was missing the method `on_end`. This caused validation to never occur at the end of training, even if the final epoch satisfied `validation_start` and `validation_interval`. I added an additional check to the test for this scenario.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [x] All GitHub Actions jobs for my pull request have passed.
- [x] **`codecov/patch`** reports high test coverage (at least 90%).
    You can find this under the "Actions" tab of the pull request once the other checks have finished.
