### PR TITLE
Add `custom_dummy_tokens` to `PretrainedTransformerTokenizer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added `custom_dummy_tokens` argument to `TestPretrainedTransformerTokenizer`.
+
 ## [v2.9.2](https://github.com/allenai/allennlp/releases/tag/v2.9.2) - 2022-03-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
 - Added `custom_dummy_tokens` argument to `TestPretrainedTransformerTokenizer`.
 
 ## [v2.9.2](https://github.com/allenai/allennlp/releases/tag/v2.9.2) - 2022-03-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `custom_dummy_tokens` argument to `TestPretrainedTransformerTokenizer`.
+- Added `verification_tokens` argument to `TestPretrainedTransformerTokenizer`.
 
 ## [v2.9.2](https://github.com/allenai/allennlp/releases/tag/v2.9.2) - 2022-03-21
 

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -55,7 +55,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         add_special_tokens: bool = True,
         max_length: Optional[int] = None,
         tokenizer_kwargs: Optional[Dict[str, Any]] = None,
-        custom_dummy_tokens: Optional[Tuple[str, str]] = None,
+        verification_tokens: Optional[Tuple[str, str]] = None,
     ) -> None:
         if tokenizer_kwargs is None:
             tokenizer_kwargs = {}

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -45,7 +45,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         Dictionary with
         [additional arguments](https://github.com/huggingface/transformers/blob/155c782a2ccd103cf63ad48a2becd7c76a7d2115/transformers/tokenization_utils.py#L691)
         for `AutoTokenizer.from_pretrained`.
-    custom_dummy_tokens: `Tuple[str, str]`, optional (default = `None`)
+    verification_tokens: `Tuple[str, str]`, optional (default = `None`)
         A pair of tokens having different token IDs. It's used for reverse-engineering special tokens.
     """  # noqa: E501
 
@@ -78,7 +78,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         self._tokenizer_lowercases = self.tokenizer_lowercases(self.tokenizer)
 
-        if custom_dummy_tokens is None:
+        if verification_tokens is None:
             try:
                 self._reverse_engineer_special_tokens("a", "b", model_name, tokenizer_kwargs)
             except AssertionError:
@@ -86,7 +86,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
                 # they don't, and so we use "1" and "2" instead.
                 self._reverse_engineer_special_tokens("1", "2", model_name, tokenizer_kwargs)
         else:
-            token_a, token_b = custom_dummy_tokens
+            token_a, token_b = verification_tokens
             self._reverse_engineer_special_tokens(token_a, token_b, model_name, tokenizer_kwargs)
 
     def _reverse_engineer_special_tokens(

--- a/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
+++ b/allennlp/data/tokenizers/pretrained_transformer_tokenizer.py
@@ -45,6 +45,8 @@ class PretrainedTransformerTokenizer(Tokenizer):
         Dictionary with
         [additional arguments](https://github.com/huggingface/transformers/blob/155c782a2ccd103cf63ad48a2becd7c76a7d2115/transformers/tokenization_utils.py#L691)
         for `AutoTokenizer.from_pretrained`.
+    custom_dummy_tokens: `Tuple[str, str]`, optional (default = `None`)
+        A pair of tokens having different token IDs. It's used for reverse-engineering special tokens.
     """  # noqa: E501
 
     def __init__(
@@ -53,6 +55,7 @@ class PretrainedTransformerTokenizer(Tokenizer):
         add_special_tokens: bool = True,
         max_length: Optional[int] = None,
         tokenizer_kwargs: Optional[Dict[str, Any]] = None,
+        custom_dummy_tokens: Optional[Tuple[str, str]] = None,
     ) -> None:
         if tokenizer_kwargs is None:
             tokenizer_kwargs = {}
@@ -75,12 +78,16 @@ class PretrainedTransformerTokenizer(Tokenizer):
 
         self._tokenizer_lowercases = self.tokenizer_lowercases(self.tokenizer)
 
-        try:
-            self._reverse_engineer_special_tokens("a", "b", model_name, tokenizer_kwargs)
-        except AssertionError:
-            # For most transformer models, "a" and "b" work just fine as dummy tokens.  For a few,
-            # they don't, and so we use "1" and "2" instead.
-            self._reverse_engineer_special_tokens("1", "2", model_name, tokenizer_kwargs)
+        if custom_dummy_tokens is None:
+            try:
+                self._reverse_engineer_special_tokens("a", "b", model_name, tokenizer_kwargs)
+            except AssertionError:
+                # For most transformer models, "a" and "b" work just fine as dummy tokens.  For a few,
+                # they don't, and so we use "1" and "2" instead.
+                self._reverse_engineer_special_tokens("1", "2", model_name, tokenizer_kwargs)
+        else:
+            token_a, token_b = custom_dummy_tokens
+            self._reverse_engineer_special_tokens(token_a, token_b, model_name, tokenizer_kwargs)
 
     def _reverse_engineer_special_tokens(
         self,

--- a/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -1,5 +1,7 @@
 from typing import Iterable, List
 
+import pytest
+
 from allennlp.common import Params
 from allennlp.common.testing import AllenNlpTestCase
 from allennlp.data import Token
@@ -341,3 +343,20 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
             "max_length": None,
             "tokenizer_kwargs": {"max_len": 10, "use_fast": True},
         }
+
+    def test_initialize_tokenizer_with_custom_dummy_tokens(self):
+        model_name = "roberta-base"
+        PretrainedTransformerTokenizer(
+            model_name,
+            custom_dummy_tokens=("cat", "dog"),
+        )
+        with pytest.raises(AssertionError):
+            PretrainedTransformerTokenizer(
+                model_name,
+                custom_dummy_tokens=("unknowntoken", "dog"),
+            )
+        with pytest.raises(AssertionError):
+            PretrainedTransformerTokenizer(
+                model_name,
+                custom_dummy_tokens=("cat", "cat"),
+            )

--- a/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
+++ b/tests/data/tokenizers/pretrained_transformer_tokenizer_test.py
@@ -344,19 +344,19 @@ class TestPretrainedTransformerTokenizer(AllenNlpTestCase):
             "tokenizer_kwargs": {"max_len": 10, "use_fast": True},
         }
 
-    def test_initialize_tokenizer_with_custom_dummy_tokens(self):
+    def test_initialize_tokenizer_with_verification_tokens(self):
         model_name = "roberta-base"
         PretrainedTransformerTokenizer(
             model_name,
-            custom_dummy_tokens=("cat", "dog"),
+            verification_tokens=("cat", "dog"),
         )
         with pytest.raises(AssertionError):
             PretrainedTransformerTokenizer(
                 model_name,
-                custom_dummy_tokens=("unknowntoken", "dog"),
+                verification_tokens=("unknowntoken", "dog"),
             )
         with pytest.raises(AssertionError):
             PretrainedTransformerTokenizer(
                 model_name,
-                custom_dummy_tokens=("cat", "cat"),
+                verification_tokens=("cat", "cat"),
             )


### PR DESCRIPTION
This commit aims to support #5597

<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Add `custom_dummy_tokens` argument to `PretrainedTransformerTokenizer`. Without that argument, initializing `PretrainedTransformerTokenizer` of some non-English models fail.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/allennlp/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
- [ ] **`codecov/patch`** reports high test coverage (at least 90%).
    You can find this under the "Actions" tab of the pull request once the other checks have finished.
