### PR TITLE
pin cached-path tighter, make sure our cached-path wrapper still returns `str`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Running the test suite out-of-tree (e.g. after installation) is now possible by pointing the environment variable `ALLENNLP_SRC_DIR` to the sources.
 - Silenced a warning that happens when you inappropriately clone a tensor.
 - Adding more clarification to the `Vocabulary` documentation around `min_pretrained_embeddings` and `only_include_pretrained_words`.
+- Fixed bug with type mismatch caused by latest release of `cached-path` that now returns a `Path` instead of a `str`.
 
 ### Added
 

--- a/allennlp/common/file_utils.py
+++ b/allennlp/common/file_utils.py
@@ -133,11 +133,13 @@ def cached_path(
             from multiple processes on the same file.
     """
     _cached_path.file_friendly_logging(common_logging.FILE_FRIENDLY_LOGGING)
-    return _cached_path.cached_path(
-        url_or_filename,
-        cache_dir=cache_dir or CACHE_DIRECTORY,
-        extract_archive=extract_archive,
-        force_extract=force_extract,
+    return str(
+        _cached_path.cached_path(
+            url_or_filename,
+            cache_dir=cache_dir or CACHE_DIRECTORY,
+            extract_archive=extract_archive,
+            force_extract=force_extract,
+        )
     )
 
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -36,6 +36,8 @@ ruamel.yaml
 # Generating markdown files from Python modules.
 pydoc-markdown>=4.0.0,<5.0.0
 databind.core
+docspec==1.2.0
+docspec-python==1.2.0
 
 mkdocs==1.2.3
 mkdocs-material>=5.5.0,<8.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 ################################
 torch>=1.6.0,<1.11.0
 torchvision>=0.8.1,<0.12.0
-cached-path>=1.0.2,<2.0.0
+cached-path>=1.0.2,<1.1.0
 fairscale==0.4.5
 jsonnet>=0.10.0 ; sys.platform != 'win32'
 nltk

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 ################################
 torch>=1.6.0,<1.11.0
 torchvision>=0.8.1,<0.12.0
-cached-path>=1.0.2,<1.1.0
+cached-path>=1.0.2,<1.2.0
 fairscale==0.4.5
 jsonnet>=0.10.0 ; sys.platform != 'win32'
 nltk


### PR DESCRIPTION
Fixes #5585

Changes proposed:
- Adds a tighter pin on `cached-path` to catch breaking changes in the future.
- Makes sure our `cached_path()` wrapper still returns a `str`.
- Also pins `docspec` which is needed to build the docs.

See also https://github.com/allenai/allennlp/pull/5586.