### PR TITLE
Adding type conversion to fix errors when calling Predictor.from_path()

### DIFF
--- a/allennlp/common/params.py
+++ b/allennlp/common/params.py
@@ -455,8 +455,9 @@ class Params(MutableMapping):
         if ext_vars is None:
             ext_vars = {}
 
-        # redirect to cache, if necessary
-        params_file = cached_path(params_file)
+        # redirect to cache, if necessary.
+        # cached_path v1.1.0 returns Path object instead of str while evaluate_file requires a str path
+        params_file = str(cached_path(params_file))
         ext_vars = {**_environment_variables(), **ext_vars}
 
         file_dict = json.loads(evaluate_file(params_file, ext_vars=ext_vars))


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #5585 .

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- convert return value from cached_path to str before calling `evaluate_file()`

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

Note that existing tests were failing before this fix so no new tests were written to demonstrate what this fix does.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
- [ ] **`codecov/patch`** reports high test coverage (at least 90%).
    You can find this under the "Actions" tab of the pull request once the other checks have finished.
