### PR TITLE
Make tests runnable out-of-tree for help with conda-packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated dependencies, especially around doc creation.
+- Running the test suite out-of-tree (e.g. after installation) is now possible by pointing the environment variable `ALLENNLP_SRC_DIR` to the sources.
 
 ## [v2.9.0](https://github.com/allenai/allennlp/releases/tag/v2.9.0) - 2022-01-27
 

--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -21,7 +21,16 @@ class AllenNlpTestCase:
     # to run test suite with finished package, which does not contain
     # tests & fixtures, we must be able to look them up somewhere else
     PROJECT_ROOT_FALLBACK = (
-        pathlib.Path(os.environ["SRC_DIR"]) if "SRC_DIR" in os.environ else PROJECT_ROOT
+        # users wanting to run test suite for installed package
+        pathlib.Path(os.environ["ALLENNLP_SRC_DIR"])
+        if "ALLENNLP_SRC_DIR" in os.environ
+        else (
+            # fallback for conda packaging
+            pathlib.Path(os.environ["SRC_DIR"])
+            if "CONDA_BUILD" in os.environ
+            # stay in-tree
+            else PROJECT_ROOT
+        )
     )
     TESTS_ROOT = PROJECT_ROOT_FALLBACK / "tests"
     FIXTURES_ROOT = PROJECT_ROOT_FALLBACK / "test_fixtures"

--- a/allennlp/common/testing/test_case.py
+++ b/allennlp/common/testing/test_case.py
@@ -18,8 +18,13 @@ class AllenNlpTestCase:
     PROJECT_ROOT = (pathlib.Path(__file__).parent / ".." / ".." / "..").resolve()
     MODULE_ROOT = PROJECT_ROOT / "allennlp"
     TOOLS_ROOT = MODULE_ROOT / "tools"
-    TESTS_ROOT = PROJECT_ROOT / "tests"
-    FIXTURES_ROOT = PROJECT_ROOT / "test_fixtures"
+    # to run test suite with finished package, which does not contain
+    # tests & fixtures, we must be able to look them up somewhere else
+    PROJECT_ROOT_FALLBACK = (
+        pathlib.Path(os.environ["SRC_DIR"]) if "SRC_DIR" in os.environ else PROJECT_ROOT
+    )
+    TESTS_ROOT = PROJECT_ROOT_FALLBACK / "tests"
+    FIXTURES_ROOT = PROJECT_ROOT_FALLBACK / "test_fixtures"
 
     def setup_method(self):
         logging.basicConfig(

--- a/tests/commands/cached_path_test.py
+++ b/tests/commands/cached_path_test.py
@@ -8,7 +8,8 @@ from allennlp.common.testing import AllenNlpTestCase
 
 class TestCachedPathCommand(AllenNlpTestCase):
     def test_local_file(self, capsys):
-        sys.argv = ["allennlp", "cached-path", "--cache-dir", str(self.TEST_DIR), "README.md"]
+        sys.argv = ["allennlp", "cached-path", "--cache-dir", str(self.TEST_DIR),
+                    str(self.PROJECT_ROOT_FALLBACK / "README.md")]
         main()
         captured = capsys.readouterr()
         assert "README.md" in captured.out

--- a/tests/commands/cached_path_test.py
+++ b/tests/commands/cached_path_test.py
@@ -8,8 +8,13 @@ from allennlp.common.testing import AllenNlpTestCase
 
 class TestCachedPathCommand(AllenNlpTestCase):
     def test_local_file(self, capsys):
-        sys.argv = ["allennlp", "cached-path", "--cache-dir", str(self.TEST_DIR),
-                    str(self.PROJECT_ROOT_FALLBACK / "README.md")]
+        sys.argv = [
+            "allennlp",
+            "cached-path",
+            "--cache-dir",
+            str(self.TEST_DIR),
+            str(self.PROJECT_ROOT_FALLBACK / "README.md"),
+        ]
         main()
         captured = capsys.readouterr()
         assert "README.md" in captured.out


### PR DESCRIPTION
The test suites of allennlp (and several sister/daughter libraries) implicitly depend on being run directly in the source directory, and cannot succeed being run against being actually installed somewhere on the system (e.g. the conda environment).

Since I like to run the full test suite wherever possible to validate that the library as packaged works correctly, I therefore need to patch this in most of the allennlp libraries. As conda-forge has now become one of the "officially" recommended ways of installation, I wanted to kindly ask if the project would consider picking up these patches (I'm using this PR as a stand-in for discussion, there'd be other very similar ones), which should hopefully not be intrusive and would help me a lot.