### PR TITLE
Add "sub_module" argument in PretrainedTransformerMismatchedEmbedder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - We can now transparently read compressed input files during prediction.
 - LZMA compression is now supported.
+- Added the argument `sub_module` in `PretrainedTransformerMismatchedEmbedder`
 
 
 ## [v2.9.0](https://github.com/allenai/allennlp/releases/tag/v2.9.0) - 2022-01-27

--- a/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
+++ b/allennlp/modules/token_embedders/pretrained_transformer_mismatched_embedder.py
@@ -26,6 +26,10 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         through the transformer model independently, and concatenate the final representations.
         Should be set to the same value as the `max_length` option on the
         `PretrainedTransformerMismatchedIndexer`.
+    sub_module: `str`, optional (default = `None`)
+        The name of a submodule of the transformer to be used as the embedder. Some transformers naturally act
+        as embedders such as BERT. However, other models consist of encoder and decoder, in which case we just
+        want to use the encoder.
     train_parameters: `bool`, optional (default = `True`)
         If this is `True`, the transformer weights get updated during training.
     last_layer_only: `bool`, optional (default = `True`)
@@ -65,6 +69,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         self,
         model_name: str,
         max_length: int = None,
+        sub_module: str = None,
         train_parameters: bool = True,
         last_layer_only: bool = True,
         override_weights_file: Optional[str] = None,
@@ -80,6 +85,7 @@ class PretrainedTransformerMismatchedEmbedder(TokenEmbedder):
         self._matched_embedder = PretrainedTransformerEmbedder(
             model_name,
             max_length=max_length,
+            sub_module=sub_module,
             train_parameters=train_parameters,
             last_layer_only=last_layer_only,
             override_weights_file=override_weights_file,


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes this question: https://stackoverflow.com/questions/71167641/in-allennlp-how-can-we-set-sub-module-argument-in-pretrainedtransformermismat

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Added "sub_module" argument in PretrainedTransformerMismatchedEmbedder initializer.


## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
- [ ] **`codecov/patch`** reports high test coverage (at least 90%).
    You can find this under the "Actions" tab of the pull request once the other checks have finished.
